### PR TITLE
3521: Do not send invalid view_runtime metrics to statsd

### DIFF
--- a/lib/metrics/controller_action_reporter.rb
+++ b/lib/metrics/controller_action_reporter.rb
@@ -8,7 +8,8 @@ module Metrics
       # args name and id get passed from ActiveSupport, however we will not need them to report.
       source = [payload[:controller], payload[:action]]
       @statsd_client.timing(Metrics::metric_key(source, TOTAL_DURATION), Metrics::duration(finish, start))
-      @statsd_client.timing(Metrics::metric_key(source, VIEW_RUNTIME), payload[:view_runtime])
+      view_runtime = payload[:view_runtime]
+      @statsd_client.timing(Metrics::metric_key(source, VIEW_RUNTIME), view_runtime) unless view_runtime.nil?
     end
   end
 end

--- a/spec/lib/metrics/controller_action_reporter_spec.rb
+++ b/spec/lib/metrics/controller_action_reporter_spec.rb
@@ -24,5 +24,15 @@ module Metrics
       expect(statsd).to receive(:timing).with("AnotherController.anotherAction.view_runtime", view_runtime)
       reporter.report('event_name', Time.now, Time.now, 'notification_id', payload)
     end
+
+    it 'should not send view rendering time if none is provided' do
+      # Rails only sets view_runtime when rendering a view,
+      # so it isn't set for redirects or AJAX responses.
+      view_runtime = nil
+      payload = { controller: 'AnotherController', action: 'anotherAction', view_runtime: view_runtime }
+      allow(statsd).to receive(:timing)
+      expect(statsd).not_to receive(:timing).with("AnotherController.anotherAction.view_runtime", view_runtime)
+      reporter.report('event_name', Time.now, Time.now, 'notification_id', payload)
+    end
   end
 end


### PR DESCRIPTION
Rails only sets view_runtime when rendering views. This means it's nil
when performing redirects or responding to AJAX requests.

Solo: @richardtowers