### PR TITLE
bau: cache phantomjs on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,6 @@ before_script:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
   - sleep 3 # give xvfb some time to start
+cache:
+  directories:
+    - $HOME/.phantomjs 


### PR DESCRIPTION
In between tests we should cache phantomjs so that we don't get intermittent
test failures because Travis is unable to download the phantomjs binary.