### PR TITLE
3626: announce form changes when selecting no documents checkbox

### DIFF
--- a/app/assets/javascripts/select_documents.js
+++ b/app/assets/javascripts/select_documents.js
@@ -11,11 +11,14 @@
     markAllAsNo: function() {
       // Mark all documents as 'No' when "I don't have documents" is selected
       var $checkbox = $(this);
-      var checkboxValue = $checkbox.val();
+      var checkboxValue = $checkbox.prop('checked');
       var $noAnswers = selectDocuments.$form.find('input[type=radio][value=false]');
 
-      if (checkboxValue === "true") {
+      if (checkboxValue === true) {
         $noAnswers.trigger('click');
+        selectDocuments.speakWarningMessage();
+      } else {
+        selectDocuments.$noDocumentsMessage.empty();
       }
     },
     unCheckNoDocuments: function() {
@@ -24,8 +27,13 @@
       $checkbox.prop('checked',false);
       $checkbox.parent('.block-label').removeClass('selected');
     },
+    speakWarningMessage: function(){
+      // let screenreader users know their choices have changed by reading a notice
+      selectDocuments.$noDocumentsMessage.text(selectDocuments.$noDocumentsMessage.data('no-documents-message'));
+    },
     init: function (){
       selectDocuments.$form = $('#validate-documents');
+      selectDocuments.$noDocumentsMessage = $('#no-documents-message');
 
       if (selectDocuments.$form.length === 1) {
         selectDocuments.$form.find('.js-no-docs').on('click',selectDocuments.markAllAsNo);

--- a/app/views/select_documents/index.html.erb
+++ b/app/views/select_documents/index.html.erb
@@ -1,6 +1,8 @@
 <% content_for :page_title, t('hub.select_documents.title') %>
 <% content_for :feedback_source, 'SELECT_DOCUMENTS_PAGE' %>
 
+<div id="no-documents-message" class="visually-hidden" aria-live="assertive" data-no-documents-message="<%= h t('hub.select_documents.no_documents_message') %>"></div>
+
 <div class="grid-row">
   <div class="column-two-thirds">
     <h1 class="heading-large"><%= t 'hub.select_documents.title' %></h1>
@@ -29,7 +31,7 @@
                   <span>
                     <span class="inner"></span>
                   </span>
-                  <%= t 'option.no'%>
+                  <%= t 'option.no' %>
                 <% end %>
               </fieldset>
             </div>
@@ -48,7 +50,7 @@
                   <span>
                     <span class="inner"></span>
                   </span>
-                  <%= t 'option.no'%>
+                  <%= t 'option.no' %>
                 <% end %>
               </fieldset>
             </div>
@@ -67,7 +69,7 @@
                   <span>
                     <span class="inner"></span>
                   </span>
-                  <%= t 'option.no'%>
+                  <%= t 'option.no' %>
                 <% end %>
               </fieldset>
             </div>
@@ -76,7 +78,7 @@
               <span>
                 <span class="inner"></span>
               </span>
-              <%= t 'hub.select_documents.question.no_documents'%>
+              <%= t 'hub.select_documents.question.no_documents' %>
             <% end %>
           </fieldset>
         <% end %>
@@ -86,7 +88,7 @@
         <div class="actions">
           <%= f.submit t('navigation.continue'), class: 'button', id: 'next-button' %>
         </div>
-  <% end %>
+    <% end %>
 
   </div>
 </div>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -95,6 +95,7 @@ cy:
     select_documents:
       title: Dewiswch yr holl ddogfennau sydd gennych
       explanation: Mae cwmnïau ardystiedig yn defnyddio gwybodaeth o wahanol ddogfennau hunaniaeth i’ch dilysu.
+      no_documents_message: Your document choices have been set to ‘no’.
       legend: Ydy’r dogfennau hyn gyda chi?
       documents_option_yes: Ydy
       question:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -92,6 +92,7 @@ en:
     select_documents:
       title: Select all the documents you have
       explanation: Certified companies use information from different identity documents to verify you.
+      no_documents_message: Your document choices have been set to ‘no’.
       legend: Do you have these documents with you?
       documents_option_yes: 'Yes'
       question:

--- a/spec/javascripts/select_documents_spec.js
+++ b/spec/javascripts/select_documents_spec.js
@@ -5,7 +5,8 @@
 
 describe("Select Documents Form", function () {
 
-    var formWithNoErrors = '<form id="validate-documents" action="/select-documents" method="POST" data-msg="Please select the documents you have">' +
+    var formWithNoErrors = '<p id="no-documents-message" class="visually-hidden" aria-live="assertive" data-no-documents-message="Your document choices have been set to ‘no’."></p>' +
+                           '<form id="validate-documents" action="/select-documents" method="POST" data-msg="Please select the documents you have">' +
                              '<div class="form-group ">' +
                                '<fieldset>' +
                                  '<legend>Do you have these documents with you?</legend>' +
@@ -165,5 +166,15 @@ describe("Select Documents Form", function () {
         this.noDocumentsCheckbox.trigger('click');
         this.selectYesPassport();
         expect(this.noDocumentsCheckbox.is(':checked')).toBe(false);
+    });
+
+    it("should alert screen readers users when no documents checkbox is checked", function () {
+        this.noDocumentsCheckbox.trigger('click');
+        expect(GOVUK.selectDocuments.$noDocumentsMessage.text()).toBe('Your document choices have been set to ‘no’.');
+    });
+
+    it("should reset the alert when no documents checkbox is unchecked", function () {
+        this.noDocumentsCheckbox.trigger('click').trigger('click');
+        expect(GOVUK.selectDocuments.$noDocumentsMessage.text()).toBe('');
     });
 });


### PR DESCRIPTION
Sighted users can see the checkboxes change to ‘no’ when the checkbox on the select documents form is checked. To replicate this behaviour for screenreader users we need to announce this change dynamically.

A visually hidden message is read out at the point that the checkbox is activated. When it is deactivated the message is blanked, but that doesn’t get read out because it’s empty.