### PR TITLE
bau: front-packager-postrm

### DIFF
--- a/packaging/postrm.sh
+++ b/packaging/postrm.sh
@@ -1,1 +1,2 @@
-rm /etc/init/front.conf
+# Commenting out the rm below as that link will not be present when this postrm runs
+#rm /etc/init/front.conf


### PR DESCRIPTION
Commenting out the rm command in the postrm.sh as it is causing errors during package removal.
As the link /etc/init/front.conf will not exist when the postrm runs.