### PR TITLE
bau: remove .env reading from puma config

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,10 +1,5 @@
 #!/usr/bin/env puma
 
-File.open('.env').each do |l|
-  v = l.split('=')
-  ENV[v[0]] = v[1]
-end
-
 environment 'production'
 
 pidfile 'tmp/puma.pid'


### PR DESCRIPTION
This isn't how we wan't to load up envvars. We will be using the config directory pkgr sets up for us.