### PR TITLE
3531: Include selected evidence in query params

### DIFF
--- a/app/controllers/select_phone_controller.rb
+++ b/app/controllers/select_phone_controller.rb
@@ -15,11 +15,9 @@ class SelectPhoneController < ApplicationController
       ANALYTICS_REPORTER.report(request, 'Phone Next')
       selected_evidence = @form.selected_evidence.concat IdpEligibility::EvidenceQueryStringParser.parse(request.query_string)
       if IDP_ELIGIBILITY_CHECKER.any?(selected_evidence, available_idps)
-        uri = URI(will_it_work_for_me_path)
-        uri.query = IdpEligibility::EvidenceQueryStringBuilder.build(selected_evidence)
-        redirect_to uri.to_s
+        redirect_to build_uri_with_evidence(will_it_work_for_me_path, selected_evidence)
       else
-        redirect_to no_mobile_phone_path
+        redirect_to build_uri_with_evidence(no_mobile_phone_path, selected_evidence)
       end
     else
       flash.now[:errors] = @form.errors.full_messages.join(', ')
@@ -31,5 +29,11 @@ private
 
   def available_idps
     SESSION_PROXY.federation_info_for_session(cookies).idps.collect { |idp| idp['simpleId'] }
+  end
+
+  def build_uri_with_evidence(path, evidence)
+    uri = URI(path)
+    uri.query = IdpEligibility::EvidenceQueryStringBuilder.build(evidence)
+    uri.to_s
   end
 end

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -112,7 +112,7 @@ cy:
     no_mobile_phone:
       title: Other ways to access the service
       heading: GOV.UK Verify won’t work for you
-      p1: You need a phone or tablet to use GOV.UK Verify. If you don’t have either of these, there are other ways you can %{other_ways_description}
+      p1: You need a phone or tablet to use GOV.UK Verify. If you don’t have either of these, there are other ways you can %{other_ways_description}.
       p2: If you don’t have a passport or UK driving licence, you will also need to install an app.
       other_ways_heading: Other ways to %{other_ways_description}
   errors:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -107,7 +107,7 @@ en:
     no_mobile_phone:
       title: Other ways to access the service
       heading: GOV.UK Verify won’t work for you
-      p1: You need a phone or tablet to use GOV.UK Verify. If you don’t have either of these, there are other ways you can %{other_ways_description}
+      p1: You need a phone or tablet to use GOV.UK Verify. If you don’t have either of these, there are other ways you can %{other_ways_description}.
       p2: If you don’t have a passport or UK driving licence, you will also need to install an app.
       other_ways_heading: Other ways to %{other_ways_description}
   errors:

--- a/spec/features/user_visits_no_mobile_phone_page_spec.rb
+++ b/spec/features/user_visits_no_mobile_phone_page_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe 'When the user visits the select phone page' do
   it 'includes other ways text' do
     visit '/no-mobile-phone'
 
-    expect(page).to have_content('Other ways text')
-    expect(page).to have_content('Other ways description')
-    expect(page).to have_css('a[href=\'http://www.example.com\']', 'with a link')
+    expect(page).to have_content("If you can't verify your identity using GOV.UK Verify, you can register for an identity profile here")
+    expect(page).to have_content('register for an identity profile')
+    expect(page).to have_css('a[href=\'http://www.example.com\']', 'here')
   end
 end

--- a/spec/features/user_visits_select_phone_page_spec.rb
+++ b/spec/features/user_visits_select_phone_page_spec.rb
@@ -17,17 +17,6 @@ RSpec.describe 'When the user visits the select phone page' do
 
       expect(page).to have_current_path(will_it_work_for_me_path, only_path: true)
     end
-
-    it 'redirects to the no mobile phone page when no idps can verify' do
-      stub_federation
-      visit '/select-phone?selected-evidence=passport&selected-evidence=driving_licence'
-
-      choose 'select_phone_form_mobile_phone_false'
-      choose 'select_phone_form_landline_false'
-      click_button 'Continue'
-
-      expect(page).to have_current_path(no_mobile_phone_path, only_path: true)
-    end
   end
 
   context 'with javascript enabled', js: true do
@@ -51,6 +40,18 @@ RSpec.describe 'When the user visits the select phone page' do
 
       expect(page).to have_current_path(select_phone_path, only_path: true)
       expect(page).to have_css '#validation-error-message-js', text: 'Please answer all the questions'
+    end
+
+    it 'redirects to the no mobile phone page when no idps can verify' do
+      stub_federation
+      visit '/select-phone?selected-evidence=passport&selected-evidence=driving_licence&selected-evidence=non_uk_id_document'
+
+      choose 'select_phone_form_mobile_phone_false'
+      choose 'select_phone_form_landline_false'
+      click_button 'Continue'
+
+      expect(page).to have_current_path(no_mobile_phone_path, only_path: true)
+      expect(query_params['selected-evidence'].to_set).to eql %w(passport driving_licence non_uk_id_document).to_set
     end
   end
 

--- a/stub/locales/rps/test-rp.yml
+++ b/stub/locales/rps/test-rp.yml
@@ -3,5 +3,5 @@ en:
     test-rp:
       name: Register for an identity profile
       analyticsDescription: analytics description for test-rp
-      other_ways_text: Other ways text <a href='http://www.example.com'>with a link</a>
-      other_ways_description: Other ways description
+      other_ways_text: If you can't verify your identity using GOV.UK Verify, you can register for an identity profile <a href='http://www.example.com'>here</a>.
+      other_ways_description: register for an identity profile


### PR DESCRIPTION
When redirecting to the "no mobile phone" dead-end page, the "select
phone" page needs to include the user's selected evidence in the query
params, to preserve the behaviour of the old front-end for analytics