### PR TITLE
zd21812: Fix undefined page titles

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,12 @@
 module ApplicationHelper
+  def page_title(title_key, locale_data = {})
+    content_for :page_title, t(title_key, locale_data)
+    content_for :page_title_in_english, t(title_key, locale_data.merge(locale: :en))
+    content_for :head do
+      tag('meta', name: 'verify|title', content: content_for(:page_title_in_english))
+    end
+  end
+
   def feedback_source
     content_for(:feedback_source) || ""
   end

--- a/app/views/about/certified_companies.html.erb
+++ b/app/views/about/certified_companies.html.erb
@@ -1,4 +1,4 @@
-<%= render 'shared/page_title', title_key: 'hub.about_certified_companies.title' %>
+<%= page_title 'hub.about_certified_companies.title' %>
 <% content_for :feedback_source, 'ABOUT_CERTIFIED_COMPANIES_PAGE' %>
 
 <p><%= t 'hub.about_certified_companies.a_certified_company_will_verify' %></p>

--- a/app/views/about/choosing_a_company.html.erb
+++ b/app/views/about/choosing_a_company.html.erb
@@ -1,4 +1,4 @@
-<%= render 'shared/page_title', title_key: 'hub.about_choosing_a_company.title' %>
+<%= page_title 'hub.about_choosing_a_company.title' %>
 <% content_for :feedback_source, 'ABOUT_CHOOSING_A_COMPANY_PAGE' %>
 
 <div class="grid-row">

--- a/app/views/about/identity_accounts.html.erb
+++ b/app/views/about/identity_accounts.html.erb
@@ -1,4 +1,4 @@
-<%= render 'shared/page_title', title_key: 'hub.about_identity_accounts.title' %>
+<%= page_title 'hub.about_identity_accounts.title' %>
 <% content_for :feedback_source, 'ABOUT_IDENTITY_ACCOUNTS_PAGE' %>
 
 <p><%= t 'hub.about_identity_accounts.content.p1' %></p>

--- a/app/views/about/index.html.erb
+++ b/app/views/about/index.html.erb
@@ -1,4 +1,4 @@
-<%= render 'shared/page_title', title_key: 'hub.about.title' %>
+<%= page_title 'hub.about.title' %>
 <% content_for :feedback_source, 'ABOUT_PAGE' %>
 
 <p><%= t 'hub.about.verify_is_a_scheme' %></p>

--- a/app/views/choose_a_certified_company/about.html.erb
+++ b/app/views/choose_a_certified_company/about.html.erb
@@ -1,6 +1,5 @@
-<% content_for :page_title, t('hub.choose_a_certified_company.about.title', display_name: @idp.display_name) %>
+<% page_title 'hub.choose_a_certified_company.about.title', { :display_name => @idp.display_name } %>
 <% content_for :feedback_source, "CHOOSE_A_CERTIFIED_COMPANY_ABOUT_#{@idp.simple_id.upcase}_PAGE" %>
-
 <%= link_to t('navigation.back'), choose_a_certified_company_path, class: 'link-back' %>
 <div class="content-inner">
   <div class="grid-row">

--- a/app/views/choose_a_certified_company/index.html.erb
+++ b/app/views/choose_a_certified_company/index.html.erb
@@ -1,4 +1,4 @@
-<%= render 'shared/page_title', title_key: 'hub.choose_a_certified_company.title' %>
+<%= page_title 'hub.choose_a_certified_company.title' %>
 <% content_for :feedback_source, 'CHOOSE_A_CERTIFIED_COMPANY_PAGE' %>
 
 <div class="content-inner">

--- a/app/views/confirm_your_identity/index.html.erb
+++ b/app/views/confirm_your_identity/index.html.erb
@@ -1,4 +1,4 @@
-<%= render 'shared/page_title', title_key: 'hub.confirm_your_identity.title' %>
+<%= page_title 'hub.confirm_your_identity.title' %>
 <% content_for :feedback_source, 'CONFIRM_YOUR_IDENTITY' %>
 
 <div class="verify-logo">

--- a/app/views/confirmation/index.html.erb
+++ b/app/views/confirmation/index.html.erb
@@ -1,4 +1,4 @@
-<%= render 'shared/page_title', title_key: 'hub.confirmation.title' %>
+<%= page_title 'hub.confirmation.title' %>
 <% content_for :feedback_source, 'CONFIRMATION_PAGE' %>
 
 <h1 class="heading-large"><%= t 'hub.confirmation.heading', display_name: @idp_name %></h1>

--- a/app/views/errors/404.html.erb
+++ b/app/views/errors/404.html.erb
@@ -1,4 +1,4 @@
-<%= render 'shared/page_title', title_key: 'errors.page_not_found.title' %>
+<%= page_title 'errors.page_not_found.title' %>
 <% content_for :feedback_source, 'ERROR_PAGE' %>
 <div class="grid-row">
   <div class="column-two-thirds">

--- a/app/views/errors/cookie_expired.html.erb
+++ b/app/views/errors/cookie_expired.html.erb
@@ -1,4 +1,4 @@
-<%= render 'shared/page_title', title_key: 'errors.cookie_expired.title' %>
+<%= page_title 'errors.cookie_expired.title' %>
 
 <% content_for :feedback_source, 'EXPIRED_ERROR_PAGE' %>
 <% content_for :piwik_custom_path, '/errors/timeout-error' %>

--- a/app/views/errors/no_cookies.html.erb
+++ b/app/views/errors/no_cookies.html.erb
@@ -1,4 +1,4 @@
-<%= render 'shared/page_title', title_key: 'errors.no_cookies.title' %>
+<%= page_title 'errors.no_cookies.title' %>
 <% content_for :feedback_source, 'COOKIE_NOT_FOUND_PAGE' %>
 <% content_for :piwik_custom_path, '/cookies-not-found' %>
 

--- a/app/views/errors/session_error.html.erb
+++ b/app/views/errors/session_error.html.erb
@@ -1,4 +1,4 @@
-<%= render 'shared/page_title', title_key: 'errors.session_error.title' %>
+<%= page_title 'errors.session_error.title' %>
 <% content_for :feedback_source, 'ERROR_PAGE' %>
 <% content_for :piwik_custom_path, '/errors/session-error' %>
 

--- a/app/views/errors/session_timeout.html.erb
+++ b/app/views/errors/session_timeout.html.erb
@@ -1,4 +1,4 @@
-<%= render 'shared/page_title', title_key: 'errors.session_timeout.title' %>
+<%= page_title 'errors.session_timeout.title' %>
 <% content_for :feedback_source, 'EXPIRED_ERROR_PAGE' %>
 <% content_for :piwik_custom_path, '/errors/timeout-error' %>
 

--- a/app/views/errors/something_went_wrong.html.erb
+++ b/app/views/errors/something_went_wrong.html.erb
@@ -1,4 +1,4 @@
-<%= render 'shared/page_title', title_key: 'errors.something_went_wrong.title' %>
+<%= page_title 'errors.something_went_wrong.title' %>
 <% content_for :feedback_source, 'ERROR_PAGE' %>
 <% content_for :piwik_custom_path, 'errors/generic-error' %>
 

--- a/app/views/failed_registration/index.html.erb
+++ b/app/views/failed_registration/index.html.erb
@@ -1,4 +1,4 @@
-<%= render 'shared/page_title', title_key: 'hub.failed_registration.title' %>
+<%= page_title 'hub.failed_registration.title' %>
 <% content_for :feedback_source, 'FAILED_REGISTRATION_PAGE' %>
 
 <div class="grid-row">

--- a/app/views/failed_sign_in/index.html.erb
+++ b/app/views/failed_sign_in/index.html.erb
@@ -1,4 +1,4 @@
-<%= render 'shared/page_title', title_key: 'hub.failed_sign_in.title' %>
+<%= page_title 'hub.failed_sign_in.title' %>
 <% content_for :feedback_source, 'FAILED_SIGN_IN_PAGE' %>
 
 <div class="grid-row">

--- a/app/views/feedback/index.html.erb
+++ b/app/views/feedback/index.html.erb
@@ -1,4 +1,4 @@
-<%= render 'shared/page_title', title_key: 'hub.feedback.title' %>
+<%= page_title 'hub.feedback.title' %>
 
 <div class="grid-row">
   <div class="column-two-thirds">

--- a/app/views/feedback/sent.html.erb
+++ b/app/views/feedback/sent.html.erb
@@ -1,4 +1,4 @@
-<%= render 'shared/page_title', title_key: 'hub.feedback_sent.title' %>
+<%= page_title 'hub.feedback_sent.title' %>
 
 <div class="grid-row">
   <div class="column-two-thirds">

--- a/app/views/other_ways_to_access_service/index.html.erb
+++ b/app/views/other_ways_to_access_service/index.html.erb
@@ -1,4 +1,4 @@
-<%= render 'shared/page_title', title_key: 'hub.other_ways_title' %>
+<%= page_title 'hub.other_ways_title' %>
 <% content_for :feedback_source, 'OTHER_WAYS_PAGE' %>
 
 <div class="grid-row">

--- a/app/views/redirect_to_idp_warning/index.html.erb
+++ b/app/views/redirect_to_idp_warning/index.html.erb
@@ -1,4 +1,4 @@
-<%= render 'shared/page_title', title_key: 'hub.redirect_to_idp_warning.title' %>
+<%= page_title 'hub.redirect_to_idp_warning.title' %>
 <% content_for :feedback_source, 'REDIRECT_TO_IDP_WARNING_PAGE' %>
 
 <div class="grid-row js-continue-to-idp" data-location="<%= url_for(controller: 'redirect_to_idp_warning', action: 'continue_ajax', locale: I18n.locale)  %>">

--- a/app/views/redirect_to_service/redirect_to_service.html.erb
+++ b/app/views/redirect_to_service/redirect_to_service.html.erb
@@ -1,4 +1,4 @@
-<%= render 'shared/page_title', title_key: @title %>
+<%= page_title @title %>
 
 <div class="content-inner js-hidden">
   <div class="grid-row">

--- a/app/views/response_processing/index.html.erb
+++ b/app/views/response_processing/index.html.erb
@@ -1,4 +1,4 @@
-<%= render 'shared/page_title', title_key: 'hub.response_processing.title' %>
+<%= page_title 'hub.response_processing.title' %>
 <% content_for :meta_refresh, '2' %>
 
 <div class="grid-row response-processing">

--- a/app/views/response_processing/matching_error.html.erb
+++ b/app/views/response_processing/matching_error.html.erb
@@ -1,4 +1,4 @@
-<%= render 'shared/page_title', title_key: 'errors.something_went_wrong.title' %>
+<%= page_title 'errors.something_went_wrong.title' %>
 <% content_for :feedback_source, 'MATCHING_ERROR_PAGE' %>
 
 <div class="grid-row">

--- a/app/views/select_documents/index.html.erb
+++ b/app/views/select_documents/index.html.erb
@@ -1,4 +1,4 @@
-<%= render 'shared/page_title', title_key: 'hub.select_documents.title' %>
+<%= page_title 'hub.select_documents.title' %>
 <% content_for :feedback_source, 'SELECT_DOCUMENTS_PAGE' %>
 
 <div id="no-documents-message" class="visually-hidden" aria-live="assertive" data-no-documents-message="<%= h t('hub.select_documents.no_documents_message') %>"></div>

--- a/app/views/select_documents/unlikely_to_verify.html.erb
+++ b/app/views/select_documents/unlikely_to_verify.html.erb
@@ -1,4 +1,4 @@
-<%= render 'shared/page_title', title_key: 'hub.other_ways_title' %>
+<%= page_title 'hub.other_ways_title' %>
 <% content_for :feedback_source, 'UNLIKELY_TO_VERIFY_PAGE' %>
 
 <div class="grid-row">

--- a/app/views/select_phone/index.html.erb
+++ b/app/views/select_phone/index.html.erb
@@ -1,4 +1,4 @@
-<%= render 'shared/page_title', title_key: 'hub.select_phone.title' %>
+<%= page_title 'hub.select_phone.title' %>
 <% content_for :feedback_source, 'SELECT_PHONE_PAGE' %>
 
 <div class="grid-row">

--- a/app/views/select_phone/no_mobile_phone.html.erb
+++ b/app/views/select_phone/no_mobile_phone.html.erb
@@ -1,4 +1,4 @@
-<%= render 'shared/page_title', title_key: 'hub.other_ways_title' %>
+<%= page_title 'hub.other_ways_title' %>
 <% content_for :feedback_source, 'NO_MOBILE_PHONE' %>
 
 <div class="grid-row">

--- a/app/views/shared/_page_title.html.erb
+++ b/app/views/shared/_page_title.html.erb
@@ -1,5 +1,0 @@
-<% content_for :page_title, t(title_key) %>
-<% content_for :page_title_in_english, t(title_key, locale: :en) %>
-<% content_for :head do
-  tag('meta', :name => 'verify|title', :content => content_for(:page_title_in_english))
-end %>

--- a/app/views/sign_in/index.html.erb
+++ b/app/views/sign_in/index.html.erb
@@ -1,4 +1,4 @@
-<%= render 'shared/page_title', title_key: 'hub.signin.title' %>
+<%= page_title 'hub.signin.title' %>
 <% content_for :feedback_source, 'SIGN_IN_PAGE' %>
 
 <%= link_to t('navigation.back'), start_path, class: 'link-back' %>

--- a/app/views/start/index.html.erb
+++ b/app/views/start/index.html.erb
@@ -1,4 +1,4 @@
-<%= render 'shared/page_title', title_key: 'hub.start.title' %>
+<%= page_title 'hub.start.title' %>
 <% content_for :body_classes, 'hub-start' %>
 <% content_for :feedback_source, 'START_PAGE' %>
 

--- a/app/views/static/forgot_company.cy.html.erb
+++ b/app/views/static/forgot_company.cy.html.erb
@@ -1,4 +1,4 @@
-<%= render 'shared/page_title', title_key: 'hub.forgot_company.title' %>
+<%= page_title 'hub.forgot_company.title' %>
 <% content_for :feedback_source, 'FORGOT_COMPANY_PAGE' %>
 
 <%= link_to t('navigation.back'), sign_in_path, class: 'link-back' %>

--- a/app/views/static/forgot_company.en.html.erb
+++ b/app/views/static/forgot_company.en.html.erb
@@ -1,4 +1,4 @@
-<%= render 'shared/page_title', title_key: 'hub.forgot_company.title' %>
+<%= page_title 'hub.forgot_company.title' %>
 <% content_for :feedback_source, 'FORGOT_COMPANY_PAGE' %>
 
 <%= link_to t('navigation.back'), sign_in_path, class: 'link-back' %>

--- a/app/views/why_companies/index.html.erb
+++ b/app/views/why_companies/index.html.erb
@@ -1,4 +1,4 @@
-<%= render 'shared/page_title', title_key: 'hub.why_companies.title' %>
+<%= page_title 'hub.why_companies.title' %>
 <% content_for :feedback_source, 'WHY_COMPANIES_PAGE' %>
 
 <div class="grid-row">

--- a/app/views/will_it_work_for_me/index.html.erb
+++ b/app/views/will_it_work_for_me/index.html.erb
@@ -1,4 +1,4 @@
-<%= render 'shared/page_title', title_key: 'hub.will_it_work_for_me.title' %>
+<%= page_title 'hub.will_it_work_for_me.title' %>
 <% content_for :feedback_source, 'WILL_IT_WORK_FOR_ME_PAGE' %>
 
 <div class="grid-row">

--- a/app/views/will_it_work_for_me/may_not_work_if_you_live_overseas.html.erb
+++ b/app/views/will_it_work_for_me/may_not_work_if_you_live_overseas.html.erb
@@ -1,4 +1,4 @@
-<%= render 'shared/page_title', title_key: 'hub.may_not_work_if_you_live_overseas.title' %>
+<%= page_title 'hub.may_not_work_if_you_live_overseas.title' %>
 <% content_for :feedback_source, 'MAY_NOT_WORK_IF_YOU_LIVE_OVERSEAS_PAGE' %>
 
 <div class="grid-row">

--- a/app/views/will_it_work_for_me/why_might_this_not_work_for_me.html.erb
+++ b/app/views/will_it_work_for_me/why_might_this_not_work_for_me.html.erb
@@ -1,4 +1,4 @@
-<%= render 'shared/page_title', title_key: 'hub.why_might_this_not_work_for_me.title' %>
+<%= page_title 'hub.why_might_this_not_work_for_me.title' %>
 <% content_for :feedback_source, 'WHY_THIS_MIGHT_NOT_WORK_FOR_ME_PAGE' %>
 
 <div class="grid-row">

--- a/app/views/will_it_work_for_me/will_not_work_without_uk_address.html.erb
+++ b/app/views/will_it_work_for_me/will_not_work_without_uk_address.html.erb
@@ -1,4 +1,4 @@
-<%= render 'shared/page_title', title_key: 'hub.will_not_work_without_uk_address.title' %>
+<%= page_title 'hub.will_not_work_without_uk_address.title' %>
 <% content_for :feedback_source, 'WILL_NOT_WORK_WITHOUT_UK_ADDRESS_PAGE' %>
 
 <div class="grid-row">


### PR DESCRIPTION
    Piwik was reporting the "about idp" page titles as "undefined". This is because
    about.html.erb wasn't using _page_title.html.erb which sets the
    meta[name="verify|title"] which is required by analytics.js to send the title.

    Changed the design to call ApplicationHelper.page_title to render titles, and
    getting rid of app/views/shared/_page_title.html.erb. This
    will allow "about idp" page to pass the display name and still have a common
    solution for displaying page titles on all pages.

solo: @oswaldquek