### PR TITLE
Make federation_info_for_session a private method

### DIFF
--- a/app/controllers/about_controller.rb
+++ b/app/controllers/about_controller.rb
@@ -17,10 +17,6 @@ class AboutController < ApplicationController
 
 private
 
-  def federation_info
-    SESSION_PROXY.federation_info_for_session(cookies)
-  end
-
   def identity_providers
     SESSION_PROXY.identity_providers(cookies)
   end

--- a/app/controllers/confirm_your_identity_controller.rb
+++ b/app/controllers/confirm_your_identity_controller.rb
@@ -24,9 +24,9 @@ private
     redirect_to sign_in_path
   end
 
-  def retrieve_last_used_idp(idp_entity_id)
-    federation_info = SESSION_PROXY.federation_info_for_session(cookies)
-    var = federation_info.idps.select { |idp| idp.entity_id == idp_entity_id }
-    IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate_collection(var)
+  def retrieve_last_used_idp(entity_id)
+    IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate_collection(
+      SESSION_PROXY.identity_providers(cookies).select { |idp| idp.entity_id == entity_id }
+    )
   end
 end

--- a/app/controllers/confirmation_controller.rb
+++ b/app/controllers/confirmation_controller.rb
@@ -6,12 +6,4 @@ class ConfirmationController < ApplicationController
     @idp_name = IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate(IdentityProvider.new(selected_idp)).display_name
     @transaction_name = current_transaction.name
   end
-
-private
-
-  def retrieve_last_used_idp(idp_entity_id)
-    federation_info = SESSION_PROXY.federation_info_for_session(cookies)
-    var = federation_info.idps.select { |idp| idp.entity_id == idp_entity_id }
-    IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate_collection(var)
-  end
 end

--- a/app/controllers/sign_in_controller.rb
+++ b/app/controllers/sign_in_controller.rb
@@ -1,8 +1,8 @@
 class SignInController < ApplicationController
   def index
-    federation_info = SESSION_PROXY.federation_info_for_session(cookies)
-
-    @identity_providers = IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate_collection(federation_info.idps)
+    @identity_providers = IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate_collection(
+      SESSION_PROXY.identity_providers(cookies)
+    )
 
     FEDERATION_REPORTER.report_sign_in(current_transaction_simple_id, request)
     render 'index'

--- a/app/models/session_proxy.rb
+++ b/app/models/session_proxy.rb
@@ -31,12 +31,6 @@ class SessionProxy
     SessionResponse.new(response || {}).tap(&:validate)
   end
 
-  def federation_info_for_session(cookies)
-    session_cookies = select_cookies(cookies, CookieNames.session_cookies)
-    response = @api_client.get(FEDERATION_INFO_PATH, cookies: session_cookies)
-    FederationInfoResponse.new(response || {}).tap(&:validate)
-  end
-
   def identity_providers(cookies)
     federation_info_for_session(cookies).idps
   end
@@ -71,5 +65,13 @@ class SessionProxy
 
   def restart_session(cookies)
     @api_client.put(SESSION_STATE_PATH, nil, cookies: select_cookies(cookies, CookieNames.session_cookies))
+  end
+
+private
+
+  def federation_info_for_session(cookies)
+    session_cookies = select_cookies(cookies, CookieNames.session_cookies)
+    response = @api_client.get(FEDERATION_INFO_PATH, cookies: session_cookies)
+    FederationInfoResponse.new(response || {}).tap(&:validate)
   end
 end

--- a/spec/models/session_proxy_spec.rb
+++ b/spec/models/session_proxy_spec.rb
@@ -58,21 +58,6 @@ describe SessionProxy do
     end
   end
 
-  describe('#federation_info_for_session') do
-    it 'should return a list of IDPs for the session' do
-      idp = { 'simpleId' => 'idp', 'entityId' => 'something' }
-
-      expect(api_client).to receive(:get)
-        .with(SessionProxy::FEDERATION_INFO_PATH, cookies: cookies)
-        .and_return('idps' => [idp], 'transactionSimpleId' => 'test-rp', 'transactionEntityId' => 'some-id')
-
-      result = session_proxy.federation_info_for_session(cookies)
-      expect(result.idps.size).to eql 1
-      expect(result.idps.first.simple_id).to eql 'idp'
-      expect(result.idps.first.entity_id).to eql 'something'
-    end
-  end
-
   describe('#identity_providers') do
     it 'should return a list of IDPs for the session' do
       idp = { 'simpleId' => 'idp', 'entityId' => 'something' }


### PR DESCRIPTION
All usages of federation_info_for_session could be replaced with identity_providers so it can now be private.

Now the API can be updated to only return the list of identity providers for that session.