### PR TITLE
BAU: move reporting of IdP login to FederationReporter

### DIFF
--- a/app/controllers/sign_in_controller.rb
+++ b/app/controllers/sign_in_controller.rb
@@ -29,7 +29,6 @@ private
   def sign_in(entity_id, display_name)
     SESSION_PROXY.select_idp(cookies, entity_id)
     set_journey_hint(entity_id, I18n.locale)
-    cvar = Analytics::CustomVariable.build(:select_idp, display_name)
-    ANALYTICS_REPORTER.report_custom_variable(request, "Sign In - #{display_name}", cvar)
+    FEDERATION_REPORTER.report_sign_in_idp_selection(request, display_name)
   end
 end

--- a/app/models/analytics/federation_reporter.rb
+++ b/app/models/analytics/federation_reporter.rb
@@ -26,6 +26,11 @@ module Analytics
       @analytics_reporter.report_custom_variable(request, action, cvar)
     end
 
+    def report_sign_in_idp_selection(request, idp_display_name)
+      cvar = Analytics::CustomVariable.build(:select_idp, idp_display_name)
+      @analytics_reporter.report_custom_variable(request, "Sign In - #{idp_display_name}", cvar)
+    end
+
   private
 
     def report_action(transaction_simple_id, request, action)

--- a/spec/models/analytics/federation_reporter_spec.rb
+++ b/spec/models/analytics/federation_reporter_spec.rb
@@ -22,6 +22,20 @@ module Analytics
       federation_reporter.report_idp_selection(idp_names, request)
     end
 
+    describe '#report_sign_in_idp_selection' do
+      it 'should build correct report' do
+        idp_display_name = 'IDCorp'
+        expect(analytics_reporter).to receive(:report_custom_variable)
+          .with(
+            request,
+            "Sign In - #{idp_display_name}",
+            3 => ['SIGNIN_IDP', idp_display_name]
+          )
+
+        federation_reporter.report_sign_in_idp_selection(request, idp_display_name)
+      end
+    end
+
     describe '#report_idp_registration' do
       it 'should report correctly if IdP was recommended' do
         idp_name = 'IDCorp'


### PR DESCRIPTION
Move the code to build the Piwik request setting the IdP selection for
login custom variable into FederationReporter.  This means the code can
be unit tested, and there's less code in the controller.