### PR TITLE
3321: show error if no answer to start page question

### DIFF
--- a/app/controllers/start_controller.rb
+++ b/app/controllers/start_controller.rb
@@ -10,7 +10,10 @@ class StartController < ApplicationController
   end
 
   def request_post
-    if params['selection'] == 'true'
+    if params['selection'].blank?
+      @error_message = 'hub.start.error_message'
+      render "index"
+    elsif params['selection'] == 'true'
       redirect_to about_path(locale: I18n.locale), status: :see_other
     else
       redirect_to sign_in_path(locale: I18n.locale), status: :see_other

--- a/app/views/start/index.html.erb
+++ b/app/views/start/index.html.erb
@@ -4,10 +4,7 @@
 <h1><%= t 'hub.start.heading' %></h1>
 
 <%= form_tag '', id: 'validate-single-question' do %>
-  <% if @has_error_message %>
-    <div class="form-group validation-message" id="validation-error-message-no-js"><%= @error_message %></div>
-  <% end %>
-  <div class="form-group <%= @has_error_message ? 'error' : '' %>">
+  <div class="form-group <%= @error_message.present? ? 'error' : '' %>">
     <fieldset>
       <label class="block-label" for="yes" onclick="">
         <input id="yes" type="radio" name="selection" value="true" />
@@ -21,6 +18,9 @@
       </label>
     </fieldset>
   </div>
+  <% if @error_message.present? %>
+    <div class="form-group error validation-message" id="validation-error-message-no-js"><%= t @error_message %></div>
+  <% end %>
 
   <div id="validation-error-message-js"></div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -13,3 +13,4 @@ en:
       answer_yes: This is my first time using Verify
       answer_no: I’ve used Verify before
       continue: Continue
+      error_message: Please answer the question

--- a/spec/features/user_submits_start_page_form_spec.rb
+++ b/spec/features/user_submits_start_page_form_spec.rb
@@ -39,4 +39,11 @@ RSpec.describe 'when user submits start page form' do
     click_button('next-button')
     expect(current_path).to eq('/sign-in')
   end
+
+  it 'will prompt for an answer if no answer is given' do
+    set_session_cookies
+    visit '/start'
+    click_button('next-button')
+    expect(page).to have_content "Please answer the question"
+  end
 end


### PR DESCRIPTION
If there is no answer then we should prompt for one.

@robinwhittleton: please, could you let me know if I should correct the styling for this error