### PR TITLE
BAU: Use the I18n module's html convention

### DIFF
--- a/app/views/errors/no_cookies.html.erb
+++ b/app/views/errors/no_cookies.html.erb
@@ -7,7 +7,7 @@
     <h1 class="heading-xlarge"><%= t 'errors.no_cookies.heading' %></h1>
     <p><%= t 'errors.no_cookies.access_restriction' %></p>
     <%= render partial: 'errors/transaction_list' %>
-    <p><%= t('errors.no_cookies.read_more').html_safe %></p>
+    <p><%= t 'errors.no_cookies.read_more_html'  %></p>
     <p class="panel panel-border-narrow"><%= t 'errors.no_cookies.enable_cookies' %></p>
   </div>
 </div>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -264,7 +264,7 @@ cy:
       title: Cwcis Ar Goll
       heading: GOV.UK Verify
       access_restriction: Gellir ond cael mynediad i GOV.UK Verify o wasanaeth y llywodraeth.
-      read_more: 'Darllenwch y <a href="https://www.gov.uk/verify" hreflang="en">Cyflwyniad i GOV.UK Verify</a> am fwy o wybodaeth.'
+      read_more_html: 'Darllenwch y <a href="https://www.gov.uk/verify" hreflang="en">Cyflwyniad i GOV.UK Verify</a> am fwy o wybodaeth.'
       enable_cookies: Os na allwch gael mynediad i GOV.UK Verify o wasanaeth y llywodraeth, dylech alluogi eich cwcis.
     session_error:
       title: Mae rhywbeth wedi mynd o’i le

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -258,7 +258,7 @@ en:
       title: Cookies Missing
       heading: GOV.UK Verify
       access_restriction: GOV.UK Verify can only be accessed from a government service.
-      read_more: 'Read the <a href="https://www.gov.uk/verify">Introduction to GOV.UK Verify</a> for more information.'
+      read_more_html: 'Read the <a href="https://www.gov.uk/verify">Introduction to GOV.UK Verify</a> for more information.'
       enable_cookies: If you can’t access GOV.UK Verify from a service, enable your cookies.
     session_error:
       title: Something went wrong


### PR DESCRIPTION
Instead of manually calling .html_safe on our translation string in the
view, use the I18n module's convention for automatically allowing HTML
in translation keys that end in _html. This has the added benefit of
making clear in the translation file that the translation string will
NOT be sanitised for HTML.

Author: @vixus0