### PR TITLE
bau: enable CSRF check for migrated endpoints

### DIFF
--- a/app/controllers/choose_a_certified_company_controller.rb
+++ b/app/controllers/choose_a_certified_company_controller.rb
@@ -1,6 +1,4 @@
 class ChooseACertifiedCompanyController < ApplicationController
-  protect_from_forgery except: :select_idp
-
   def index
     grouped_identity_providers = IDP_ELIGIBILITY_CHECKER.group_by_recommendation(selected_evidence_values, identity_providers)
     @recommended_idps = IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate_collection(grouped_identity_providers.recommended)

--- a/app/controllers/redirect_to_idp_warning_controller.rb
+++ b/app/controllers/redirect_to_idp_warning_controller.rb
@@ -1,6 +1,4 @@
 class RedirectToIdpWarningController < ApplicationController
-  protect_from_forgery except: :continue
-
   helper_method :user_has_no_docs?, :other_ways_description
 
   def index


### PR DESCRIPTION
These endpoints are now served by the new FE only so the CSRF check should be
enabled.