### PR TITLE
3517: integrate raven into the rails logger

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -58,18 +58,17 @@ private
   end
 
   def session_timeout(exception)
-    logger.error(exception)
+    logger.info(exception)
     render_error('session_timeout', :forbidden)
   end
 
   def session_error(exception)
-    logger.error(exception)
+    logger.warn(exception)
     render_error('session_error', :bad_request)
   end
 
   def something_went_wrong(exception)
     logger.error(exception)
-    Raven.capture_exception(exception)
     render_error('something_went_wrong', :internal_server_error)
   end
 

--- a/config/initializers/raven.rb
+++ b/config/initializers/raven.rb
@@ -1,5 +1,9 @@
 require 'raven/processor/cookies'
+require 'support/raven/logger'
+
 Raven.configure do |config|
   config.ssl_verification = false
   config.processors << Raven::Processor::Cookies
 end
+
+Rails.logger.extend(ActiveSupport::Logger.broadcast(Support::Raven::Logger.new))

--- a/lib/support/raven/logger.rb
+++ b/lib/support/raven/logger.rb
@@ -1,0 +1,41 @@
+module Support
+  module Raven
+    class Logger < ::Logger
+      def initialize
+        super(nil)
+        @formatter = RavenFormatter.new
+        @logdev = RavenWriter.new
+      end
+
+      def add(severity, _exception = nil, _progname = nil, &block)
+        if severity >= ::Logger::ERROR
+          super
+        end
+        true
+      end
+
+      # A Formatter which returns an exception if its there
+      class RavenFormatter < ::Logger::Formatter
+        # This method is invoked when a log event occurs
+        def call(_severity, _timestamp, _progname, msg)
+          case msg
+          when ::Exception
+            msg
+          when String
+            msg
+          else
+            msg.inspect
+          end
+        end
+      end
+
+      class RavenWriter
+        def write(exception = nil)
+          unless exception.nil?
+            ::Raven.capture_exception(exception)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/support/raven/logger_spec.rb
+++ b/spec/lib/support/raven/logger_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+require 'logger'
+require 'support/raven/logger'
+
+describe Support::Raven::Logger do
+  let(:logger) { Support::Raven::Logger.new }
+  context "#error" do
+    it 'will send exceptions to sentry' do
+      raven = double(:raven)
+      stub_const("Raven", raven)
+      error = StandardError.new
+      expect(raven).to receive(:capture_exception).with(error)
+      logger.error(error)
+    end
+
+    it 'will send non-exceptions to sentry after inspection' do
+      raven = double(:raven)
+      stub_const("Raven", raven)
+      msg = double(:message)
+      inspected = double(:inspected)
+      expect(msg).to receive(:inspect).and_return inspected
+      expect(raven).to receive(:capture_exception).with(inspected)
+      logger.error(msg)
+    end
+
+    it 'will send string to sentry as string' do
+      raven = double(:raven)
+      stub_const("Raven", raven)
+      msg = "foobar"
+      expect(raven).to receive(:capture_exception).with(msg)
+      logger.error(msg)
+    end
+  end
+
+  context "not #error" do
+    it 'will not send non-error level exceptions to sentry' do
+      raven = double(:raven)
+      stub_const("Raven", raven)
+      error = StandardError.new
+      expect(raven).to_not receive(:capture_exception)
+      logger.warn(error)
+    end
+  end
+end


### PR DESCRIPTION
Now when we send error messages to the Rails logger they will be sent to Sentry
using Raven as well as our other loggers. This should allow us to not have to explicitly capture exceptions
where we are currently logging errors.

In order to integrate with the Rails logger we provider a logger for raven that
implements the ::Logger interface. It is then added to the Rails logger as an
additional output using ActiveSupport::Logger::broadcast.

Also, provided an integration test.