### PR TITLE
3568: start storing evidence answers in session cookie

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -40,6 +40,18 @@ class ApplicationController < ActionController::Base
     }
   end
 
+  def store_selected_evidence(hash)
+    stored_selected_evidence.merge!(hash)
+  end
+
+  def stored_selected_evidence
+    session[:selected_evidence] ||= {}
+  end
+
+  def selected_evidence_values
+    stored_selected_evidence.values.flatten
+  end
+
 private
 
   def render_error(partial, status)

--- a/app/controllers/saml_controller.rb
+++ b/app/controllers/saml_controller.rb
@@ -3,6 +3,7 @@ class SamlController < ApplicationController
   skip_before_action :validate_cookies
 
   def request_post
+    reset_session
     cookies_from_api = authn_request_proxy.create_session(params['SAMLRequest'], params['RelayState'])
     cookies_from_api.each { |name, value| set_secure_cookie(name, value) }
     if params['journey_hint'].present?

--- a/app/controllers/select_documents_controller.rb
+++ b/app/controllers/select_documents_controller.rb
@@ -11,6 +11,7 @@ class SelectDocumentsController < ApplicationController
     if @form.valid?
       ANALYTICS_REPORTER.report(request, 'Select Documents Next')
       selected_evidence = @form.selected_evidence
+      store_selected_evidence(documents: selected_evidence)
       if documents_eligibility_checker.any?(selected_evidence, available_idps)
         uri = URI(select_phone_path)
         uri.query = IdpEligibility::EvidenceQueryStringBuilder.build(selected_evidence)

--- a/app/controllers/select_phone_controller.rb
+++ b/app/controllers/select_phone_controller.rb
@@ -13,7 +13,9 @@ class SelectPhoneController < ApplicationController
     @form = SelectPhoneForm.new(SelectPhoneFormMapper.map(params))
     if @form.valid?
       ANALYTICS_REPORTER.report(request, 'Phone Next')
-      selected_evidence = @form.selected_evidence.concat IdpEligibility::EvidenceQueryStringParser.parse(request.query_string)
+      selected_phone_evidence = @form.selected_evidence
+      store_selected_evidence(phone: selected_phone_evidence)
+      selected_evidence = selected_phone_evidence + IdpEligibility::EvidenceQueryStringParser.parse(request.query_string)
       if idp_eligibility_checker.any?(selected_evidence, available_idps)
         redirect_to build_uri_with_evidence(will_it_work_for_me_path, selected_evidence)
       else

--- a/spec/feature_helper.rb
+++ b/spec/feature_helper.rb
@@ -77,7 +77,7 @@ def cookie_value(cookie_name)
     end
     journey_hint_cookie[:value]
   else
-    Capybara.current_session.driver.request.cookies[cookie_name]
+    Capybara.current_session.driver.request.cookies.fetch(cookie_name)
   end
 end
 
@@ -102,4 +102,33 @@ end
 def query_params
   current_uri = URI.parse(page.current_url)
   current_uri.query ? CGI::parse(current_uri.query) : {}
+end
+
+def decrypt_session_cookie(cookie)
+  cookie = CGI.unescape(cookie)
+  config = Rails.application.config
+  secrets = Rails.application.secrets
+
+  encrypted_cookie_salt = config.action_dispatch.encrypted_cookie_salt # "encrypted cookie" by default
+  encrypted_signed_cookie_salt = config.action_dispatch.encrypted_signed_cookie_salt # "signed encrypted cookie" by default
+
+  key_generator = ActiveSupport::KeyGenerator.new(secrets.secret_key_base, iterations: 1000)
+  secret = key_generator.generate_key(encrypted_cookie_salt)
+  sign_secret = key_generator.generate_key(encrypted_signed_cookie_salt)
+
+  serializer = ActionDispatch::Cookies::JsonSerializer
+
+  encryptor = ActiveSupport::MessageEncryptor.new(secret, sign_secret, serializer: serializer)
+  encryptor.decrypt_and_verify(cookie)
+end
+
+def current_session
+  session_key = Rails
+    .application
+    .config
+    .session_options
+    .fetch(:key)
+
+  session_cookie = cookie_value(session_key)
+  decrypt_session_cookie(session_cookie)
 end

--- a/spec/features/user_visits_select_documents_page_spec.rb
+++ b/spec/features/user_visits_select_documents_page_spec.rb
@@ -1,7 +1,7 @@
 require 'feature_helper'
 require 'i18n'
 
-RSpec.describe 'When the user visits the select documents page' do
+RSpec.feature 'When the user visits the select documents page' do
   before(:each) do
     set_session_cookies!
   end
@@ -26,6 +26,7 @@ RSpec.describe 'When the user visits the select documents page' do
     click_button 'Continue'
 
     expect(page).to have_current_path(select_phone_path, only_path: true)
+    expect(current_session["selected_evidence"]).to eql("documents" => %w{driving_licence})
   end
 
   it 'redirects to the select phone page when no docs checked' do

--- a/spec/features/user_visits_select_phone_page_spec.rb
+++ b/spec/features/user_visits_select_phone_page_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe 'When the user visits the select phone page' do
 
       expect(page).to have_current_path(will_it_work_for_me_path, only_path: true)
       expect(query_params['selected-evidence'].to_set).to eql %w(mobile_phone smart_phone passport driving_licence).to_set
+      expect(current_session['selected_evidence']).to eql('phone' => %w{mobile_phone smart_phone})
     end
 
     it 'should display a validation message when user does not answer mobile phone question' do
@@ -52,6 +53,7 @@ RSpec.describe 'When the user visits the select phone page' do
 
       expect(page).to have_current_path(no_mobile_phone_path, only_path: true)
       expect(query_params['selected-evidence'].to_set).to eql %w(passport driving_licence non_uk_id_document).to_set
+      expect(current_session['selected_evidence']).to eql('phone' => [])
     end
   end
 


### PR DESCRIPTION
Stores the selected evidence answers in the session, but for now they will not
be read anywhere in the application.

The intention is that we will use the session store to remove the use of the
propagated query params.

Answers are currently stored and associated with a key for the type of
evidence/page they are related to. This way we should be given a guarantee that
only the most recent answers to questions are stored in the cache.