### PR TITLE
bau: Fix shellcheck warnings

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,5 +1,6 @@
-#/usr/bin/env sh
+#!/usr/bin/env sh
+
 RAILS_ENV=production bundle exec rake assets:precompile
 RAILS_ENV=production bundle exec rake tmp:clear
 cp -r public/new-assets public/assets
-pkgr package . --version=${BUILD_NUMBER} --iteration=1 --name=front
+pkgr package . --version="${BUILD_NUMBER}" --iteration=1 --name=front

--- a/kill-service.sh
+++ b/kill-service.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 if [ -a 'tmp/puma.pid' ]
 then
-  kill `cat tmp/puma.pid`
+  kill "$(cat tmp/puma.pid)"
 fi


### PR DESCRIPTION
One incorrect hashbang, a couple of warnings about using quotes to
prevent spaces / globs being misintepreted.

Solo: @richardtowers