### PR TITLE
3673 Show no docs interstitial page content when only foreign id is ch…

### DIFF
--- a/app/controllers/redirect_to_idp_warning_controller.rb
+++ b/app/controllers/redirect_to_idp_warning_controller.rb
@@ -1,6 +1,6 @@
 class RedirectToIdpWarningController < ApplicationController
   SELECTED_IDP_HISTORY_LENGTH = 5
-  helper_method :user_has_no_docs?, :other_ways_description
+  helper_method :user_has_no_docs_or_foreign_id_only?, :other_ways_description
 
   def index
     @idp = decorated_idp
@@ -63,7 +63,15 @@ private
     @other_ways_description = current_transaction.other_ways_description
   end
 
+  def user_has_no_docs_or_foreign_id_only?
+    user_has_no_docs? || user_has_foreign_doc_only?
+  end
+
   def user_has_no_docs?
     (stored_selected_evidence['documents'] || []).empty?
+  end
+
+  def user_has_foreign_doc_only?
+    stored_selected_evidence['documents'] == ['non_uk_id_document']
   end
 end

--- a/app/views/redirect_to_idp_warning/_recommended.html.erb
+++ b/app/views/redirect_to_idp_warning/_recommended.html.erb
@@ -1,4 +1,4 @@
-<% if user_has_no_docs? %>
+<% if user_has_no_docs_or_foreign_id_only? %>
     <%= idp.special_no_docs_instructions.html_safe %>
 <% end %>
 

--- a/app/views/redirect_to_idp_warning/index.html.erb
+++ b/app/views/redirect_to_idp_warning/index.html.erb
@@ -17,7 +17,7 @@
                        type: 'submit'
         %>
     <% end %>
-    <% if user_has_no_docs? && @recommended %>
+    <% if user_has_no_docs_or_foreign_id_only? && @recommended %>
         <%= other_ways(@idp) %>
     <% end %>
   </div>

--- a/spec/features/user_visits_redirect_to_idp_warning_page_spec.rb
+++ b/spec/features/user_visits_redirect_to_idp_warning_page_spec.rb
@@ -37,6 +37,13 @@ RSpec.describe 'When the user visits the redirect to IDP warning page' do
       selected_evidence: { phone: %w(mobile_phone smart_phone), documents: [] },
     )
   }
+  let(:given_a_session_with_non_uk_id_document_evidence) {
+    page.set_rack_session(
+      selected_idp: { entity_id: 'http://idpwithnonukid.com', simple_id: 'stub-idp-four' },
+      selected_idp_was_recommended: true,
+      selected_evidence: { phone: %w(mobile_phone smart_phone), documents: %w(non_uk_id_document) },
+    )
+  }
   let(:select_idp_stub_request) {
     stub_session_select_idp_request(
       encrypted_entity_id,
@@ -143,6 +150,16 @@ RSpec.describe 'When the user visits the redirect to IDP warning page' do
     visit '/redirect-to-idp-warning'
 
     expect(page).to have_content 'You’ll now verify your identity on No Docs IDP’s website.'
+    expect(page).to have_content 'Additional IDP Instructions'
+    expect(page).to have_link 'other ways to register for an identity profile', href: other_ways_to_access_service_path
+  end
+
+  it 'includes specific IDP text and link to the other ways when user has only foreign id document' do
+    page.set_rack_session(transaction_simple_id: 'test-rp')
+    given_a_session_with_non_uk_id_document_evidence
+    visit '/redirect-to-idp-warning'
+
+    expect(page).to have_content 'You’ll now verify your identity on Best ID’s website.'
     expect(page).to have_content 'Additional IDP Instructions'
     expect(page).to have_link 'other ways to register for an identity profile', href: other_ways_to_access_service_path
   end

--- a/spec/features/user_visits_redirect_to_idp_warning_page_spec.rb
+++ b/spec/features/user_visits_redirect_to_idp_warning_page_spec.rb
@@ -149,7 +149,7 @@ RSpec.describe 'When the user visits the redirect to IDP warning page' do
     given_a_session_with_no_document_evidence
     visit '/redirect-to-idp-warning'
 
-    expect(page).to have_content 'You’ll now verify your identity on No Docs IDP’s website.'
+    expect(page).to have_content I18n.t 'hub.redirect_to_idp_warning.recommended.p1', name: 'No Docs IDP'
     expect(page).to have_content 'Additional IDP Instructions'
     expect(page).to have_link 'other ways to register for an identity profile', href: other_ways_to_access_service_path
   end
@@ -159,7 +159,7 @@ RSpec.describe 'When the user visits the redirect to IDP warning page' do
     given_a_session_with_non_uk_id_document_evidence
     visit '/redirect-to-idp-warning'
 
-    expect(page).to have_content 'You’ll now verify your identity on Best ID’s website.'
+    expect(page).to have_content I18n.t 'hub.redirect_to_idp_warning.recommended.p1', name: 'Best ID'
     expect(page).to have_content 'Additional IDP Instructions'
     expect(page).to have_link 'other ways to register for an identity profile', href: other_ways_to_access_service_path
   end

--- a/stub/idp-rules/stub-idp-four.yml
+++ b/stub/idp-rules/stub-idp-four.yml
@@ -1,0 +1,3 @@
+simpleIds: [ "stub-idp-four" ]
+rules:
+  - [ "non_uk_id_document" ]

--- a/stub/locales/idps/stub-idp-four.yml
+++ b/stub/locales/idps/stub-idp-four.yml
@@ -2,6 +2,14 @@ en:
   idps:
     stub-idp-four:
       name: "Best ID"
+      tagline: "a really really cool identity provider"
+      about: |
+          <p>Best ID is the premier identity proofing service around.</p>
+          <p>Once you get verified you can transact with online government services.</p>
+      requirements:
+        - "A requirement"
+      special_no_docs_instructions_html: "<p>Additional IDP Instructions</p>"
+      no_docs_requirement: "If you do not have a current account"
       contact_details: |
         <strong id="stub-idp-four-contact-details">4 Head Road</strong>
 cy:


### PR DESCRIPTION
…osen

This is a need only for experian at the moment.
However, we don't drive the display logic by IDPs
instead we manage it through the content configuration
for IDPs. We have no_docs content only for experian at the moment.

Authors: @veda