### PR TITLE
BAU: don't rescue standard errors in development

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,7 +10,7 @@ class ApplicationController < ActionController::Base
   helper_method :transactions_list
   helper_method :public_piwik
 
-  rescue_from StandardError, with: :something_went_wrong
+  rescue_from StandardError, with: :something_went_wrong unless Rails.env == 'development'
   rescue_from Api::SessionError, with: :session_error
   rescue_from Api::SessionTimeoutError, with: :session_timeout
 


### PR DESCRIPTION
It's useful to see the error and stack trace in the browser when you're
developing.