### PR TITLE
3341: Support multiple simple Ids per IdP

### DIFF
--- a/app/models/idp_eligibility/rules_loader.rb
+++ b/app/models/idp_eligibility/rules_loader.rb
@@ -7,7 +7,10 @@ module IdpEligibility
       rules_files = File.join(rules_path, '*.yml')
       Dir::glob(rules_files) do |file|
         yaml = YAML::load_file(file)
-        rules[yaml.fetch('simpleId')] = yaml.fetch('rules')
+        idp_rules = yaml.fetch('rules')
+        yaml.fetch('simpleIds').each do |simple_id|
+          rules[simple_id] = idp_rules
+        end
       end
       rules
     end

--- a/spec/features/user_visits_select_documents_page_spec.rb
+++ b/spec/features/user_visits_select_documents_page_spec.rb
@@ -78,23 +78,8 @@ RSpec.describe 'When the user visits the select documents page' do
     expect(a_request(:get, INTERNAL_PIWIK.url).with(query: hash_including(piwik_request))).to have_been_made.once
   end
 
-  # The RackTest driver doesn't report multiple query params with the same key in page.current_url
-  # We set js to true so that the test runs in a real browser (using Selenium) instead
-  context 'with selenium', js: true do
-    it 'redirects to the select phone page with selected evidence query parameters' do
-      stub_federation
-      visit '/select-documents'
-
-      choose 'select_documents_form_driving_licence_true'
-      choose 'select_documents_form_passport_true'
-      choose 'select_documents_form_non_uk_id_document_true'
-      click_button 'Continue'
-
-      expect(page).to have_current_path(select_phone_path, only_path: true)
-      expect_evidence_params(%w(driving_licence passport non_uk_id_document))
-    end
-
-    it 'redirects to the select phone page with selected-evidence param set to no-documents when no docs checked' do
+  context 'when redirecting to the select phone page' do
+    it 'sets selected-evidence param to no-documents when no docs checked' do
       stub_federation_no_docs
       visit '/select-documents'
 
@@ -103,6 +88,23 @@ RSpec.describe 'When the user visits the select documents page' do
 
       expect(page).to have_current_path(select_phone_path, only_path: true)
       expect_evidence_params(%w(no_documents))
+    end
+
+    # The RackTest driver doesn't report multiple query params with the same key in page.current_url
+    # We set js to true so that the test runs in a real browser (using Selenium) instead
+    context 'with selenium', js: true do
+      it 'includes selected-evidence params for all selected documents' do
+        stub_federation
+        visit '/select-documents'
+
+        choose 'select_documents_form_driving_licence_true'
+        choose 'select_documents_form_passport_true'
+        choose 'select_documents_form_non_uk_id_document_true'
+        click_button 'Continue'
+
+        expect(page).to have_current_path(select_phone_path, only_path: true)
+        expect_evidence_params(%w(driving_licence passport non_uk_id_document))
+      end
     end
   end
 end

--- a/spec/fixtures/bad_rules/stub-idp-one_missing_keys.yml
+++ b/spec/fixtures/bad_rules/stub-idp-one_missing_keys.yml
@@ -1,3 +1,3 @@
-simpleId: "example-idp"
+simpleIds: [ "example-idp" ]
 blah:
   - [ "passport", "driving_licence" ]

--- a/spec/fixtures/good_rules/stub-idp-one.yml
+++ b/spec/fixtures/good_rules/stub-idp-one.yml
@@ -1,3 +1,3 @@
-simpleId: "example-idp"
+simpleIds: [ "example-idp", "example-idp-stub" ]
 rules:
   - [ "passport", "driving_licence" ]

--- a/spec/models/idp_eligibility/rules_loader_spec.rb
+++ b/spec/models/idp_eligibility/rules_loader_spec.rb
@@ -9,7 +9,11 @@ module IdpEligibility
 
     describe '#load' do
       it 'should load rules from YAML files' do
-        rules_hash = { 'example-idp' => [%w(passport driving_licence)] }
+        evidence = [%w(passport driving_licence)]
+        rules_hash = {
+          'example-idp' => evidence,
+          'example-idp-stub' => evidence
+        }
         expect(RulesLoader.load(fixtures('good_rules'))).to eql(rules_hash)
       end
 

--- a/stub/rules/stub-idp-no-docs.yml
+++ b/stub/rules/stub-idp-no-docs.yml
@@ -1,3 +1,3 @@
-simpleId: "stub-idp-no-docs"
+simpleIds: [ "stub-idp-no-docs" ]
 rules:
   - [ ]

--- a/stub/rules/stub-idp-one.yml
+++ b/stub/rules/stub-idp-one.yml
@@ -1,3 +1,3 @@
-simpleId: "stub-idp-one"
+simpleIds: [ "stub-idp-one" ]
 rules:
   - [ "driving_licence" ]


### PR DESCRIPTION
In the old frontend we support multiple simple ids per IdP to avoid
duplicating config.  This adds minimal support for the same thing.