### PR TITLE
3628: store current identity providers in session

### DIFF
--- a/app/controllers/about_controller.rb
+++ b/app/controllers/about_controller.rb
@@ -9,15 +9,9 @@ class AboutController < ApplicationController
   end
 
   def certified_companies
-    @identity_providers = IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate_collection(identity_providers)
+    @identity_providers = IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate_collection(current_identity_providers)
   end
 
   def choosing_a_company
-  end
-
-private
-
-  def identity_providers
-    SESSION_PROXY.identity_providers(cookies)
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -132,6 +132,11 @@ private
   end
 
   def selected_identity_provider
-    IdentityProvider.new(session.fetch(:selected_idp))
+    IdentityProvider.from_session(session.fetch(:selected_idp))
+  end
+
+  def current_identity_providers
+    session[:identity_providers] ||= SESSION_PROXY.identity_providers(cookies)
+    @current_identity_providers ||= session[:identity_providers].map { |obj| IdentityProvider.from_session(obj) }
   end
 end

--- a/app/controllers/choose_a_certified_company_controller.rb
+++ b/app/controllers/choose_a_certified_company_controller.rb
@@ -2,7 +2,7 @@ class ChooseACertifiedCompanyController < ApplicationController
   protect_from_forgery except: :select_idp
 
   def index
-    grouped_identity_providers = IDP_ELIGIBILITY_CHECKER.group_by_recommendation(selected_evidence_values, identity_providers)
+    grouped_identity_providers = IDP_ELIGIBILITY_CHECKER.group_by_recommendation(selected_evidence_values, current_identity_providers)
     @recommended_idps = IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate_collection(grouped_identity_providers.recommended)
     @non_recommended_idps = IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate_collection(grouped_identity_providers.non_recommended)
   end
@@ -15,7 +15,7 @@ class ChooseACertifiedCompanyController < ApplicationController
 
   def about
     simple_id = params[:company]
-    matching_idp = identity_providers.detect { |idp| idp.simple_id == simple_id }
+    matching_idp = current_identity_providers.detect { |idp| idp.simple_id == simple_id }
     @idp = IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate(matching_idp)
     if @idp.viewable?
       grouped_identity_providers = IDP_ELIGIBILITY_CHECKER.group_by_recommendation(selected_evidence_values, [@idp])
@@ -24,11 +24,5 @@ class ChooseACertifiedCompanyController < ApplicationController
     else
       render 'errors/404', status: 404
     end
-  end
-
-private
-
-  def identity_providers
-    SESSION_PROXY.identity_providers(cookies)
   end
 end

--- a/app/controllers/confirm_your_identity_controller.rb
+++ b/app/controllers/confirm_your_identity_controller.rb
@@ -26,7 +26,7 @@ private
 
   def retrieve_last_used_idp(entity_id)
     IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate_collection(
-      SESSION_PROXY.identity_providers(cookies).select { |idp| idp.entity_id == entity_id }
+      current_identity_providers.select { |idp| idp.entity_id == entity_id }
     )
   end
 end

--- a/app/controllers/select_documents_controller.rb
+++ b/app/controllers/select_documents_controller.rb
@@ -9,7 +9,7 @@ class SelectDocumentsController < ApplicationController
       ANALYTICS_REPORTER.report(request, 'Select Documents Next')
       selected_evidence = @form.selected_evidence
       store_selected_evidence('documents', selected_evidence)
-      if documents_eligibility_checker.any?(selected_evidence_values, available_idps)
+      if documents_eligibility_checker.any?(selected_evidence_values, current_identity_providers)
         redirect_to select_phone_path
       else
         redirect_to unlikely_to_verify_path
@@ -23,12 +23,6 @@ class SelectDocumentsController < ApplicationController
   def unlikely_to_verify
     @other_ways_description = current_transaction.other_ways_description
     @other_ways_text = current_transaction.other_ways_text
-  end
-
-private
-
-  def available_idps
-    SESSION_PROXY.identity_providers(cookies)
   end
 
   def documents_eligibility_checker

--- a/app/controllers/select_phone_controller.rb
+++ b/app/controllers/select_phone_controller.rb
@@ -8,7 +8,7 @@ class SelectPhoneController < ApplicationController
     if @form.valid?
       ANALYTICS_REPORTER.report(request, 'Phone Next')
       store_selected_evidence('phone', @form.selected_evidence)
-      if idp_eligibility_checker.any?(selected_evidence_values, available_idps)
+      if idp_eligibility_checker.any?(selected_evidence_values, current_identity_providers)
         redirect_to will_it_work_for_me_path
       else
         redirect_to no_mobile_phone_path
@@ -25,10 +25,6 @@ class SelectPhoneController < ApplicationController
   end
 
 private
-
-  def available_idps
-    SESSION_PROXY.identity_providers(cookies)
-  end
 
   def idp_eligibility_checker
     IDP_ELIGIBILITY_CHECKER

--- a/app/controllers/sign_in_controller.rb
+++ b/app/controllers/sign_in_controller.rb
@@ -1,7 +1,7 @@
 class SignInController < ApplicationController
   def index
     @identity_providers = IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate_collection(
-      SESSION_PROXY.identity_providers(cookies)
+      current_identity_providers
     )
 
     FEDERATION_REPORTER.report_sign_in(current_transaction_simple_id, request)

--- a/app/models/identity_provider.rb
+++ b/app/models/identity_provider.rb
@@ -15,4 +15,9 @@ class IdentityProvider
       'entity_id' => hash['entityId']
     )
   end
+
+  def self.from_session(object)
+    return object if object.is_a? IdentityProvider
+    return new(object) if object.is_a? Hash
+  end
 end

--- a/spec/features/cache_identity_providers_in_session_spec.rb
+++ b/spec/features/cache_identity_providers_in_session_spec.rb
@@ -1,0 +1,19 @@
+require 'feature_helper'
+require 'api_test_helper'
+RSpec.feature 'current identity providers are stored in session', type: :feature do
+  it 'asks for the identity providers only once' do
+    set_session_cookies!
+    stub_identity_providers_request = stub_federation
+    visit choose_a_certified_company_path
+    visit choose_a_certified_company_path
+    expect(stub_identity_providers_request).to have_been_made.once
+  end
+
+  it 'will work across multiple controllers' do
+    set_session_cookies!
+    stub_identity_providers_request = stub_federation
+    visit about_certified_companies_path
+    visit sign_in_path
+    expect(stub_identity_providers_request).to have_been_made.once
+  end
+end

--- a/spec/models/identity_provider_spec.rb
+++ b/spec/models/identity_provider_spec.rb
@@ -23,4 +23,16 @@ RSpec.describe IdentityProvider do
     expect(idp.simple_id).to eql 'simpleId1'
     expect(idp.entity_id).to eql 'entityId1'
   end
+
+  it 'should load from session' do
+    idp = IdentityProvider.from_session('entity_id' => 'entityId1', 'simple_id' => 'simpleId1')
+    expect(idp.simple_id).to eql 'simpleId1'
+    expect(idp.entity_id).to eql 'entityId1'
+  end
+
+  it 'should load from session' do
+    provider = IdentityProvider.new('entity_id' => 'entityId1', 'simple_id' => 'simpleId1')
+    idp = IdentityProvider.from_session(provider)
+    expect(idp).to eql provider
+  end
 end


### PR DESCRIPTION
Identity Providers will be lazily loaded into the session object as they're
required. This should reduce the number of internal API calls needed when we
need to work with the list of available IDPs.

This has been taken as a step towards returning the list of IDPs at the start of
a session alongside the session's transaction.

I'm of two minds regarding whether this code should be placed inside a mixin or
interstitial controller base class (e.g. ChooseACertifiedCompanyController
< FederationController < ApplicationController) so I'm open to opinions.