### PR TITLE
3321: allow for localised routes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,8 @@ ruby '2.3.0'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '4.2.5.1'
 gem 'rails-i18n', '~> 4.0'
+gem 'route_translator', '~> 4.2'
+
 # Use SCSS for stylesheets
 gem 'sass-rails', '~> 5.0'
 # Use Uglifier as compressor for JavaScript assets

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,6 +143,9 @@ GEM
     rake (10.5.0)
     rdoc (4.2.1)
     ref (2.0.0)
+    route_translator (4.2.4)
+      actionpack (>= 3.2, < 5.0)
+      activesupport (>= 3.2, < 5.0)
     rspec-core (3.4.2)
       rspec-support (~> 3.4.0)
     rspec-expectations (3.4.0)
@@ -231,6 +234,7 @@ DEPENDENCIES
   rack-handlers
   rails (= 4.2.5.1)
   rails-i18n (~> 4.0)
+  route_translator (~> 4.2)
   rspec-rails (~> 3.4.0)
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)

--- a/app/controllers/start_controller.rb
+++ b/app/controllers/start_controller.rb
@@ -11,9 +11,9 @@ class StartController < ApplicationController
 
   def request_post
     if params['selection'] == 'true'
-      redirect_to "/about", status: :see_other
+      redirect_to about_path(locale: I18n.locale), status: :see_other
     else
-      redirect_to "/sign-in", status: :see_other
+      redirect_to sign_in_path(locale: I18n.locale), status: :see_other
     end
   end
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,4 +15,19 @@
   </main>
 <% end %>
 
+<% content_for :footer_support_links do %>
+  <h2 class="visuallyhidden">Support links</h2>
+  <ul>
+    <li><a href="https://gov.uk/help">Help</a></li>
+    <li>
+      <% if params[:locale] != 'cy' %>
+        <%= link_to 'Cymraeg', url_for(locale: 'cy'), lang: 'cy', hreflang: 'cy' %>
+      <% else %>
+        <%= link_to 'English', url_for(locale: 'en'), lang: 'en', hreflang: 'en' %>
+      <% end %>
+    </li>
+    <li>Built by the <a href="https://gds.blog.gov.uk">Government Digital Service</a></li>
+  </ul>
+<% end %>
+
 <%= render file: 'layouts/govuk_template' %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -27,6 +27,11 @@ module VerifyFrontend
 
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
-    # config.i18n.default_locale = :de
+    config.i18n.default_locale = :en
+
+    RouteTranslator.config do |config|
+      config.hide_locale = true
+      config.available_locales = [:en,:cy]
+    end
   end
 end

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -1,11 +1,15 @@
 # FIXME: Google translated Welsh
 cy:
+  routes:
+    start: dechrau
+    about: am
+    sign_in: mewngofnodi
   phase_banner:
     title: Mae hwn yn wasanaeth newydd - Bydd eich %{feedback_link} yn ein helpu i wella.
     feedback: adborth
   hub:
     start:
       title: Mewngofnodi gyda GOV.UK Verify
-      answer_yes: Mae hyn yn fy amser cyntaf gan ddefnyddio GOV.UK Verify 
-      answer_no: Rwyf wedi defnyddio GOV.UK Verify cyn
+      answer_yes: Mae hyn yn fy amser cyntaf gan ddefnyddio Verify
+      answer_no: Rwyf wedi defnyddio Verify cyn
       continue: Parhau

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,10 +1,14 @@
 en:
+  routes:
+    start: start
+    about: about
+    sign_in: sign-in
   phase_banner:
     title: This is a new service – your %{feedback_link} will help us to improve it.
     feedback: feedback
   hub:
     start:
       title: Sign in with GOV.UK Verify
-      answer_yes: This is my first time using GOV.UK Verify
-      answer_no: I’ve used GOV.UK Verify before
+      answer_yes: This is my first time using Verify
+      answer_no: I’ve used Verify before
       continue: Continue

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,18 +5,19 @@ Rails.application.routes.draw do
   # You can have the root of your site routed with "root"
   # root 'welcome#index'
 
-  # Example of regular route:
-  #   get 'products/:id' => 'catalog#view'
   post 'SAML2/SSO' => 'saml#request_post'
-  post 'start' => 'start#request_post'
-  post 'dechrau' => 'start#request_post', defaults: { locale: 'cy' }
-  get 'start' => 'start#index'
-  get 'dechrau' => 'start#index', defaults: { locale: 'cy' }
-  get 'about' => 'about#index'
-  get 'sign-in' => 'sign_in#index'
 
   if ['test', 'development'].include? Rails.env
     get 'test-saml' => 'test_saml#index'
+  end
+
+  localized do
+    get 'start', to: 'start#index', as: :start
+    post 'start', to: 'start#request_post', as: :start
+
+    get 'sign_in', to: 'sign_in#index', as: :sign_in
+
+    get 'about', to: 'about#index', as: :about
   end
 
   # Example of named route that can be invoked with purchase_url(id: product.id)


### PR DESCRIPTION
The route_translator gem allows route names to be moved into the locale dictionaries. Redirects will need to have `I18n.locale` passed through manually.