### PR TITLE
3632: accessibility amends

### DIFF
--- a/app/assets/stylesheets/_application.scss
+++ b/app/assets/stylesheets/_application.scss
@@ -14,4 +14,4 @@
 @import "pages/select-phone";
 @import "pages/choose_a_certified_company";
 @import "pages/confirm_your_identity";
-
+@import "pages/cookies";

--- a/app/assets/stylesheets/_govuk-elements-overrides.scss
+++ b/app/assets/stylesheets/_govuk-elements-overrides.scss
@@ -158,6 +158,7 @@
     padding: 15px;
     margin: 15px 0;
     color: $red;
+    background: transparent;
     font-weight: bold;
     text-decoration: none;
   }

--- a/app/assets/stylesheets/pages/_cookies.scss
+++ b/app/assets/stylesheets/pages/_cookies.scss
@@ -1,0 +1,18 @@
+.cookies-table {
+  td {
+    vertical-align: top;
+    width: 30%;
+  }
+
+  td+td {
+    width: 45%;
+  }
+
+  td+td+td {
+    width: 25%;
+  }
+
+  var {
+    font-style: normal;
+  }
+}

--- a/app/assets/stylesheets/pages/_start.scss
+++ b/app/assets/stylesheets/pages/_start.scss
@@ -113,14 +113,7 @@
   .error,
   .validation-message {
     border-color: $white;
-  }
-
-  .validation-message {
-    color: $white;
-
-    :focus {
-      background-color: $mainstream-brand;
-    }
+    color: inherit;
   }
 
   .block-label {

--- a/app/views/choose_a_certified_company/_idp_option.html.erb
+++ b/app/views/choose_a_certified_company/_idp_option.html.erb
@@ -6,16 +6,17 @@
     </p>
   </div>
   <% button_class = recommended ? 'button' : 'button-link' %>
-  <%= form_for(identity_provider, url: '', html: {class: 'idp-option'}) do |f| %>
+  <%= form_for(identity_provider, url: choose_a_certified_company_submit_path, html: {class: 'idp-option', id: nil}) do |f| %>
       <%= f.button t('hub.choose_a_certified_company.choose_idp', name: identity_provider.display_name),
                      class: button_class,
                      name: identity_provider.simple_id,
+                     id: nil,
                      type: 'submit',
                      value: identity_provider.display_name
       %>
-      <%= hidden_field_tag 'selected-idp', identity_provider.entity_id %>
-      <%= hidden_field_tag 'recommended-idp', recommended %>
-      <%= f.hidden_field :entity_id %>
-      <%= f.hidden_field :simple_id %>
+      <%= hidden_field_tag 'selected-idp', identity_provider.entity_id, id: nil %>
+      <%= hidden_field_tag 'recommended-idp', recommended, id: nil %>
+      <%= f.hidden_field :entity_id, id: nil %>
+      <%= f.hidden_field :simple_id, id: nil %>
   <% end %>
 </div>

--- a/app/views/choose_a_certified_company/about.html.erb
+++ b/app/views/choose_a_certified_company/about.html.erb
@@ -8,7 +8,7 @@
       <h1 class="heading-large"><%= @idp.display_name %></h1>
       <div class="about-idp-content">
         <p class="subtitle"><%= t 'hub.choose_a_certified_company.about.information_provided_by', name: @idp.display_name %></p>
-        <p><%= @idp.about_content.html_safe %></p>
+        <%= @idp.about_content.html_safe %>
       </div>
       <%= render partial: 'select_idp_form', locals: {recommended: @recommended, identity_provider: @idp} %>
     </div>

--- a/app/views/cookies/index.cy.html.erb
+++ b/app/views/cookies/index.cy.html.erb
@@ -17,76 +17,77 @@
     </div>
     <h2 class="heading-medium">How cookies are used by GOV.UK Verify</h2>
     <p>A cookie that helps to improve security is set on your computer when you sign in to use a service.</p>
-    <table class="table-font-xsmall">
-      <thead>
-        <tr>
-          <th>Name</th>
-          <th>Purpose</th>
-          <th>Expires</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>x-govuk-secure-cookie</td>
-          <td>When you’re trying to use a service on GOV.UK, this cookie makes sure that no other user can login with your information</td>
-          <td>When you close your browser window</td>
-        </tr>
-        <tr>
-          <td>x_govuk_session_cookie</td>
-          <td>This cookie contains randomly generated characters so we can identify you during your visit</td>
-          <td>When you close your browser window</td>
-        </tr>
-        <tr>
-          <td>_verify-frontend_session</td>
-          <td>This cookie is used to hold information regarding your session, including which government service you’re using, your answers to filter questions, and which certified company you select so that we can present information relevant to your choices. This information is secured so that only GOV.UK Verify can read it</td>
-          <td>When you close your browser window</td>
-        </tr>
-        <tr>
-          <td>session_start_time</td>
-          <td>This provides the start time of your session</td>
-          <td>When you close your browser window</td>
-        </tr>
-        <tr>
-          <td>seen_cookie_message</td>
-          <td>Saves a message to let us know that you have seen our cookie message</td>
-          <td>1 month</td>
-        </tr>
-        <tr>
-          <td>_pk_id</td>
-          <td>This helps us identify how you use GOV.UK so we can make the site better</td>
-          <td>2 years</td>
-        </tr>
-        <tr>
-          <td>_pk_ses</td>
-          <td>This works with _pk_id to count the number of times you visit the site</td>
-          <td>30 minutes</td>
-        </tr>
-        <tr>
-          <td>_pk_ref</td>
-          <td>This provides information about how you reached the site</td>
-          <td>6 months</td>
-        </tr>
-        <tr>
-          <td>verify-journey-hint</td>
-          <td>This identifies the certified company you signed in with for your session. We use this cookie to send you to that certified company if the government service you’re using needs to re-confirm your identity</td>
-          <td>When you close your browser window</td>
-        </tr>
-        <tr>
-          <td>verify-front-journey-hint</td>
-          <td>This identifies the certified company you signed in with for your session and if you were using the English or Welsh version of Verify. We use this cookie to send you to that certified company if the government service you’re using needs to re-confirm your identity</td>
-          <td>When you close your browser window</td>
-        </tr>
-        <tr>
-          <td>PIWIK_VISITOR_ID</td>
-          <td>This provides information about your visit for our analytics, which allows us to improve the service</td>
-          <td>When you close your browser window</td>
-        </tr>
-        <tr>
-          <td>ab_test</td>
-          <td>This lets us know your visit is part of a test to help us improve GOV.UK Verify</td>
-          <td>2 weeks</td>
-        </tr>
-      </tbody>
-    </table>
   </div>
 </div>
+
+<table class="cookies-table table-font-xsmall">
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Purpose</th>
+      <th>Expires</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><var>x-govuk-secure-cookie</var></td>
+      <td>When you’re trying to use a service on GOV.UK, this cookie makes sure that no other user can login with your information</td>
+      <td>When you close your browser window</td>
+    </tr>
+    <tr>
+      <td><var>x_govuk_session_cookie</var></td>
+      <td>This cookie contains randomly generated characters so we can identify you during your visit</td>
+      <td>When you close your browser window</td>
+    </tr>
+    <tr>
+      <td><var>_verify-frontend_session</var></td>
+      <td>This cookie is used to hold information regarding your session, including which government service you’re using, your answers to filter questions, and which certified company you select so that we can present information relevant to your choices. This information is secured so that only GOV.UK Verify can read it</td>
+      <td>When you close your browser window</td>
+    </tr>
+    <tr>
+      <td><var>session_start_time</var></td>
+      <td>This provides the start time of your session</td>
+      <td>When you close your browser window</td>
+    </tr>
+    <tr>
+      <td><var>seen_cookie_message</var></td>
+      <td>Saves a message to let us know that you have seen our cookie message</td>
+      <td>1 month</td>
+    </tr>
+    <tr>
+      <td><var>_pk_id</var></td>
+      <td>This helps us identify how you use GOV.UK so we can make the site better</td>
+      <td>2 years</td>
+    </tr>
+    <tr>
+      <td><var>_pk_ses</var></td>
+      <td>This works with _pk_id to count the number of times you visit the site</td>
+      <td>30 minutes</td>
+    </tr>
+    <tr>
+      <td><var>_pk_ref</var></td>
+      <td>This provides information about how you reached the site</td>
+      <td>6 months</td>
+    </tr>
+    <tr>
+      <td><var>verify-journey-hint</var></td>
+      <td>This identifies the certified company you signed in with for your session. We use this cookie to send you to that certified company if the government service you’re using needs to re-confirm your identity</td>
+      <td>When you close your browser window</td>
+    </tr>
+    <tr>
+      <td><var>verify-front-journey-hint</var></td>
+      <td>This identifies the certified company you signed in with for your session and if you were using the English or Welsh version of Verify. We use this cookie to send you to that certified company if the government service you’re using needs to re-confirm your identity</td>
+      <td>When you close your browser window</td>
+    </tr>
+    <tr>
+      <td><var>PIWIK_VISITOR_ID</var></td>
+      <td>This provides information about your visit for our analytics, which allows us to improve the service</td>
+      <td>When you close your browser window</td>
+    </tr>
+    <tr>
+      <td><var>ab_test</var></td>
+      <td>This lets us know your visit is part of a test to help us improve GOV.UK Verify</td>
+      <td>2 weeks</td>
+    </tr>
+  </tbody>
+</table>

--- a/app/views/cookies/index.en.html.erb
+++ b/app/views/cookies/index.en.html.erb
@@ -17,76 +17,77 @@
     </div>
     <h2 class="heading-medium">How cookies are used by GOV.UK Verify</h2>
     <p>A cookie that helps to improve security is set on your computer when you sign in to use a service.</p>
-    <table class="table-font-xsmall">
-      <thead>
-        <tr>
-          <th>Name</th>
-          <th>Purpose</th>
-          <th>Expires</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>x-govuk-secure-cookie</td>
-          <td>When you’re trying to use a service on GOV.UK, this cookie makes sure that no other user can login with your information</td>
-          <td>When you close your browser window</td>
-        </tr>
-        <tr>
-          <td>x_govuk_session_cookie</td>
-          <td>This cookie contains randomly generated characters so we can identify you during your visit</td>
-          <td>When you close your browser window</td>
-        </tr>
-        <tr>
-          <td>_verify-frontend_session</td>
-          <td>This cookie is used to hold information regarding your session, including which government service you’re using, your answers to filter questions, and which certified company you select so that we can present information relevant to your choices. This information is secured so that only GOV.UK Verify can read it</td>
-          <td>When you close your browser window</td>
-        </tr>
-        <tr>
-          <td>session_start_time</td>
-          <td>This provides the start time of your session</td>
-          <td>When you close your browser window</td>
-        </tr>
-        <tr>
-          <td>seen_cookie_message</td>
-          <td>Saves a message to let us know that you have seen our cookie message</td>
-          <td>1 month</td>
-        </tr>
-        <tr>
-          <td>_pk_id</td>
-          <td>This helps us identify how you use GOV.UK so we can make the site better</td>
-          <td>2 years</td>
-        </tr>
-        <tr>
-          <td>_pk_ses</td>
-          <td>This works with _pk_id to count the number of times you visit the site</td>
-          <td>30 minutes</td>
-        </tr>
-        <tr>
-          <td>_pk_ref</td>
-          <td>This provides information about how you reached the site</td>
-          <td>6 months</td>
-        </tr>
-        <tr>
-          <td>verify-journey-hint</td>
-          <td>This identifies the certified company you signed in with for your session. We use this cookie to send you to that certified company if the government service you’re using needs to re-confirm your identity</td>
-          <td>When you close your browser window</td>
-        </tr>
-        <tr>
-          <td>verify-front-journey-hint</td>
-          <td>This identifies the certified company you signed in with for your session and if you were using the English or Welsh version of Verify. We use this cookie to send you to that certified company if the government service you’re using needs to re-confirm your identity</td>
-          <td>When you close your browser window</td>
-        </tr>
-        <tr>
-          <td>PIWIK_VISITOR_ID</td>
-          <td>This provides information about your visit for our analytics, which allows us to improve the service</td>
-          <td>When you close your browser window</td>
-        </tr>
-        <tr>
-          <td>ab_test</td>
-          <td>This lets us know your visit is part of a test to help us improve GOV.UK Verify</td>
-          <td>2 weeks</td>
-        </tr>
-      </tbody>
-    </table>
   </div>
 </div>
+
+<table class="cookies-table table-font-xsmall">
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Purpose</th>
+      <th>Expires</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><var>x-govuk-secure-cookie</var></td>
+      <td>When you’re trying to use a service on GOV.UK, this cookie makes sure that no other user can login with your information</td>
+      <td>When you close your browser window</td>
+    </tr>
+    <tr>
+      <td><var>x_govuk_session_cookie</var></td>
+      <td>This cookie contains randomly generated characters so we can identify you during your visit</td>
+      <td>When you close your browser window</td>
+    </tr>
+    <tr>
+      <td><var>_verify-frontend_session</var></td>
+      <td>This cookie is used to hold information regarding your session, including which government service you’re using, your answers to filter questions, and which certified company you select so that we can present information relevant to your choices. This information is secured so that only GOV.UK Verify can read it</td>
+      <td>When you close your browser window</td>
+    </tr>
+    <tr>
+      <td><var>session_start_time</var></td>
+      <td>This provides the start time of your session</td>
+      <td>When you close your browser window</td>
+    </tr>
+    <tr>
+      <td><var>seen_cookie_message</var></td>
+      <td>Saves a message to let us know that you have seen our cookie message</td>
+      <td>1 month</td>
+    </tr>
+    <tr>
+      <td><var>_pk_id</var></td>
+      <td>This helps us identify how you use GOV.UK so we can make the site better</td>
+      <td>2 years</td>
+    </tr>
+    <tr>
+      <td><var>_pk_ses</var></td>
+      <td>This works with _pk_id to count the number of times you visit the site</td>
+      <td>30 minutes</td>
+    </tr>
+    <tr>
+      <td><var>_pk_ref</var></td>
+      <td>This provides information about how you reached the site</td>
+      <td>6 months</td>
+    </tr>
+    <tr>
+      <td><var>verify-journey-hint</var></td>
+      <td>This identifies the certified company you signed in with for your session. We use this cookie to send you to that certified company if the government service you’re using needs to re-confirm your identity</td>
+      <td>When you close your browser window</td>
+    </tr>
+    <tr>
+      <td><var>verify-front-journey-hint</var></td>
+      <td>This identifies the certified company you signed in with for your session and if you were using the English or Welsh version of Verify. We use this cookie to send you to that certified company if the government service you’re using needs to re-confirm your identity</td>
+      <td>When you close your browser window</td>
+    </tr>
+    <tr>
+      <td><var>PIWIK_VISITOR_ID</var></td>
+      <td>This provides information about your visit for our analytics, which allows us to improve the service</td>
+      <td>When you close your browser window</td>
+    </tr>
+    <tr>
+      <td><var>ab_test</var></td>
+      <td>This lets us know your visit is part of a test to help us improve GOV.UK Verify</td>
+      <td>2 weeks</td>
+    </tr>
+  </tbody>
+</table>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,9 +19,9 @@
 <% end %>
 
 <% content_for :footer_support_links do %>
-  <h2 class="visuallyhidden">Support links</h2>
+  <h2 class="visuallyhidden"><%= t 'footer.support_links' %></h2>
   <ul>
-    <li><a href="https://gov.uk/help">Help</a></li>
+    <li><a href="https://gov.uk/help" hreflang="en"><%= t 'footer.help' %></a></li>
     <li><%= link_to(t('hub.cookies.title'), cookies_path) %></li>
     <li><%= link_to(t('hub.privacy_notice.title'), privacy_notice_path) %></li>
     <li>
@@ -31,7 +31,7 @@
         <%= link_to(t('hub.feedback.title'), feedback_path) %>
     <% end %>
     </li>
-    <li>Built by the <a href="https://gds.blog.gov.uk">Government Digital Service</a></li>
+    <li><%= t 'footer.built_by_the' %> <a href="https://gds.blog.gov.uk" lang="en" hreflang="en">Government Digital Service</a></li>
   </ul>
 <% end %>
 

--- a/app/views/select_documents/index.html.erb
+++ b/app/views/select_documents/index.html.erb
@@ -17,58 +17,58 @@
             <div class="form-group">
               <fieldset class="inline">
                 <span>1. <%= t 'hub.select_documents.question.driving_licence'%></span>
-                <label class="block-label">
+                <%= f.label :driving_licence_true, {class: 'block-label', onclick: ''} do %>
                   <%= f.radio_button :driving_licence, 'true' %>
                   <span>
                     <span class="inner"></span>
                   </span>
                   <%= t 'hub.select_documents.documents_option_yes' %>
-                </label>
-                <label class="block-label">
+                <% end %>
+                <%= f.label :driving_licence_false, {class: 'block-label', onclick: ''} do %>
                   <%= f.radio_button :driving_licence, 'false' %>
                   <span>
                     <span class="inner"></span>
                   </span>
                   <%= t 'option.no'%>
-                </label>
+                <% end %>
               </fieldset>
             </div>
             <div class="form-group">
               <fieldset class="inline">
                 <span>2. <%= t 'hub.select_documents.question.passport'%></span>
-                <label class="block-label">
+                <%= f.label :passport_true, {class: 'block-label', onclick: ''} do %>
                   <%= f.radio_button :passport, 'true' %>
                   <span>
                     <span class="inner"></span>
                   </span>
                   <%= t 'hub.select_documents.documents_option_yes'%>
-                </label>
-                <label class="block-label" >
+                <% end %>
+                <%= f.label :passport_false, {class: 'block-label', onclick: ''} do %>
                   <%= f.radio_button :passport, 'false' %>
                   <span>
                     <span class="inner"></span>
                   </span>
                   <%= t 'option.no'%>
-                </label>
+                <% end %>
               </fieldset>
             </div>
             <div class="form-group">
               <fieldset class="inline">
                 <span>3. <%= t 'hub.select_documents.question.non_uk_id_document'%></span>
-                <label class="block-label" >
+                <%= f.label :non_uk_id_document_true, {class: 'block-label', onclick: ''} do %>
                   <%= f.radio_button :non_uk_id_document, 'true' %>
                   <span>
                     <span class="inner"></span>
                   </span>
                   <%= t 'hub.select_documents.documents_option_yes'%>
-                </label>
-                <label class="block-label" >
+                <% end %>
+                <%= f.label :non_uk_id_document_false, {class: 'block-label', onclick: ''} do %>
                   <%= f.radio_button :non_uk_id_document, 'false' %>
                   <span>
                     <span class="inner"></span>
                   </span>
                   <%= t 'option.no'%>
-                </label>
+                <% end %>
               </fieldset>
             </div>
             <%= f.label :no_documents, {class: 'block-label'} do %>

--- a/app/views/select_phone/index.html.erb
+++ b/app/views/select_phone/index.html.erb
@@ -16,66 +16,66 @@
         <%= content_tag :div, class: form_question_class do %>
             <fieldset class="inline">
               <legend class="visually-hidden"><%= t 'hub.select_phone.question.mobile_phone' %></legend>
-              <label class="block-label">
+              <%= f.label :mobile_phone_true, {class: 'block-label', onclick: ''} do %>
                 <%= f.radio_button :mobile_phone, 'true' %>
                 <span>
                   <span class="inner"></span>
                 </span>
                 <%= t 'hub.select_phone.question.mobile_phone_option_yes' %>
-              </label>
-              <label class="block-label">
+              <% end %>
+              <%= f.label :mobile_phone_false, {class: 'block-label', onclick: ''} do %>
                 <%= f.radio_button :mobile_phone, 'false' %>
                 <span>
                   <span class="inner"></span>
                 </span>
                 <%= t 'option.no' %>
-              </label>
+              <% end %>
             </fieldset>
         <% end %>
 
         <%= content_tag :div, id: 'smartphone-question', class: hidden_form_question_class do %>
             <fieldset>
               <legend><%= t 'hub.select_phone.question.smart_phone' %></legend>
-              <label class="block-label">
+              <%= f.label :smart_phone_true, {class: 'block-label', onclick: ''} do %>
                 <%= f.radio_button :smart_phone, 'true' %>
                 <span>
                   <span class="inner"></span>
                 </span>
                 <%= t 'hub.select_phone.question.smart_phone_option_yes' %>
-              </label>
-              <label class="block-label">
+              <% end %>
+              <%= f.label :smart_phone_false, {class: 'block-label', onclick: ''} do %>
                 <%= f.radio_button :smart_phone, 'false' %>
                 <span>
                   <span class="inner"></span>
                 </span>
                 <%= t 'option.no' %>
-              </label>
-              <label class="block-label">
-                <%= f.radio_button :smart_phone, 'false', id: nil %>
+              <% end %>
+              <%= f.label :smart_phone_unsure, {class: 'block-label', onclick: ''} do %>
+                <%= f.radio_button :smart_phone, 'false', id: :select_phone_form_smart_phone_unsure %>
                 <span>
                   <span class="inner"></span>
                 </span>
                 <%= t 'option.unknown' %>
-              </label>
+              <% end %>
             </fieldset>
         <% end %>
         <%= content_tag :div, id: 'landline-question', class: hidden_form_question_class do %>
             <fieldset class="inline">
               <legend><%= t 'hub.select_phone.question.landline' %></legend>
-              <label class="block-label">
+              <%= f.label :landline_true, {class: 'block-label', onclick: ''} do %>
                 <%= f.radio_button :landline, 'true' %>
                 <span>
                   <span class="inner"></span>
                 </span>
                 <%= t 'hub.select_phone.question.landline_option_yes' %>
-              </label>
-              <label class="block-label">
+              <% end %>
+              <%= f.label :landline_false, {class: 'block-label', onclick: ''} do %>
                 <%= f.radio_button :landline, 'false' %>
                 <span>
                   <span class="inner"></span>
                 </span>
                 <%= t 'option.no' %>
-              </label>
+              <% end %>
             </fieldset>
         <% end %>
 

--- a/app/views/select_phone/index.html.erb
+++ b/app/views/select_phone/index.html.erb
@@ -5,7 +5,8 @@
   <div class="column-two-thirds">
     <h1 class="heading-large"><%= t 'hub.select_phone.title' %></h1>
     <p><%= t 'hub.select_phone.explanation' %></p>
-    <%= form_for @form, url: '', html: { id: 'validate-phone', class: 'select-phone-form', novalidate: 'novalidate', 'data-msg': t('hub.select_phone.errors.no_selection')} do |f| %>
+
+    <%= form_for @form, url: select_phone_path, html: { id: 'validate-phone', class: 'select-phone-form', novalidate: 'novalidate', 'data-msg': t('hub.select_phone.errors.no_selection')} do |f| %>
         <% if flash[:errors] %>
             <div id="validation-error-message-no-js" class="validation-message form-group">
               <p class="error"><%= flash[:errors] %></p>
@@ -50,7 +51,7 @@
                 <%= t 'option.no' %>
               </label>
               <label class="block-label">
-                <%= f.radio_button :smart_phone, 'false' %>
+                <%= f.radio_button :smart_phone, 'false', id: nil %>
                 <span>
                   <span class="inner"></span>
                 </span>

--- a/app/views/shared/_idp_list.erb
+++ b/app/views/shared/_idp_list.erb
@@ -15,8 +15,8 @@
                                type: "submit",
                                value: identity_provider.display_name
                 %>
-                <%= hidden_field_tag 'selected-idp-entity-id', identity_provider.entity_id %>
-                <%= hidden_field_tag 'selected-idp-display-name', identity_provider.display_name %>
+                <%= hidden_field_tag 'selected-idp-entity-id', identity_provider.entity_id, id: nil %>
+                <%= hidden_field_tag 'selected-idp-display-name', identity_provider.display_name, id: nil %>
             <% end %>
           </div>
         </div>

--- a/app/views/start/index.html.erb
+++ b/app/views/start/index.html.erb
@@ -4,7 +4,7 @@
 
 <h1><%= t 'hub.start.heading' %></h1>
 
-<%= form_tag '', id: 'start-page-form', class: 'js-validate', novalidate: 'novalidate' do %>
+<%= form_tag start_path, id: 'start-page-form', class: 'js-validate', novalidate: 'novalidate' do %>
   <div class="form-group <%= @error_message.present? ? 'error' : '' %>">
     <fieldset>
       <label class="block-label" for="yes" onclick="">

--- a/app/views/will_it_work_for_me/index.html.erb
+++ b/app/views/will_it_work_for_me/index.html.erb
@@ -13,65 +13,65 @@
         <%= content_tag :div, class: form_question_class do %>
             <fieldset class="inline">
               <legend><%= t 'hub.will_it_work_for_me.question.above_age_threshold' %></legend>
-              <label class="block-label">
+              <%= f.label :above_age_threshold_true, {class: 'block-label', onclick: ''} do %>
                 <%= f.radio_button :above_age_threshold, 'true' %>
                 <span>
                   <span class="inner"></span>
                 </span>
                 <%= t 'hub.will_it_work_for_me.question.option_yes' %>
-              </label>
-              <label class="block-label">
+              <% end %>
+              <%= f.label :above_age_threshold_false, {class: 'block-label', onclick: ''} do %>
                 <%= f.radio_button :above_age_threshold, 'false' %>
                 <span>
                   <span class="inner"></span>
                 </span>
                 <%= t 'option.no' %>
-              </label>
+              <% end %>
             </fieldset>
         <% end %>
         <%= content_tag :div, class: form_question_class do %>
             <fieldset class="inline">
               <legend><%= t 'hub.will_it_work_for_me.question.resident_last_12_months' %></legend>
-              <label class="block-label">
+              <%= f.label :resident_last_12_months_true, {class: 'block-label', onclick: ''} do %>
                 <%= f.radio_button :resident_last_12_months, 'true' %>
                 <span>
                   <span class="inner"></span>
                 </span>
                 <%= t 'hub.will_it_work_for_me.question.option_yes' %>
-              </label>
-              <label class="block-label">
+              <% end %>
+              <%= f.label :resident_last_12_months_false, {class: 'block-label', onclick: ''} do %>
                 <%= f.radio_button :resident_last_12_months, 'false' %>
                 <span>
                   <span class="inner"></span>
                 </span>
                 <%= t 'option.no' %>
-              </label>
+              <% end %>
             </fieldset>
         <% end %>
         <%= content_tag :div, id: :not_resident_reason, class: hidden_form_question_class do %>
             <fieldset class="inline">
               <legend><%= t 'hub.will_it_work_for_me.question.not_resident_reason.title' %></legend>
-              <label class="block-label">
+              <%= f.label :not_resident_reason_movedrecently, {class: 'block-label', onclick: ''} do %>
                 <%= f.radio_button :not_resident_reason, 'MovedRecently' %>
                 <span>
                   <span class="inner"></span>
                 </span>
                 <%= t 'hub.will_it_work_for_me.question.not_resident_reason.recently' %>
-              </label>
-              <label class="block-label">
+              <% end %>
+              <%= f.label :not_resident_reason_addressbutnotresident, {class: 'block-label', onclick: ''} do %>
                 <%= f.radio_button :not_resident_reason, 'AddressButNotResident' %>
                 <span>
                   <span class="inner"></span>
                 </span>
                 <%= t 'hub.will_it_work_for_me.question.not_resident_reason.not_resident' %>
-              </label>
-              <label class="block-label">
+              <% end %>
+              <%= f.label :not_resident_reason_noaddress, {class: 'block-label', onclick: ''} do %>
                 <%= f.radio_button :not_resident_reason, 'NoAddress' %>
                 <span>
                   <span class="inner"></span>
                 </span>
                 <%= t 'hub.will_it_work_for_me.question.not_resident_reason.no_address' %>
-              </label>
+              <% end %>
             </fieldset>
         <% end %>
 

--- a/app/views/will_it_work_for_me/index.html.erb
+++ b/app/views/will_it_work_for_me/index.html.erb
@@ -4,7 +4,7 @@
 <div class="grid-row">
   <div class="column-two-thirds">
     <h1 class="heading-large"><%= t 'hub.will_it_work_for_me.heading' %></h1>
-    <%= form_for @form, url: '', html: { id: 'validate-will-it-work-for-me', class: 'will-it-work-for-me-form', novalidate: 'novalidate', 'data-msg': t('hub.will_it_work_for_me.question.errors.no_selection')} do |f| %>
+    <%= form_for @form, url: will_it_work_for_me_path, html: { id: 'validate-will-it-work-for-me', class: 'will-it-work-for-me-form heading-banner-top-margin', novalidate: 'novalidate', 'data-msg': t('hub.will_it_work_for_me.question.errors.no_selection')} do |f| %>
         <% if flash[:errors] %>
             <div id="validation-error-message-no-js" class="validation-message form-group">
               <p class="error"><%= flash[:errors] %></p>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -37,6 +37,10 @@ cy:
   translation_in_progress_banner:
     message: Mae GOV.UK Verify wrthi’n cael ei gyfieithu i’r Gymraeg. Rydym yn cyfieithu tudalennau bob wythnos rhwng nawr a diwedd mis Ebrill. Mae eich %{feedback_link} yn ein helpu i wella’r cyfieithiad.
     feedback: adborth
+  footer:
+    support_links: Support links
+    help: Help
+    built_by_the: Built by the
   hub:
     other_ways_heading: Ffyrdd eraill i %{other_ways_description}
     start:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,6 +34,10 @@ en:
     title: This is a trial service.
     feedback_message: Your %{feedback_link} will help us to improve it.
     feedback: feedback
+  footer:
+    support_links: Support links
+    help: Help
+    built_by_the: Built by the
   hub:
     other_ways_heading: Other ways to %{other_ways_description}
     start:

--- a/stub/locales/idps/stub-idp-no-docs.yml
+++ b/stub/locales/idps/stub-idp-no-docs.yml
@@ -2,7 +2,7 @@ en:
   idps:
     stub-idp-no-docs:
       name: "No Docs IDP"
-      about: "The number one source of identities without documents."
+      about: "<p>The number one source of identities without documents.</p>"
       requirements:
         - "A requirement"
       special_no_docs_instructions_html: "<p>Additional IDP Instructions</p>"

--- a/stub/locales/idps/stub-idp-one.yml
+++ b/stub/locales/idps/stub-idp-one.yml
@@ -13,7 +13,7 @@ en:
             <li>Tell us about yourself</li>
             <li>Create a password</li>
           </ol>
-          Once you get verified you can transact with online government services.
+          <p>Once you get verified you can transact with online government services.</p>
       requirements:
         - a UK passport
         - a UK photocard driving licence


### PR DESCRIPTION
Grab bag of mini accessibility improvements, but as a quick list:

- fix the specified language of the remaining footer links
- update the cookies page to make it more legible
- fix broken `<p>` tags on the about page
- `<form>` tags need a non-empty action according to the specs
- make sure that all radio buttons are programmatically associated with their labels
- fix the red-on-yellow error text contrast