### PR TITLE
BAU: Split feature test runs from other tests

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -2,10 +2,7 @@
 bundle
 export HEADLESS=true
 export DISPLAY=:0
-bundle exec govuk-lint-ruby app lib spec
-bundle exec govuk-lint-sass app/assets/stylesheets
-bundle exec rspec
-bundle exec rake spec:javascripts
+. ./pre-commit.sh
 RAILS_ENV=production dotenv bundle exec rake assets:precompile
 RAILS_ENV=production dotenv bundle exec rake tmp:clear
 

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -2,5 +2,6 @@
 
 bundle exec govuk-lint-ruby app config lib spec
 bundle exec govuk-lint-sass app/assets/stylesheets
-bundle exec rspec
+bundle exec rspec --exclude-pattern "spec/features/*_spec.rb"
+bundle exec rspec --pattern "spec/features/*_spec.rb"
 bundle exec rake spec:javascripts


### PR DESCRIPTION
Running all tests together would allow features tests to pass even if
they were missing require statements. This is because the require
statements were present in the unit tests, so the classes were already
available when feature tests ran.

e.g. Removing "require 'select_phone_form_mapper'" from
select_phone_controller would not cause failures when running
pre-commit.

Using the exclude pattern means that if any new test folders added, they
will get picked up in the normal test run.

Also changes jenkins.sh to use commands from pre-commit.sh

Author: @lloydnye