### PR TITLE
3559 fix fingerprint test issues

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,6 +67,7 @@ end
 group :test, :development do
   gem 'rspec-rails', '~> 3.4.0'
   gem 'capybara', '~> 2.6'
+  gem 'capybara-puma'
   gem 'govuk-lint'
   gem 'webmock', require: false
   gem 'rack-test'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,6 +50,9 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    capybara-puma (1.0.1)
+      capybara
+      puma
     childprocess (0.5.9)
       ffi (~> 1.0, >= 1.0.11)
     concurrent-ruby (1.0.1)
@@ -270,6 +273,7 @@ PLATFORMS
 DEPENDENCIES
   byebug
   capybara (~> 2.6)
+  capybara-puma
   connection_pool
   dotenv-rails
   govuk-lint

--- a/spec/features/requests_fingerprint_asset_spec.rb
+++ b/spec/features/requests_fingerprint_asset_spec.rb
@@ -23,7 +23,6 @@ RSpec.describe 'When the user visits the start page' do
 
   context 'when JS is enabled', js: true do
     it 'requests the fingerprint asset with the fingerprint in the query params' do
-      skip('Fingerprint.js does not behave as expected on Travis') if ENV['TRAVIS'] == 'true'
       query_params_hash = nil
       expect(request_log).to receive(:log) { |arg| query_params_hash = arg }
       set_session_cookies!


### PR DESCRIPTION
Currently the fingerprint JS test can fail if the browser used has lots of plugins installed.  This fixes that by using Puma instead of WEBrick when a server is required in the tests.