### PR TITLE
3342: Move HTML formatting into localisation file

### DIFF
--- a/app/views/why_companies/index.html.erb
+++ b/app/views/why_companies/index.html.erb
@@ -4,14 +4,8 @@
 <div class="grid-row">
   <div class="column-two-thirds">
     <%= link_to t('navigation.back'), @choose_a_certified_company_link, class: 'link-back' %>
-
     <h1 class="heading-large"><%= t('hub.why_companies.title') %></h1>
-
-    <p><%= t('hub.why_companies.content.p1') %></p>
-    <p><%= t('hub.why_companies.content.p2') %></p>
-    <p><%= t('hub.why_companies.content.p3') %></p>
-    <p><%= t('hub.why_companies.content.p4') %></p>
-    <p><%= t('hub.why_companies.content.p5') %></p>
-    <p><%= link_to(t('hub.why_companies.content.choose_a_company'), @choose_a_certified_company_link) %></p>
+    <%= t('hub.why_companies.content_html') %>
+    <p><%= link_to(t('hub.why_companies.choose_a_company'), @choose_a_certified_company_link) %></p>
   </div>
 </div>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -180,13 +180,13 @@ cy:
         close: close
     why_companies:
       title: Why there’s a choice of companies
-      content:
-        p1: More certified companies means a more secure system - information is not stored in one place, but is split up in lots of different places, making it safer.
-        p2: It’s your right to choose who you want to deal with from these companies. It’s also your right to change which company you deal with at any time.
-        p3: When verifying your identity, these companies can use their own records, and they’re certified to access information like credit records. They do this to check information you provide from passports and driving licences is correct.
-        p4: Certified companies meet strict government privacy standards, so you can trust them with your information. They won’t use your information for any other purpose without your consent.
-        p5: There’s no effect on your credit score.
-        choose_a_company: Choose a company
+      choose_a_company: Choose a company
+      content_html: |
+        <p>More certified companies means a more secure system - information is not stored in one place, but is split up in lots of different places, making it safer.</p>
+        <p>It’s your right to choose who you want to deal with from these companies. It’s also your right to change which company you deal with at any time.</p>
+        <p>When verifying your identity, these companies can use their own records, and they’re certified to access information like credit records. They do this to check information you provide from passports and driving licences is correct.</p>
+        <p>Certified companies meet strict government privacy standards, so you can trust them with your information. They won’t use your information for any other purpose without your consent.</p>
+        <p>There’s no effect on your credit score.</p>
   errors:
     transaction_list:
       title: Dod o hyd i'r gwasanaeth rydych yn ei ddefnyddio i ddechrau eto

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -177,13 +177,13 @@ en:
         close: close
     why_companies:
       title: Why there’s a choice of companies
-      content:
-        p1: More certified companies means a more secure system - information is not stored in one place, but is split up in lots of different places, making it safer.
-        p2: It’s your right to choose who you want to deal with from these companies. It’s also your right to change which company you deal with at any time.
-        p3: When verifying your identity, these companies can use their own records, and they’re certified to access information like credit records. They do this to check information you provide from passports and driving licences is correct.
-        p4: Certified companies meet strict government privacy standards, so you can trust them with your information. They won’t use your information for any other purpose without your consent.
-        p5: There’s no effect on your credit score.
-        choose_a_company: Choose a company
+      choose_a_company: Choose a company
+      content_html: |
+        <p>More certified companies means a more secure system - information is not stored in one place, but is split up in lots of different places, making it safer.</p>
+        <p>It’s your right to choose who you want to deal with from these companies. It’s also your right to change which company you deal with at any time.</p>
+        <p>When verifying your identity, these companies can use their own records, and they’re certified to access information like credit records. They do this to check information you provide from passports and driving licences is correct.</p>
+        <p>Certified companies meet strict government privacy standards, so you can trust them with your information. They won’t use your information for any other purpose without your consent.</p>
+        <p>There’s no effect on your credit score.</p>
   errors:
     transaction_list:
       title: Find the service you were using to start again


### PR DESCRIPTION
The template shouldn't constrain how the content for the why-companies
page can be formatted (within reason).

Author: @vixus0