### PR TITLE
bau: support custom ssl context

### DIFF
--- a/app/models/api/client.rb
+++ b/app/models/api/client.rb
@@ -3,23 +3,24 @@ module Api
   class Client
     DEFAULT_OPTIONS = {}
 
-    def initialize(host, response_handler)
+    def initialize(host, response_handler, options = {})
       @host = host
       @response_handler = response_handler
+      @ssl_context = options[:ssl_context]
     end
 
     def get(path, options = DEFAULT_OPTIONS)
-      response = client(options).get(uri(path), params: options[:params])
+      response = client(options).get(uri(path), params: options[:params], ssl_context: @ssl_context)
       @response_handler.handle_response(response.status, 200, response.to_s)
     end
 
     def post(path, body)
-      response = client.post(uri(path), json: body)
+      response = client.post(uri(path), json: body, ssl_context: @ssl_context)
       @response_handler.handle_response(response.status, 201, response.to_s)
     end
 
     def put(path, body, options = DEFAULT_OPTIONS)
-      response = client(options).put(uri(path), json: body)
+      response = client(options).put(uri(path), json: body, ssl_context: @ssl_context)
       @response_handler.handle_response(response.status, 200, response.to_s)
     end
 

--- a/config/initializers/configuration.rb
+++ b/config/initializers/configuration.rb
@@ -7,4 +7,5 @@ CONFIG = Configuration.load! do
   option_string 'logo_directory', 'LOGO_DIRECTORY'
   option_string 'zdd_file', 'ZDD_LATCH'
   option_string 'polling_wait_time', 'POLLING_WAIT_TIME'
+  option_string 'api_cert_path', 'API_CERT_PATH', allow_missing: true
 end

--- a/config/initializers/proxies.rb
+++ b/config/initializers/proxies.rb
@@ -1,5 +1,11 @@
+require 'ssl_context_factory'
 API_HOST = CONFIG.api_host
-api_client = Api::Client.new(API_HOST, Api::ResponseHandler.new)
+
+context = SSLContextFactory.new.create_context(
+  cert_path: CONFIG.api_cert_path,
+)
+
+api_client = Api::Client.new(API_HOST, Api::ResponseHandler.new, ssl_context: context)
 SESSION_PROXY = SessionProxy.new(api_client)
 
 federation_translator = Display::FederationTranslator.new

--- a/lib/ssl_context_factory.rb
+++ b/lib/ssl_context_factory.rb
@@ -1,0 +1,9 @@
+class SSLContextFactory
+  def create_context(options = {})
+    OpenSSL::SSL::SSLContext.new(:TLSv1_2).tap do |context|
+      options.try(:cert_path) do |path|
+        context.cert = OpenSSL::X509Certificate.new(path)
+      end
+    end
+  end
+end

--- a/spec/lib/configuration_spec.rb
+++ b/spec/lib/configuration_spec.rb
@@ -18,6 +18,20 @@ describe Configuration do
     }.to raise_error Configuration::MissingEnvVarError, "An Environment Variable named 'FOOBAZ' could not be found"
   end
 
+  it 'will fallback to a default if provided it' do
+    config = Configuration.load! do
+      option_string 'foobaz', 'FOOBAZ', default: 'bar'
+    end
+    expect(config.foobaz).to eql 'bar'
+  end
+
+  it 'can be missing' do
+    config = Configuration.load! do
+      option_string 'foobaz', 'FOOBAZ', allow_missing: true
+    end
+    expect(config.foobaz).to eql nil
+  end
+
   it 'will not share config with other classes' do
     expect(ENV).to receive(:fetch).with("FOOBAZ").and_return('foo')
     Configuration.load! do
@@ -28,37 +42,72 @@ describe Configuration do
     expect { config.foobaz }.to raise_error NoMethodError
   end
 
-  it 'should load a boolean environment variable' do
-    expect(ENV).to receive(:fetch).with("FOOBAZ").and_return('true')
-    config = Configuration.load! do
-      option_bool 'foobaz', 'FOOBAZ'
-    end
-    expect(config.foobaz).to eql true
-  end
-
-  it 'should raise an error when boolean environment variable has invalid value' do
-    expect(ENV).to receive(:fetch).with("FOOBAZ").and_return('bad value')
-    expect {
-      Configuration.load! do
+  context "bools" do
+    it 'should load a boolean environment variable' do
+      expect(ENV).to receive(:fetch).with("FOOBAZ").and_return('true')
+      config = Configuration.load! do
         option_bool 'foobaz', 'FOOBAZ'
       end
-    }.to raise_error Configuration::InvalidEnvVarError, "Boolean Environment Variable 'FOOBAZ' must be 'true' or 'false'"
-  end
-
-  it 'should load an integer environment variable' do
-    expect(ENV).to receive(:fetch).with("FOOBAZ").and_return('10')
-    config = Configuration.load! do
-      option_int 'foobaz', 'FOOBAZ'
+      expect(config.foobaz).to eql true
     end
-    expect(config.foobaz).to eql 10
+
+    it 'should raise an error when boolean environment variable has invalid value' do
+      expect(ENV).to receive(:fetch).with("FOOBAZ").and_return('bad value')
+      expect {
+        Configuration.load! do
+          option_bool 'foobaz', 'FOOBAZ'
+        end
+      }.to raise_error Configuration::InvalidEnvVarError, "Boolean Environment Variable 'FOOBAZ' must be 'true' or 'false'"
+    end
+
+    it 'will fallback to a default if provided it' do
+      config = Configuration.load! do
+        option_bool 'foobaz', 'FOOBAZ', default: true
+      end
+      expect(config.foobaz).to eql true
+    end
+
+    it 'can\'t be missing' do
+      expect {
+        Configuration.load! do
+          option_bool 'foobaz', 'FOOBAZ', allow_missing: true
+        end
+      }.to raise_error Configuration::InvalidEnvVarError, "Boolean Environment Variable 'FOOBAZ' must be 'true' or 'false'"
+    end
   end
 
-  it 'should raise an error when integer environment variable has invalid value' do
-    expect(ENV).to receive(:fetch).with("FOOBAZ").and_return('bad value')
-    expect {
-      Configuration.load! do
+  context "integers" do
+    it 'should load an integer environment variable' do
+      expect(ENV).to receive(:fetch).with("FOOBAZ").and_return('10')
+      config = Configuration.load! do
         option_int 'foobaz', 'FOOBAZ'
       end
-    }.to raise_error Configuration::InvalidEnvVarError, "Integer Environment Variable 'FOOBAZ' must be a valid integer"
+      expect(config.foobaz).to eql 10
+    end
+
+    it 'should raise an error when integer environment variable has invalid value' do
+      expect(ENV).to receive(:fetch).with("FOOBAZ").and_return('bad value')
+      expect {
+        Configuration.load! do
+          option_int 'foobaz', 'FOOBAZ'
+        end
+      }.to raise_error Configuration::InvalidEnvVarError, "Integer Environment Variable 'FOOBAZ' must be a valid integer"
+    end
+
+    it 'will fallback to a default if provided it' do
+      config = Configuration.load! do
+        option_int 'foobaz', 'FOOBAZ', default: 10
+      end
+      expect(config.foobaz).to eql 10
+    end
+
+
+    it 'can\'t be missing' do
+      expect {
+        Configuration.load! do
+          option_int 'foobaz', 'FOOBAZ', allow_missing: true
+        end
+      }.to raise_error Configuration::InvalidEnvVarError, "Integer Environment Variable 'FOOBAZ' must be a valid integer"
+    end
   end
 end


### PR DESCRIPTION
Major aim of this PR is to open up the ability to configure the TLS behaviour of our HTTP client. This is achieved by the supplying a SSLContext object which affects the TLS behaviour (verification mode, certs for verification, protocols etc).

In order to support this, I have adapted the configuration class to support default or missing values.

