### PR TITLE
3712: Allow flag to not be in config

### DIFF
--- a/config/initializers/rp_config.rb
+++ b/config/initializers/rp_config.rb
@@ -1,1 +1,1 @@
-CONTINUE_ON_FAILED_REGISTRATION_RPS = RP_CONFIG.fetch('allow_continue_on_failed_registration', ifnone: [])
+CONTINUE_ON_FAILED_REGISTRATION_RPS = RP_CONFIG.fetch('allow_continue_on_failed_registration', [])

--- a/config/initializers/rp_config.rb
+++ b/config/initializers/rp_config.rb
@@ -1,1 +1,1 @@
-CONTINUE_ON_FAILED_REGISTRATION_RPS = RP_CONFIG.fetch('allow_continue_on_failed_registration')
+CONTINUE_ON_FAILED_REGISTRATION_RPS = RP_CONFIG.fetch('allow_continue_on_failed_registration', ifnone: [])


### PR DESCRIPTION
Build is failing because 'allow_continue_on_failed_registration' is not
set in the verify-frontend-federation-config configuration. This change
allows for the flag not being set, returning empty array instead of nil.