### PR TITLE
3340: Add ids to 'next' buttons for acceptance tests

### DIFF
--- a/app/views/about/certified_companies.html.erb
+++ b/app/views/about/certified_companies.html.erb
@@ -14,7 +14,7 @@
 <p><%= t 'hub.about_certified_companies.no_charge' %></p>
 
 <div class="actions">
-  <%= link_to t('navigation.next'), about_identity_accounts_path, class: 'button' %>
+  <%= link_to t('navigation.next'), about_identity_accounts_path, class: 'button', id: 'next-button' %>
 </div>
 
 <details>

--- a/app/views/about/choosing_a_company.html.erb
+++ b/app/views/about/choosing_a_company.html.erb
@@ -9,5 +9,5 @@
   </div>
 </div>
 <div class="actions">
-  <%= link_to t('navigation.continue'), select_documents_path, class: 'button' %>
+  <%= link_to t('navigation.continue'), select_documents_path, class: 'button', id: 'next-button' %>
 </div>

--- a/app/views/about/identity_accounts.html.erb
+++ b/app/views/about/identity_accounts.html.erb
@@ -6,7 +6,7 @@
 <p><%= t 'hub.about_identity_accounts.content.p3' %></p>
 
 <div class="actions">
-  <%= link_to t('navigation.start_now'), about_choosing_a_company_path, class: 'button' %>
+  <%= link_to t('navigation.start_now'), about_choosing_a_company_path, class: 'button', id: 'next-button' %>
 </div>
 
 <details>

--- a/app/views/about/index.html.erb
+++ b/app/views/about/index.html.erb
@@ -5,5 +5,5 @@
 <p><%= t 'hub.about.its_secure' %></p>
 
 <div class="actions">
-  <%= link_to t('navigation.next'), about_certified_companies_path, class: 'button' %>
+  <%= link_to t('navigation.next'), about_certified_companies_path, class: 'button', id: 'next-button' %>
 </div>


### PR DESCRIPTION
Our acceptance tests rely on the 'next' buttons having IDs to locate and
click them