### PR TITLE
3321: Add gov uk selection button styles

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,10 +1,15 @@
 //= require jquery
 //= require jquery_ujs
 //= require jquery.validate
+//= require govuk/selection-buttons
 //= require_tree .
 
 window.GOVUK.validation.init();
 
 $(function () {
+  // Use GOV.UK selection-buttons.js to set selected and focused states for block labels
+  var $blockLabelInput = $(".block-label").find("input[type='radio'],input[type='checkbox']");
+  new GOVUK.SelectionButtons($blockLabelInput);
+
   window.GOVUK.validation.attach();
 });

--- a/app/assets/stylesheets/_application.scss
+++ b/app/assets/stylesheets/_application.scss
@@ -1,5 +1,7 @@
 // Import GOV.UK frontend toolkit
 @import "_govuk-elements";
 
+@import "_govuk-elements-overrides";
+
 // Specific pages
 @import "pages/_start";

--- a/app/assets/stylesheets/_application.scss
+++ b/app/assets/stylesheets/_application.scss
@@ -2,4 +2,4 @@
 @import "_govuk-elements";
 
 // Specific pages
-@import "pages/_start"
+@import "pages/_start";

--- a/app/assets/stylesheets/_govuk-elements-overrides.scss
+++ b/app/assets/stylesheets/_govuk-elements-overrides.scss
@@ -1,0 +1,3 @@
+.js-enabled label.selected {
+  background: initial;
+}

--- a/app/assets/stylesheets/elements/forms/_form-block-labels.scss
+++ b/app/assets/stylesheets/elements/forms/_form-block-labels.scss
@@ -55,7 +55,6 @@
 
 // Add selected state
 .js-enabled label.selected {
-  background: $white;
   border-color: $black;
 }
 

--- a/app/assets/stylesheets/elements/forms/_form-block-labels.scss
+++ b/app/assets/stylesheets/elements/forms/_form-block-labels.scss
@@ -55,6 +55,7 @@
 
 // Add selected state
 .js-enabled label.selected {
+  background: $white;
   border-color: $black;
 }
 


### PR DESCRIPTION
These set the whole label to be highlighted when an input is selected.
This needs reviewing by @robinwhittleton and will probably want to
change.

In particular: I had to modify one of the scss files inside gov uk elements. I'm not sure this was the right thing to do? Will it make upgrading difficult?

(Recreated from #17 which was targetting the wrong branch)