### PR TITLE
3517: Bar access when session is in completed state

### DIFF
--- a/app/models/cookie_validator.rb
+++ b/app/models/cookie_validator.rb
@@ -3,6 +3,7 @@ class CookieValidator
     @validators = [
       NoCookiesValidator.new,
       MissingCookiesValidator.new,
+      SessionIdCookieValidator.new,
       SessionStartTimeCookieValidator.new(session_duration)
     ]
   end

--- a/app/models/cookie_validator/session_id_cookie_validator.rb
+++ b/app/models/cookie_validator/session_id_cookie_validator.rb
@@ -1,0 +1,13 @@
+class CookieValidator
+  class SessionIdCookieValidator
+    NO_CURRENT_SESSION = 'no-current-session'.freeze
+    def validate(cookies)
+      session_id = cookies[::CookieNames::SESSION_ID_COOKIE_NAME]
+      if session_id == NO_CURRENT_SESSION
+        ValidationFailure.deleted_session
+      else
+        SuccessfulValidation
+      end
+    end
+  end
+end

--- a/app/models/cookie_validator/successful_validation.rb
+++ b/app/models/cookie_validator/successful_validation.rb
@@ -1,3 +1,3 @@
 class CookieValidator
-  SuccessfulValidation = Validation.new
+  SuccessfulValidation = Validation.new.freeze
 end

--- a/app/models/cookie_validator/validation_failure.rb
+++ b/app/models/cookie_validator/validation_failure.rb
@@ -19,6 +19,11 @@ class CookieValidator
       ValidationFailure.new(:something_went_wrong, :internal_server_error, message)
     end
 
+    DELETED_SESSION_MESSAGE = "Secure cookie was set to a deleted session value 'no-current-session', indicating a previously completed session.".freeze
+    def self.deleted_session
+      ValidationFailure.new(:something_went_wrong, :forbidden, DELETED_SESSION_MESSAGE)
+    end
+
     def initialize(type, status, message)
       @type = type
       @status = status

--- a/spec/models/cookie_validator_spec.rb
+++ b/spec/models/cookie_validator_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'models/cookie_validator'
+require 'models/cookie_validator/session_id_cookie_validator'
 require 'models/cookie_validator/session_start_time_cookie_validator'
 require 'models/cookie_validator/missing_cookies_validator'
 require 'models/cookie_validator/no_cookies_validator'
@@ -99,5 +100,13 @@ describe CookieValidator do
     expect(validation).to_not be_ok
     expect(validation.type).to eql :cookie_expired
     expect(validation.message).to eql 'session_start_time cookie for session "my-session-id" has expired'
+  end
+
+  it "will fail validation if session id cookie is set to 'no-current-session'" do
+    cookies[CookieNames::SESSION_ID_COOKIE_NAME] = 'no-current-session'
+    validation = cookie_validator.validate(cookies)
+    expect(validation).to_not be_ok
+    expect(validation.type).to eql :something_went_wrong
+    expect(validation.message).to eql "Secure cookie was set to a deleted session value 'no-current-session', indicating a previously completed session."
   end
 end


### PR DESCRIPTION
When a session is completed the sessionId is set to 'no-current-session' and
this should prevent a user from being view pages on the Hub.

Currently, this check is happening within our backend API and the FE is
receiving a 403 response, that's sent to Sentry, and which isn't very clear or
convenient.

By performing the check within the FE we remove the call to the API and the
Sentry output.