### PR TITLE
3517: use more consistent error messages for api failures

### DIFF
--- a/app/models/api/response_handler.rb
+++ b/app/models/api/response_handler.rb
@@ -12,17 +12,22 @@ module Api
 
     def handle_error(body, status)
       json = parse_json(body, status) || {}
-      error_id = json.fetch('id', 'NONE')
-      error_type = json.fetch('type', 'NONE')
-      case error_type
+      error_message = message(status, json)
+      case json.fetch('type', 'NONE')
       when SessionError::TYPE
-        raise SessionError, "Received #{status} with type: '#{error_type}' and id: '#{error_id}'"
+        raise SessionError, error_message
       when SessionTimeoutError::TYPE
-        raise SessionTimeoutError, "Received #{status} with type: '#{error_type}' and id: '#{error_id}'"
+        raise SessionTimeoutError, error_message
       else
-        error_message = json.fetch('errors', []).join(', ')
-        raise Error, "Received #{status} with error message: [#{error_message}] and id: '#{error_id}'"
+        raise Error, error_message
       end
+    end
+
+    def message(status, json)
+      id = json.fetch('id', 'NONE')
+      type = json.fetch('type', 'NONE')
+      errors = json.fetch('errors', []).join(', ')
+      "Received #{status} with error message: [#{errors}], type: '#{type}' and id: '#{id}'"
     end
 
 

--- a/spec/models/api/response_handler_spec.rb
+++ b/spec/models/api/response_handler_spec.rb
@@ -32,24 +32,24 @@ module Api
         error_message = 'something must be something, other thing must be this thing'
         expect {
           response_handler.handle_response(422, 200, json)
-        }.to raise_error Error, "Received 422 with error message: [#{error_message}] and id: 'NONE'"
+        }.to raise_error Error, "Received 422 with error message: [#{error_message}], type: 'NONE' and id: 'NONE'"
       end
       it 'errors when receiving 500 and empty JSON' do
         expect {
           response_handler.handle_response(500, 200, '')
-        }.to raise_error Error, 'Received 500 with error message: [] and id: \'NONE\''
+        }.to raise_error Error, 'Received 500 with error message: [], type: \'NONE\' and id: \'NONE\''
       end
 
       it 'raises an error when API response is not ok with message' do
         expect {
-          response_handler.handle_response(400, 200, '{"errors": ["Failure"]}')
-        }.to raise_error Error, 'Received 400 with error message: [Failure] and id: \'NONE\''
+          response_handler.handle_response(400, 200, '{"errors": ["Failure"], "type": "BAD THING"}')
+        }.to raise_error Error, 'Received 400 with error message: [Failure], type: \'BAD THING\' and id: \'NONE\''
       end
 
       it 'raises an error when API response is not ok with id' do
         expect {
           response_handler.handle_response(500, 200, '{"id": "1234"}')
-        }.to raise_error Error, 'Received 500 with error message: [] and id: \'1234\''
+        }.to raise_error Error, 'Received 500 with error message: [], type: \'NONE\' and id: \'1234\''
       end
 
 
@@ -62,21 +62,21 @@ module Api
       it 'raises an error when API response is not ok with JSON, but message missing' do
         expect {
           response_handler.handle_response(500, 200, '{}')
-        }.to raise_error Error, 'Received 500 with error message: [] and id: \'NONE\''
+        }.to raise_error Error, 'Received 500 with error message: [], type: \'NONE\' and id: \'NONE\''
       end
 
       it 'raises a session error' do
         error_body = { id: '0', type: 'SESSION_ERROR' }
         expect {
           response_handler.handle_response(400, 200, error_body.to_json)
-        }.to raise_error SessionError, 'Received 400 with type: \'SESSION_ERROR\' and id: \'0\''
+        }.to raise_error SessionError, 'Received 400 with error message: [], type: \'SESSION_ERROR\' and id: \'0\''
       end
 
       it 'raises a session timeout error' do
         error_body = { id: '0', type: 'SESSION_TIMEOUT' }
         expect {
           response_handler.handle_response(400, 200, error_body.to_json)
-        }.to raise_error SessionTimeoutError, 'Received 400 with type: \'SESSION_TIMEOUT\' and id: \'0\''
+        }.to raise_error SessionTimeoutError, 'Received 400 with error message: [], type: \'SESSION_TIMEOUT\' and id: \'0\''
       end
     end
   end


### PR DESCRIPTION
This commit introduces a more consistent approach to logging api errors. This
way we can ensure we get the full content of the error response.