### PR TITLE
3517: start localising the routes to the about pages

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -3,7 +3,7 @@ cy:
     start: dechrau
     about: am
     sign_in: mewngofnodi
-    about_certified_companies: am-gwmnïau-ardystiedig
+    about_certified_companies: am-gwmniau-ardystiedig
     about_identity_accounts: am-gyfrifon-hunaniaeth
     about_choosing_a_company: am-ddewis-cwmni
     select_documents: dewis-dogfennau

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,10 @@ Rails.application.routes.draw do
     post 'start', to: 'start#request_post', as: :start
     get 'sign_in', to: 'sign_in#index', as: :sign_in
     post 'sign_in', to: 'sign_in#select_idp', as: :sign_in
+    get 'about', to: 'about#index', as: :about
+    get 'about_certified_companies', to: 'about#certified_companies', as: :about_certified_companies
+    get 'about_identity_accounts', to: 'about#identity_accounts', as: :about_identity_accounts
+    get 'about_choosing_a_company', to: 'about#choosing_a_company', as: :about_choosing_a_company
   end
 
   get '/redirect-to-service/error', to: redirect("#{API_HOST}/redirect-to-service/error")
@@ -28,10 +32,6 @@ Rails.application.routes.draw do
   put 'select-idp', to: 'select_idp#select_idp', as: :select_idp
   get 'service-status', to: 'service_status#index', as: :service_status
 
-  get 'about', to: 'about#index', as: :about
-  get 'about-certified-companies', to: 'about#certified_companies', as: :about_certified_companies
-  get 'about-identity-accounts', to: 'about#identity_accounts', as: :about_identity_accounts
-  get 'about-choosing-a-company', to: 'about#choosing_a_company', as: :about_choosing_a_company
   get 'select-documents', to: 'select_documents#index', as: :select_documents
   post 'select-documents', to: 'select_documents#select_documents', as: :select_documents_submit
 

--- a/spec/features/user_visits_about_certified_companies_page_spec.rb
+++ b/spec/features/user_visits_about_certified_companies_page_spec.rb
@@ -18,11 +18,11 @@ RSpec.describe 'When the user visits the about certified companies page' do
     expect_feedback_source_to_be(page, 'ABOUT_CERTIFIED_COMPANIES_PAGE')
   end
 
-  it 'displays content in Welsh', pending: true do
+  it 'displays content in Welsh' do
     visit '/am-gwmniau-ardystiedig'
 
     expect(page).to have_content 'Sut y gall cwmnïau wirio hunaniaeth'
-    expect(page).to have_content 'Gall y cwmnïau hyn yn defnyddio eu data eu hunain'
+    expect(page).to have_content 'Gall y cwmnïau hyn ddefnyddio eu data eu hunain'
   end
 
   it 'displays IdPs that are enabled' do

--- a/spec/features/user_visits_about_choosing_a_company_page_spec.rb
+++ b/spec/features/user_visits_about_choosing_a_company_page_spec.rb
@@ -12,10 +12,10 @@ RSpec.describe 'When the user visits the about choosing a company page' do
     expect_feedback_source_to_be(page, 'ABOUT_CHOOSING_A_COMPANY_PAGE')
   end
 
-  it 'will display content in Welsh', pending: true do
-    visit '/am-ddewis-a-gwmni'
+  it 'will display content in Welsh' do
+    visit '/am-ddewis-cwmni'
 
-    expect(page).to have_content 'Dod o hyd i\'r cwmni hawl i wirio chi'
+    expect(page).to have_content 'Dod o hyd i\'r cwmni iawn i\'ch dilysu chi'
   end
 
   it 'will take user to select documents page when user clicks "Continue"' do

--- a/spec/features/user_visits_about_identity_accounts_page_spec.rb
+++ b/spec/features/user_visits_about_identity_accounts_page_spec.rb
@@ -16,10 +16,10 @@ RSpec.describe 'When the user visits the about identity accounts page' do
     expect_feedback_source_to_be(page, 'ABOUT_IDENTITY_ACCOUNTS_PAGE')
   end
 
-  it 'displays content in Welsh', pending: true do
-    visit '/am-hunaniaeth-cyfrifon'
+  it 'displays content in Welsh' do
+    visit '/am-gyfrifon-hunaniaeth'
 
-    expect(page).to have_content 'Dilysu eich hunaniaeth yn cymryd tua 10 munud.'
+    expect(page).to have_content 'Mae dilysu eich hunaniaeth yn cymryd tua 10 munud.'
   end
 
   it 'will show "Where you can use your identity account" section listing public transactions' do

--- a/spec/features/user_visits_about_page_spec.rb
+++ b/spec/features/user_visits_about_page_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'When the user visits the about page' do
     expect_feedback_source_to_be(page, 'ABOUT_PAGE')
   end
 
-  it 'will display the about page in Welsh', pending: true do
+  it 'will display the about page in Welsh' do
     visit '/am'
     expect(page).to have_content 'GOV.UK Verify yn gynllun i frwydro yn erbyn'
     expect(page).to have_css 'html[lang=cy]'


### PR DESCRIPTION
Once this goes live the about pages should be visible in welsh to welsh language users.