### PR TITLE
1977: fix about page title

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -55,7 +55,7 @@ cy:
     privacy_notice:
       title: Hysbysiad preifatrwydd
     about:
-      title: Am sicrwydd hunaniaeth
+      title: Am GOV.UK Verify
       verify_is_a_scheme: Mae GOV.UK Verify yn gynllun i frwydro yn erbyn y broblem gynyddol o ddwyn hunaniaeth ar-lein.
       its_secure: Mae'n ddiogel, ac yn atal rhywun rhag esgus bod yn chi.
     about_certified_companies:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -52,7 +52,7 @@ en:
     privacy_notice:
       title: Privacy notice
     about:
-      title: About identity assurance
+      title: About GOV.UK Verify
       verify_is_a_scheme: GOV.UK Verify is a scheme to fight the growing problem of online identity theft.
       its_secure: It’s secure, and stops someone from pretending to be you.
     about_certified_companies:


### PR DESCRIPTION
‘identity assurance’ should be ‘GOV.UK Verify’ on the about page title.