### PR TITLE
BAU: Remove Pact and replace with Sinatra middleware

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,7 +68,7 @@ group :test, :development do
   gem 'govuk-lint'
   gem 'webmock', require: false
   gem 'rack-test'
-  gem 'pact'
+  gem 'sinatra'
   gem 'headless'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,7 +41,6 @@ GEM
     ast (2.2.0)
     astrolabe (1.3.1)
       parser (~> 2.2)
-    awesome_print (1.6.1)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
     builder (3.2.2)
@@ -71,7 +70,6 @@ GEM
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.10)
-    find_a_port (1.0.1)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
     govuk-lint (0.8.1)
@@ -127,37 +125,6 @@ GEM
     multipart-post (2.0.0)
     nokogiri (1.6.7.2)
       mini_portile2 (~> 2.0.0.rc2)
-    pact (1.9.0)
-      awesome_print (~> 1.1)
-      find_a_port (~> 1.0.1)
-      json
-      pact-mock_service (~> 0.7)
-      pact-support (~> 0.5)
-      rack-test (~> 0.6.2)
-      randexp (~> 0.1.7)
-      rspec (>= 2.14)
-      term-ansicolor (~> 1.0)
-      thor
-      webrick
-    pact-mock_service (0.8.1)
-      find_a_port (~> 1.0.1)
-      json
-      pact-support (~> 0.5.3)
-      rack
-      rack-test (~> 0.6.2)
-      rspec (>= 2.14)
-      term-ansicolor (~> 1.0)
-      thor
-      webrick
-    pact-support (0.5.4)
-      awesome_print (~> 1.1)
-      find_a_port (~> 1.0.1)
-      json
-      rack-test (~> 0.6.2)
-      randexp (~> 0.1.7)
-      rspec (>= 2.14)
-      term-ansicolor (~> 1.0)
-      thor
     parser (2.3.0.6)
       ast (~> 2.2)
     phantomjs (2.1.1.0)
@@ -165,6 +132,8 @@ GEM
     puma (3.1.1)
     rack (1.6.4)
     rack-handlers (0.7.2)
+      rack
+    rack-protection (1.5.3)
       rack
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -197,7 +166,6 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rainbow (2.1.0)
     rake (10.5.0)
-    randexp (0.1.7)
     rdoc (4.2.2)
       json (~> 1.4)
     ref (2.0.0)
@@ -205,10 +173,6 @@ GEM
     route_translator (4.3.0)
       actionpack (>= 3.2, < 5.0)
       activesupport (>= 3.2, < 5.0)
-    rspec (3.4.0)
-      rspec-core (~> 3.4.0)
-      rspec-expectations (~> 3.4.0)
-      rspec-mocks (~> 3.4.0)
     rspec-core (3.4.4)
       rspec-support (~> 3.4.0)
     rspec-expectations (3.4.0)
@@ -253,9 +217,12 @@ GEM
       childprocess (~> 0.5)
       rubyzip (~> 1.0)
       websocket (~> 1.0)
-    spring (1.6.4)
     sentry-raven (0.15.6)
       faraday (>= 0.7.6)
+    sinatra (1.4.7)
+      rack (~> 1.5)
+      rack-protection (~> 1.4)
+      tilt (>= 1.3, < 3)
     spring (1.6.3)
     sprockets (3.5.2)
       concurrent-ruby (~> 1.0)
@@ -266,8 +233,6 @@ GEM
       sprockets (>= 3.0.0)
     statsd-ruby (1.3.0)
     stud (0.0.22)
-    term-ansicolor (1.3.2)
-      tins (~> 1.0)
     therubyracer (0.12.2)
       libv8 (~> 3.16.14.0)
       ref
@@ -292,7 +257,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
-    webrick (1.3.1)
     websocket (1.2.2)
     xpath (2.0.0)
       nokogiri (~> 1.3)
@@ -314,7 +278,6 @@ DEPENDENCIES
   jquery-rails
   jquery-validation-rails (~> 1.13, >= 1.13.1)
   logstash-logger
-  pact
   puma
   rack-handlers
   rack-test
@@ -327,6 +290,7 @@ DEPENDENCIES
   sdoc (~> 0.4.0)
   selenium-webdriver
   sentry-raven
+  sinatra
   spring
   statsd-ruby (~> 1.3.0)
   therubyracer

--- a/spec/mock_piwik_middleware.rb
+++ b/spec/mock_piwik_middleware.rb
@@ -1,0 +1,11 @@
+class MockPiwikMiddleware < Sinatra::Base
+  def initialize(request_log)
+    super
+    @request_log = request_log
+  end
+
+  get '/piwik.php' do
+    @request_log.log(params)
+    'OK'
+  end
+end


### PR DESCRIPTION
Pact caused issues with testing during Jenkins builds.
We now test Piwik requests using a mock Piwik endpoint implemented with
Sinatra. This gets added as middleware to the Capybara server so
requests made to Piwik can be inspected by us during tests.

Authors: @richardtowers @vixus0