### PR TITLE
BAU: Remove duplicated code from IDP eligibility checker

### DIFF
--- a/app/models/evidence.rb
+++ b/app/models/evidence.rb
@@ -1,6 +1,0 @@
-module Evidence
-  PHONE_ATTRIBUTES = [:mobile_phone, :smart_phone, :landline].freeze
-  DOCUMENT_ATTRIBUTES = [:passport, :driving_licence, :non_uk_id_document].freeze
-
-  ALL_ATTRIBUTES = (PHONE_ATTRIBUTES + DOCUMENT_ATTRIBUTES).freeze
-end

--- a/app/models/idp_eligibility/checker.rb
+++ b/app/models/idp_eligibility/checker.rb
@@ -1,5 +1,7 @@
 module IdpEligibility
   class Checker
+    include Evidence
+
     def initialize(rules_repository)
       @rules_repository = rules_repository
     end
@@ -23,7 +25,7 @@ module IdpEligibility
   private
 
     def docs_only_mask
-      [:passport, :driving_licence, :non_uk_id_document].to_set
+      DOCUMENT_ATTRIBUTES.to_set
     end
 
     def idps_at_document_stage(evidence)

--- a/app/models/idp_eligibility/evidence.rb
+++ b/app/models/idp_eligibility/evidence.rb
@@ -1,0 +1,8 @@
+module IdpEligibility
+  module Evidence
+    PHONE_ATTRIBUTES = [:mobile_phone, :smart_phone, :landline].freeze
+    DOCUMENT_ATTRIBUTES = [:passport, :driving_licence, :non_uk_id_document].freeze
+
+    ALL_ATTRIBUTES = (PHONE_ATTRIBUTES + DOCUMENT_ATTRIBUTES).freeze
+  end
+end

--- a/app/models/select_documents_form.rb
+++ b/app/models/select_documents_form.rb
@@ -1,6 +1,6 @@
 class SelectDocumentsForm
   include ActiveModel::Model
-  include Evidence
+  include IdpEligibility::Evidence
 
   attr_reader :driving_licence, :passport, :non_uk_id_document, :no_documents
   validate :one_must_be_present

--- a/app/models/select_phone_form.rb
+++ b/app/models/select_phone_form.rb
@@ -1,6 +1,6 @@
 class SelectPhoneForm
   include ActiveModel::Model
-  include Evidence
+  include IdpEligibility::Evidence
 
   attr_reader :mobile_phone, :smart_phone, :landline
 

--- a/lib/evidence_query_string_parser.rb
+++ b/lib/evidence_query_string_parser.rb
@@ -1,5 +1,5 @@
 class EvidenceQueryStringParser
-  include Evidence
+  include IdpEligibility::Evidence
 
   def self.parse(query_string)
     result = []

--- a/spec/lib/evidence_query_string_parser_spec.rb
+++ b/spec/lib/evidence_query_string_parser_spec.rb
@@ -1,4 +1,3 @@
-require 'models/evidence'
 require 'evidence_query_string_parser'
 
 describe EvidenceQueryStringParser do

--- a/spec/models/evidence/select_documents_form_spec.rb
+++ b/spec/models/evidence/select_documents_form_spec.rb
@@ -1,6 +1,5 @@
 require 'spec_helper'
 require 'rails_helper'
-require 'evidence'
 
 module Evidence
   describe SelectDocumentsForm do


### PR DESCRIPTION
The IdpEligibility::Checker class defined a mask consisting of all the
document evidence. This was duplicated in Evidence::DOCUMENT_ATTRIBUTES
which would mean two places to maintain a list of document-related
evidence items. Evidence has now been made a submodule of
IdpEligibility which had the added bonus of removing some requires from
specs.

Author: @vixus0