### PR TITLE
3657: stop sending 404s to sentry

### DIFF
--- a/lib/support/raven/logger.rb
+++ b/lib/support/raven/logger.rb
@@ -31,7 +31,7 @@ module Support
 
       class RavenWriter
         def write(exception = nil)
-          unless exception.nil?
+          unless exception.nil? || exception.is_a?(ActionController::RoutingError)
             ::Raven.capture_exception(exception)
           end
         end

--- a/spec/lib/support/raven/logger_spec.rb
+++ b/spec/lib/support/raven/logger_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'logger'
 require 'support/raven/logger'
-
+require 'action_controller/metal/exceptions'
 describe Support::Raven::Logger do
   let(:logger) { Support::Raven::Logger.new }
   context "#error" do
@@ -10,6 +10,14 @@ describe Support::Raven::Logger do
       stub_const("Raven", raven)
       error = StandardError.new
       expect(raven).to receive(:capture_exception).with(error)
+      logger.error(error)
+    end
+
+    it 'will not send routing exceptions to sentry' do
+      raven = double(:raven)
+      stub_const("Raven", raven)
+      error = ActionController::RoutingError.new(nil)
+      expect(raven).to_not receive(:capture_exception).with(error)
       logger.error(error)
     end
 


### PR DESCRIPTION
We currently hook up sentry to the raven logger to capture exceptions and error
messages. 404s are logged as errors using the `ActionController::RoutingError`.
As 404s are not something we can action usually this change will remove them
from Sentry.