### PR TITLE
3685: Don't trust user input

### DIFF
--- a/app/assets/javascripts/continue_to_idp.js
+++ b/app/assets/javascripts/continue_to_idp.js
@@ -12,18 +12,15 @@
     attach: function () {
       var $container = $('.js-continue-to-idp');
       $container.on('submit', '.js-idp-form', function (e) {
-        var simpleId, entityId, displayName;
         var $originalForm = $(e.target);
         e.preventDefault();
-        displayName = $originalForm.find('.js-display-name').val();
-        entityId = $originalForm.find('.js-entity-id').val();
-        simpleId = $originalForm.find('.js-simple-id').val();
+        var simpleId = $originalForm.find('.js-simple-id').val();
         $.ajax({
           type: 'PUT',
           url: $container.data('location'),
           contentType: "application/json",
           processData: false,
-          data: JSON.stringify({ entityId: entityId, displayName: displayName, simpleId: simpleId }),
+          data: JSON.stringify({ simpleId: simpleId }),
           timeout: 5000
         }).done(function(response) {
           var $samlForm;

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -91,6 +91,14 @@ private
     end
   end
 
+  def render_not_found
+    set_locale
+    respond_to do |format|
+      format.html { render 'errors/404', status: 404 }
+      format.json { render json: {}, status: 404 }
+    end
+  end
+
   def cookie_validator
     COOKIE_VALIDATOR
   end
@@ -146,5 +154,16 @@ private
 
   def hide_available_languages
     @hide_available_languages = true
+  end
+
+  def for_viewable_idp(simple_id)
+    matching_idp = current_identity_providers.detect { |idp| idp.simple_id == simple_id }
+    idp = IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate(matching_idp)
+    if idp.viewable?
+      yield idp
+    else
+      logger.error 'Unrecognised IdP simple id'
+      render_not_found
+    end
   end
 end

--- a/app/controllers/sign_in_controller.rb
+++ b/app/controllers/sign_in_controller.rb
@@ -9,19 +9,20 @@ class SignInController < ApplicationController
   end
 
   def select_idp
-    idp_form = params.fetch('identity_provider')
-    idp = IdentityProvider.new(idp_form)
-    display_name = idp_form.fetch('display_name', idp.entity_id)
-    sign_in(idp.entity_id, display_name)
-    session[:selected_idp] = idp
-    redirect_to redirect_to_idp_path
+    for_viewable_idp(params.fetch('simple_id')) do |decorated_idp|
+      sign_in(decorated_idp.entity_id, decorated_idp.display_name)
+      session[:selected_idp] = decorated_idp.identity_provider
+      redirect_to redirect_to_idp_path
+    end
   end
 
   def select_idp_ajax
-    sign_in(params.fetch('entityId'), params.fetch('displayName'))
-    authn_request_json = SESSION_PROXY.idp_authn_request(cookies)
-    session[:selected_idp] = IdentityProvider.new('simple_id' => params.fetch('simpleId'), 'entity_id' => params.fetch('entityId'))
-    render json: authn_request_json
+    for_viewable_idp(params.fetch('simpleId')) do |decorated_idp|
+      sign_in(decorated_idp.entity_id, decorated_idp.display_name)
+      authn_request_json = SESSION_PROXY.idp_authn_request(cookies)
+      session[:selected_idp] = decorated_idp.identity_provider
+      render json: authn_request_json
+    end
   end
 
 private

--- a/app/models/idp_eligibility/checker.rb
+++ b/app/models/idp_eligibility/checker.rb
@@ -12,6 +12,10 @@ module IdpEligibility
       !filter_recommended_idps(evidence, enabled_idps).empty?
     end
 
+    def recommended?(idp, evidence, enabled_idps)
+      filter_recommended_idps(evidence, enabled_idps).include? idp
+    end
+
     def group_by_recommendation(evidence, enabled_idps)
       recommended_idps = filter_recommended_idps(evidence, enabled_idps)
       non_recommended_idps = enabled_idps - recommended_idps

--- a/app/views/choose_a_certified_company/_idp_option.html.erb
+++ b/app/views/choose_a_certified_company/_idp_option.html.erb
@@ -14,9 +14,6 @@
                      type: 'submit',
                      value: identity_provider.display_name
       %>
-      <%= hidden_field_tag 'selected-idp', identity_provider.entity_id, id: nil %>
-      <%= hidden_field_tag 'recommended-idp', recommended, id: nil %>
-      <%= f.hidden_field :entity_id, id: nil, class: 'js-entity-id' %>
-      <%= f.hidden_field :simple_id, id: nil, class: 'js-simple-id' %>
+      <%= hidden_field_tag 'simple_id', identity_provider.simple_id, id: nil %>
   <% end %>
 </div>

--- a/app/views/choose_a_certified_company/_select_idp_form.html.erb
+++ b/app/views/choose_a_certified_company/_select_idp_form.html.erb
@@ -5,8 +5,5 @@
                  type: 'submit',
                  value: identity_provider.display_name
     %>
-    <%= hidden_field_tag 'selected-idp', identity_provider.entity_id %>
-    <%= hidden_field_tag 'recommended-idp', recommended %>
-    <%= f.hidden_field :entity_id %>
-    <%= f.hidden_field :simple_id %>
+    <%= hidden_field_tag 'simple_id', identity_provider.simple_id, id: nil %>
 <% end %>

--- a/app/views/shared/_idp_list.erb
+++ b/app/views/shared/_idp_list.erb
@@ -17,12 +17,8 @@
                              type: 'submit',
                              value: identity_provider.display_name
                 %>
-                <%= hidden_field_tag 'selected-idp-entity-id', identity_provider.entity_id, id: nil %>
-                <%= hidden_field_tag 'selected-idp-display-name', identity_provider.display_name, id: nil %>
-                <%= f.hidden_field :entity_id, id: nil, class: 'js-entity-id' %>
-                <%= f.hidden_field :simple_id, id: nil, class: 'js-simple-id' %>
-                <%= f.hidden_field :display_name, id: nil, class: 'js-display-name' %>
-          <% end %>
+                <%= hidden_field_tag 'simple_id', identity_provider.simple_id, id: nil, class: 'js-simple-id' %>
+            <% end %>
           </div>
         </div>
       </div>

--- a/spec/features/user_visits_choose_a_certified_company_page_spec.rb
+++ b/spec/features/user_visits_choose_a_certified_company_page_spec.rb
@@ -10,16 +10,12 @@ RSpec.describe 'When the user visits the choose a certified company page' do
   let(:selected_evidence) { { documents: [:passport, :driving_licence], phone: [:mobile_phone] } }
   let(:given_a_session_with_selected_evidence) {
     page.set_rack_session(
-      selected_idp: { entity_id: 'http://idcorp.com', simple_id: 'stub-idp-one' },
-      selected_idp_was_recommended: true,
       selected_evidence: selected_evidence,
     )
   }
 
   let(:given_a_session_without_selected_evidence) {
     page.set_rack_session(
-      selected_idp: { entity_id: 'http://idcorp.com', simple_id: 'stub-idp-one' },
-      selected_idp_was_recommended: true,
       selected_evidence: {},
     )
   }
@@ -84,6 +80,34 @@ RSpec.describe 'When the user visits the choose a certified company page' do
     expect(page).to have_current_path(redirect_to_idp_warning_path)
     expect(page.get_rack_session_key('selected_idp')).to eql('entity_id' => entity_id, 'simple_id' => 'stub-idp-one')
     expect(page.get_rack_session_key('selected_idp_was_recommended')).to eql false
+  end
+
+  it 'records details in session when a recommended IdP is selected' do
+    stub_federation
+    given_a_session_with_selected_evidence
+    visit '/choose-a-certified-company'
+
+    within('#matching-idps') do
+      click_button 'Choose IDCorp'
+    end
+
+    expect(page.get_rack_session_key('selected_idp_was_recommended')).to eql true
+    expect(page.get_rack_session_key('selected_idp')).to eql('entity_id' => 'http://idcorp.com', 'simple_id' => 'stub-idp-one')
+  end
+
+  it 'rejects unrecognised simple ids' do
+    stub_federation
+    given_a_session_with_selected_evidence
+    visit '/choose-a-certified-company'
+
+    first('input[value=stub-idp-one]', visible: false).set('bob')
+    within('#matching-idps') do
+      click_button 'Choose IDCorp'
+    end
+
+    expect(page).to have_content(I18n.translate('errors.page_not_found.title'))
+    expect(page.get_rack_session['selected_idp']).to be_nil
+    expect(page.get_rack_session['selected_idp_was_recommended']).to be_nil
   end
 
   it 'redirects to the choose a certified company about page when selecting About link' do

--- a/spec/features/user_visits_the_choose_a_certified_company_about_idp_page_spec.rb
+++ b/spec/features/user_visits_the_choose_a_certified_company_about_idp_page_spec.rb
@@ -1,6 +1,7 @@
 require 'feature_helper'
+require 'api_test_helper'
 
-RSpec.feature 'user visits the choose a certified about idp page', type: :feature do
+RSpec.feature 'user visits the choose a certified company about idp page', type: :feature do
   let(:selected_evidence) { { documents: [:passport, :driving_licence], phone: [:mobile_phone] } }
   let(:given_a_session_with_selected_evidence) {
     page.set_rack_session(
@@ -9,7 +10,7 @@ RSpec.feature 'user visits the choose a certified about idp page', type: :featur
       selected_evidence: selected_evidence,
     )
   }
-  scenario 'user visit about page for stub-idp-one and chooses it when its recommended' do
+  scenario 'user chooses a recommended idp' do
     entity_id = 'my-entity-id'
     stub_federation(entity_id)
     set_session_cookies!
@@ -22,14 +23,14 @@ RSpec.feature 'user visits the choose a certified about idp page', type: :featur
     expect(page.get_rack_session_key('selected_idp_was_recommended')).to eql true
   end
 
-  scenario 'user visit about page for a non-existent idp' do
+  scenario 'for a non-existent idp' do
     stub_federation
     set_session_cookies!
     visit choose_a_certified_company_about_path('foobar')
     expect(page).to have_content(I18n.translate("errors.page_not_found.title"))
   end
 
-  scenario 'user visit about page for a idp that is not viewable' do
+  scenario 'for an idp that is not viewable' do
     idps = [
         { 'simpleId' => 'foobar', 'entityId' => 'foobar' },
     ]
@@ -40,7 +41,7 @@ RSpec.feature 'user visits the choose a certified about idp page', type: :featur
     expect(page).to have_content(I18n.translate("errors.page_not_found.title"))
   end
 
-  scenario 'user clicks back link from choose-a-certified-company-about page' do
+  scenario 'user clicks back link' do
     entity_id = 'my-entity-id'
     stub_federation(entity_id)
     set_session_cookies!

--- a/spec/javascripts/continue_to_idp_spec.js
+++ b/spec/javascripts/continue_to_idp_spec.js
@@ -10,15 +10,11 @@ describe('Continue to IDP', function () {
       html = '<div class="js-continue-to-idp" data-location="/foobar">'
            + '<form class="js-idp-form first-form" action="">'
            +   '<button type=submit value="IDCorpDisplayName"></button>'
-           +   '<input class=js-entity-id type="hidden" value="idcorp-entity-id" name="identity_provider[entity_id]">'
-           +   '<input class=js-simple-id type="hidden" value="idcorp-simple-id" name="identity_provider[simple_id]">'
-           +   '<input class=js-display-name type="hidden" value="IDCorp display name" name="identity_provider[display_name]">'
+           +   '<input class=js-simple-id type="hidden" value="idcorp-simple-id" name="company">'
            + '</form>'
            + '<form class="js-idp-form second-form" action="">'
            +   '<button type=submit value="IDCorpZweiDisplayName"></button>'
-           +   '<input class=js-entity-id type="hidden" value="idcorpzwei-entity-id" name="identity_provider[entity_id]">'
-           +   '<input class=js-simple-id type="hidden" value="idcorpzwei-simple-id" name="identity_provider[simple_id]">'
-           +   '<input class=js-display-name type="hidden" value="IDCorp Zwei display name" name="identity_provider[display_name]">'
+           +   '<input class=js-simple-id type="hidden" value="idcorpzwei-simple-id" name="company">'
            + '</form>'
            + '<form id=post-to-idp>'
            +   '<input name=SAMLRequest type=hidden>'
@@ -57,7 +53,7 @@ describe('Continue to IDP', function () {
         })
       });
       expect(jasmine.Ajax.requests.mostRecent().url).toBe(apiPath);
-      expect(jasmine.Ajax.requests.mostRecent().params).toBe('{"entityId":"idcorpzwei-entity-id","displayName":"IDCorp Zwei display name","simpleId":"idcorpzwei-simple-id"}');
+      expect(jasmine.Ajax.requests.mostRecent().params).toBe('{"simpleId":"idcorpzwei-simple-id"}');
     });
     it('should populate the SAML request form with the AJAX response and submit it', function () {
       $(document).submit(formSpy);

--- a/spec/models/idp_eligibility/checker_spec.rb
+++ b/spec/models/idp_eligibility/checker_spec.rb
@@ -64,5 +64,23 @@ module IdpEligibility
         expect(grouped_idps.non_recommended).to eql([])
       end
     end
+
+    describe '#recommended?' do
+      it 'should return false when idp cannot verify with evidence' do
+        enabled_idps = singleton_idp
+        allow(rules_repository).to receive(:rules).and_return('idp' => [[:passport]])
+        user_docs = [:driving_licence]
+
+        expect(checker.recommended?(idp1, user_docs, enabled_idps)).to eql(false)
+      end
+
+      it 'should return true when idp can verify with evidence' do
+        enabled_idps = singleton_idp
+        allow(rules_repository).to receive(:rules).and_return('idp' => [[:passport]])
+        user_docs = [:passport]
+
+        expect(checker.recommended?(idp1, user_docs, enabled_idps)).to eql(true)
+      end
+    end
   end
 end


### PR DESCRIPTION
There are a few places where we rely on form params to provide
information about the IdP selected by the user, for instance the entity
id and display name.

There's no need to do this any more, because this information can be
retrieved from the session given the simple id, and doing it this way
reduces the opportunity for a malicious user to introduce bad data.

This change removes the entity id and display name from IdP selection
forms, and just uses the simple id to look up the IdP and get the rest
of the information.