### PR TITLE
3685: Remove support for old form params

### DIFF
--- a/app/controllers/choose_a_certified_company_controller.rb
+++ b/app/controllers/choose_a_certified_company_controller.rb
@@ -6,7 +6,7 @@ class ChooseACertifiedCompanyController < ApplicationController
   end
 
   def select_idp
-    select_viewable_idp(params.fetch('entity_id') { params.fetch('identity_provider').fetch('entity_id') }) do |decorated_idp|
+    select_viewable_idp(params.fetch('entity_id')) do |decorated_idp|
       session[:selected_idp_was_recommended] =
         IDP_RECOMMENDATION_GROUPER.recommended?(decorated_idp.identity_provider, selected_evidence, current_identity_providers)
       redirect_to redirect_to_idp_warning_path

--- a/app/controllers/sign_in_controller.rb
+++ b/app/controllers/sign_in_controller.rb
@@ -9,7 +9,7 @@ class SignInController < ApplicationController
   end
 
   def select_idp
-    select_viewable_idp(params.fetch('entity_id') { params.fetch('identity_provider').fetch('entity_id') }) do |decorated_idp|
+    select_viewable_idp(params.fetch('entity_id')) do |decorated_idp|
       sign_in(decorated_idp.entity_id, decorated_idp.display_name)
       redirect_to redirect_to_idp_path
     end


### PR DESCRIPTION
This removes support for the original form params used when selecting an
IdP - we needed to accept them for a while after rolling out the new
code to just use the entity id to identity the IdP, to avoid breaking
the journey for users who had already loaded one of the selection pages
at the time of the roll-out.