### PR TITLE
BAU: fix confirmation button alignment

### DIFF
--- a/app/assets/stylesheets/pages/_slides.scss
+++ b/app/assets/stylesheets/pages/_slides.scss
@@ -28,14 +28,12 @@
   }
 
   h1 {
-
-    @include bold-27;
-
     @include media (mobile) {
       margin-top: $gutter-half;
       margin-bottom: $gutter-half;
     }
 
+    margin-top: 0;
     margin-bottom: $gutter;
   }
 
@@ -94,10 +92,6 @@
 // ==========================================================================
 
 .hub-start {
-
-  h1 {
-    @include bold-36;
-  }
 
   .button {
     @include media(tablet) {

--- a/app/views/confirmation/index.html.erb
+++ b/app/views/confirmation/index.html.erb
@@ -1,8 +1,7 @@
-<% content_for :body_classes, 'hub-start' %>
 <%= render partial: 'shared/page_title', locals: {:title_key => 'hub.confirmation.title'} %>
 <% content_for :feedback_source, 'CONFIRMATION_PAGE' %>
 
-<h1><%= t 'hub.confirmation.heading', display_name: @idp_name %></h1>
+<h1 class="heading-large"><%= t 'hub.confirmation.heading', display_name: @idp_name %></h1>
 <p><%= t 'hub.confirmation.message' %></p>
 <div class="actions">
   <%= link_to @transaction_name.capitalize, response_processing_path, class: 'button', id:'next-button' %>

--- a/app/views/start/index.html.erb
+++ b/app/views/start/index.html.erb
@@ -2,7 +2,7 @@
 <% content_for :body_classes, 'hub-start' %>
 <% content_for :feedback_source, 'START_PAGE' %>
 
-<h1><%= t 'hub.start.heading' %></h1>
+<h1 class="heading-large"><%= t 'hub.start.heading' %></h1>
 
 <%= form_tag start_path, id: 'start-page-form', class: 'js-validate', novalidate: 'novalidate' do %>
   <div class="form-group <%= @error_message.present? ? 'error' : '' %>">


### PR DESCRIPTION
The confirmation page is using the `.hub-start` class to get a bigger heading than usual, but that has the side effect of pushing the button left by 15px (we do this on the start page to align with the radio buttons).

If we use [elements’ `.heading-x` classes](http://govuk-elements.herokuapp.com/typography/#typography-headings) to control heading styles we can remove our custom weights and the class from the confirmation page that was affecting the button margin. The only change we need to make to our CSS is to remove the top margin on headings.