### PR TITLE
bau: Small fixes recommended by rubocop

### DIFF
--- a/app/controllers/start_controller.rb
+++ b/app/controllers/start_controller.rb
@@ -8,7 +8,7 @@ class StartController < ApplicationController
   def request_post
     if params['selection'].blank?
       @error_message = 'hub.start.error_message'
-      render "index"
+      render 'index'
     elsif params['selection'] == 'true'
       redirect_to about_path(locale: I18n.locale), status: :see_other
     else

--- a/app/models/cookie_names.rb
+++ b/app/models/cookie_names.rb
@@ -1,9 +1,9 @@
 module CookieNames
-  SECURE_COOKIE_NAME = "x-govuk-secure-cookie"
-  SESSION_ID_COOKIE_NAME = "x_govuk_session_cookie"
-  SESSION_STARTED_TIME_COOKIE_NAME = "session_start_time"
-  VERIFY_JOURNEY_HINT = "verify-journey-hint"
-  PIWIK_VISITOR_ID = 'PIWIK_VISITOR_ID'
+  SECURE_COOKIE_NAME = 'x-govuk-secure-cookie'.freeze
+  SESSION_ID_COOKIE_NAME = 'x_govuk_session_cookie'.freeze
+  SESSION_STARTED_TIME_COOKIE_NAME = 'session_start_time'.freeze
+  VERIFY_JOURNEY_HINT = 'verify-journey-hint'.freeze
+  PIWIK_VISITOR_ID = 'PIWIK_VISITOR_ID'.freeze
 
   def self.session_cookies
     [SECURE_COOKIE_NAME, SESSION_ID_COOKIE_NAME, SESSION_STARTED_TIME_COOKIE_NAME]

--- a/app/models/session_proxy.rb
+++ b/app/models/session_proxy.rb
@@ -1,13 +1,13 @@
 
 class SessionProxy
-  PATH = "/session"
-  FEDERATION_INFO_PATH = "#{PATH}/federation"
-  SELECT_IDP_PATH = "#{PATH}/select-idp"
-  IDP_AUTHN_REQUEST_PATH = "#{PATH}/idp-authn-request"
-  PARAM_SAML_REQUEST = "samlRequest"
-  PARAM_RELAY_STATE = "relayState"
-  PARAM_ORIGINATING_IP = "originatingIp"
-  PARAM_ENTITY_ID = 'entityId'
+  PATH = '/session'.freeze
+  FEDERATION_INFO_PATH = "#{PATH}/federation".freeze
+  SELECT_IDP_PATH = "#{PATH}/select-idp".freeze
+  IDP_AUTHN_REQUEST_PATH = "#{PATH}/idp-authn-request".freeze
+  PARAM_SAML_REQUEST = 'samlRequest'.freeze
+  PARAM_RELAY_STATE = 'relayState'.freeze
+  PARAM_ORIGINATING_IP = 'originatingIp'.freeze
+  PARAM_ENTITY_ID = 'entityId'.freeze
 
   def initialize(api_client, originating_ip_store)
     @api_client = api_client
@@ -20,9 +20,9 @@ class SessionProxy
 
   def create_session(saml_request, relay_state)
     body = {
-        PARAM_SAML_REQUEST => saml_request,
-        PARAM_RELAY_STATE => relay_state,
-        PARAM_ORIGINATING_IP => originating_ip
+      PARAM_SAML_REQUEST => saml_request,
+      PARAM_RELAY_STATE => relay_state,
+      PARAM_ORIGINATING_IP => originating_ip
     }
     @api_client.post(PATH, body)
   end
@@ -41,8 +41,8 @@ class SessionProxy
 
   def select_idp(cookies, entity_id)
     body = {
-        PARAM_ENTITY_ID => entity_id,
-        PARAM_ORIGINATING_IP => originating_ip
+      PARAM_ENTITY_ID => entity_id,
+      PARAM_ORIGINATING_IP => originating_ip
     }
     response = @api_client.put(SELECT_IDP_PATH, body, cookies: select_cookies(cookies, CookieNames.session_cookies))
     SelectIdpResponse.new(response || {}).tap { |message|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,4 @@
 Rails.application.routes.draw do
-  mount JasmineRails::Engine => '/specs' if defined?(JasmineRails)
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".
 
@@ -12,6 +11,7 @@ Rails.application.routes.draw do
   match "/404", to: "errors#page_not_found", via: :all
 
   if %w(test development).include? Rails.env
+    mount JasmineRails::Engine => '/specs' if defined?(JasmineRails)
     get 'test-saml' => 'test_saml#index'
     post 'test-idp-request-endpoint' => 'test_saml#idp_request'
   end

--- a/lib/originating_ip_store.rb
+++ b/lib/originating_ip_store.rb
@@ -1,6 +1,6 @@
 require 'request_store'
 module OriginatingIpStore
-  UNDETERMINED_IP = '<PRINCIPAL IP ADDRESS COULD NOT BE DETERMINED>'
+  UNDETERMINED_IP = '<PRINCIPAL IP ADDRESS COULD NOT BE DETERMINED>'.freeze
 
   def self.store(request)
     originating_ip = request.headers.fetch('X-Forwarded-For') { UNDETERMINED_IP }


### PR DESCRIPTION
Running rubocop with a stricter config than the GDS defaults raises some
interesting things such as freezing strings which are intended to be
constant (strings are mutable by default in Ruby). I think we should
consider making some changes to our rubocop config to catch these
things.

Includes a separate change which will only include the JasmineRails
routes if we are in test or development env, they are currently excluded
by the dependency gem not being available in production.