### PR TITLE
Initial production Puma config

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-front: bundle exec puma -p 50301 --env production
+front: bundle exec puma

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,0 +1,15 @@
+#!/usr/bin/env puma
+
+environment 'production'
+
+daemonize
+pidfile 'tmp/puma.pid'
+state_path 'tmp/puma.state'
+stdout_redirect 'log/puma.stdout', 'log/puma.stderr', true
+
+bind 'unix://tmp/puma.sock'
+bind 'tcp://127.0.0.1:50301'
+
+workers 2
+
+activate_control_app 'unix://tmp/pumactl.sock', { no_token: true }


### PR DESCRIPTION
- Rails env is always production
- workers set to 2 for now, unknown how many cores production machines
  will have for now. (See https://github.com/puma/puma#clustered-mode )