### PR TITLE
3491: introduce a separate checker for documents

### DIFF
--- a/app/controllers/select_documents_controller.rb
+++ b/app/controllers/select_documents_controller.rb
@@ -11,7 +11,7 @@ class SelectDocumentsController < ApplicationController
     if @form.valid?
       ANALYTICS_REPORTER.report(request, 'Select Documents Next')
       selected_evidence = @form.selected_evidence
-      if IDP_ELIGIBILITY_CHECKER.any_for_documents?(selected_evidence, available_idps)
+      if documents_eligibility_checker.any?(selected_evidence, available_idps)
         uri = URI(select_phone_path)
         uri.query = IdpEligibility::EvidenceQueryStringBuilder.build(selected_evidence)
         redirect_to uri.to_s
@@ -28,5 +28,9 @@ private
 
   def available_idps
     SESSION_PROXY.federation_info_for_session(cookies).idps.collect { |idp| idp['simpleId'] }
+  end
+
+  def documents_eligibility_checker
+    DOCUMENTS_ELIGIBILITY_CHECKER
   end
 end

--- a/app/controllers/select_phone_controller.rb
+++ b/app/controllers/select_phone_controller.rb
@@ -14,7 +14,7 @@ class SelectPhoneController < ApplicationController
     if @form.valid?
       ANALYTICS_REPORTER.report(request, 'Phone Next')
       selected_evidence = @form.selected_evidence.concat IdpEligibility::EvidenceQueryStringParser.parse(request.query_string)
-      if IDP_ELIGIBILITY_CHECKER.any?(selected_evidence, available_idps)
+      if idp_eligibility_checker.any?(selected_evidence, available_idps)
         redirect_to build_uri_with_evidence(will_it_work_for_me_path, selected_evidence)
       else
         redirect_to build_uri_with_evidence(no_mobile_phone_path, selected_evidence)
@@ -35,5 +35,9 @@ private
     uri = URI(path)
     uri.query = IdpEligibility::EvidenceQueryStringBuilder.build(evidence)
     uri.to_s
+  end
+
+  def idp_eligibility_checker
+    IDP_ELIGIBILITY_CHECKER
   end
 end

--- a/app/models/idp_eligibility/checker.rb
+++ b/app/models/idp_eligibility/checker.rb
@@ -16,28 +16,5 @@ module IdpEligibility
       recommended_idps = matching_idps.keys
       (recommended_idps & enabled_idps).length > 0
     end
-
-    def any_for_documents?(evidence, enabled_idps)
-      recommended_idps = idps_at_document_stage(evidence)
-      (recommended_idps & enabled_idps).length > 0
-    end
-
-  private
-
-    def docs_only_mask
-      DOCUMENT_ATTRIBUTES.to_set
-    end
-
-    def idps_at_document_stage(evidence)
-      evidence_set = evidence.to_set
-      matching_idps = @rules_repository.rules.select do |_, evidence_rule_collection|
-        evidence_rule_collection
-          .lazy
-          .map(&:to_set)
-          .map { |evidence_rule| evidence_rule & docs_only_mask }
-          .any? { |evidence_rule| evidence_rule.subset?(evidence_set) }
-      end
-      matching_idps.keys
-    end
   end
 end

--- a/app/models/idp_eligibility/document_checker.rb
+++ b/app/models/idp_eligibility/document_checker.rb
@@ -1,0 +1,9 @@
+module IdpEligibility
+  class DocumentChecker < DelegateClass(IdpEligibility::Checker)
+    def initialize(rules_repository)
+      attributes = Evidence::DOCUMENT_ATTRIBUTES
+      masking_rules_repository = IdpEligibility::MaskingRulesRepository.new(rules_repository, attributes)
+      super(IdpEligibility::Checker.new(masking_rules_repository))
+    end
+  end
+end

--- a/app/models/idp_eligibility/masking_rules_repository.rb
+++ b/app/models/idp_eligibility/masking_rules_repository.rb
@@ -1,0 +1,21 @@
+module IdpEligibility
+  class MaskingRulesRepository
+    attr_reader :rules
+    def initialize(repository, rule_mask)
+      @rules = apply_mask(repository.rules, rule_mask)
+    end
+
+  private
+
+    def apply_mask(unmasked_rules, rule_mask)
+      unmasked_rules.inject({}) { |masked_rules, (id, rule_collection)|
+        masked_rules[id] = apply_mask_to_collection(rule_collection, rule_mask)
+        masked_rules
+      }
+    end
+
+    def apply_mask_to_collection(collection, rule_mask)
+      collection.map { |evidence_rule| evidence_rule & rule_mask }
+    end
+  end
+end

--- a/app/models/idp_eligibility/rules_repository.rb
+++ b/app/models/idp_eligibility/rules_repository.rb
@@ -4,13 +4,13 @@ module IdpEligibility
 
     def initialize(rules_hash)
       @rules = {}
-      rules_hash.each { |simple_id, rules| @rules[simple_id] = symbolize_rules(rules) }
+      rules_hash.each { |simple_id, rules| @rules[simple_id] = symbolize_rules(rules).to_set }
     end
 
   private
 
     def symbolize_rules(rule_list)
-      rule_list.collect { |evidence| evidence.collect(&:to_sym) }
+      rule_list.collect { |evidence| evidence.collect(&:to_sym).to_set }
     end
   end
 end

--- a/config/initializers/idp_eligibility.rb
+++ b/config/initializers/idp_eligibility.rb
@@ -1,2 +1,4 @@
-RULES_REPOSITORY = IdpEligibility::RulesRepository.new(IdpEligibility::RulesLoader.load(CONFIG.rules_directory))
-IDP_ELIGIBILITY_CHECKER = IdpEligibility::Checker.new(RULES_REPOSITORY)
+rules_repository = IdpEligibility::RulesRepository.new(IdpEligibility::RulesLoader.load(CONFIG.rules_directory))
+
+DOCUMENTS_ELIGIBILITY_CHECKER = IdpEligibility::DocumentChecker.new(rules_repository)
+IDP_ELIGIBILITY_CHECKER = IdpEligibility::Checker.new(rules_repository)

--- a/spec/models/idp_eligibility/checker_spec.rb
+++ b/spec/models/idp_eligibility/checker_spec.rb
@@ -1,73 +1,23 @@
 require 'spec_helper'
 require 'models/idp_eligibility/checker'
-module IdpEligibility
-  describe Checker do
-    let(:rules_repository) { double(:rules_repository) }
-    before(:each) { @checker = Checker.new(rules_repository) }
+require 'set'
 
-    describe '#any?' do
+module IdpEligibility
+  RSpec.describe Checker do
+    let(:rules_repository) { double(:rules_repository) }
+    let(:checker) { Checker.new(rules_repository) }
+
+    context '#any?' do
       it 'should return true when user has evidence accepted by an idp' do
         allow(rules_repository).to receive(:rules).and_return('idp' => [[:mobile_phone]])
         user_evidence = [:mobile_phone]
-        expect(@checker.any?(user_evidence, ['idp'])).to be_truthy
+        expect(checker.any?(user_evidence, ['idp'])).to be_truthy
       end
 
       it 'should return false when user does not have evidence accepted by any idp' do
         allow(rules_repository).to receive(:rules).and_return('idp' => [[:mobile_phone]])
         user_evidence = [:landline]
-        expect(@checker.any?(user_evidence, ['idp'])).to be_falsey
-      end
-    end
-
-    describe '#any_for_documents?' do
-      it 'should return false when no idp rules are set up' do
-        allow(rules_repository).to receive(:rules).and_return({})
-        user_docs = [:passport]
-        expect(@checker.any_for_documents?(user_docs, ['idp'])).to be_falsey
-      end
-
-      it 'should return false when user has no documents matching rules' do
-        allow(rules_repository).to receive(:rules).and_return('licence-accepting-idp' => [[:driving_licence]])
-        user_docs = []
-        expect(@checker.any_for_documents?(user_docs, ['licence-accepting-idp'])).to be_falsey
-      end
-
-      it 'should return true when user has evidence accepted by an idp' do
-        allow(rules_repository).to receive(:rules).and_return('licence-accepting-idp' => [[:driving_licence]])
-        user_docs = [:driving_licence]
-        expect(@checker.any_for_documents?(user_docs, ['licence-accepting-idp'])).to be_truthy
-      end
-
-      it 'should return true when user has no docs and idp accepts no docs' do
-        allow(rules_repository).to receive(:rules).and_return('no-doc-accepting-idp' => [[]])
-        user_docs = []
-        expect(@checker.any_for_documents?(user_docs, ['no-doc-accepting-idp'])).to be_truthy
-      end
-
-      it 'should return false when user has a document that does not match rules' do
-        allow(rules_repository).to receive(:rules).and_return('licence-accepting-idp' => [[:driving_licence]])
-        user_docs = [:passport]
-        expect(@checker.any_for_documents?(user_docs, ['licence-accepting-idp'])).to be_falsey
-      end
-
-      it 'should ignore non document stage requirements' do
-        allow(rules_repository).to receive(:rules).and_return('licence-accepting-idp' => [[:hat, :driving_licence]])
-        user_docs = [:driving_licence]
-        expect(@checker.any_for_documents?(user_docs, ['licence-accepting-idp'])).to be_truthy
-      end
-
-      it 'should work when no idps are enabled' do
-        enabled_idps = []
-        allow(rules_repository).to receive(:rules).and_return('no-doc-accepting-idp' => [[]])
-        user_docs = []
-        expect(@checker.any_for_documents?(user_docs, enabled_idps)).to be_falsey
-      end
-
-      it 'should exclude idps that are not enabled' do
-        enabled_idps = ['idp']
-        allow(rules_repository).to receive(:rules).and_return('no-doc-accepting-idp' => [[]])
-        user_docs = []
-        expect(@checker.any_for_documents?(user_docs, enabled_idps)).to be_falsey
+        expect(checker.any?(user_evidence, ['idp'])).to be_falsey
       end
     end
   end

--- a/spec/models/idp_eligibility/document_checker_spec.rb
+++ b/spec/models/idp_eligibility/document_checker_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+require 'models/idp_eligibility/checker'
+require 'models/idp_eligibility/masking_rules_repository'
+require 'models/idp_eligibility/document_checker'
+require 'models/idp_eligibility/evidence'
+require 'set'
+
+module IdpEligibility
+  RSpec.describe DocumentChecker do
+    let(:rules_repository) { double(:rules_repository) }
+    let(:checker) { DocumentChecker.new(rules_repository) }
+
+    context '#any?' do
+      it 'should return false when no idp rules are set up' do
+        allow(rules_repository).to receive(:rules).and_return({})
+        user_docs = [:passport]
+        expect(checker.any?(user_docs, ['idp'])).to be_falsey
+      end
+
+      it 'should return false when user has no documents matching rules' do
+        allow(rules_repository).to receive(:rules).and_return('licence-accepting-idp' => [[:driving_licence]])
+        user_docs = []
+        expect(checker.any?(user_docs, ['licence-accepting-idp'])).to be_falsey
+      end
+
+      it 'should return true when user has evidence accepted by an idp' do
+        allow(rules_repository).to receive(:rules).and_return('licence-accepting-idp' => [[:driving_licence]])
+        user_docs = [:driving_licence]
+        expect(checker.any?(user_docs, ['licence-accepting-idp'])).to be_truthy
+      end
+
+      it 'should return true when user has no docs and idp accepts no docs' do
+        allow(rules_repository).to receive(:rules).and_return('no-doc-accepting-idp' => [[]])
+        user_docs = []
+        expect(checker.any?(user_docs, ['no-doc-accepting-idp'])).to be_truthy
+      end
+
+      it 'should return false when user has a document that does not match rules' do
+        allow(rules_repository).to receive(:rules).and_return('licence-accepting-idp' => [[:driving_licence]])
+        user_docs = [:passport]
+        expect(checker.any?(user_docs, ['licence-accepting-idp'])).to be_falsey
+      end
+
+      it 'should ignore non document stage requirements' do
+        allow(rules_repository).to receive(:rules).and_return('licence-accepting-idp' => [[:hat, :driving_licence]])
+        user_docs = [:driving_licence]
+        expect(checker.any?(user_docs, ['licence-accepting-idp'])).to be_truthy
+      end
+
+      it 'should work when no idps are enabled' do
+        allow(rules_repository).to receive(:rules).and_return('no-doc-accepting-idp' => [[]])
+      end
+    end
+  end
+end

--- a/spec/models/idp_eligibility/masking_rules_repository_spec.rb
+++ b/spec/models/idp_eligibility/masking_rules_repository_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+require 'models/idp_eligibility/masking_rules_repository'
+
+module IdpEligibility
+  RSpec.describe MaskingRulesRepository do
+    it 'applies a mask of whitelisted attributes to every rule contained within an exisiting repository' do
+      mask = %w{passport driving_licence}
+      rule_repository = double(:rule_repository)
+      unmasked = {
+        'idp_one' => [%w{passport mobile_phone}, %w{driving_licence landline}, %w{mobile_phone landline}],
+        'idp_two' => [%w{passport driving_licence}, %w{mobile_phone smart_phone}]
+      }
+      expect(rule_repository).to receive(:rules).and_return(unmasked)
+      expected = {
+        'idp_one' => [%w{passport}, %w{driving_licence}, []],
+        'idp_two' => [%w{passport driving_licence}, []]
+      }
+      expect(MaskingRulesRepository.new(rule_repository, mask).rules).to eql expected
+    end
+  end
+end

--- a/spec/models/idp_eligibility/rules_repository_spec.rb
+++ b/spec/models/idp_eligibility/rules_repository_spec.rb
@@ -7,7 +7,7 @@ module IdpEligibility
       it 'should convert idp rules to symbols' do
         rules_hash = { 'example-idp' => [%w(passport driving_licence)] }
         repository = RulesRepository.new(rules_hash)
-        expect(repository.rules).to eql('example-idp' => [[:passport, :driving_licence]])
+        expect(repository.rules).to eql('example-idp' => [[:passport, :driving_licence].to_set].to_set)
       end
     end
   end


### PR DESCRIPTION
Document eligibility checking is now performed using a separate checker `DocumentChecker`.

This checker works by applying an attributes mask to the rules defined by its supplied `RuleRepository` through `MaskingRulesRepository`. The masked rules are then supplied to the regular checker as it is a delegate of the `DocumentChecker`.

NOTE: I'm unsure about using DelegateClass here for the document checker. We could probably just use plain old inheritence, but I wanted to imply that the `DocumentChecker` was composed of the `Checker`, `MaskingRulesRepository` and the attribute masked which I think using inheritance confuses things.