### PR TITLE
3333: Fix jenkins script to precompile assets seperately

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,2 +1,3 @@
 #/usr/bin/env sh
+RAILS_ENV=production bundle exec rake assets:precompile
 pkgr package . --version=${BUILD_NUMBER} --name=front


### PR DESCRIPTION
This was breaking the building of the assets as pkgr wasn't passing the
environment variables properly. This should
allow it to get the environment variable from the dotenv file.

Once this is merged, we can remove a line from our jenkins job.

Single: WillPearson