### PR TITLE
Move language link to below the phase banner

### DIFF
--- a/app/assets/stylesheets/_application.scss
+++ b/app/assets/stylesheets/_application.scss
@@ -1,7 +1,9 @@
 // Import GOV.UK frontend toolkit
 @import "_govuk-elements";
-
 @import "_govuk-elements-overrides";
+
+// helpers for common page elements
+@import "helpers/available-languages";
 
 // Specific pages
 @import "pages/_start";

--- a/app/assets/stylesheets/helpers/_available-languages.scss
+++ b/app/assets/stylesheets/helpers/_available-languages.scss
@@ -1,0 +1,44 @@
+.available-languages {
+  @include grid-column(1/3, tablet, right);
+
+  ul {
+    @extend %contain-floats;
+    list-style: none;
+    padding: $gutter-half 0 $gutter-one-third;
+    border-bottom: 1px solid $border-colour;
+
+    li {
+      float: left;
+      display: block;
+      border-right: 1px solid $border-colour;
+      padding: 0 $gutter-one-third 0 0;
+      height: 16px;
+      margin: 3px $gutter-one-third 2px 0;
+
+      &.last {
+        border-right: 0;
+      }
+
+      a,
+      span {
+        display: block;
+        margin-top: -1px;
+        @include core-16;
+      }
+
+      .direction-rtl & {
+        direction: rtl;
+        float: right;
+        text-align: start;
+        border-left: 1px solid $border-colour;
+        border-right: 0;
+        margin: 3px 0 2px $gutter-one-third;
+        padding: 0 0 0 $gutter-one-third;
+
+        &.last {
+          border-left: 0;
+        }
+      }
+    }
+  }
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,6 +11,9 @@
 <% content_for :content do %>
   <main id="content">
     <%= render 'shared/phase_banner' %>
+    <div class="grid-row">
+      <%= render 'shared/available_languages' %>
+    </div>
     <%= content_for?(:main) ? yield(:main) : yield %>
   </main>
 <% end %>
@@ -19,13 +22,6 @@
   <h2 class="visuallyhidden">Support links</h2>
   <ul>
     <li><a href="https://gov.uk/help">Help</a></li>
-    <li>
-      <% if params[:locale] != 'cy' %>
-        <%= link_to 'Cymraeg', url_for(locale: 'cy'), lang: 'cy', hreflang: 'cy' %>
-      <% else %>
-        <%= link_to 'English', url_for(locale: 'en'), lang: 'en', hreflang: 'en' %>
-      <% end %>
-    </li>
     <li>Built by the <a href="https://gds.blog.gov.uk">Government Digital Service</a></li>
   </ul>
 <% end %>

--- a/app/views/shared/_available_languages.html.erb
+++ b/app/views/shared/_available_languages.html.erb
@@ -1,0 +1,19 @@
+
+<div class="available-languages">
+  <ul>
+    <li class="translation">
+      <% if params[:locale] == 'en' %>
+        <span>English</span>
+      <% else %>
+        <%= link_to 'English', url_for(locale: 'en'), lang: 'en', hreflang: 'en' %>
+      <% end %>
+    </li>
+    <li class="translation last">
+      <% if params[:locale] == 'cy' %>
+        <span>Cymraeg</span>
+      <% else %>
+        <%= link_to 'Cymraeg', url_for(locale: 'cy'), lang: 'cy', hreflang: 'cy' %>
+      <% end %>
+    </li>
+  </ul>
+</div>


### PR DESCRIPTION
This replicates the styles and markup used on GOV.UK (for example on https://www.gov.uk/government/organisations/wales-office). We’re doing this because previous user research has indicated that where content is directly translated, Welsh language users sometimes like to flick between the versions to make sure they’re getting correct content.

The placement of these links on Verify is provisional, but has been approved by @alextea for the time being.