### PR TITLE
3729: proxy ip addr as header when request RP response

### DIFF
--- a/app/models/session_proxy.rb
+++ b/app/models/session_proxy.rb
@@ -24,6 +24,10 @@ class SessionProxy
     @originating_ip_store.get
   end
 
+  def x_forwarded_for
+    { "X-Forwarded-For" => originating_ip }
+  end
+
   def create_session(saml_request, relay_state)
     body = {
       PARAM_SAML_REQUEST => saml_request,
@@ -72,12 +76,16 @@ class SessionProxy
   end
 
   def response_for_rp(cookies)
-    response = @api_client.get(RESPONSE_FOR_RP_PATH, cookies: select_cookies(cookies, CookieNames.session_cookies))
+    response = @api_client.get(RESPONSE_FOR_RP_PATH,
+                               headers: x_forwarded_for,
+                               cookies: select_cookies(cookies, CookieNames.session_cookies))
     ResponseForRp.new(response || {}).tap(&:validate)
   end
 
   def error_response_for_rp(cookies)
-    response = @api_client.get(ERROR_RESPONSE_FOR_RP_PATH, cookies: select_cookies(cookies, CookieNames.session_cookies))
+    response = @api_client.get(ERROR_RESPONSE_FOR_RP_PATH,
+                               headers: x_forwarded_for,
+                               cookies: select_cookies(cookies, CookieNames.session_cookies))
     ResponseForRp.new(response || {}).tap(&:validate)
   end
 

--- a/spec/api_test_helper.rb
+++ b/spec/api_test_helper.rb
@@ -79,13 +79,17 @@ def stub_matching_outcome(outcome = MatchingOutcomeResponse::WAIT)
   stub_request(:get, api_uri('session/matching-outcome')).to_return(body: { 'outcome' => outcome }.to_json)
 end
 
+def x_forwarded_for
+  { "X-Forwarded-For" => '<PRINCIPAL IP ADDRESS COULD NOT BE DETERMINED>' }
+end
+
 def stub_response_for_rp
   response_body = {
     'postEndpoint' => '/test-rp',
     'samlMessage' => 'a saml message',
     'relayState' => 'a relay state'
   }
-  stub_request(:get, api_uri('session/response-for-rp/success')).to_return(body: response_body.to_json)
+  stub_request(:get, api_uri('session/response-for-rp/success')).with(headers: x_forwarded_for).to_return(body: response_body.to_json)
 end
 
 def stub_error_response_for_rp
@@ -94,5 +98,5 @@ def stub_error_response_for_rp
       'samlMessage' => 'a saml message',
       'relayState' => 'a relay state'
   }
-  stub_request(:get, api_uri('session/response-for-rp/error')).to_return(body: response_body.to_json)
+  stub_request(:get, api_uri('session/response-for-rp/error')).with(headers: x_forwarded_for).to_return(body: response_body.to_json)
 end


### PR DESCRIPTION
The IP address for the user is sent as the X-Forwarded-For header