### PR TITLE
3370: Fix the iteration number to 1 for deploys

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,3 +1,3 @@
 #/usr/bin/env sh
 RAILS_ENV=production bundle exec rake assets:precompile
-pkgr package . --version=${BUILD_NUMBER} --name=front
+pkgr package . --version=${BUILD_NUMBER} --iteration=1 --name=front


### PR DESCRIPTION
As we need to sepcify the iteration number for deploying
new versions we need it to be predictable.

I can't set it to the empty string currently, so 1 it is.

Single: WillPearson