### PR TITLE
3668: Remove selected evidence from session

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -53,24 +53,8 @@ class ApplicationController < ActionController::Base
     }
   end
 
-  def store_selected_evidence(stage, evidence)
-    stored_selected_evidence[stage] = evidence
-  end
-
-  def store_selected_answers(stage, answers)
-    stored_selected_answers[stage] = answers
-  end
-
-  def stored_selected_evidence
-    session[:selected_evidence] ||= {}
-  end
-
-  def stored_selected_answers
-    session[:selected_answers] ||= {}
-  end
-
-  def selected_evidence_values
-    stored_selected_evidence.values.flatten.map(&:to_sym)
+  def selected_answer_store
+    @selected_answer_store ||= SelectedAnswerStore.new(session)
   end
 
   def set_journey_hint(idp_entity_id, locale)

--- a/app/controllers/choose_a_certified_company_controller.rb
+++ b/app/controllers/choose_a_certified_company_controller.rb
@@ -1,6 +1,6 @@
 class ChooseACertifiedCompanyController < ApplicationController
   def index
-    grouped_identity_providers = IDP_ELIGIBILITY_CHECKER.group_by_recommendation(selected_evidence_values, current_identity_providers)
+    grouped_identity_providers = IDP_ELIGIBILITY_CHECKER.group_by_recommendation(selected_answer_store.selected_evidence, current_identity_providers)
     @recommended_idps = IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate_collection(grouped_identity_providers.recommended)
     @non_recommended_idps = IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate_collection(grouped_identity_providers.non_recommended)
   end
@@ -8,7 +8,7 @@ class ChooseACertifiedCompanyController < ApplicationController
   def select_idp
     select_viewable_idp(params.fetch('entity_id') { params.fetch('identity_provider').fetch('entity_id') }) do |decorated_idp|
       session[:selected_idp_was_recommended] =
-        IDP_ELIGIBILITY_CHECKER.recommended?(decorated_idp.identity_provider, selected_evidence_values, current_identity_providers)
+        IDP_ELIGIBILITY_CHECKER.recommended?(decorated_idp.identity_provider, selected_answer_store.selected_evidence, current_identity_providers)
       redirect_to redirect_to_idp_warning_path
     end
   end
@@ -18,7 +18,7 @@ class ChooseACertifiedCompanyController < ApplicationController
     matching_idp = current_identity_providers.detect { |idp| idp.simple_id == simple_id }
     @idp = IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate(matching_idp)
     if @idp.viewable?
-      grouped_identity_providers = IDP_ELIGIBILITY_CHECKER.group_by_recommendation(selected_evidence_values, [@idp])
+      grouped_identity_providers = IDP_ELIGIBILITY_CHECKER.group_by_recommendation(selected_answer_store.selected_evidence, [@idp])
       @recommended = grouped_identity_providers.recommended.any?
       render 'about'
     else

--- a/app/controllers/redirect_to_idp_warning_controller.rb
+++ b/app/controllers/redirect_to_idp_warning_controller.rb
@@ -47,7 +47,7 @@ private
       selected_idp_names << idp_name
       session[:selected_idp_names] = selected_idp_names
     end
-    FEDERATION_REPORTER.report_idp_registration(request, idp_name, selected_idp_names, selected_evidence_values, recommended?)
+    FEDERATION_REPORTER.report_idp_registration(request, idp_name, selected_idp_names, selected_answer_store.selected_evidence, recommended?)
   end
 
   def recommended?
@@ -67,10 +67,10 @@ private
   end
 
   def user_has_no_docs?
-    (stored_selected_evidence['documents'] || []).empty?
+    selected_answer_store.selected_evidence_for('documents').empty?
   end
 
   def user_has_foreign_doc_only?
-    stored_selected_evidence['documents'] == ['non_uk_id_document']
+    selected_answer_store.selected_evidence_for('documents') == [:non_uk_id_document]
   end
 end

--- a/app/controllers/select_documents_controller.rb
+++ b/app/controllers/select_documents_controller.rb
@@ -7,9 +7,8 @@ class SelectDocumentsController < ApplicationController
     @form = SelectDocumentsForm.new(params['select_documents_form'] || {})
     if @form.valid?
       report_to_analytics('Select Documents Next')
-      store_selected_evidence('documents', @form.selected_evidence)
-      store_selected_answers('documents', @form.selected_answers)
-      if documents_eligibility_checker.any?(selected_evidence_values, current_identity_providers)
+      selected_answer_store.store_selected_answers('documents', @form.selected_answers)
+      if documents_eligibility_checker.any?(selected_answer_store.selected_evidence, current_identity_providers)
         redirect_to select_phone_path
       else
         redirect_to unlikely_to_verify_path

--- a/app/controllers/select_phone_controller.rb
+++ b/app/controllers/select_phone_controller.rb
@@ -7,9 +7,8 @@ class SelectPhoneController < ApplicationController
     @form = SelectPhoneForm.new(params['select_phone_form'] || {})
     if @form.valid?
       report_to_analytics('Phone Next')
-      store_selected_evidence('phone', @form.selected_evidence)
-      store_selected_answers('phone', @form.selected_answers)
-      if idp_eligibility_checker.any?(selected_evidence_values, current_identity_providers)
+      selected_answer_store.store_selected_answers('phone', @form.selected_answers)
+      if idp_eligibility_checker.any?(selected_answer_store.selected_evidence, current_identity_providers)
         redirect_to will_it_work_for_me_path
       else
         redirect_to no_mobile_phone_path

--- a/app/models/select_documents_form.rb
+++ b/app/models/select_documents_form.rb
@@ -13,18 +13,14 @@ class SelectDocumentsForm
     @no_documents = hash[:no_documents]
   end
 
-  def selected_evidence
-    IdpEligibility::Evidence::DOCUMENT_ATTRIBUTES.select { |attr| public_send(attr) == 'true' }
-  end
-
   def selected_answers
     answers = {}
     IdpEligibility::Evidence::DOCUMENT_ATTRIBUTES.each do |attr|
       result = public_send(attr)
       if no_documents_checked?
-        answers[attr] = 'false'
+        answers[attr] = false
       elsif %w(true false).include?(result)
-        answers[attr] = result
+        answers[attr] = (result == 'true')
       end
     end
     answers

--- a/app/models/select_phone_form.rb
+++ b/app/models/select_phone_form.rb
@@ -12,16 +12,12 @@ class SelectPhoneForm
     @landline = params[:landline]
   end
 
-  def selected_evidence
-    IdpEligibility::Evidence::PHONE_ATTRIBUTES.select { |attr| public_send(attr) == 'true' }
-  end
-
   def selected_answers
     answers = {}
     IdpEligibility::Evidence::PHONE_ATTRIBUTES.each do |attr|
       result = public_send(attr)
       if %w(true false).include?(result)
-        answers[attr] = result
+        answers[attr] = result == 'true'
       end
     end
     answers

--- a/app/models/selected_answer_store.rb
+++ b/app/models/selected_answer_store.rb
@@ -1,0 +1,33 @@
+class SelectedAnswerStore
+  def initialize(session)
+    @session = session
+  end
+
+  def store_selected_answers(stage, answers)
+    stored_selected_answers[stage] = answers
+  end
+
+  def stored_selected_answers
+    @session[:selected_answers] ||= {}
+  end
+
+  def selected_evidence
+    answers_hash = stored_selected_answers.values.reduce(:merge)
+    if answers_hash.nil?
+      []
+    else
+      as_evidence_array(answers_hash)
+    end
+  end
+
+  def selected_evidence_for(stage)
+    answers_hash = stored_selected_answers.fetch(stage, {})
+    as_evidence_array(answers_hash)
+  end
+
+private
+
+  def as_evidence_array(hash)
+    hash.select { |_, value| value }.keys.map(&:to_sym)
+  end
+end

--- a/spec/features/idp_selections_reported_to_piwik_spec.rb
+++ b/spec/features/idp_selections_reported_to_piwik_spec.rb
@@ -3,7 +3,7 @@ require 'api_test_helper'
 require 'piwik_test_helper'
 
 RSpec.describe 'When the user selects an IDP' do
-  let(:selected_evidence) { { phone: %w(mobile_phone smart_phone), documents: %w(passport) } }
+  let(:selected_answers) { { phone: { mobile_phone: true, smart_phone: true }, documents: { passport: true } } }
   let(:location) { '/test-idp-request-endpoint' }
   let(:idp_1_entity_id) { 'http://idcorp.com' }
   let(:idp_2_entity_id) { 'other-entity-id' }

--- a/spec/features/user_visits_choose_a_certified_company_page_spec.rb
+++ b/spec/features/user_visits_choose_a_certified_company_page_spec.rb
@@ -7,16 +7,24 @@ RSpec.describe 'When the user visits the choose a certified company page' do
     set_session_cookies!
   end
 
-  let(:selected_evidence) { { documents: [:passport, :driving_licence], phone: [:mobile_phone] } }
-  let(:given_a_session_with_selected_evidence) {
+  let(:selected_answers) {
+    {
+      documents: { passport: true, driving_licence: true },
+      phone: { mobile_phone: true, landline: true }
+    }
+  }
+
+  let(:given_a_session_with_selected_answers) {
     page.set_rack_session(
-      selected_evidence: selected_evidence,
+      selected_answers: selected_answers,
     )
   }
 
-  let(:given_a_session_without_selected_evidence) {
+  let(:given_a_session_without_selected_answers) {
     page.set_rack_session(
-      selected_evidence: {},
+      selected_answers: {
+        documents: { passport: false }
+      },
     )
   }
 
@@ -29,7 +37,7 @@ RSpec.describe 'When the user visits the choose a certified company page' do
 
   it 'displays recommended IDPs' do
     stub_federation
-    given_a_session_with_selected_evidence
+    given_a_session_with_selected_answers
     visit '/choose-a-certified-company'
 
     expect(page).to have_current_path(choose_a_certified_company_path)
@@ -42,7 +50,7 @@ RSpec.describe 'When the user visits the choose a certified company page' do
 
   it 'displays only non recommended IDPs if no recommendations' do
     stub_federation
-    given_a_session_without_selected_evidence
+    given_a_session_without_selected_answers
     visit '/choose-a-certified-company'
     expect(page).to have_current_path(choose_a_certified_company_path)
     within('#non-matching-idps') do
@@ -54,7 +62,7 @@ RSpec.describe 'When the user visits the choose a certified company page' do
 
   it 'recommends some IDPs and hides others' do
     stub_federation_no_docs
-    given_a_session_without_selected_evidence
+    given_a_session_without_selected_answers
     visit '/choose-a-certified-company'
 
     expect(page).to have_content('Based on your answers, 1 company can verify you now:')
@@ -84,7 +92,7 @@ RSpec.describe 'When the user visits the choose a certified company page' do
 
   it 'records details in session when a recommended IdP is selected' do
     stub_federation
-    given_a_session_with_selected_evidence
+    given_a_session_with_selected_answers
     visit '/choose-a-certified-company'
 
     within('#matching-idps') do
@@ -97,7 +105,7 @@ RSpec.describe 'When the user visits the choose a certified company page' do
 
   it 'rejects unrecognised simple ids' do
     stub_federation
-    given_a_session_with_selected_evidence
+    given_a_session_with_selected_answers
     visit '/choose-a-certified-company'
 
     first('input[value="http://idcorp.com"]', visible: false).set('bob')

--- a/spec/features/user_visits_confirm_your_identity_page_spec.rb
+++ b/spec/features/user_visits_confirm_your_identity_page_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe 'When the user visits the confirm-your-identity page' do
       page.set_rack_session(
         selected_idp: { entity_id: 'http://idcorp.com', simple_id: 'stub-idp-one' },
         selected_idp_was_recommended: true,
-        selected_evidence: { phone: %w(mobile_phone smart_phone), documents: %w(passport) },
+        selected_answers: { phone: { mobile_phone: true, smart_phone: true }, documents: { passport: true } },
       )
       set_up_session('stub-idp-one')
 

--- a/spec/features/user_visits_redirect_to_idp_warning_page_spec.rb
+++ b/spec/features/user_visits_redirect_to_idp_warning_page_spec.rb
@@ -8,40 +8,41 @@ RSpec.describe 'When the user visits the redirect to IDP warning page' do
   let(:encrypted_entity_id) { 'an-encrypted-entity-id' }
   let(:location) { '/test-idp-request-endpoint' }
   let(:selected_evidence) { { phone: %w(mobile_phone smart_phone), documents: %w(passport) } }
+  let(:selected_answers) { { phone: { mobile_phone: true, smart_phone: true }, documents: { passport: true } } }
   let(:idp_entity_id) { 'http://idcorp.com' }
   let(:given_an_idp_with_no_display_data) {
     page.set_rack_session(
       selected_idp: { entity_id: idp_entity_id, simple_id: 'stub-idp-x' },
       selected_idp_was_recommended: true,
-      selected_evidence: selected_evidence,
+      selected_answers: selected_answers,
     )
   }
   let(:given_a_session_with_document_evidence) {
     page.set_rack_session(
       selected_idp: { entity_id: idp_entity_id, simple_id: 'stub-idp-one' },
       selected_idp_was_recommended: true,
-      selected_evidence: selected_evidence,
+      selected_answers: selected_answers,
     )
   }
   let(:given_a_session_with_non_recommended_idp) {
     page.set_rack_session(
       selected_idp: { entity_id: idp_entity_id, simple_id: 'stub-idp-one' },
       selected_idp_was_recommended: false,
-      selected_evidence: selected_evidence,
+      selected_answers: selected_answers,
     )
   }
   let(:given_a_session_with_no_document_evidence) {
     page.set_rack_session(
       selected_idp: { entity_id: 'http://idpnodocs.com', simple_id: 'stub-idp-no-docs' },
       selected_idp_was_recommended: true,
-      selected_evidence: { phone: %w(mobile_phone smart_phone), documents: [] },
+      selected_answers: { phone: { mobile_phone: true, smart_phone: true }, documents: {} },
     )
   }
   let(:given_a_session_with_non_uk_id_document_evidence) {
     page.set_rack_session(
       selected_idp: { entity_id: 'http://idpwithnonukid.com', simple_id: 'stub-idp-four' },
       selected_idp_was_recommended: true,
-      selected_evidence: { phone: %w(mobile_phone smart_phone), documents: %w(non_uk_id_document) },
+      selected_answers: { phone: { mobile_phone: true, smart_phone: true }, documents: { non_uk_id_document: true } },
     )
   }
   let(:select_idp_stub_request) {

--- a/spec/features/user_visits_select_documents_page_spec.rb
+++ b/spec/features/user_visits_select_documents_page_spec.rb
@@ -28,8 +28,7 @@ RSpec.feature 'When the user visits the select documents page' do
     click_button 'Continue'
 
     expect(page).to have_current_path(select_phone_path, only_path: true)
-    expect(page.get_rack_session['selected_evidence']).to eql('documents' => %w{driving_licence})
-    expect(page.get_rack_session['selected_answers']).to eql('documents' => { 'driving_licence' => 'true', 'passport' => 'false' })
+    expect(page.get_rack_session['selected_answers']).to eql('documents' => { 'driving_licence' => true, 'passport' => false })
   end
 
   it 'redirects to the select phone page when no docs checked' do

--- a/spec/features/user_visits_select_phone_page_spec.rb
+++ b/spec/features/user_visits_select_phone_page_spec.rb
@@ -3,12 +3,12 @@ require 'api_test_helper'
 require 'uri'
 
 RSpec.describe 'When the user visits the select phone page' do
-  let(:selected_evidence) { { documents: [:passport, :driving_licence] } }
+  let(:selected_answers) { { documents: { passport: true, driving_licence: true } } }
   let(:given_a_session_with_document_evidence) {
     page.set_rack_session(
       selected_idp: { entity_id: 'http://idcorp.com', simple_id: 'stub-idp-one' },
       selected_idp_was_recommended: true,
-      selected_evidence: selected_evidence,
+      selected_answers: selected_answers,
     )
   }
 
@@ -27,8 +27,7 @@ RSpec.describe 'When the user visits the select phone page' do
       click_button 'Continue'
 
       expect(page).to have_current_path(will_it_work_for_me_path, only_path: true)
-      expect(page.get_rack_session['selected_evidence']).to eql('phone' => %w(mobile_phone smart_phone))
-      expect(page.get_rack_session['selected_answers']).to eql('phone' => { 'mobile_phone' => 'true', 'smart_phone' => 'true', 'landline' => 'false' })
+      expect(page.get_rack_session['selected_answers']).to eql('phone' => { 'mobile_phone' => true, 'smart_phone' => true, 'landline' => false })
     end
 
     it 'allows you to overwrite the values of your selected evidence' do
@@ -48,7 +47,9 @@ RSpec.describe 'When the user visits the select phone page' do
       click_button 'Continue'
 
       expect(page).to have_current_path(no_mobile_phone_path)
-      expect(page.get_rack_session['selected_evidence']).to eql('phone' => [], 'documents' => %w{passport driving_licence})
+      expect(page.get_rack_session['selected_answers']).to eql(
+        'phone' => { 'mobile_phone' => false, 'landline' => false },
+        'documents' => { 'passport' => true, 'driving_licence' => true })
     end
 
     it 'shows an error message when no selections are made' do
@@ -72,7 +73,9 @@ RSpec.describe 'When the user visits the select phone page' do
       click_button 'Continue'
 
       expect(page).to have_current_path(will_it_work_for_me_path)
-      expect(page.get_rack_session['selected_evidence']).to eql('phone' => %w{mobile_phone smart_phone}, 'documents' => %w{passport driving_licence})
+      expect(page.get_rack_session['selected_answers']).to eql(
+        'phone' => { 'mobile_phone' => true, 'smart_phone' => true },
+        'documents' => { 'passport' => true, 'driving_licence' => true })
     end
 
     it 'should display a validation message when user does not answer mobile phone question' do
@@ -94,7 +97,7 @@ RSpec.describe 'When the user visits the select phone page' do
       click_button 'Continue'
 
       expect(page).to have_current_path(no_mobile_phone_path)
-      expect(page.get_rack_session['selected_evidence']).to eql('phone' => [])
+      expect(page.get_rack_session['selected_answers']).to eql('phone' => { 'mobile_phone' => false, 'landline' => false })
     end
   end
 

--- a/spec/features/user_visits_the_choose_a_certified_company_about_idp_page_spec.rb
+++ b/spec/features/user_visits_the_choose_a_certified_company_about_idp_page_spec.rb
@@ -2,19 +2,19 @@ require 'feature_helper'
 require 'api_test_helper'
 
 RSpec.feature 'user visits the choose a certified company about idp page', type: :feature do
-  let(:selected_evidence) { { documents: [:passport, :driving_licence], phone: [:mobile_phone] } }
-  let(:given_a_session_with_selected_evidence) {
+  let(:selected_answers) { { documents: { passport: true, driving_licence: true }, phone: { mobile_phone: true } } }
+  let(:given_a_session_with_selected_answers) {
     page.set_rack_session(
       selected_idp: { entity_id: 'http://idcorp.com', simple_id: 'stub-idp-one' },
       selected_idp_was_recommended: true,
-      selected_evidence: selected_evidence,
+      selected_answers: selected_answers,
     )
   }
   scenario 'user chooses a recommended idp' do
     entity_id = 'my-entity-id'
     stub_federation(entity_id)
     set_session_cookies!
-    given_a_session_with_selected_evidence
+    given_a_session_with_selected_answers
     visit choose_a_certified_company_about_path('stub-idp-one')
     expect(page).to have_content("ID Corp is the premier identity proofing service around.")
     click_button "Choose IDCorp"
@@ -45,7 +45,7 @@ RSpec.feature 'user visits the choose a certified company about idp page', type:
     entity_id = 'my-entity-id'
     stub_federation(entity_id)
     set_session_cookies!
-    given_a_session_with_selected_evidence
+    given_a_session_with_selected_answers
     visit choose_a_certified_company_about_path('stub-idp-one')
     click_link 'Back'
     expect(page).to have_current_path(choose_a_certified_company_path)

--- a/spec/models/select_documents_form_spec.rb
+++ b/spec/models/select_documents_form_spec.rb
@@ -59,30 +59,6 @@ describe SelectDocumentsForm do
     expect(form.errors.full_messages).to eql ['Please check your selection']
   end
 
-  describe '#selected_evidence' do
-    it 'should return a list of the selected evidence' do
-      form = SelectDocumentsForm.new(
-        driving_licence: 'true',
-        passport: 'true',
-        non_uk_id_document: 'false',
-        no_documents: 'false'
-      )
-      evidence = form.selected_evidence
-      expect(evidence).to eql([:passport, :driving_licence])
-    end
-
-    it 'should return a list of the selected evidence when there is an empty value' do
-      form = SelectDocumentsForm.new(
-        driving_licence: 'true',
-        passport: '',
-        non_uk_id_document: 'false',
-        no_documents: 'false'
-      )
-      evidence = form.selected_evidence
-      expect(evidence).to eql([:driving_licence])
-    end
-  end
-
   describe '#selected_answers' do
     it 'should return a hash of the selected answers' do
       form = SelectDocumentsForm.new(
@@ -92,7 +68,7 @@ describe SelectDocumentsForm do
         no_documents: 'false'
       )
       evidence = form.selected_answers
-      expect(evidence).to eql(passport: 'true', driving_licence: 'true', non_uk_id_document: 'false')
+      expect(evidence).to eql(passport: true, driving_licence: true, non_uk_id_document: false)
     end
 
     it 'should not return selected answers when there is no value' do
@@ -102,7 +78,7 @@ describe SelectDocumentsForm do
         no_documents: 'false'
       )
       evidence = form.selected_answers
-      expect(evidence).to eql(driving_licence: 'true')
+      expect(evidence).to eql(driving_licence: true)
     end
 
     it 'should return all documents answers as false if no documents is checked' do
@@ -110,7 +86,7 @@ describe SelectDocumentsForm do
         no_documents: 'true'
       )
       evidence = form.selected_answers
-      expect(evidence).to eql(driving_licence: 'false', passport: 'false', non_uk_id_document: 'false')
+      expect(evidence).to eql(driving_licence: false, passport: false, non_uk_id_document: false)
     end
   end
 end

--- a/spec/models/select_documents_form_spec.rb
+++ b/spec/models/select_documents_form_spec.rb
@@ -77,16 +77,16 @@ describe SelectDocumentsForm do
         non_uk_id_document: '',
         no_documents: 'false'
       )
-      evidence = form.selected_answers
-      expect(evidence).to eql(driving_licence: true)
+      answers = form.selected_answers
+      expect(answers).to eql(driving_licence: true)
     end
 
     it 'should return all documents answers as false if no documents is checked' do
       form = SelectDocumentsForm.new(
         no_documents: 'true'
       )
-      evidence = form.selected_answers
-      expect(evidence).to eql(driving_licence: false, passport: false, non_uk_id_document: false)
+      answers = form.selected_answers
+      expect(answers).to eql(driving_licence: false, passport: false, non_uk_id_document: false)
     end
   end
 end

--- a/spec/models/select_phone_form_spec.rb
+++ b/spec/models/select_phone_form_spec.rb
@@ -55,8 +55,8 @@ describe SelectPhoneForm do
       form = SelectPhoneForm.new(
         mobile_phone: 'true'
       )
-      evidence = form.selected_answers
-      expect(evidence).to eql(mobile_phone: true)
+      answers = form.selected_answers
+      expect(answers).to eql(mobile_phone: true)
     end
 
     it 'should not return selected answers when there is no value' do
@@ -64,8 +64,8 @@ describe SelectPhoneForm do
         mobile_phone: 'false',
         smart_phone: ''
       )
-      evidence = form.selected_answers
-      expect(evidence).to eql(mobile_phone: false)
+      answers = form.selected_answers
+      expect(answers).to eql(mobile_phone: false)
     end
   end
 

--- a/spec/models/select_phone_form_spec.rb
+++ b/spec/models/select_phone_form_spec.rb
@@ -56,7 +56,7 @@ describe SelectPhoneForm do
         mobile_phone: 'true'
       )
       evidence = form.selected_answers
-      expect(evidence).to eql(mobile_phone: 'true')
+      expect(evidence).to eql(mobile_phone: true)
     end
 
     it 'should not return selected answers when there is no value' do
@@ -65,7 +65,7 @@ describe SelectPhoneForm do
         smart_phone: ''
       )
       evidence = form.selected_answers
-      expect(evidence).to eql(mobile_phone: 'false')
+      expect(evidence).to eql(mobile_phone: false)
     end
   end
 

--- a/spec/models/selected_answer_store_spec.rb
+++ b/spec/models/selected_answer_store_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+require 'models/selected_answer_store'
+
+RSpec.describe SelectedAnswerStore do
+  it 'should store answers for a given stage' do
+    session = {}
+    document_answers = {
+      passport: true,
+      driving_licence: false
+    }
+    store = SelectedAnswerStore.new(session)
+    store.store_selected_answers('documents', document_answers)
+    expect(session[:selected_answers]).to eql('documents' => document_answers)
+  end
+
+  it 'should return selected evidence for a given stage' do
+    session = {}
+    document_answers = {
+      passport: true,
+      driving_licence: false
+    }
+    store = SelectedAnswerStore.new(session)
+    store.store_selected_answers('documents', document_answers)
+    expect(store.selected_evidence_for('documents')).to eql [:passport]
+  end
+
+  it 'should return all selected evidence' do
+    session = {}
+    document_answers = {
+      passport: true,
+      driving_licence: false
+    }
+    phone_answers = {
+      mobile_phone: true
+    }
+    store = SelectedAnswerStore.new(session)
+    store.store_selected_answers('documents', document_answers)
+    store.store_selected_answers('phone', phone_answers)
+    expect(store.selected_evidence).to eql [:passport, :mobile_phone]
+  end
+end


### PR DESCRIPTION
**Please do not merge** - 1a0ab09 needs to have been live for at least one session length (2 hours) to ensure all the users have the `selected_answers` hash in their sessions.

We are now using selected answers exclusively for determining which IDPs
are displayed to the user. SelectedAnswerStore is responsible for
mapping the user's answers to the evidence array that is used for IDP
filtering.

Authors: @vixus0 @andrien.ricketts @richardTowers