### PR TITLE
3648: set the locale for rescued errors

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -84,6 +84,7 @@ private
   end
 
   def render_error(partial, status)
+    set_locale
     respond_to do |format|
       format.html { render "errors/#{partial}", status: status, layout: 'application' }
       format.json { render json: {}, status: status }

--- a/spec/features/user_encounters_error_page_spec.rb
+++ b/spec/features/user_encounters_error_page_spec.rb
@@ -96,4 +96,13 @@ RSpec.describe 'user encounters error page' do
     expect(page).to have_css "#piwik-custom-url", text: "errors/generic-error"
     expect(page.status_code).to eq(500)
   end
+
+  it 'will present the something went wrong page when secure cookie is invalid' do
+    set_session_cookies!
+    stub_transactions_list
+    stub_request(:get, api_federation_endpoint).and_return(status: 403)
+    visit sign_in_cy_path
+    expect(page).to have_content I18n.translate('errors.something_went_wrong.heading', locale: :cy)
+    expect(page.status_code).to eq(500)
+  end
 end


### PR DESCRIPTION
When an exception is thrown from within a controller a class method `rescue_from` is used to rescue and render an error page. As this is a occuring within the context of the class method, the locale set within an instance of a controller is lost and we need to call set_locale witin the error page rendering methods.