### PR TITLE
3642: Other ways to access service page

### DIFF
--- a/app/controllers/other_ways_to_access_service_controller.rb
+++ b/app/controllers/other_ways_to_access_service_controller.rb
@@ -1,0 +1,6 @@
+class OtherWaysToAccessServiceController < ApplicationController
+  def index
+    @other_ways_description = current_transaction.other_ways_description
+    @other_ways_text = current_transaction.other_ways_text
+  end
+end

--- a/app/views/other_ways_to_access_service/index.html.erb
+++ b/app/views/other_ways_to_access_service/index.html.erb
@@ -1,0 +1,11 @@
+<% content_for :page_title, t('hub.other_ways_to_access_service.title') %>
+<% content_for :feedback_source, 'OTHER_WAYS_PAGE' %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <h1 class="heading-xlarge"><%= t 'hub.other_ways_heading', other_ways_description: @other_ways_description %></h1>
+    <div class="other-ways-to-complete-transaction">
+      <%= @other_ways_text.html_safe %>
+    </div>
+  </div>
+</div>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -252,6 +252,8 @@ cy:
         <p>You may have selected the wrong company. Check your emails and text messages for confirmation of who verified you.</p>
         <p>You can be verified by another company at any time. You won’t lose any data on GOV.UK services you’ve used.</p>
       start_again: "Start again"
+    other_ways_to_access_service:
+      title: Other ways to access the service
   errors:
     transaction_list:
       title: Dod o hyd i’r gwasanaeth rydych yn ei ddefnyddio i ddechrau eto

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -246,6 +246,8 @@ en:
         <p>You may have selected the wrong company. Check your emails and text messages for confirmation of who verified you.</p>
         <p>You can be verified by another company at any time. You won’t lose any data on GOV.UK services you’ve used.</p>
       start_again: "Start again"
+    other_ways_to_access_service:
+      title: Other ways to access the service
   errors:
     transaction_list:
       title: Find the service you were using to start again

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,7 +62,8 @@ Rails.application.routes.draw do
   get 'failed-sign-in', to: 'failed_sign_in#index', as: :failed_sign_in
   get 'failed-sign-in-cy', to: 'failed_sign_in#index'
   get 'other-ways-to-access-service', to: 'other_ways_to_access_service#index', as: :other_ways_to_access_service
-  get 'other-ways-to-access-service-cy', to: 'other_ways_to_access_service#index'
+  get 'other-ways-to-access-service-cy', to: 'other_ways_to_access_service#index' #TODO: delete after localization
+  get 'other-ways-to-access', to: 'other_ways_to_access_service#index' #TODO: delete after localization
 
   if Rails.env == 'development'
     get 'feedback', to: redirect("#{API_HOST}/feedback")

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,16 +61,16 @@ Rails.application.routes.draw do
   get 'failed-registration-cy', to: 'failed_registration#index'
   get 'failed-sign-in', to: 'failed_sign_in#index', as: :failed_sign_in
   get 'failed-sign-in-cy', to: 'failed_sign_in#index'
+  get 'other-ways-to-access-service', to: 'other_ways_to_access_service#index', as: :other_ways_to_access_service
+  get 'other-ways-to-access-service-cy', to: 'other_ways_to_access_service#index'
 
   if Rails.env == 'development'
     get 'feedback', to: redirect("#{API_HOST}/feedback")
     get 'forgot-company', to: redirect("#{API_HOST}/forgot-company"), as: :forgot_company
-    get 'other-ways-to-access-service', to: redirect("#{API_HOST}/other-ways-to-access-service"), as: :other_ways_to_access_service
     get 'response-processing', to: redirect("#{API_HOST}/response-processing"), as: :response_processing
   else
     get 'feedback', to: 'feedback#index', as: :feedback
     get 'forgot-company', to: 'forgot_company#index', as: :forgot_company
-    get 'other-ways-to-access-service', to: 'other_ways_to_access_service#index', as: :other_ways_to_access_service
     get 'response-processing', to: 'response_processing#index', as: :response_processing
   end
 

--- a/spec/features/user_visits_other_ways_to_access_page_spec.rb
+++ b/spec/features/user_visits_other_ways_to_access_page_spec.rb
@@ -1,0 +1,18 @@
+require 'feature_helper'
+
+RSpec.describe 'When the user visits the other ways to access page' do
+  before(:each) do
+    set_session_cookies!
+    page.set_rack_session(transaction_simple_id: 'test-rp')
+  end
+
+  it 'includes expected content' do
+    visit '/other-ways-to-access-service'
+
+    expect(page).to have_title 'Other ways to access the service - GOV.UK Verify - GOV.UK'
+    expect(page).to have_content 'Other ways to register for an identity profile'
+    expect(page).to have_content 'If you can’t verify your identity using GOV.UK Verify, you can register for an identity profile'
+    expect(page).to have_link 'here', href: 'http://www.example.com'
+    expect_feedback_source_to_be(page, 'OTHER_WAYS_PAGE')
+  end
+end


### PR DESCRIPTION
routes.rb includes other-ways-to-access-service-cy to ensure ZDD compliance
when we get to releasing the localized version in a later release.

@oswaldquek