### PR TITLE
bau: fix some missed out page titles

### DIFF
--- a/app/views/choose_a_certified_company/about.html.erb
+++ b/app/views/choose_a_certified_company/about.html.erb
@@ -1,4 +1,5 @@
 <% content_for :page_title, t('hub.choose_a_certified_company.about.title', name: @idp.display_name) %>
+<% content_for :page_title_in_english, t('hub.choose_a_certified_company.about.title', name: @idp.display_name, locale: :en) %>
 <% content_for :feedback_source, "CHOOSE_A_CERTIFIED_COMPANY_ABOUT_#{@idp.simple_id.upcase}_PAGE" %>
 
 <%= link_to t('navigation.back'), choose_a_certified_company_path, class: 'link-back' %>

--- a/app/views/redirect_to_idp/index.html.erb
+++ b/app/views/redirect_to_idp/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, 'Loading' %>
+<%= render partial: 'shared/page_title', locals: {:title_key => 'hub.redirect_to_idp.loading'} %>
 
 <div class="content">
   <div class="grid-row">

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -280,6 +280,7 @@ cy:
     redirect_to_idp:
       heading: Continue to next step
       description: Because Javascript is not enabled on your browser, you must press the continue button
+      loading: Loading
   errors:
     transaction_list:
       title: Dod o hyd i’r gwasanaeth rydych yn ei ddefnyddio i ddechrau eto

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -274,6 +274,7 @@ en:
     redirect_to_idp:
       heading: Continue to next step
       description: Because Javascript is not enabled on your browser, you must press the continue button
+      loading: Loading
   errors:
     transaction_list:
       title: Find the service you were using to start again


### PR DESCRIPTION
- redirect-to-idp page now has a translated page title
with page title in English
- about a company page now has a page title in english

Authors: @yolinas