### PR TITLE
3495 report custom variables with friendly names

### DIFF
--- a/app/assets/javascripts/sign_in.js
+++ b/app/assets/javascripts/sign_in.js
@@ -12,16 +12,18 @@
     attach: function () {
       var $container = $('.js-idp-option-container')
       $container.on('submit', '.idp-option', function (e) {
-        var entityId;
+        var entityId, displayName;
         var $originalForm = $(e.target);
         e.preventDefault();
-        entityId = $originalForm.find('button').attr('name');
+        var selectIdpButton = $originalForm.find('button');
+        entityId = selectIdpButton.attr('name');
+        displayName = selectIdpButton.attr('value');
         $.ajax({
           type: 'PUT',
           url: '/select-idp',
           contentType: "application/json",
           processData: false,
-          data: JSON.stringify({ entityId: entityId }),
+          data: JSON.stringify({ entityId: entityId, displayName: displayName }),
           timeout: 5000
         }).done(function(response) {
           var $samlForm;

--- a/app/controllers/about_controller.rb
+++ b/app/controllers/about_controller.rb
@@ -2,8 +2,13 @@ class AboutController < ApplicationController
   layout 'start', except: [:choosing_a_company]
 
   def index
-    cvar = Analytics::CustomVariable.build(:rp, federation_info[:transaction_entity_id])
-    ANALYTICS_REPORTER.report_custom_variable(request, 'The Yes option was selected on the start page', cvar)
+    transaction_analytics_description =
+      FEDERATION_TRANSLATOR.translate("rps.#{federation_info[:transaction_simple_id]}.analyticsDescription")
+
+    ANALYTICS_REPORTER.report_custom_variable(
+      request,
+      "The Yes option was selected on the start page #{transaction_analytics_description}",
+      Analytics::CustomVariable.build(:rp, transaction_analytics_description))
   end
 
   def certified_companies

--- a/app/controllers/about_controller.rb
+++ b/app/controllers/about_controller.rb
@@ -2,13 +2,7 @@ class AboutController < ApplicationController
   layout 'start', except: [:choosing_a_company]
 
   def index
-    transaction_analytics_description =
-      FEDERATION_TRANSLATOR.translate("rps.#{federation_info[:transaction_simple_id]}.analyticsDescription")
-
-    ANALYTICS_REPORTER.report_custom_variable(
-      request,
-      "The Yes option was selected on the start page #{transaction_analytics_description}",
-      Analytics::CustomVariable.build(:rp, transaction_analytics_description))
+    FEDERATION_REPORTER.report_registration(federation_info[:transaction_simple_id], request)
   end
 
   def certified_companies

--- a/app/controllers/select_idp_controller.rb
+++ b/app/controllers/select_idp_controller.rb
@@ -1,9 +1,10 @@
 class SelectIdpController < ApplicationController
   def select_idp
     entity_id = params.fetch('entityId')
+    display_name = params.fetch('displayName')
     select_idp_response = SESSION_PROXY.select_idp(cookies, entity_id)
-    cvar = Analytics::CustomVariable.build(:select_idp, entity_id)
-    ANALYTICS_REPORTER.report_custom_variable(request, "Sign In - #{entity_id}", cvar)
+    cvar = Analytics::CustomVariable.build(:select_idp, display_name)
+    ANALYTICS_REPORTER.report_custom_variable(request, "Sign In - #{display_name}", cvar)
     cookies[CookieNames::VERIFY_JOURNEY_HINT] = select_idp_response.encrypted_entity_id
     authn_request_json = SESSION_PROXY.idp_authn_request(cookies)
     render json: authn_request_json

--- a/app/controllers/sign_in_controller.rb
+++ b/app/controllers/sign_in_controller.rb
@@ -4,11 +4,7 @@ class SignInController < ApplicationController
   def index
     federation_info = FEDERATION_INFO_GETTER.get_info(cookies)
     @identity_providers = federation_info[:idp_display_data]
-    transaction_analytics_description = FEDERATION_TRANSLATOR.translate("rps.#{federation_info[:transaction_simple_id]}.analyticsDescription")
-    ANALYTICS_REPORTER.report_custom_variable(
-      request,
-      "The No option was selected on the introduction page #{transaction_analytics_description}",
-      Analytics::CustomVariable.build(:rp, transaction_analytics_description))
+    FEDERATION_REPORTER.report_sign_in(federation_info[:transaction_simple_id], request)
     render 'index'
   end
 

--- a/app/controllers/sign_in_controller.rb
+++ b/app/controllers/sign_in_controller.rb
@@ -10,11 +10,12 @@ class SignInController < ApplicationController
   end
 
   def select_idp
-    entity_id = params.fetch('selected-idp')
+    entity_id = params.fetch('selected-idp-entity-id')
+    display_name = params.fetch('selected-idp-display-name')
     select_idp_response = SESSION_PROXY.select_idp(cookies, entity_id)
     cookies[CookieNames::VERIFY_JOURNEY_HINT] = select_idp_response.encrypted_entity_id
-    cvar = Analytics::CustomVariable.build(:select_idp, entity_id)
-    ANALYTICS_REPORTER.report_custom_variable(request, "Sign In - #{entity_id}", cvar)
+    cvar = Analytics::CustomVariable.build(:select_idp, display_name)
+    ANALYTICS_REPORTER.report_custom_variable(request, "Sign In - #{display_name}", cvar)
     redirect_to redirect_to_idp_path
   end
 end

--- a/app/controllers/sign_in_controller.rb
+++ b/app/controllers/sign_in_controller.rb
@@ -4,8 +4,11 @@ class SignInController < ApplicationController
   def index
     federation_info = FEDERATION_INFO_GETTER.get_info(cookies)
     @identity_providers = federation_info[:idp_display_data]
-    cvar = Analytics::CustomVariable.build(:rp, federation_info[:transaction_entity_id])
-    ANALYTICS_REPORTER.report_custom_variable(request, 'The No option was selected on the introduction page', cvar)
+    transaction_analytics_description = FEDERATION_TRANSLATOR.translate("rps.#{federation_info[:transaction_simple_id]}.analyticsDescription")
+    ANALYTICS_REPORTER.report_custom_variable(
+      request,
+      "The No option was selected on the introduction page #{transaction_analytics_description}",
+      Analytics::CustomVariable.build(:rp, transaction_analytics_description))
     render 'index'
   end
 

--- a/app/models/analytics/federation_reporter.rb
+++ b/app/models/analytics/federation_reporter.rb
@@ -6,21 +6,22 @@ module Analytics
     end
 
     def report_sign_in(transaction_simple_id, request)
-      transaction_analytics_description = @federation_translator.translate(
-        "rps.#{transaction_simple_id}.analyticsDescription")
-      ANALYTICS_REPORTER.report_custom_variable(
-        request,
-        "The No option was selected on the introduction page #{transaction_analytics_description}",
-        Analytics::CustomVariable.build(:rp, transaction_analytics_description))
+      report_action(transaction_simple_id, request, 'The No option was selected on the introduction page')
     end
 
     def report_registration(transaction_simple_id, request)
+      report_action(transaction_simple_id, request, 'The Yes option was selected on the start page')
+    end
+
+  private
+
+    def report_action(transaction_simple_id, request, action)
       transaction_analytics_description =
         FEDERATION_TRANSLATOR.translate("rps.#{transaction_simple_id}.analyticsDescription")
 
       ANALYTICS_REPORTER.report_custom_variable(
         request,
-        "The Yes option was selected on the start page #{transaction_analytics_description}",
+        "#{action} #{transaction_analytics_description}",
         Analytics::CustomVariable.build(:rp, transaction_analytics_description))
     end
   end

--- a/app/models/analytics/federation_reporter.rb
+++ b/app/models/analytics/federation_reporter.rb
@@ -16,13 +16,16 @@ module Analytics
   private
 
     def report_action(transaction_simple_id, request, action)
-      transaction_analytics_description =
-        FEDERATION_TRANSLATOR.translate("rps.#{transaction_simple_id}.analyticsDescription")
-
-      ANALYTICS_REPORTER.report_custom_variable(
-        request,
-        "#{action} #{transaction_analytics_description}",
-        Analytics::CustomVariable.build(:rp, transaction_analytics_description))
+      begin
+        transaction_analytics_description =
+          @federation_translator.translate("rps.#{transaction_simple_id}.analyticsDescription")
+        @analytics_reporter.report_custom_variable(
+          request,
+          "#{action} #{transaction_analytics_description}",
+          Analytics::CustomVariable.build(:rp, transaction_analytics_description))
+      rescue Display::FederationTranslator::TranslationError => e
+        Rails.logger.warn e
+      end
     end
   end
 end

--- a/app/models/analytics/federation_reporter.rb
+++ b/app/models/analytics/federation_reporter.rb
@@ -21,7 +21,7 @@ module Analytics
           @federation_translator.translate("rps.#{transaction_simple_id}.analyticsDescription")
         @analytics_reporter.report_custom_variable(
           request,
-          "#{action} #{transaction_analytics_description}",
+          action,
           Analytics::CustomVariable.build(:rp, transaction_analytics_description))
       rescue Display::FederationTranslator::TranslationError => e
         Rails.logger.warn e

--- a/app/models/analytics/federation_reporter.rb
+++ b/app/models/analytics/federation_reporter.rb
@@ -1,0 +1,17 @@
+module Analytics
+  class FederationReporter
+    def initialize(federation_translator, analytics_reporter)
+      @federation_translator = federation_translator
+      @analytics_reporter = analytics_reporter
+    end
+
+    def report_sign_in(transaction_simple_id, request)
+      transaction_analytics_description = @federation_translator.translate(
+        "rps.#{transaction_simple_id}.analyticsDescription")
+      ANALYTICS_REPORTER.report_custom_variable(
+        request,
+        "The No option was selected on the introduction page #{transaction_analytics_description}",
+        Analytics::CustomVariable.build(:rp, transaction_analytics_description))
+    end
+  end
+end

--- a/app/models/analytics/federation_reporter.rb
+++ b/app/models/analytics/federation_reporter.rb
@@ -13,5 +13,15 @@ module Analytics
         "The No option was selected on the introduction page #{transaction_analytics_description}",
         Analytics::CustomVariable.build(:rp, transaction_analytics_description))
     end
+
+    def report_registration(transaction_simple_id, request)
+      transaction_analytics_description =
+        FEDERATION_TRANSLATOR.translate("rps.#{transaction_simple_id}.analyticsDescription")
+
+      ANALYTICS_REPORTER.report_custom_variable(
+        request,
+        "The Yes option was selected on the start page #{transaction_analytics_description}",
+        Analytics::CustomVariable.build(:rp, transaction_analytics_description))
+    end
   end
 end

--- a/app/models/display/federation/federation_info_getter.rb
+++ b/app/models/display/federation/federation_info_getter.rb
@@ -11,7 +11,10 @@ module Display
         # We need to randomise the order of IDPs so that it satisfies the need for us to be unbiased in displaying the IDPs.
         idp_display_data = @display_correlator.correlate(federation_info.idps.shuffle)
 
-        { idp_display_data: idp_display_data, transaction_entity_id: federation_info.transaction_entity_id }
+        { idp_display_data: idp_display_data,
+          transaction_simple_id: federation_info.transaction_simple_id,
+          transaction_entity_id: federation_info.transaction_entity_id
+        }
       end
     end
   end

--- a/app/models/federation_info_response.rb
+++ b/app/models/federation_info_response.rb
@@ -1,11 +1,13 @@
 class FederationInfoResponse
   include ActiveModel::Model
 
-  attr_reader :idps, :transaction_entity_id
+  attr_reader :idps, :transaction_simple_id, :transaction_entity_id
   validates_presence_of :transaction_entity_id
+  validates_presence_of :transaction_simple_id
 
   def initialize(hash)
     @idps = hash['idps']
+    @transaction_simple_id = hash['transactionSimpleId']
     @transaction_entity_id = hash['transactionEntityId']
   end
 end

--- a/app/views/sign_in/index.html.erb
+++ b/app/views/sign_in/index.html.erb
@@ -22,7 +22,8 @@
                                    type: "submit",
                                    value: identity_provider.display_name
                     %>
-                    <input name="selected-idp" type="hidden" value="<%= identity_provider.entity_id %>" />
+                    <input name="selected-idp-entity-id" type="hidden" value="<%= identity_provider.entity_id %>" />
+                    <input name="selected-idp-display-name" type="hidden" value="<%= identity_provider.display_name %>" />
                 <% end %>
               </div>
             </div>

--- a/app/views/sign_in/index.html.erb
+++ b/app/views/sign_in/index.html.erb
@@ -22,8 +22,8 @@
                                    type: "submit",
                                    value: identity_provider.display_name
                     %>
-                    <input name="selected-idp-entity-id" type="hidden" value="<%= identity_provider.entity_id %>" />
-                    <input name="selected-idp-display-name" type="hidden" value="<%= identity_provider.display_name %>" />
+                    <%= hidden_field_tag 'selected-idp-entity-id', identity_provider.entity_id %>
+                    <%= hidden_field_tag 'selected-idp-display-name', identity_provider.display_name %>
                 <% end %>
               </div>
             </div>

--- a/config/initializers/federation.rb
+++ b/config/initializers/federation.rb
@@ -1,0 +1,1 @@
+FEDERATION_TRANSLATOR = Display::FederationTranslator.new

--- a/config/initializers/piwik.rb
+++ b/config/initializers/piwik.rb
@@ -11,3 +11,5 @@ if INTERNAL_PIWIK.enabled?
 else
   ANALYTICS_REPORTER = Analytics::NullReporter.new
 end
+
+FEDERATION_REPORTER = Analytics::FederationReporter.new(FEDERATION_TRANSLATOR, ANALYTICS_REPORTER)

--- a/config/initializers/proxies.rb
+++ b/config/initializers/proxies.rb
@@ -5,11 +5,12 @@ api_client = Api::Client.new(API_HOST, Api::ResponseHandler.new)
 
 SESSION_PROXY = SessionProxy.new(api_client, OriginatingIpStore)
 
-federation_translator = Display::FederationTranslator.new
+FEDERATION_TRANSLATOR = Display::FederationTranslator.new
+
 TRANSACTION_LISTER = Display::Rp::TransactionLister.new(
   Display::Rp::TransactionsProxy.new(api_client),
-  Display::Rp::DisplayDataCorrelator.new(federation_translator))
+  Display::Rp::DisplayDataCorrelator.new(FEDERATION_TRANSLATOR))
 
 FEDERATION_INFO_GETTER = Display::Federation::FederationInfoGetter.new(
   SESSION_PROXY,
-  Display::Idp::DisplayDataCorrelator.new(federation_translator, CONFIG.logo_directory, CONFIG.white_logo_directory))
+  Display::Idp::DisplayDataCorrelator.new(FEDERATION_TRANSLATOR, CONFIG.logo_directory, CONFIG.white_logo_directory))

--- a/config/initializers/proxies.rb
+++ b/config/initializers/proxies.rb
@@ -5,8 +5,6 @@ api_client = Api::Client.new(API_HOST, Api::ResponseHandler.new)
 
 SESSION_PROXY = SessionProxy.new(api_client, OriginatingIpStore)
 
-FEDERATION_TRANSLATOR = Display::FederationTranslator.new
-
 TRANSACTION_LISTER = Display::Rp::TransactionLister.new(
   Display::Rp::TransactionsProxy.new(api_client),
   Display::Rp::DisplayDataCorrelator.new(FEDERATION_TRANSLATOR))

--- a/lib/analytics/piwik_client.rb
+++ b/lib/analytics/piwik_client.rb
@@ -24,7 +24,9 @@ module Analytics
 
     def do_report(params, headers)
       begin
-        client.get(@path, params: params, headers: headers)
+        response = client.get(@path, params: params, headers: headers)
+        Rails.logger.debug("Reporting analytics with params: #{params}, headers: #{headers}")
+        response
       rescue HTTP::Error => e
         Rails.logger.error('Analytics reporting error: ' + e.message)
       end

--- a/spec/feature_helper.rb
+++ b/spec/feature_helper.rb
@@ -31,8 +31,8 @@ def stub_transactions_list
   stub_request(:get, api_transactions_endpoint).to_return(body: transactions.to_json, status: 200)
 end
 
-def stub_federation
-  body = { 'idps' => [{ 'simpleId' => 'stub-idp-one', 'entityId' => 'http://idcorp.com' }], 'transactionEntityId' => 'some-id' }
+def stub_federation(idp_entity_id = 'http://idcorp.com')
+  body = { 'idps' => [{ 'simpleId' => 'stub-idp-one', 'entityId' => "#{idp_entity_id}" }], 'transactionEntityId' => 'some-id' }
   stub_request(:get, api_uri('session/federation')).to_return(body: body.to_json)
 end
 

--- a/spec/feature_helper.rb
+++ b/spec/feature_helper.rb
@@ -32,10 +32,8 @@ def stub_transactions_list
 end
 
 def stub_federation(idp_entity_id = 'http://idcorp.com')
-  body = { 'idps' => [{ 'simpleId' => 'stub-idp-one', 'entityId' => "#{idp_entity_id}" }], 'transactionSimpleId' => 'test-rp', 'transactionEntityId' => 'some-entity-id' }
+  body = { 'idps' => [{ 'simpleId' => 'stub-idp-one', 'entityId' => idp_entity_id }], 'transactionSimpleId' => 'test-rp', 'transactionEntityId' => 'some-entity-id' }
   stub_request(:get, api_uri('session/federation')).to_return(body: body.to_json)
-  # body = { 'idps' => [{ 'simpleId' => 'stub-idp-one', 'entityId' => "#{idp_entity_id}" }], 'transactionEntityId' => 'some-id' }
-  # stub_request(:get, api_uri('session/federation')).to_return(body: body.to_json)
 end
 
 def stub_federation_no_docs

--- a/spec/feature_helper.rb
+++ b/spec/feature_helper.rb
@@ -32,12 +32,14 @@ def stub_transactions_list
 end
 
 def stub_federation(idp_entity_id = 'http://idcorp.com')
-  body = { 'idps' => [{ 'simpleId' => 'stub-idp-one', 'entityId' => "#{idp_entity_id}" }], 'transactionEntityId' => 'some-id' }
+  body = { 'idps' => [{ 'simpleId' => 'stub-idp-one', 'entityId' => "#{idp_entity_id}" }], 'transactionSimpleId' => 'test-rp', 'transactionEntityId' => 'some-entity-id' }
   stub_request(:get, api_uri('session/federation')).to_return(body: body.to_json)
+  # body = { 'idps' => [{ 'simpleId' => 'stub-idp-one', 'entityId' => "#{idp_entity_id}" }], 'transactionEntityId' => 'some-id' }
+  # stub_request(:get, api_uri('session/federation')).to_return(body: body.to_json)
 end
 
 def stub_federation_no_docs
-  body = { 'idps' => [{ 'simpleId' => 'stub-idp-no-docs', 'entityId' => 'http://idcorp.nodoc.com' }], 'transactionEntityId' => 'some-id' }
+  body = { 'idps' => [{ 'simpleId' => 'stub-idp-no-docs', 'entityId' => 'http://idcorp.nodoc.com' }], 'transactionSimpleId' => 'test-rp', 'transactionEntityId' => 'some-id' }
   stub_request(:get, api_uri('session/federation')).to_return(body: body.to_json)
 end
 

--- a/spec/features/server_sends_analytics_spec.rb
+++ b/spec/features/server_sends_analytics_spec.rb
@@ -2,7 +2,7 @@ require 'feature_helper'
 
 RSpec.describe 'When a page with a virtual page view is visited' do
   it 'sends a virtual page view to analytics' do
-    body = { 'idps' => [{ 'simpleId' => 'stub-idp-one', 'entityId' => 'http://idpcorp.com' }], 'transactionEntityId' => 'some-id' }
+    body = { 'idps' => [{ 'simpleId' => 'stub-idp-one', 'entityId' => 'http://idpcorp.com' }], 'transactionSimpleId' => 'test-rp', 'transactionEntityId' => 'some-id' }
     stub_request(:get, api_uri('session/federation')).to_return(body: body.to_json)
     stub_request(:get, INTERNAL_PIWIK.url).with(query: hash_including({}))
     set_session_cookies!

--- a/spec/features/user_selects_idp_spec.rb
+++ b/spec/features/user_selects_idp_spec.rb
@@ -12,7 +12,7 @@ end
 def then_custom_variable_reported_for_sign_in
   piwik_request = {
       '_cvar' => "{\"1\":[\"RP\",\"#{transaction_analytics_description}\"]}",
-      'action_name' => "The No option was selected on the introduction page #{transaction_analytics_description}",
+      'action_name' => 'The No option was selected on the introduction page',
   }
   expect(a_request(:get, INTERNAL_PIWIK.url).with(query: hash_including(piwik_request))).to have_been_made.once
 end

--- a/spec/features/user_selects_idp_spec.rb
+++ b/spec/features/user_selects_idp_spec.rb
@@ -15,7 +15,7 @@ def given_im_on_the_sign_in_page
 end
 
 def when_i_select_an_idp
-  click_button('IDCorp')
+  click_button(idp_display_name)
 end
 
 def then_im_at_the_idp
@@ -29,8 +29,8 @@ def then_im_at_the_idp
   expect(a_request(:get, api_uri('session/idp-authn-request'))
            .with(query: { 'originatingIp' => originating_ip })).to have_been_made.once
   piwik_request = {
-      '_cvar' => "{\"3\":[\"SIGNIN_IDP\",\"#{idp_entity_id}\"]}",
-      'action_name' => 'Sign In - ' + idp_entity_id,
+      '_cvar' => "{\"3\":[\"SIGNIN_IDP\",\"#{idp_display_name}\"]}",
+      'action_name' => 'Sign In - ' + idp_display_name,
   }
   expect(a_request(:get, INTERNAL_PIWIK.url).with(query: hash_including(piwik_request))).to have_been_made.once
 end
@@ -45,6 +45,7 @@ end
 
 RSpec.describe 'user selects an IDP on the sign in page' do
   let(:idp_entity_id) { 'http://idcorp.com' }
+  let(:idp_display_name) { 'IDCorp' }
   let(:body) {
     [
       { 'simpleId' => 'stub-idp-zero', 'entityId' => 'idp-zero' },

--- a/spec/features/user_selects_idp_spec.rb
+++ b/spec/features/user_selects_idp_spec.rb
@@ -20,7 +20,6 @@ end
 def given_im_on_the_sign_in_page
   cookies
   visit '/sign-in'
-  then_custom_variable_reported_for_sign_in
 end
 
 def when_i_select_an_idp
@@ -82,6 +81,7 @@ RSpec.describe 'user selects an IDP on the sign in page' do
     it 'will redirect the user to the IDP' do
       given_api_requests_have_been_mocked!
       given_im_on_the_sign_in_page
+      then_custom_variable_reported_for_sign_in
       when_i_select_an_idp
       then_im_at_the_idp
     end
@@ -91,6 +91,7 @@ RSpec.describe 'user selects an IDP on the sign in page' do
     it 'will display the interstitial page and on submit will redirect the user to IDP' do
       given_api_requests_have_been_mocked!
       given_im_on_the_sign_in_page
+      then_custom_variable_reported_for_sign_in
       when_i_select_an_idp
       then_im_at_the_interstitial_page
       when_i_choose_to_continue

--- a/spec/features/user_selects_idp_spec.rb
+++ b/spec/features/user_selects_idp_spec.rb
@@ -9,9 +9,18 @@ def given_api_requests_have_been_mocked!
   stub_request(:get, INTERNAL_PIWIK.url).with(query: hash_including({}))
 end
 
+def then_custom_variable_reported_for_sign_in
+  piwik_request = {
+      '_cvar' => "{\"1\":[\"RP\",\"#{transaction_analytics_description}\"]}",
+      'action_name' => "The No option was selected on the introduction page #{transaction_analytics_description}",
+  }
+  expect(a_request(:get, INTERNAL_PIWIK.url).with(query: hash_including(piwik_request))).to have_been_made.once
+end
+
 def given_im_on_the_sign_in_page
   cookies
   visit '/sign-in'
+  then_custom_variable_reported_for_sign_in
 end
 
 def when_i_select_an_idp
@@ -46,6 +55,7 @@ end
 RSpec.describe 'user selects an IDP on the sign in page' do
   let(:idp_entity_id) { 'http://idcorp.com' }
   let(:idp_display_name) { 'IDCorp' }
+  let(:transaction_analytics_description) { 'analytics description for test-rp' }
   let(:body) {
     [
       { 'simpleId' => 'stub-idp-zero', 'entityId' => 'idp-zero' },

--- a/spec/features/user_submits_start_page_form_spec.rb
+++ b/spec/features/user_submits_start_page_form_spec.rb
@@ -2,7 +2,7 @@ require 'feature_helper'
 require 'models/cookie_names'
 
 def given_api_returns_federation_info
-  body = { 'idps' => [{ 'simpleId' => 'stub-idp-one', 'entityId' => 'http://idcorp.com' }], 'transactionEntityId' => 'some-id' }
+  body = { 'idps' => [{ 'simpleId' => 'stub-idp-one', 'entityId' => 'http://idcorp.com' }], 'transactionSimpleId' => 'test-rp', 'transactionEntityId' => 'some-id' }
   stub_request(:get, api_uri('session/federation')).to_return(body: body.to_json)
 end
 
@@ -45,7 +45,7 @@ RSpec.describe 'when user submits start page form' do
     piwik_request = {
         'rec' => '1',
         'apiv' => '1',
-        '_cvar' => '{"1":["RP","some-id"]}'
+        '_cvar' => '{"1":["RP","analytics description for test-rp"]}'
     }
     expect(a_request(:get, INTERNAL_PIWIK.url).with(query: hash_including(piwik_request))).to have_been_made.once
   end

--- a/spec/features/user_visits_about_certified_companies_page_spec.rb
+++ b/spec/features/user_visits_about_certified_companies_page_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'When the user visits the about certified companies page' do
   let(:idp_entity_id) { 'http://idcorp.com' }
 
   before(:each) do
-    body = { 'idps' => [{ 'simpleId' => 'stub-idp-one', 'entityId' => 'http://idpcorp.com' }], 'transactionEntityId' => 'some-id' }
+    body = { 'idps' => [{ 'simpleId' => 'stub-idp-one', 'entityId' => 'http://idpcorp.com' }], 'transactionSimpleId' => 'test-rp', 'transactionEntityId' => 'some-id' }
     stub_request(:get, api_uri('session/federation')).to_return(body: body.to_json)
     stub_transactions_list
     set_session_cookies!

--- a/spec/features/user_visits_about_page_spec.rb
+++ b/spec/features/user_visits_about_page_spec.rb
@@ -26,15 +26,14 @@ RSpec.describe 'When the user visits the about page' do
   end
 
   it 'will go to certified companies page when next is clicked' do
-    transaction_analytics_description = 'analytics description for test-rp'
     visit '/about'
     expect(page).to have_content 'GOV.UK Verify is a scheme to fight the growing problem of online identity theft'
     click_link('Next')
     expect(page).to have_current_path('/about-certified-companies')
 
     piwik_request = {
-        '_cvar' => "{\"1\":[\"RP\",\"#{transaction_analytics_description}\"]}",
-        'action_name' => "The Yes option was selected on the start page #{transaction_analytics_description}",
+        '_cvar' => "{\"1\":[\"RP\",\"analytics description for test-rp\"]}",
+        'action_name' => 'The Yes option was selected on the start page',
     }
     expect(a_request(:get, INTERNAL_PIWIK.url).with(query: hash_including(piwik_request))).to have_been_made.once
   end

--- a/spec/features/user_visits_about_page_spec.rb
+++ b/spec/features/user_visits_about_page_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe 'When the user visits the about page' do
     set_session_cookies!
     body = {
       'idps' => [{ 'simpleId' => 'stub-idp-one', 'entityId' => 'http://idpcorp.com' }],
+      'transactionSimpleId' => 'test-rp',
       'transactionEntityId' => transaction_entity_id
     }
     stub_request(:get, api_uri('session/federation')).to_return(body: body.to_json)
@@ -25,14 +26,15 @@ RSpec.describe 'When the user visits the about page' do
   end
 
   it 'will go to certified companies page when next is clicked' do
+    transaction_analytics_description = 'analytics description for test-rp'
     visit '/about'
     expect(page).to have_content 'GOV.UK Verify is a scheme to fight the growing problem of online identity theft'
     click_link('Next')
     expect(page).to have_current_path('/about-certified-companies')
 
     piwik_request = {
-        '_cvar' => "{\"1\":[\"RP\",\"#{transaction_entity_id}\"]}",
-        'action_name' => 'The Yes option was selected on the start page',
+        '_cvar' => "{\"1\":[\"RP\",\"#{transaction_analytics_description}\"]}",
+        'action_name' => "The Yes option was selected on the start page #{transaction_analytics_description}",
     }
     expect(a_request(:get, INTERNAL_PIWIK.url).with(query: hash_including(piwik_request))).to have_been_made.once
   end

--- a/spec/javascripts/sign_in_spec.js
+++ b/spec/javascripts/sign_in_spec.js
@@ -9,10 +9,10 @@ describe('The sign in page', function () {
       formSpy,
       html = '<div class="js-idp-option-container">'
            + '<form class="idp-option first-form" action="">'
-           +   '<button type=submit name=IDCorp></button>'
+           +   '<button type=submit name=IDCorp value="IDCorpDisplayName"></button>'
            + '</form>'
            + '<form class="idp-option second-form" action="">'
-           +   '<button type=submit name=IDCorpZwei></button>'
+           +   '<button type=submit name=IDCorpZwei value="IDCorpZweiDisplayName"></button>'
            + '</form>'
            + '<form id=post-to-idp>'
            +   '<input name=SAMLRequest type=hidden>'
@@ -51,7 +51,7 @@ describe('The sign in page', function () {
         })
       });
       expect(jasmine.Ajax.requests.mostRecent().url).toBe(apiPath);
-      expect(jasmine.Ajax.requests.mostRecent().params).toBe('{"entityId":"IDCorpZwei"}');
+      expect(jasmine.Ajax.requests.mostRecent().params).toBe('{"entityId":"IDCorpZwei","displayName":"IDCorpZweiDisplayName"}');
     });
     it('should populate the SAML request form with the AJAX response and submit it', function () {
       $(document).submit(formSpy);

--- a/spec/lib/analytics/piwik_client_spec.rb
+++ b/spec/lib/analytics/piwik_client_spec.rb
@@ -42,6 +42,11 @@ module Analytics
 
     context "can be not async" do
       it "will return the response" do
+        rails = double(:rails)
+        stub_const("Rails", rails)
+        logger = double(:logger)
+        expect(rails).to receive(:logger).and_return logger
+        expect(logger).to receive(:debug)
         stub_request(:get, url).and_return(status: 200)
         response = PiwikClient.new(url, async: false).report({}, {})
         expect(response.status).to eql 200

--- a/spec/logger_helper.rb
+++ b/spec/logger_helper.rb
@@ -1,0 +1,6 @@
+def stub_logger
+  logger = double(:logger)
+  rails_double = double(:rails, logger: logger)
+  stub_const('Rails', rails_double)
+  logger
+end

--- a/spec/models/analytics/federation_reporter_spec.rb
+++ b/spec/models/analytics/federation_reporter_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+require 'models/analytics/federation_reporter'
+require 'analytics'
+require 'models/display/federation_translator'
+require 'logger_helper'
+
+module Analytics
+  describe FederationReporter do
+    let(:federation_translator) { double(:federation_translator) }
+    let(:analytics_reporter) { double(:analytics_reporter) }
+    let(:federation_reporter) { FederationReporter.new(federation_translator, analytics_reporter) }
+    let(:request) { double(:request) }
+
+    describe '#report_sign_in' do
+      it 'should report custom variable with No option message' do
+        simple_id = 'id'
+        description = 'description'
+        allow(federation_translator).to receive(:translate)
+          .with('rps.id.analyticsDescription')
+          .and_return(description)
+        expect(analytics_reporter).to receive(:report_custom_variable)
+          .with(
+            request,
+            'The No option was selected on the introduction page description',
+            1 => %w[RP description]
+          )
+
+        federation_reporter.report_sign_in(simple_id, request)
+      end
+
+      it 'should not report custom variable if transaction analytics description is not available' do
+        translation_error = Display::FederationTranslator::TranslationError.new
+        allow(federation_translator).to receive(:translate)
+          .with('rps.id.analyticsDescription')
+          .and_raise(translation_error)
+        expect(stub_logger).to receive(:warn).with(translation_error).at_least(:once)
+        allow(analytics_reporter).to receive(:report_custom_variable)
+
+        federation_reporter.report_sign_in('id', request)
+
+        expect(analytics_reporter).to_not have_received(:report_custom_variable)
+      end
+    end
+  end
+end

--- a/spec/models/analytics/federation_reporter_spec.rb
+++ b/spec/models/analytics/federation_reporter_spec.rb
@@ -12,7 +12,7 @@ module Analytics
     let(:request) { double(:request) }
 
     describe '#report_sign_in' do
-      it 'should report custom variable with No option message' do
+      it 'should report custom variable for sign in' do
         simple_id = 'id'
         description = 'description'
         allow(federation_translator).to receive(:translate)
@@ -21,11 +21,27 @@ module Analytics
         expect(analytics_reporter).to receive(:report_custom_variable)
           .with(
             request,
-            'The No option was selected on the introduction page description',
+            'The No option was selected on the introduction page',
             1 => %w[RP description]
           )
 
         federation_reporter.report_sign_in(simple_id, request)
+      end
+
+      it 'should report custom variable for registration' do
+        simple_id = 'id'
+        description = 'description'
+        allow(federation_translator).to receive(:translate)
+          .with('rps.id.analyticsDescription')
+          .and_return(description)
+        expect(analytics_reporter).to receive(:report_custom_variable)
+          .with(
+            request,
+            'The Yes option was selected on the start page',
+            1 => %w[RP description]
+          )
+
+        federation_reporter.report_registration(simple_id, request)
       end
 
       it 'should not report custom variable if transaction analytics description is not available' do

--- a/spec/models/display/federation/federation_info_getter_spec.rb
+++ b/spec/models/display/federation/federation_info_getter_spec.rb
@@ -4,13 +4,15 @@ require 'rails_helper'
 module Display
   module Federation
     describe FederationInfoGetter do
-      it 'will return a list of IDPs for Displaying in an idp picker' do
+      it 'will return a list of IDPs along with transaction entity and simple id' do
         cookie_jar = double(:cookie_jar)
         session_proxy = double(:session_proxy)
         idp_display_correlator = double(:idp_display_correlator)
 
         idp_list = double(:idp_list)
-        federation_info = FederationInfoResponse.new('idps' => idp_list, 'transactionEntityId' => 'blah')
+        transaction_simple_id = 'simple_id_blah'
+        transaction_entity_id = 'entity_id_blah'
+        federation_info = FederationInfoResponse.new('idps' => idp_list, 'transactionSimpleId' => transaction_simple_id, 'transactionEntityId' => transaction_entity_id)
         idp_display_data = double(:idp_display_data)
 
         federation_info_getter = FederationInfoGetter.new(session_proxy, idp_display_correlator)
@@ -20,7 +22,8 @@ module Display
 
         hash = federation_info_getter.get_info(cookie_jar)
         expect(hash[:idp_display_data]).to eql(idp_display_data)
-        expect(hash[:transaction_entity_id]).to eql('blah')
+        expect(hash[:transaction_entity_id]).to eql(transaction_entity_id)
+        expect(hash[:transaction_simple_id]).to eql(transaction_simple_id)
       end
     end
   end

--- a/spec/models/display/idp/display_data_correlator_spec.rb
+++ b/spec/models/display/idp/display_data_correlator_spec.rb
@@ -1,5 +1,6 @@
 require 'models/display/idp/display_data_correlator'
 require 'models/display/federation_translator'
+require 'logger_helper'
 
 module Display
   module Idp
@@ -23,10 +24,7 @@ module Display
 
       it "will skip IDP if translations can't be found" do
         translation_error = Display::FederationTranslator::TranslationError.new
-        logger = double(:logger)
-        rails_double = double(:rails, logger: logger)
-        stub_const('Rails', rails_double)
-        expect(logger).to receive(:error).with(translation_error).at_least(:once)
+        expect(stub_logger).to receive(:error).with(translation_error).at_least(:once)
 
         allow(translator).to receive(:translate).with('idps.test-simple-id.name').and_raise(translation_error)
         idp_list = [{ 'simpleId' => 'test-simple-id', 'entityId' => 'test-entity-id' }]

--- a/spec/models/session_proxy_spec.rb
+++ b/spec/models/session_proxy_spec.rb
@@ -47,6 +47,17 @@ describe SessionProxy do
     expect(result.idps).to eq idp_list
   end
 
+  it 'should fail to return federation info if transaction simple id is missing' do
+    idp_list = double(:idp_list)
+
+    expect(api_client).to receive(:get)
+      .with(SessionProxy::FEDERATION_INFO_PATH, cookies: expected_cookie_hash)
+      .and_return('idps' => idp_list, 'transactionEntityId' => 'some-id')
+    expect {
+      SessionProxy.new(api_client, originating_ip_store).federation_info_for_session(cookie_hash)
+    }.to raise_error SessionProxy::ModelError, 'Transaction simple can\'t be blank'
+  end
+
   it 'should select an IDP for the session' do
     ip_address = '1.1.1.1'
     body = { 'entityId' => 'an-entity-id', 'originatingIp' => ip_address }

--- a/spec/models/session_proxy_spec.rb
+++ b/spec/models/session_proxy_spec.rb
@@ -42,7 +42,7 @@ describe SessionProxy do
 
     expect(api_client).to receive(:get)
       .with(SessionProxy::FEDERATION_INFO_PATH, cookies: expected_cookie_hash)
-      .and_return('idps' => idp_list, 'transactionEntityId' => 'some-id')
+      .and_return('idps' => idp_list, 'transactionSimpleId' => 'test-rp', 'transactionEntityId' => 'some-id')
     result = SessionProxy.new(api_client, originating_ip_store).federation_info_for_session(cookie_hash)
     expect(result.idps).to eq idp_list
   end

--- a/stub/locales/rps/headless-rp.yml
+++ b/stub/locales/rps/headless-rp.yml
@@ -2,3 +2,4 @@ en:
   rps:
     headless-rp:
       name: Become the headless horse person
+      analyticsDescription: analytics description for headless-rp

--- a/stub/locales/rps/loa1-test-rp.yml
+++ b/stub/locales/rps/loa1-test-rp.yml
@@ -2,3 +2,4 @@ en:
   rps:
     loa1-test-rp:
       name: register for an LOA1 identity profile
+      analyticsDescription: analytics description for loa1-test-rp

--- a/stub/locales/rps/test-rp-noc3.yml
+++ b/stub/locales/rps/test-rp-noc3.yml
@@ -2,3 +2,4 @@ en:
   rps:
     test-rp-noc3:
       name: Register for an identity profile (forceauthn & no cycle3)
+      analyticsDescription: analytics description for test-rp-noc3

--- a/stub/locales/rps/test-rp-repudiation.yml
+++ b/stub/locales/rps/test-rp-repudiation.yml
@@ -2,3 +2,4 @@ en:
   rps:
     test-rp-repudiation:
       name: Register for an identity profile (repudiation step)
+      analyticsDescription: analytics description for test-rp-repudiation

--- a/stub/locales/rps/test-rp.yml
+++ b/stub/locales/rps/test-rp.yml
@@ -2,3 +2,4 @@ en:
   rps:
     test-rp:
       name: Register for an identity profile
+      analyticsDescription: analytics description for test-rp


### PR DESCRIPTION
Adds friendly names when reporting custom variables. 

Work was paired, but have since rebased solo to include latest master changes, hence PR. 