### PR TITLE
3453: Add banner explaining incomplete translation

### DIFF
--- a/app/assets/stylesheets/helpers/_available-languages.scss
+++ b/app/assets/stylesheets/helpers/_available-languages.scss
@@ -1,3 +1,9 @@
+.banner-translation-in-progress {
+  @include grid-column(2 / 3, tablet, left);
+  @include core-16;
+  padding-top: $gutter-half;
+}
+
 .available-languages {
   @include grid-column(1 / 3, tablet, right);
 

--- a/app/views/shared/_available_languages.html.erb
+++ b/app/views/shared/_available_languages.html.erb
@@ -1,4 +1,11 @@
 
+<% if params[:locale] == 'cy' %>
+<div class="banner-translation-in-progress">
+  <% if feedback_source.present? %>
+  <%= t('translation_in_progress_banner.message', feedback_link: link_to(t('translation_in_progress_banner.feedback'), feedback_path('feedback-source' => feedback_source))).html_safe %>
+  <% end %>
+</div>
+<% end %>
 <div class="available-languages">
   <ul>
     <li class="translation">

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -15,6 +15,9 @@ cy:
     title: Mae hwn yn wasanaeth newydd.
     feedback_message: Bydd eich %{feedback_link} yn ein helpu i wella.
     feedback: adborth
+  translation_in_progress_banner:
+    message: Mae GOV.UK Verify wrthi’n cael ei gyfieithu i’r Gymraeg. Rydym yn cyfieithu tudalennau bob wythnos rhwng nawr a diwedd mis Ebrill. Mae eich %{feedback_link} yn ein helpu i wella’r cyfieithiad.
+    feedback: adborth
   hub:
     start:
       title: Dechrau


### PR DESCRIPTION
As we add new pages to the frontend we will not always have a full
translation ready. This banner which only appears for Welsh language
users explains this

  GOV.UK Verify is in the process of being translated into Welsh. We're
  translating pages every week between now and the end of April. Your
  feedback helps us improve the translation.

The banner includes a link for users to provide feedback.