### PR TITLE
Revert "3531: Enable localised route for no mobile phone"

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,7 +29,6 @@ Rails.application.routes.draw do
     post 'select_documents', to: 'select_documents#select_documents', as: :select_documents_submit
     get 'select_phone', to: 'select_phone#index', as: :select_phone
     post 'select_phone', to: 'select_phone#select_phone', as: :select_phone_submit
-    get 'no_mobile_phone', to: 'no_mobile_phone#index', as: :no_mobile_phone
   end
 
   get '/redirect-to-service/error', to: redirect("#{API_HOST}/redirect-to-service/error")
@@ -41,6 +40,7 @@ Rails.application.routes.draw do
   post 'select-phone', to: 'select_phone#select_phone', as: :select_phone_submit
   get 'will-it-work-for-me', to: 'will_it_work_for_me#index', as: :will_it_work_for_me
   post 'will-it-work-for-me', to: 'will_it_work_for_me#will_it_work_for_me', as: :will_it_work_for_me_submit
+  get 'no-mobile-phone', to: 'no_mobile_phone#index', as: :no_mobile_phone
 
   if Rails.env == 'development'
     get 'confirm-your-identity', to: redirect("#{API_HOST}/confirm-your-identity"), as: :confirm_your_identity

--- a/spec/features/user_visits_no_mobile_phone_page_spec.rb
+++ b/spec/features/user_visits_no_mobile_phone_page_spec.rb
@@ -6,16 +6,6 @@ RSpec.describe 'When the user visits the select phone page' do
     stub_federation
   end
 
-  it 'displays the page in Welsh' do
-    visit '/no-mobile-phone-cy'
-    expect(page).to have_css 'html[lang=cy]'
-  end
-
-  it 'displays the page in English' do
-    visit '/no-mobile-phone'
-    expect(page).to have_css 'html[lang=en]'
-  end
-
   it 'includes the appropriate feedback source' do
     visit '/no-mobile-phone'
 


### PR DESCRIPTION
This was merged prematurely. We need to release without these changes to prevent 404 errors.

Reverts alphagov/verify-frontend#64