### PR TITLE
BAU: Fix RP name on matching error page

### DIFF
--- a/app/views/response_processing/matching_error.html.erb
+++ b/app/views/response_processing/matching_error.html.erb
@@ -5,7 +5,7 @@
   <div class="column-two-thirds">
     <h1 class="heading-xlarge"><%= t 'errors.something_went_wrong.heading' %></h1>
     <p>
-      <%= t('hub.response_processing.matching_error.problem', rp_name: 'Test RP') %>
+      <%= t('hub.response_processing.matching_error.problem', rp_name: @rp_name) %>
     </p>
     <p><%= t('hub.response_processing.matching_error.start_again_message_html', start_again_link: link_to(t('hub.response_processing.matching_error.start_again_link'), redirect_to_service_error_path)) %></p>
 


### PR DESCRIPTION
Currently we're saying

Sorry, Test RP is having technical problems.

When there's a matching error