### PR TITLE
bau: don't send raven log messages to sentry

### DIFF
--- a/lib/support/raven/logger.rb
+++ b/lib/support/raven/logger.rb
@@ -30,10 +30,14 @@ module Support
       end
 
       class RavenWriter
-        def write(exception = nil)
-          unless exception.nil? || exception.is_a?(ActionController::RoutingError)
-            ::Raven.capture_exception(exception)
+        def write(msg = nil)
+          unless msg.nil? || msg.is_a?(ActionController::RoutingError) || message_is_raven_log?(msg)
+            ::Raven.capture_exception(msg)
           end
+        end
+
+        def message_is_raven_log?(message)
+          message.is_a?(String) && message.start_with?(::Raven::Logger::LOG_PREFIX)
         end
       end
     end

--- a/spec/lib/support/raven/logger_spec.rb
+++ b/spec/lib/support/raven/logger_spec.rb
@@ -2,40 +2,39 @@ require 'spec_helper'
 require 'logger'
 require 'support/raven/logger'
 require 'action_controller/metal/exceptions'
+require 'raven'
 describe Support::Raven::Logger do
   let(:logger) { Support::Raven::Logger.new }
   context "#error" do
     it 'will send exceptions to sentry' do
-      raven = double(:raven)
-      stub_const("Raven", raven)
       error = StandardError.new
-      expect(raven).to receive(:capture_exception).with(error)
+      expect(Raven).to receive(:capture_exception).with(error)
       logger.error(error)
     end
 
     it 'will not send routing exceptions to sentry' do
-      raven = double(:raven)
-      stub_const("Raven", raven)
       error = ActionController::RoutingError.new(nil)
-      expect(raven).to_not receive(:capture_exception).with(error)
+      expect(Raven).to_not receive(:capture_exception).with(error)
       logger.error(error)
     end
 
     it 'will send non-exceptions to sentry after inspection' do
-      raven = double(:raven)
-      stub_const("Raven", raven)
       msg = double(:message)
       inspected = double(:inspected)
       expect(msg).to receive(:inspect).and_return inspected
-      expect(raven).to receive(:capture_exception).with(inspected)
+      expect(Raven).to receive(:capture_exception).with(inspected)
       logger.error(msg)
     end
 
     it 'will send string to sentry as string' do
-      raven = double(:raven)
-      stub_const("Raven", raven)
       msg = "foobar"
-      expect(raven).to receive(:capture_exception).with(msg)
+      expect(Raven).to receive(:capture_exception).with(msg)
+      logger.error(msg)
+    end
+
+    it 'will not send strings with the raven prefix to sentry' do
+      msg = "** [Raven] foobar"
+      expect(Raven).to_not receive(:capture_exception)
       logger.error(msg)
     end
   end


### PR DESCRIPTION
If raven-ruby encounters an error while sending a message to Sentry (e.g.
a network error) it will use the rails logger to log an error message.
Unfortunately, we try to log error messages from the Rails logger to Sentry
using Raven so this introduces a bit of a loop which can result in a segfault if
the network error persists.

This change instructs our mechanism that logs messages to sentry from the Rails
logger to ignore messages that start with the Raven log message prefix.