### PR TITLE
3475 welsh titles in english

### DIFF
--- a/app/assets/javascripts/analytics.js
+++ b/app/assets/javascripts/analytics.js
@@ -9,7 +9,8 @@
     var trackerUrl = $('#piwik-url').text(),
         siteId,
         customUrl,
-        piwikAnalyticsQueue;
+        piwikAnalyticsQueue,
+        enTitle;
 
     if(!trackerUrl) {
         return;
@@ -17,9 +18,10 @@
 
     siteId = $('#piwik-site-id').text();
     customUrl = $('#piwik-custom-url').text();
+    enTitle = $('meta[name="verify|title"]').attr("content") + " - GOV.UK Verify - GOV.UK";
 
     piwikAnalyticsQueue = [
-      ['setDocumentTitle', document.title ],
+      ['setDocumentTitle', enTitle ],
       ['trackPageView'],
       ['enableLinkTracking'],
       [setPiwikVisitorIdCookie],

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -16,7 +16,7 @@ module ApplicationHelper
         idsite: public_piwik.site_id,
         rec: 1,
         rand: Random.rand(2**32 - 1),
-        action_name: content_for(:page_title),
+        action_name: "#{content_for(:page_title_in_english)} - GOV.UK Verify - GOV.UK",
     }
     hash[:url] = piwik_custom_url if piwik_custom_url?
     hash.to_query

--- a/app/views/about/index.html.erb
+++ b/app/views/about/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, t('hub.about.title') %>
+<%= render partial: 'shared/page_title', locals: {:title_key => 'hub.about.title'} %>
 <% content_for :feedback_source, 'ABOUT_PAGE' %>
 
 <p><%= t 'hub.about.verify_is_a_scheme' %></p>

--- a/app/views/choose_a_certified_company/index.html.erb
+++ b/app/views/choose_a_certified_company/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, t('hub.choose_a_certified_company.title') %>
+<%= render partial: 'shared/page_title', locals: {:title_key => 'hub.choose_a_certified_company.title'} %>
 <% content_for :feedback_source, 'CHOOSE_A_CERTIFIED_COMPANY_PAGE' %>
 
 <div class="content-inner">

--- a/app/views/confirm_your_identity/index.html.erb
+++ b/app/views/confirm_your_identity/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, t('hub.confirm_your_identity.title') %>
+<%= render partial: 'shared/page_title', locals: {:title_key => 'hub.confirm_your_identity.title'} %>
 <% content_for :feedback_source, 'CONFIRM_YOUR_IDENTITY' %>
 
 <div class="verify-logo">

--- a/app/views/confirmation/index.html.erb
+++ b/app/views/confirmation/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :body_classes, 'hub-start' %>
-<% content_for :page_title, t('hub.confirmation.title') %>
+<%= render partial: 'shared/page_title', locals: {:title_key => 'hub.confirmation.title'} %>
 <% content_for :feedback_source, 'CONFIRMATION_PAGE' %>
 
 <h1><%= t 'hub.confirmation.heading', idp_name: @idp_name %></h1>

--- a/app/views/errors/404.html.erb
+++ b/app/views/errors/404.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, t('errors.page_not_found.title') %>
+<%= render partial: 'shared/page_title', locals: {:title_key => 'errors.page_not_found.title'} %>
 <% content_for :feedback_source, 'ERROR_PAGE' %>
 <div class="grid-row">
   <div class="column-two-thirds">

--- a/app/views/errors/cookie_expired.html.erb
+++ b/app/views/errors/cookie_expired.html.erb
@@ -1,4 +1,5 @@
-<% content_for :page_title, t('errors.cookie_expired.title') %>
+<%= render partial: 'shared/page_title', locals: {:title_key => 'errors.cookie_expired.title'} %>
+
 <% content_for :feedback_source, 'EXPIRED_ERROR_PAGE' %>
 <% content_for :piwik_custom_path, '/errors/timeout-error' %>
 

--- a/app/views/errors/no_cookies.html.erb
+++ b/app/views/errors/no_cookies.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, t('errors.no_cookies.title') %>
+<%= render partial: 'shared/page_title', locals: {:title_key => 'errors.no_cookies.title'} %>
 <% content_for :feedback_source, 'COOKIE_NOT_FOUND_PAGE' %>
 <% content_for :piwik_custom_path, '/cookies-not-found' %>
 

--- a/app/views/errors/session_error.html.erb
+++ b/app/views/errors/session_error.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, t('errors.session_error.title') %>
+<%= render partial: 'shared/page_title', locals: {:title_key => 'errors.session_error.title'} %>
 <% content_for :feedback_source, 'ERROR_PAGE' %>
 <% content_for :piwik_custom_path, '/errors/session-error' %>
 

--- a/app/views/errors/session_timeout.html.erb
+++ b/app/views/errors/session_timeout.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, t('errors.session_timeout.title') %>
+<%= render partial: 'shared/page_title', locals: {:title_key => 'errors.session_timeout.title'} %>
 <% content_for :feedback_source, 'EXPIRED_ERROR_PAGE' %>
 <% content_for :piwik_custom_path, '/errors/timeout-error' %>
 

--- a/app/views/errors/something_went_wrong.html.erb
+++ b/app/views/errors/something_went_wrong.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, t('errors.something_went_wrong.title') %>
+<%= render partial: 'shared/page_title', locals: {:title_key => 'errors.something_went_wrong.title'} %>
 <% content_for :feedback_source, 'ERROR_PAGE' %>
 <% content_for :piwik_custom_path, 'errors/generic-error' %>
 

--- a/app/views/failed_registration/index.html.erb
+++ b/app/views/failed_registration/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, t('hub.failed_registration.title') %>
+<%= render partial: 'shared/page_title', locals: {:title_key => 'hub.failed_registration.title'} %>
 <% content_for :feedback_source, 'FAILED_REGISTRATION_PAGE' %>
 
 <div class="grid-row">

--- a/app/views/failed_sign_in/index.html.erb
+++ b/app/views/failed_sign_in/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, t('hub.failed_sign_in.title') %>
+<%= render partial: 'shared/page_title', locals: {:title_key => 'hub.failed_sign_in.title'} %>
 <% content_for :feedback_source, 'FAILED_SIGN_IN_PAGE' %>
 
 <div class="grid-row">

--- a/app/views/other_ways_to_access_service/index.html.erb
+++ b/app/views/other_ways_to_access_service/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, t('hub.other_ways_title') %>
+<%= render partial: 'shared/page_title', locals: {:title_key => 'hub.other_ways_title'} %>
 <% content_for :feedback_source, 'OTHER_WAYS_PAGE' %>
 
 <div class="grid-row">

--- a/app/views/redirect_to_idp_warning/index.html.erb
+++ b/app/views/redirect_to_idp_warning/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, t('hub.redirect_to_idp_warning.title') %>
+<%= render partial: 'shared/page_title', locals: {:title_key => 'hub.redirect_to_idp_warning.title'} %>
 <% content_for :feedback_source, 'REDIRECT_TO_IDP_WARNING_PAGE' %>
 
 <div class="grid-row js-continue-to-idp" data-location="<%= url_for(controller: 'redirect_to_idp_warning', action: 'continue_ajax', locale: I18n.locale)  %>">

--- a/app/views/response_processing/matching_error.html.erb
+++ b/app/views/response_processing/matching_error.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, t('errors.something_went_wrong.title') %>
+<%= render partial: 'shared/page_title', locals: {:title_key => 'errors.something_went_wrong.title'} %>
 <% content_for :feedback_source, 'MATCHING_ERROR_PAGE' %>
 
 <div class="grid-row">

--- a/app/views/select_documents/index.html.erb
+++ b/app/views/select_documents/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, t('hub.select_documents.title') %>
+<%= render partial: 'shared/page_title', locals: {:title_key => 'hub.select_documents.title'} %>
 <% content_for :feedback_source, 'SELECT_DOCUMENTS_PAGE' %>
 
 <div id="no-documents-message" class="visually-hidden" aria-live="assertive" data-no-documents-message="<%= h t('hub.select_documents.no_documents_message') %>"></div>

--- a/app/views/select_documents/unlikely_to_verify.html.erb
+++ b/app/views/select_documents/unlikely_to_verify.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, t('hub.other_ways_title') %>
+<%= render partial: 'shared/page_title', locals: {:title_key => 'hub.other_ways_title'} %>
 <% content_for :feedback_source, 'UNLIKELY_TO_VERIFY_PAGE' %>
 
 <div class="grid-row">

--- a/app/views/select_phone/index.html.erb
+++ b/app/views/select_phone/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, t('hub.select_phone.title') %>
+<%= render partial: 'shared/page_title', locals: {:title_key => 'hub.select_phone.title'} %>
 <% content_for :feedback_source, 'SELECT_PHONE_PAGE' %>
 
 <div class="grid-row">

--- a/app/views/select_phone/no_mobile_phone.html.erb
+++ b/app/views/select_phone/no_mobile_phone.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, t('hub.other_ways_title') %>
+<%= render partial: 'shared/page_title', locals: {:title_key => 'hub.other_ways_title'} %>
 <% content_for :feedback_source, 'NO_MOBILE_PHONE' %>
 
 <div class="grid-row">

--- a/app/views/shared/_page_title.html.erb
+++ b/app/views/shared/_page_title.html.erb
@@ -1,0 +1,5 @@
+<% content_for :page_title, t(title_key) %>
+<% content_for :page_title_in_english, t(title_key, locale: :en) %>
+<% content_for :head do
+  tag('meta', :name => 'verify|title', :content => content_for(:page_title_in_english))
+end %>

--- a/app/views/sign_in/index.html.erb
+++ b/app/views/sign_in/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, t('hub.signin.title') %>
+<%= render partial: 'shared/page_title', locals: {:title_key => 'hub.signin.title'} %>
 <% content_for :feedback_source, 'SIGN_IN_PAGE' %>
 
 <%= link_to t('navigation.back'), start_path, class: 'link-back' %>

--- a/app/views/start/index.html.erb
+++ b/app/views/start/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, t('hub.start.title') %>
+<%= render partial: 'shared/page_title', locals: {:title_key => 'hub.start.title'} %>
 <% content_for :body_classes, 'hub-start' %>
 <% content_for :feedback_source, 'START_PAGE' %>
 

--- a/app/views/why_companies/index.html.erb
+++ b/app/views/why_companies/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, t('hub.why_companies.title') %>
+<%= render partial: 'shared/page_title', locals: {:title_key => 'hub.why_companies.title'} %>
 <% content_for :feedback_source, 'WHY_COMPANIES_PAGE' %>
 
 <div class="grid-row">

--- a/app/views/will_it_work_for_me/index.html.erb
+++ b/app/views/will_it_work_for_me/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, t('hub.will_it_work_for_me.title') %>
+<%= render partial: 'shared/page_title', locals: {:title_key => 'hub.will_it_work_for_me.title'} %>
 <% content_for :feedback_source, 'WILL_IT_WORK_FOR_ME_PAGE' %>
 
 <div class="grid-row">

--- a/app/views/will_it_work_for_me/may_not_work_if_you_live_overseas.html.erb
+++ b/app/views/will_it_work_for_me/may_not_work_if_you_live_overseas.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, t('hub.may_not_work_if_you_live_overseas.title') %>
+<%= render partial: 'shared/page_title', locals: {:title_key => 'hub.may_not_work_if_you_live_overseas.title'} %>
 <% content_for :feedback_source, 'MAY_NOT_WORK_IF_YOU_LIVE_OVERSEAS_PAGE' %>
 
 <div class="grid-row">

--- a/app/views/will_it_work_for_me/why_might_this_not_work_for_me.html.erb
+++ b/app/views/will_it_work_for_me/why_might_this_not_work_for_me.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, t('hub.why_might_this_not_work_for_me.title') %>
+<%= render partial: 'shared/page_title', locals: {:title_key => 'hub.why_might_this_not_work_for_me.title'} %>
 <% content_for :feedback_source, 'WHY_THIS_MIGHT_NOT_WORK_FOR_ME_PAGE' %>
 
 <div class="grid-row">

--- a/app/views/will_it_work_for_me/will_not_work_without_uk_address.html.erb
+++ b/app/views/will_it_work_for_me/will_not_work_without_uk_address.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, t('hub.will_not_work_without_uk_address.title') %>
+<%= render partial: 'shared/page_title', locals: {:title_key => 'hub.will_not_work_without_uk_address.title'} %>
 <% content_for :feedback_source, 'WILL_NOT_WORK_WITHOUT_UK_ADDRESS_PAGE' %>
 
 <div class="grid-row">

--- a/spec/features/users_browser_sends_client_side_analytics_spec.rb
+++ b/spec/features/users_browser_sends_client_side_analytics_spec.rb
@@ -36,6 +36,17 @@ RSpec.describe 'When the user visits the start page' do
       expect(page).to have_content 'Sign in with GOV.UK Verify'
     end
 
+    it 'and in Welsh sends the page title in English to analytics' do
+      expect(request_log).to receive(:log).with(
+        hash_including(
+          'action_name' => 'Start - GOV.UK Verify - GOV.UK',
+          'idsite' => '5'
+        )
+      )
+      set_session_cookies!
+      visit '/dechrau'
+    end
+
     it 'sends a page view with a custom url for error pages' do
       stub_transactions_list
       expect(request_log).to receive(:log).with(
@@ -64,6 +75,15 @@ RSpec.describe 'When the user visits the start page' do
       expect(image_src).to match(/rand=\d+/)
       expect(image_src).to match(/action_name=Start\+-\+GOV\.UK\+Verify\+-\+GOV\.UK/)
       expect(image_src).to_not include('url')
+    end
+
+    it 'and in Welsh sends the page title in English to analytics' do
+      set_session_cookies!
+      visit '/dechrau'
+      noscript_image = page.find(:id, 'piwik-noscript-tracker')
+      expect(noscript_image).to_not be_nil
+      image_src = noscript_image['src']
+      expect(image_src).to match(/action_name=Start\+-\+GOV\.UK\+Verify\+-\+GOV\.UK/)
     end
 
     it 'sends a page view with a custom url for error pages' do


### PR DESCRIPTION
This PR will render page titles in english in a meta tag so that we could use english titles irrespective of the language chose to report to analytics.