### PR TITLE
3517: remove port config for piwik

### DIFF
--- a/.env
+++ b/.env
@@ -10,7 +10,6 @@ METRICS_ENABLED=false
 LOG_LEVEL=debug
 RULES_DIRECTORY=stub/idp-rules
 
-PUBLIC_PIWIK_HOST=https://localhost
-INTERNAL_PIWIK_HOST=https://localhost
-PIWIK_PORT=1235
+PUBLIC_PIWIK_HOST=https://localhost:1235
+INTERNAL_PIWIK_HOST=https://localhost:1235
 PIWIK_SITE_ID=1

--- a/.env.test
+++ b/.env.test
@@ -1,7 +1,6 @@
 API_HOST=http://api.com:50190
 METRICS_ENABLED=false
 
-PUBLIC_PIWIK_HOST=http://localhost
-INTERNAL_PIWIK_HOST=http://localhost
-PIWIK_PORT=4242
+PUBLIC_PIWIK_HOST=http://localhost:4242
+INTERNAL_PIWIK_HOST=http://localhost:4242
 PIWIK_SITE_ID=5

--- a/config/initializers/configuration.rb
+++ b/config/initializers/configuration.rb
@@ -18,7 +18,6 @@ CONFIG = Configuration.load! do
   end
   option_string 'internal_piwik_host', 'INTERNAL_PIWIK_HOST', allow_missing: true
   option_string 'public_piwik_host', 'PUBLIC_PIWIK_HOST', allow_missing: true
-  option_int 'piwik_port', 'PIWIK_PORT', default: 443
   option_int 'piwik_site_id', 'PIWIK_SITE_ID', default: 1
   option_int 'read_timeout', 'READ_TIMEOUT', default: 60
   option_int 'connect_timeout', 'CONNECT_TIMEOUT', default: 4

--- a/config/initializers/piwik.rb
+++ b/config/initializers/piwik.rb
@@ -2,8 +2,8 @@ require 'piwik'
 require 'analytics'
 require 'originating_ip_store'
 
-INTERNAL_PIWIK = Piwik.new(CONFIG.internal_piwik_host, CONFIG.piwik_port, CONFIG.piwik_site_id)
-PUBLIC_PIWIK = Piwik.new(CONFIG.public_piwik_host, CONFIG.piwik_port, CONFIG.piwik_site_id)
+INTERNAL_PIWIK = Piwik.new(CONFIG.internal_piwik_host, CONFIG.piwik_site_id)
+PUBLIC_PIWIK = Piwik.new(CONFIG.public_piwik_host, CONFIG.piwik_site_id)
 
 if INTERNAL_PIWIK.enabled?
   client = Analytics::PiwikClient.new(INTERNAL_PIWIK.url, async: Rails.env != 'test')

--- a/lib/piwik.rb
+++ b/lib/piwik.rb
@@ -3,10 +3,10 @@ require 'uri'
 class Piwik
   attr_reader :url, :site_id
 
-  def initialize(host, port, site_id)
+  def initialize(host, site_id)
     @enabled = host.present?
     if @enabled
-      @url = URI.join("#{host}:#{port}", "/piwik.php")
+      @url = URI.parse(File.join(host, "piwik.php"))
     end
     @site_id = site_id
   end

--- a/spec/lib/piwik_spec.rb
+++ b/spec/lib/piwik_spec.rb
@@ -3,36 +3,31 @@ require 'active_support/core_ext/string'
 
 RSpec.describe Piwik do
   it 'should correctly generate a url' do
-    piwik = Piwik.new('http://www.example.com', 1234, 1)
-    expect(piwik.url.to_s).to eql 'http://www.example.com:1234/piwik.php'
-  end
-
-  it 'should use default https port' do
-    piwik = Piwik.new('https://www.example.com', 443, 1)
-    expect(piwik.url.to_s).to eql 'https://www.example.com/piwik.php'
+    piwik = Piwik.new('http://www.example.com:1234/foo', 1)
+    expect(piwik.url.to_s).to eql 'http://www.example.com:1234/foo/piwik.php'
   end
 
   it 'has a site id' do
-    piwik = Piwik.new('https://www.example.com', 443, 5)
+    piwik = Piwik.new('https://www.example.com', 5)
     expect(piwik.site_id).to eql 5
   end
 
   it 'is disabled when piwik_host is nil' do
-    piwik = Piwik.new(nil, 443, 5)
+    piwik = Piwik.new(nil, 5)
     expect(piwik.enabled?).to eql false
   end
 
   it 'is disabled when piwik_host is an empty string' do
-    piwik = Piwik.new('', 443, 5)
+    piwik = Piwik.new('', 5)
     expect(piwik.enabled?).to eql false
   end
 
   it 'is enabled when piwik_host is present' do
-    piwik = Piwik.new('https://www.example.com', 443, 5)
+    piwik = Piwik.new('https://www.example.com', 5)
     expect(piwik.enabled?).to eql true
   end
 
   it 'will raise when piwik_host is not valid uri' do
-    expect { Piwik.new('foo:: :   :///', 443, 5) }.to raise_error URI::InvalidURIError
+    expect { Piwik.new('foo:: :   :///', 5) }.to raise_error URI::InvalidURIError
   end
 end


### PR DESCRIPTION
The PORT is never configured outside of the local environment so it seems a bit
wasteful to provide a discrete setting for it when it can be included in the
PIWIK HOST options