### PR TITLE
bau: explicity use dotenv for assets precompile

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -6,8 +6,8 @@ bundle exec govuk-lint-ruby app lib spec
 bundle exec govuk-lint-sass app/assets/stylesheets
 bundle exec rspec
 bundle exec rake spec:javascripts
-RAILS_ENV=production bundle exec rake assets:precompile
-RAILS_ENV=production bundle exec rake tmp:clear
+RAILS_ENV=production dotenv bundle exec rake assets:precompile
+RAILS_ENV=production dotenv bundle exec rake tmp:clear
 
 cp -r public/new-assets public/assets
 


### PR DESCRIPTION
Explicity set dotenv for assets precompile rather than relying on the CI node.