### PR TITLE
BAU: Remove custom panels CSS

### DIFF
--- a/app/assets/stylesheets/_application.scss
+++ b/app/assets/stylesheets/_application.scss
@@ -4,7 +4,6 @@
 
 // helpers for common page elements
 @import "helpers/available-languages";
-@import "helpers/panels";
 
 // Specific pages
 @import "pages/slides";

--- a/app/assets/stylesheets/helpers/_panels.scss
+++ b/app/assets/stylesheets/helpers/_panels.scss
@@ -1,6 +1,0 @@
-.panel-indent {
-  @extend %contain-floats;
-  clear: both;
-  border-left: 4px solid $border-colour;
-  padding: 10px 0 0 $gutter-half;
-}

--- a/app/assets/stylesheets/pages/_slides.scss
+++ b/app/assets/stylesheets/pages/_slides.scss
@@ -84,7 +84,7 @@
       color: $white;
     }
 
-    .panel-indent {
+    .panel {
       border-left-color: $white;
     }
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -31,7 +31,7 @@ module ApplicationHelper
   end
 
   def hidden_form_question_class
-    [form_question_class, 'panel-indent', 'js-hidden'].join(' ')
+    [form_question_class, 'panel', 'panel-border-narrow', 'js-hidden'].join(' ')
   end
 
   def fingerprint_path

--- a/app/views/about/certified_companies.html.erb
+++ b/app/views/about/certified_companies.html.erb
@@ -21,7 +21,7 @@
   <summary>
     <span class="summary"><%= t 'hub.about_certified_companies.summary' %></span>
   </summary>
-  <div class="panel-indent">
+  <div class="panel panel-border-narrow">
     <p><%= t 'hub.about_certified_companies.details.p1' %></p>
     <p><%= t 'hub.about_certified_companies.details.p2' %></p>
     <p><%= t 'hub.about_certified_companies.details.p3' %></p>

--- a/app/views/about/identity_accounts.html.erb
+++ b/app/views/about/identity_accounts.html.erb
@@ -13,7 +13,7 @@
   <summary>
     <span class="summary"><%= t 'hub.about_identity_accounts.summary' %></span>
   </summary>
-  <div class="panel-indent">
+  <div class="panel panel-border-narrow">
     <p><%= t 'hub.about_identity_accounts.details' %></p>
     <ul class="list-bullet list">
       <% transactions_list.public.each do |transaction| -%>

--- a/app/views/choose_a_certified_company/index.html.erb
+++ b/app/views/choose_a_certified_company/index.html.erb
@@ -33,7 +33,7 @@
         <summary>
           <span class="summary"><%= t 'hub.choose_a_certified_company.show_all_companies' %></span>
         </summary>
-        <div class="panel-indent">
+        <div class="panel panel-border-narrow">
           <% @non_recommended_idps.each do |identity_provider| %>
             <%= render partial: 'idp_option', locals: {recommended: false, identity_provider: identity_provider} %>
           <% end %>

--- a/app/views/errors/no_cookies.html.erb
+++ b/app/views/errors/no_cookies.html.erb
@@ -8,6 +8,6 @@
     <p><%= t 'errors.no_cookies.access_restriction' %></p>
     <%= render partial: 'errors/transaction_list' %>
     <p><%= t('errors.no_cookies.read_more').html_safe %></p>
-    <p class="panel-indent"><%= t 'errors.no_cookies.enable_cookies' %></p>
+    <p class="panel panel-border-narrow"><%= t 'errors.no_cookies.enable_cookies' %></p>
   </div>
 </div>

--- a/app/views/static/cookies.cy.html.erb
+++ b/app/views/static/cookies.cy.html.erb
@@ -10,7 +10,7 @@
       <li>measure how you use the website so it can be updated and improved based on your needs</li>
       <li>remember the notifications you’ve seen so that we don’t show them to you again</li>
     </ul>
-    <div class="panel-indent">
+    <div class="panel panel-border-narrow">
       <p>GOV.UK cookies aren’t used to identify you personally.</p>
       <p>You’ll normally see a message on the site before we store a cookie on your computer.</p>
       <p>Find out more about <a href="http://www.aboutcookies.org/">how to manage cookies.</a></p>

--- a/app/views/static/cookies.en.html.erb
+++ b/app/views/static/cookies.en.html.erb
@@ -10,7 +10,7 @@
       <li>measure how you use the website so it can be updated and improved based on your needs</li>
       <li>remember the notifications you’ve seen so that we don’t show them to you again</li>
     </ul>
-    <div class="panel-indent">
+    <div class="panel panel-border-narrow">
       <p>GOV.UK cookies aren’t used to identify you personally.</p>
       <p>You’ll normally see a message on the site before we store a cookie on your computer.</p>
       <p>Find out more about <a href="http://www.aboutcookies.org/">how to manage cookies.</a></p>


### PR DESCRIPTION
We had carried over some CSS from the old frontend for panels (elements
that were distinguished from surrounding text with a left border). The
panels CSS already exists in GOV.UK elements and our templates should
be using those classes as they are visually nearly identical.

Author: @vixus0