### PR TITLE
3347: add support for zdd endpoints

### DIFF
--- a/.env
+++ b/.env
@@ -3,3 +3,4 @@ API_HOST=http://localhost:50190
 RP_DISPLAY_LOCALES=stub/locales/rps
 IDP_DISPLAY_LOCALES=stub/locales/idps
 LOGO_DIRECTORY=/stub-logos
+ZDD_LATCH=.service_unavailable

--- a/.env
+++ b/.env
@@ -4,3 +4,4 @@ RP_DISPLAY_LOCALES=stub/locales/rps
 IDP_DISPLAY_LOCALES=stub/locales/idps
 LOGO_DIRECTORY=/stub-logos
 ZDD_LATCH=.service_unavailable
+POLLING_WAIT_TIME=2

--- a/.pkgr.yml
+++ b/.pkgr.yml
@@ -1,3 +1,4 @@
 before:
   - bundle config --local build.nokogiri "--use-system-libraries --with-xml2-include=/usr/include/libxml2"
 after_install: 'packaging/postinst.sh'
+after_remove: 'packaging/postrm.sh'

--- a/Gemfile
+++ b/Gemfile
@@ -61,4 +61,5 @@ group :test, :development do
   gem 'capybara', '~> 2.6'
   gem 'govuk-lint'
   gem 'webmock', require: false
+  gem 'rack-test'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -255,6 +255,7 @@ DEPENDENCIES
   jquery-validation-rails (~> 1.13, >= 1.13.1)
   puma
   rack-handlers
+  rack-test
   rails (= 4.2.5.2)
   rails-i18n (~> 4.0)
   route_translator (~> 4.2)

--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,7 @@
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
 require File.expand_path('../config/application', __FILE__)
+require 'fileutils'
 
 Rails.application.load_tasks
 

--- a/app/controllers/service_status_controller.rb
+++ b/app/controllers/service_status_controller.rb
@@ -2,7 +2,7 @@ class ServiceStatusController < ApplicationController
   skip_before_action :validate_cookies
 
   def zdd_latch_file
-    ENV.fetch('ZDD_LATCH')
+    CONFIG.zdd_file
   end
 
   def index

--- a/app/controllers/service_status_controller.rb
+++ b/app/controllers/service_status_controller.rb
@@ -1,12 +1,8 @@
 class ServiceStatusController < ApplicationController
   skip_before_action :validate_cookies
 
-  def zdd_latch_file
-    CONFIG.zdd_file
-  end
-
   def index
-    if File.exist?(zdd_latch_file)
+    if ServiceStatus.unavailable?
       render nothing: true, status: 503
     else
       render nothing: true, status: 200

--- a/app/controllers/service_status_controller.rb
+++ b/app/controllers/service_status_controller.rb
@@ -1,0 +1,15 @@
+class ServiceStatusController < ApplicationController
+  skip_before_action :validate_cookies
+
+  def zdd_latch_file
+    ENV.fetch('ZDD_LATCH')
+  end
+
+  def index
+    if File.exist?(zdd_latch_file)
+      render nothing: true, status: 503
+    else
+      render nothing: true, status: 200
+    end
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,9 +12,6 @@ require "sprockets/railtie"
 # require "rails/test_unit/railtie"
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
-
-require File.expand_path('../../lib/service_status_filter', __FILE__)
-
 Bundler.require(*Rails.groups)
 
 module VerifyFrontend
@@ -31,7 +28,6 @@ module VerifyFrontend
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     config.i18n.default_locale = :en
 
-    config.middleware.use 'ServiceStatusFilter'
 
     RouteTranslator.config do |config|
       config.hide_locale = true

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,9 +10,11 @@ require "action_controller/railtie"
 require "action_view/railtie"
 require "sprockets/railtie"
 # require "rails/test_unit/railtie"
-
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
+
+require File.expand_path('../../lib/service_status_filter', __FILE__)
+
 Bundler.require(*Rails.groups)
 
 module VerifyFrontend
@@ -30,6 +32,8 @@ module VerifyFrontend
     config.i18n.default_locale = :en
     config.i18n.load_path +=  Dir[File.join(ENV.fetch('RP_DISPLAY_LOCALES'), '*.{rb,yml}').to_s]
     config.i18n.load_path +=  Dir[File.join(ENV.fetch('IDP_DISPLAY_LOCALES'), '*.{rb,yml}').to_s]
+
+    config.middleware.use 'ServiceStatusFilter'
 
     RouteTranslator.config do |config|
       config.hide_locale = true

--- a/config/application.rb
+++ b/config/application.rb
@@ -30,8 +30,6 @@ module VerifyFrontend
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     config.i18n.default_locale = :en
-    config.i18n.load_path +=  Dir[File.join(ENV.fetch('RP_DISPLAY_LOCALES'), '*.{rb,yml}').to_s]
-    config.i18n.load_path +=  Dir[File.join(ENV.fetch('IDP_DISPLAY_LOCALES'), '*.{rb,yml}').to_s]
 
     config.middleware.use 'ServiceStatusFilter'
 

--- a/config/initializers/configuration.rb
+++ b/config/initializers/configuration.rb
@@ -1,0 +1,9 @@
+require 'configuration'
+CONFIG = Configuration.load! do
+  option 'rp_display_locales', 'RP_DISPLAY_LOCALES'
+  option 'idp_display_locales', 'IDP_DISPLAY_LOCALES'
+  option 'session_cookie_duration', 'SESSION_COOKIE_DURATION_IN_HOURS'
+  option 'api_host', 'API_HOST'
+  option 'logo_directory', 'LOGO_DIRECTORY'
+  option 'zdd_file', 'ZDD_LATCH'
+end

--- a/config/initializers/configuration.rb
+++ b/config/initializers/configuration.rb
@@ -6,4 +6,5 @@ CONFIG = Configuration.load! do
   option 'api_host', 'API_HOST'
   option 'logo_directory', 'LOGO_DIRECTORY'
   option 'zdd_file', 'ZDD_LATCH'
+  option 'polling_wait_time', 'POLLING_WAIT_TIME'
 end

--- a/config/initializers/cookie_validator.rb
+++ b/config/initializers/cookie_validator.rb
@@ -1,4 +1,2 @@
-session_cookie_duration_in_hours = ENV.fetch("SESSION_COOKIE_DURATION_IN_HOURS") do 
-  raise "A session cookie duration must be provided via SESSION_COOKIE_DURATION_IN_HOURS"
-end
+session_cookie_duration_in_hours = CONFIG.session_cookie_duration
 COOKIE_VALIDATOR = CookieValidator.new(Integer(session_cookie_duration_in_hours))

--- a/config/initializers/federation_localisation.rb
+++ b/config/initializers/federation_localisation.rb
@@ -1,0 +1,3 @@
+
+Rails.application.config.i18n.load_path +=  Dir[File.join(CONFIG.rp_display_locales, '*.{rb,yml}').to_s]
+Rails.application.config.i18n.load_path +=  Dir[File.join(CONFIG.idp_display_locales, '*.{rb,yml}').to_s]

--- a/config/initializers/proxies.rb
+++ b/config/initializers/proxies.rb
@@ -1,4 +1,4 @@
-API_HOST = ENV.fetch("API_HOST") { raise "An API host must be provided with API_HOST" }
+API_HOST = CONFIG.api_host
 api_client = Api::Client.new(API_HOST, Api::ResponseHandler.new)
 SESSION_PROXY = SessionProxy.new(api_client)
 
@@ -9,4 +9,4 @@ TRANSACTION_LISTER = Display::Rp::TransactionLister.new(
 
 IDENTITY_PROVIDER_LISTER = Display::Idp::IdentityProviderLister.new(
   SESSION_PROXY,
-  Display::Idp::DisplayDataCorrelator.new(federation_translator, ENV.fetch('LOGO_DIRECTORY')))
+  Display::Idp::DisplayDataCorrelator.new(federation_translator, CONFIG.logo_directory))

--- a/config/initializers/service_status_filter.rb
+++ b/config/initializers/service_status_filter.rb
@@ -1,0 +1,2 @@
+require 'service_status_filter'
+Rails.application.config.middleware.use 'ServiceStatusFilter'

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -7,8 +7,5 @@ state_path 'tmp/puma.state'
 stdout_redirect 'log/puma.stdout', 'log/puma.stderr', true
 
 bind 'unix://tmp/puma.sock'
-bind 'tcp://127.0.0.1:50301'
 
 workers 2
-
-activate_control_app 'unix://tmp/pumactl.sock', { no_token: true }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,7 @@ Rails.application.routes.draw do
     get '/redirect-to-service/error', to: redirect("#{API_HOST}/redirect-to-service/error")
 
     put 'select-idp', to: 'select_idp#select_idp', as: :select_idp
+    get 'service-status', to: 'service_status#index', as: :service_status
 
     if Rails.env == 'development'
       get 'about', to: redirect("#{API_HOST}/about")

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -1,0 +1,17 @@
+class Configuration
+  MissingEnvVarError = Class.new(StandardError)
+  def self.load!(&blk)
+    config = Configuration.new
+    config.instance_eval(&blk)
+    config
+  end
+
+  def option(name, envvar)
+    value = ENV.fetch(envvar) do
+      raise MissingEnvVarError, "An Environment Variable named '#{envvar}' could not be found"
+    end
+    instance_variable_set("@#{name}", value)
+    eigenclass = class << self; self; end
+    eigenclass.class_eval { attr_reader name }
+  end
+end

--- a/lib/service_status.rb
+++ b/lib/service_status.rb
@@ -1,0 +1,5 @@
+class ServiceStatus
+  def self.unavailable?
+    File.exist?(::CONFIG.zdd_file)
+  end
+end

--- a/lib/service_status_filter.rb
+++ b/lib/service_status_filter.rb
@@ -1,0 +1,18 @@
+class ServiceStatusFilter
+  def initialize(app)
+    @app = app
+  end
+
+  def zdd_latch_file
+    ENV.fetch('ZDD_LATCH')
+  end
+
+  def call(env)
+    status, headers, response = @app.call(env)
+    if File.exist?(zdd_latch_file)
+      [status, headers.merge("Connection" => "close"), response]
+    else
+      [status, headers, response]
+    end
+  end
+end

--- a/lib/service_status_filter.rb
+++ b/lib/service_status_filter.rb
@@ -1,15 +1,12 @@
+require 'service_status'
 class ServiceStatusFilter
   def initialize(app)
     @app = app
   end
 
-  def zdd_latch_file
-    CONFIG.zdd_file
-  end
-
   def call(env)
     status, headers, response = @app.call(env)
-    if File.exist?(zdd_latch_file)
+    if ServiceStatus.unavailable?
       [status, headers.merge("Connection" => "close"), response]
     else
       [status, headers, response]

--- a/lib/service_status_filter.rb
+++ b/lib/service_status_filter.rb
@@ -4,7 +4,7 @@ class ServiceStatusFilter
   end
 
   def zdd_latch_file
-    ENV.fetch('ZDD_LATCH')
+    CONFIG.zdd_file
   end
 
   def call(env)

--- a/lib/tasks/zdd.rake
+++ b/lib/tasks/zdd.rake
@@ -3,11 +3,11 @@ namespace :zdd do
   desc 'set the service unavailable'
   task set_unavailable: :environment do
     FileUtils.touch(CONFIG.zdd_file)
+    sleep Integer(CONFIG.polling_wait_time)
   end
 
   desc 'reset service availability'
   task reset: :environment do
     FileUtils.rm(CONFIG.zdd_file, force: true)
-    sleep Integer(CONFIG.polling_wait_time)
   end
 end

--- a/lib/tasks/zdd.rake
+++ b/lib/tasks/zdd.rake
@@ -1,0 +1,13 @@
+require 'fileutils'
+namespace :zdd do
+  desc 'set the service unavailable'
+  task set_unavailable: :environment do
+    FileUtils.touch(CONFIG.zdd_file)
+  end
+
+  desc 'reset service availability'
+  task reset: :environment do
+    FileUtils.rm(CONFIG.zdd_file, force: true)
+    sleep Integer(CONFIG.polling_wait_time)
+  end
+end

--- a/packaging/postinst.sh
+++ b/packaging/postinst.sh
@@ -1,4 +1,4 @@
-front scale front=1
+ln -fs /opt/front/upstart/front.conf /etc/init/front.conf
 mkdir -p /ida
 [ ! -L /ida/front ] && ln -s /opt/front /ida/front
 front run rake tmp:create

--- a/packaging/postrm.sh
+++ b/packaging/postrm.sh
@@ -1,0 +1,1 @@
+rm /etc/init/front.conf

--- a/spec/features/service_set_unavailable_spec.rb
+++ b/spec/features/service_set_unavailable_spec.rb
@@ -1,0 +1,16 @@
+require 'feature_helper'
+
+describe 'service reports the on service status', type: :request do
+  it "is OK when ZDD_LATCH doesn't exist" do
+    response = get('/service-status')
+    expect(response).to eql 200
+  end
+
+  it "is not OK when ZDD_LATCH does exist" do
+    file = Tempfile.new('zdd_file')
+    expect(ENV).to receive(:fetch).with("ZDD_LATCH").twice.and_return(file.path)
+    response = get('/service-status')
+    expect(response).to eql 503
+    expect(@response.headers["Connection"]).to eql "close"
+  end
+end

--- a/spec/features/service_set_unavailable_spec.rb
+++ b/spec/features/service_set_unavailable_spec.rb
@@ -8,7 +8,7 @@ describe 'service reports the on service status', type: :request do
 
   it "is not OK when ZDD_LATCH does exist" do
     file = Tempfile.new('zdd_file')
-    expect(ENV).to receive(:fetch).with("ZDD_LATCH").twice.and_return(file.path)
+    expect(CONFIG).to receive(:zdd_file).twice.and_return(file.path)
     response = get('/service-status')
     expect(response).to eql 503
     expect(@response.headers["Connection"]).to eql "close"

--- a/spec/lib/configuration_spec.rb
+++ b/spec/lib/configuration_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+require 'configuration'
+
+describe Configuration do
+  it "loads up env vars!" do
+    expect(ENV).to receive(:fetch).with("FOOBAZ").and_return('foo')
+    config = Configuration.load! do
+      option 'foobaz', 'FOOBAZ'
+    end
+    expect(config.foobaz).to eql 'foo'
+  end
+
+  it "will raise an error when the envvar is unset" do
+    expect {
+      Configuration.load! do
+        option 'foobaz', 'FOOBAZ'
+      end
+    }.to raise_error Configuration::MissingEnvVarError, "An Environment Variable named 'FOOBAZ' could not be found"
+  end
+
+  it "will not share config with other classes" do
+    expect(ENV).to receive(:fetch).with("FOOBAZ").and_return('foo')
+    Configuration.load! do
+      option 'foobaz', 'FOOBAZ'
+    end
+    config = Configuration.load! do
+    end
+    expect { config.foobaz }.to raise_error NoMethodError
+  end
+end

--- a/spec/lib/service_status_spec.rb
+++ b/spec/lib/service_status_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+require 'tempfile'
+require 'service_status'
+describe ServiceStatus do
+  it "is availble when zdd file doesn't exist" do
+    file = Tempfile.new
+    path = file.path
+    file.unlink
+    stub_const("CONFIG", double(:config, zdd_file: path))
+    expect(ServiceStatus.unavailable?).to eql false
+  end
+
+  it "is availble when zdd file does exist" do
+    file = Tempfile.new
+    path = file.path
+    stub_const("CONFIG", double(:config, zdd_file: path))
+    expect(ServiceStatus.unavailable?).to eql true
+  end
+end

--- a/upstart/front.conf
+++ b/upstart/front.conf
@@ -1,0 +1,20 @@
+description "Upstart for front Service"
+start on (started network-interface
+          or started network-manager
+          or started networking) and filesystem
+
+stop on runlevel [!2345]
+
+console log
+
+setuid front
+
+pre-stop script
+  front run rake zdd:set_unavailable
+  sleep $SLEEP_TIME
+end script
+
+script
+  front run rake zdd:reset
+  front run front >> /var/log/front/front-1.log 2>&1
+end script

--- a/upstart/front.conf
+++ b/upstart/front.conf
@@ -11,7 +11,6 @@ setuid front
 
 pre-stop script
   front run rake zdd:set_unavailable
-  sleep $SLEEP_TIME
 end script
 
 script


### PR DESCRIPTION
The commit provides support for the ZDD orchestration we use in our microservices. It is hoped that with this functionality in place we can drop the new frontend into our architecture without changing how we run our deployments. Our main goal for ZDD compliance is the ability to drain new requests from an instance of our microservices.

Our services are ZDD compliant, or able to drain, when they provide the following functionality:
* An endpoint `/service-status` that reports a 200 when the service is available for new requests or a 503 when it is unavailable and should no longer issue new requests
* A filter/middleware that will add a 'Connection: close' response header to all responses when the service is unavailable and should no longer handle new requests.
* The ability to set a property which sets the service unavailable to no longer handle new requests.

In order to provide this functionality to our app I have done the following:

1. Introduced an ENVVAR `ZDD_LATCH` that points to a file
2. Created an object `ServiceStatus` that will be `unavailable?` when the file defined by `ZDD_LATCH` exists
3. Add an endpoint `/service-status` that reports a 200 when `ServiceStatus.unavailable?` is false and a 503 when `ServiceStatus.unavailable?` is true
4. Add a middleware `ServiceStatusFilter` that will add `Connection: close` when `ServiceStatus.unavailable?` is true
5. Add a rake task `zdd:set_unavailable` that will create the file defined by `ZDD_LATCH` then sleep for a few seconds
6. Add a rake task `zdd:reset` that will remove the file defined by `ZDD_LATCH`
7. Introduce a custom upstart script that will run `zdd:reset` on startup and `zdd:set_unavailable` before stopping