### PR TITLE
3530: Add dead-end page for no documents

### DIFF
--- a/app/controllers/unlikely_to_verify_controller.rb
+++ b/app/controllers/unlikely_to_verify_controller.rb
@@ -1,4 +1,7 @@
 class UnlikelyToVerifyController < ApplicationController
   def index
+    transaction_details = TRANSACTION_INFO_GETTER.get_info(cookies)
+    @other_ways_description = transaction_details.other_ways_description
+    @other_ways_text = transaction_details.other_ways_text
   end
 end

--- a/app/views/unlikely_to_verify/index.html.erb
+++ b/app/views/unlikely_to_verify/index.html.erb
@@ -1,0 +1,12 @@
+<% content_for :page_title, t('hub.unlikely_to_verify.title') %>
+<% content_for :feedback_source, 'UNLIKELY_TO_VERIFY_PAGE' %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <h1 class="heading-xlarge"><%= t 'hub.unlikely_to_verify.heading' %></h1>
+
+    <p><%= t 'hub.unlikely_to_verify.explanation' %></p>
+    <%= render partial: 'shared/other_ways', locals: {other_ways_text: @other_ways_text, other_ways_description: @other_ways_description} %>
+  </div>
+</div>
+

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -15,6 +15,7 @@ cy:
     will_not_work_without_uk_address: will-not-work-without-uk-address-cy
     choose_a_certified_company: choose-a-certified-company-cy
     why_companies: why-companies-cy
+    unlikely_to_verify: unlikely-to-verify-cy
   navigation:
     next: Nesaf
     start_now: Dechreuwch nawr
@@ -191,6 +192,10 @@ cy:
         <p>When verifying your identity, these companies can use their own records, and they’re certified to access information like credit records. They do this to check information you provide from passports and driving licences is correct.</p>
         <p>Certified companies meet strict government privacy standards, so you can trust them with your information. They won’t use your information for any other purpose without your consent.</p>
         <p>There’s no effect on your credit score.</p>
+    unlikely_to_verify:
+      title: Other ways to access the service
+      heading: GOV.UK Verify won’t work for you
+      explanation: You need a valid passport, photocard driving licence or national identity card (ID card) to get your identity verified.
   errors:
     transaction_list:
       title: Dod o hyd i'r gwasanaeth rydych yn ei ddefnyddio i ddechrau eto

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -15,6 +15,7 @@ en:
     will_not_work_without_uk_address: will-not-work-without-uk-address
     choose_a_certified_company: choose-a-certified-company
     why_companies: why-companies
+    unlikely_to_verify: unlikely-to-verify
   navigation:
     next: Next
     start_now: Start now
@@ -185,6 +186,10 @@ en:
         <p>When verifying your identity, these companies can use their own records, and they’re certified to access information like credit records. They do this to check information you provide from passports and driving licences is correct.</p>
         <p>Certified companies meet strict government privacy standards, so you can trust them with your information. They won’t use your information for any other purpose without your consent.</p>
         <p>There’s no effect on your credit score.</p>
+    unlikely_to_verify:
+      title: Other ways to access the service
+      heading: GOV.UK Verify won’t work for you
+      explanation: You need a valid passport, photocard driving licence or national identity card (ID card) to get your identity verified.
   errors:
     transaction_list:
       title: Find the service you were using to start again

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,7 @@ Rails.application.routes.draw do
     get 'choose_a_certified_company', to: 'choose_a_certified_company#index', as: :choose_a_certified_company
     post 'choose_a_certified_company', to: 'choose_a_certified_company#select_idp', as: :choose_a_certified_company_submit
     get 'why_companies', to: 'why_companies#index', as: :why_companies
+    get 'unlikely_to_verify', to: 'unlikely_to_verify#index', as: :unlikely_to_verify
   end
 
   get '/redirect-to-service/error', to: redirect("#{API_HOST}/redirect-to-service/error")
@@ -52,7 +53,6 @@ Rails.application.routes.draw do
     get 'privacy-notice', to: redirect("#{API_HOST}/privacy-notice"), as: :privacy_notice
     get 'cookies', to: redirect("#{API_HOST}/cookies"), as: :cookies
     get 'forgot-company', to: redirect("#{API_HOST}/forgot-company"), as: :forgot_company
-    get 'unlikely-to-verify', to: redirect("#{API_HOST}/unlikely-to-verify"), as: :unlikely_to_verify
     get 'redirect-to-idp-warning', to: redirect("#{API_HOST}/redirect-to-idp-warning"), as: :redirect_to_idp_warning
   else
     get 'confirm-your-identity', to: 'confirm_your_identity#index', as: :confirm_your_identity
@@ -60,7 +60,6 @@ Rails.application.routes.draw do
     get 'privacy-notice', to: 'privacy_notice#index', as: :privacy_notice
     get 'cookies', to: 'cookies#index', as: :cookies
     get 'forgot-company', to: 'forgot_company#index', as: :forgot_company
-    get 'unlikely-to-verify', to: 'unlikely_to_verify#index', as: :unlikely_to_verify
     get 'redirect-to-idp-warning', to: 'redirect_to_idp_warning#index', as: :redirect_to_idp_warning
   end
 

--- a/spec/features/user_visits_unlikely_to_verify_page_spec.rb
+++ b/spec/features/user_visits_unlikely_to_verify_page_spec.rb
@@ -1,0 +1,34 @@
+require 'feature_helper'
+
+RSpec.describe 'When the user visits the unlikely-to-verify page' do
+  before(:each) do
+    set_session_cookies!
+    stub_federation
+  end
+
+  it 'displays the page in Welsh' do
+    visit '/unlikely-to-verify-cy'
+    expect(page).to have_content('You need a valid passport, photocard driving licence or national identity card (ID card) to get your identity verified.')
+    expect(page).to have_css 'html[lang=cy]'
+  end
+
+  it 'displays the page in English' do
+    visit '/unlikely-to-verify'
+    expect(page).to have_content('You need a valid passport, photocard driving licence or national identity card (ID card) to get your identity verified.')
+    expect(page).to have_css 'html[lang=en]'
+  end
+
+  it 'includes other ways text' do
+    visit '/unlikely-to-verify'
+
+    expect(page).to have_content("If you can't verify your identity using GOV.UK Verify, you can register for an identity profile here")
+    expect(page).to have_content('register for an identity profile')
+    expect(page).to have_link 'here', href: 'http://www.example.com'
+  end
+
+  it 'includes the appropriate feedback source' do
+    visit '/unlikely-to-verify'
+
+    expect_feedback_source_to_be(page, 'UNLIKELY_TO_VERIFY_PAGE')
+  end
+end


### PR DESCRIPTION
This adds the dead-end page that the user will see if no IdPs can verify
at the 'select documents' stage.  It's not currently possible to hit
this page because at least one IdP can verify with no documents, but
it's good to have this page as a fall-back in case that changes.