### PR TITLE
z21168 : changing hint text for private transactions

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -263,7 +263,7 @@ cy:
   errors:
     transaction_list:
       title: Dod o hyd i’r gwasanaeth rydych yn ei ddefnyddio i ddechrau eto
-      hint: Dilynwch y cyfarwyddiadau sydd yn yr e-bost a gawsoch
+      hint: Follow the instructions you received.
     cookie_expired:
       title: Mae eich sesiwn wedi amseru allan
       feedback_message: Defnyddiwch yr %{feedback_link} i ofyn cwestiwn, hysbysu problem neu awgrymu gwelliant.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -257,7 +257,7 @@ en:
   errors:
     transaction_list:
       title: Find the service you were using to start again
-      hint: Follow the instructions contained in the email you received
+      hint: Follow the instructions you received.
     cookie_expired:
       title: Your session has timed out
       feedback_message: Use the %{feedback_link} to ask a question, report a problem or suggest an improvement.


### PR DESCRIPTION
We are changing the text that appears under private transaction
names in the transaction list of the timeout page so that it is
more generic.

Authors: @yolinas