### PR TITLE
3276: send orignating IP when requesting the RP response

### DIFF
--- a/app/models/session_proxy.rb
+++ b/app/models/session_proxy.rb
@@ -72,12 +72,12 @@ class SessionProxy
   end
 
   def response_for_rp(cookies)
-    response = @api_client.get(RESPONSE_FOR_RP_PATH, cookies: select_cookies(cookies, CookieNames.session_cookies))
+    response = @api_client.get(RESPONSE_FOR_RP_PATH, cookies: select_cookies(cookies, CookieNames.session_cookies), params: { PARAM_ORIGINATING_IP => originating_ip })
     ResponseForRp.new(response || {}).tap(&:validate)
   end
 
   def error_response_for_rp(cookies)
-    response = @api_client.get(ERROR_RESPONSE_FOR_RP_PATH, cookies: select_cookies(cookies, CookieNames.session_cookies))
+    response = @api_client.get(ERROR_RESPONSE_FOR_RP_PATH, cookies: select_cookies(cookies, CookieNames.session_cookies), params: { PARAM_ORIGINATING_IP => originating_ip })
     ResponseForRp.new(response || {}).tap(&:validate)
   end
 

--- a/spec/api_test_helper.rb
+++ b/spec/api_test_helper.rb
@@ -79,13 +79,21 @@ def stub_matching_outcome(outcome = MatchingOutcomeResponse::WAIT)
   stub_request(:get, api_uri('session/matching-outcome')).to_return(body: { 'outcome' => outcome }.to_json)
 end
 
+def originating_ip_param
+  {
+    SessionProxy::PARAM_ORIGINATING_IP => '<PRINCIPAL IP ADDRESS COULD NOT BE DETERMINED>'
+  }
+end
+
 def stub_response_for_rp
   response_body = {
     'postEndpoint' => '/test-rp',
     'samlMessage' => 'a saml message',
     'relayState' => 'a relay state'
   }
-  stub_request(:get, api_uri('session/response-for-rp/success')).to_return(body: response_body.to_json)
+  stub_request(:get, api_uri('session/response-for-rp/success'))
+  .with(query: originating_ip_param)
+  .to_return(body: response_body.to_json)
 end
 
 def stub_error_response_for_rp
@@ -94,5 +102,7 @@ def stub_error_response_for_rp
       'samlMessage' => 'a saml message',
       'relayState' => 'a relay state'
   }
-  stub_request(:get, api_uri('session/response-for-rp/error')).to_return(body: response_body.to_json)
+  stub_request(:get, api_uri('session/response-for-rp/error'))
+  .with(query: originating_ip_param)
+  .to_return(body: response_body.to_json)
 end

--- a/spec/features/user_visits_redirect_to_service_page_spec.rb
+++ b/spec/features/user_visits_redirect_to_service_page_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'When the user visits the redirect to service page' do
     end
 
     it 'supports the welsh language for error' do
-      visit 'redirect-to-service/error-cy'
+      visit  redirect_to_service_error_cy_path
       expect(page).to have_css 'html[lang=cy]'
     end
 


### PR DESCRIPTION
We want to be able to audit the IP address of the requestor of the RP response