### PR TITLE
bau: use headless gem for headless browsing on jenkins

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,6 +66,7 @@ group :test, :development do
   gem 'webmock', require: false
   gem 'rack-test'
   gem 'pact'
+  gem 'headless'
 end
 
 gem 'logstash-logger'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,7 @@ GEM
     govuk_template (0.17.0)
       rails (>= 3.1)
     hashdiff (0.3.0)
+    headless (2.2.2)
     http (1.0.3)
       addressable (~> 2.3)
       http-cookie (~> 1.0)
@@ -300,6 +301,7 @@ DEPENDENCIES
   govuk-lint
   govuk_frontend_toolkit
   govuk_template
+  headless
   http (~> 1.0.0)
   jasmine-rails
   jbuilder (~> 2.0)

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,7 +1,8 @@
 #!/bin/sh -eu
-
-RAILS_ENV="production" bundle exec rake assets:precompile
-RAILS_ENV="production" bundle exec rake tmp:clear
+bundle
+HEADLESS=true DISPLAY=:0 ./pre-commit.sh
+RAILS_ENV=production bundle exec rake assets:precompile
+RAILS_ENV=production bundle exec rake tmp:clear
 
 cp -r public/new-assets public/assets
 

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,5 +1,9 @@
 #!/bin/sh -eu
 bundle
+bundle exec govuk-lint-ruby app lib spec
+bundle exec govuk-lint-sass app/assets/stylesheets
+bundle exec rspec
+bundle exec rake spec:javascripts
 HEADLESS=true DISPLAY=:0 ./pre-commit.sh
 RAILS_ENV=production bundle exec rake assets:precompile
 RAILS_ENV=production bundle exec rake tmp:clear

--- a/spec/feature_helper.rb
+++ b/spec/feature_helper.rb
@@ -3,6 +3,17 @@ require 'capybara/rspec'
 require 'webmock/rspec'
 WebMock.disable_net_connect!(allow_localhost: true)
 
+if ENV['HEADLESS'] == 'true'
+  require 'headless'
+  headless = Headless.new
+  headless.start
+  at_exit do
+    exit_status = $!.status if $!.is_a?(SystemExit)
+    headless.destroy
+    exit exit_status if exit_status
+  end
+end
+
 def api_transactions_endpoint
   api_uri('transactions')
 end


### PR DESCRIPTION
Allows feature tests to be run on jenkins using the headless.

Also, adds tests explicitly to `jenkins.sh`