### PR TITLE
3733 move age questions to start

### DIFF
--- a/app/controllers/about_controller.rb
+++ b/app/controllers/about_controller.rb
@@ -13,5 +13,6 @@ class AboutController < ApplicationController
   end
 
   def choosing_a_company
+    @next_path = show_age_question_first? ? will_it_work_for_me_path : select_documents_path
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -74,7 +74,7 @@ class ApplicationController < ActionController::Base
 private
 
   def show_age_question_first?
-    true
+    session[:show_age_question_first] == true
   end
 
   def uri_with_query(path, query_string)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -73,6 +73,10 @@ class ApplicationController < ActionController::Base
 
 private
 
+  def show_age_question_first?
+    true
+  end
+
   def uri_with_query(path, query_string)
     uri = URI(path)
     uri.query = query_string

--- a/app/controllers/select_phone_controller.rb
+++ b/app/controllers/select_phone_controller.rb
@@ -9,7 +9,11 @@ class SelectPhoneController < ApplicationController
       report_to_analytics('Phone Next')
       selected_answer_store.store_selected_answers('phone', @form.selected_answers)
       if idp_eligibility_checker.any?(selected_evidence, current_identity_providers)
-        redirect_to will_it_work_for_me_path
+        if show_age_question_first?
+          redirect_to choose_a_certified_company_path
+        else
+          redirect_to will_it_work_for_me_path
+        end
       else
         redirect_to no_mobile_phone_path
       end

--- a/app/controllers/will_it_work_for_me_controller.rb
+++ b/app/controllers/will_it_work_for_me_controller.rb
@@ -17,11 +17,13 @@ class WillItWorkForMeController < ApplicationController
   def why_might_this_not_work_for_me
     @other_ways_description = current_transaction.other_ways_description
     @other_ways_text = current_transaction.other_ways_text
+    @next_path = show_age_question_first? ? select_documents_path : choose_a_certified_company_path
   end
 
   def may_not_work_if_you_live_overseas
     @other_ways_description = current_transaction.other_ways_description
     @other_ways_text = current_transaction.other_ways_text
+    @next_path = show_age_question_first? ? select_documents_path : choose_a_certified_company_path
   end
 
   def will_not_work_without_uk_address
@@ -33,7 +35,11 @@ private
 
   def redirect_path
     if @form.resident_last_12_months?
-      @form.above_age_threshold? ? choose_a_certified_company_path : why_might_this_not_work_for_me_path
+      if @form.above_age_threshold?
+        show_age_question_first? ? select_documents_path : choose_a_certified_company_path
+      else
+        why_might_this_not_work_for_me_path
+      end
     elsif @form.address_but_not_resident?
       may_not_work_if_you_live_overseas_path
     elsif @form.no_uk_address?

--- a/app/views/about/choosing_a_company.html.erb
+++ b/app/views/about/choosing_a_company.html.erb
@@ -9,5 +9,5 @@
   </div>
 </div>
 <div class="actions">
-  <%= link_to t('navigation.continue'), select_documents_path, class: 'button', id: 'next-button' %>
+  <%= link_to t('navigation.continue'), @next_path, class: 'button', id: 'next-button' %>
 </div>

--- a/app/views/will_it_work_for_me/may_not_work_if_you_live_overseas.html.erb
+++ b/app/views/will_it_work_for_me/may_not_work_if_you_live_overseas.html.erb
@@ -25,7 +25,7 @@
 
     <p><%= t 'hub.may_not_work_if_you_live_overseas.youll_also_need' %></p>
 
-    <p><%= link_to t('hub.may_not_work_if_you_live_overseas.try_to_verify'), choose_a_certified_company_path %></p>
+    <p><%= link_to t('hub.may_not_work_if_you_live_overseas.try_to_verify'), @next_path %></p>
 
     <%= render partial: 'shared/other_ways', locals: { other_ways_text: @other_ways_text, other_ways_description: @other_ways_description } %>
   </div>

--- a/app/views/will_it_work_for_me/why_might_this_not_work_for_me.html.erb
+++ b/app/views/will_it_work_for_me/why_might_this_not_work_for_me.html.erb
@@ -23,7 +23,7 @@
 
     <p><%= t 'hub.why_might_this_not_work_for_me.youll_also_need' %></p>
 
-    <p><%= link_to t('hub.why_might_this_not_work_for_me.try_to_verify'), choose_a_certified_company_path, id: 'verify-identity-online' %></p>
+    <p><%= link_to t('hub.why_might_this_not_work_for_me.try_to_verify'), @next_path, id: 'verify-identity-online' %></p>
 
 
     <%= render partial: 'shared/other_ways', locals: { other_ways_text: @other_ways_text, other_ways_description: @other_ways_description } %>

--- a/spec/features/user_visits_about_choosing_a_company_page_spec.rb
+++ b/spec/features/user_visits_about_choosing_a_company_page_spec.rb
@@ -18,10 +18,10 @@ RSpec.describe 'When the user visits the about choosing a company page' do
     expect(page).to have_content 'Dod o hyd i’r cwmni iawn i’ch dilysu chi'
   end
 
-  it 'will take user to select documents page when user clicks "Continue"' do
+  it 'will take user to will-it-work-for-me page when user clicks "Continue"' do
     visit '/about-choosing-a-company'
 
     click_link 'Continue'
-    expect(page).to have_current_path('/select-documents')
+    expect(page).to have_current_path('/will-it-work-for-me')
   end
 end

--- a/spec/features/user_visits_about_choosing_a_company_page_spec.rb
+++ b/spec/features/user_visits_about_choosing_a_company_page_spec.rb
@@ -18,10 +18,25 @@ RSpec.describe 'When the user visits the about choosing a company page' do
     expect(page).to have_content 'Dod o hyd i’r cwmni iawn i’ch dilysu chi'
   end
 
-  it 'will take user to will-it-work-for-me page when user clicks "Continue"' do
+  it 'will take user to select documents page when user clicks "Continue"' do
     visit '/about-choosing-a-company'
 
     click_link 'Continue'
-    expect(page).to have_current_path('/will-it-work-for-me')
+    expect(page).to have_current_path(select_documents_path)
+  end
+
+  context 'for users on the age questions first journey' do
+    before(:each) do
+      page.set_rack_session(
+        show_age_question_first: true
+      )
+    end
+
+    it 'will take user to will-it-work-for-me page when user clicks "Continue"' do
+      visit '/about-choosing-a-company'
+
+      click_link 'Continue'
+      expect(page).to have_current_path(will_it_work_for_me_path)
+    end
   end
 end

--- a/spec/features/user_visits_may_not_work_if_you_live_overseas_spec.rb
+++ b/spec/features/user_visits_may_not_work_if_you_live_overseas_spec.rb
@@ -16,11 +16,28 @@ RSpec.describe 'When the user visits the may-not-work-if-you-live-overseas page'
     expect(page).to have_link 'here', href: 'http://www.example.com'
   end
 
-  it 'redirects to select documents page if user clicks try to verify link' do
+  it 'redirects to IdP picker page if user clicks try to verify link' do
+    stub_federation
     visit may_not_work_if_you_live_overseas_path
 
     click_link 'I’d like to try to verify my identity online'
 
-    expect(page).to have_current_path(select_documents_path)
+    expect(page).to have_current_path(choose_a_certified_company_path)
+  end
+
+  context 'for users on the age questions first journey' do
+    before(:each) do
+      page.set_rack_session(
+        show_age_question_first: true
+      )
+    end
+
+    it 'redirects to select documents page if user clicks try to verify link' do
+      visit may_not_work_if_you_live_overseas_path
+
+      click_link 'I’d like to try to verify my identity online'
+
+      expect(page).to have_current_path(select_documents_path)
+    end
   end
 end

--- a/spec/features/user_visits_may_not_work_if_you_live_overseas_spec.rb
+++ b/spec/features/user_visits_may_not_work_if_you_live_overseas_spec.rb
@@ -4,15 +4,23 @@ require 'api_test_helper'
 RSpec.describe 'When the user visits the may-not-work-if-you-live-overseas page' do
   before(:each) do
     set_session_cookies!
+    page.set_rack_session(transaction_simple_id: 'test-rp')
   end
 
-  it 'includes the appropriate feedback source amd other ways text' do
-    page.set_rack_session(transaction_simple_id: 'test-rp')
+  it 'includes the appropriate feedback source and other ways text' do
     visit '/may-not-work-if-you-live-overseas'
 
     expect_feedback_source_to_be(page, 'MAY_NOT_WORK_IF_YOU_LIVE_OVERSEAS_PAGE')
     expect(page).to have_content('If you can’t verify your identity using GOV.UK Verify, you can register for an identity profile here')
     expect(page).to have_content('register for an identity profile')
     expect(page).to have_link 'here', href: 'http://www.example.com'
+  end
+
+  it 'redirects to select documents page if user clicks try to verify link' do
+    visit may_not_work_if_you_live_overseas_path
+
+    click_link 'I’d like to try to verify my identity online'
+
+    expect(page).to have_current_path(select_documents_path)
   end
 end

--- a/spec/features/user_visits_select_phone_page_spec.rb
+++ b/spec/features/user_visits_select_phone_page_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'When the user visits the select phone page' do
   end
 
   context 'with javascript disabled' do
-    it 'redirects to the will it work for me page when user has a phone' do
+    it 'redirects to the idp picker page when user has a phone' do
       stub_federation_no_docs
       visit '/select-phone'
 
@@ -26,7 +26,7 @@ RSpec.describe 'When the user visits the select phone page' do
       choose 'select_phone_form_landline_false'
       click_button 'Continue'
 
-      expect(page).to have_current_path(will_it_work_for_me_path, only_path: true)
+      expect(page).to have_current_path(choose_a_certified_company_path, only_path: true)
       expect(page.get_rack_session['selected_answers']).to eql('phone' => { 'mobile_phone' => true, 'smart_phone' => true, 'landline' => false })
     end
 
@@ -39,7 +39,7 @@ RSpec.describe 'When the user visits the select phone page' do
       choose 'select_phone_form_landline_false'
       click_button 'Continue'
 
-      expect(page).to have_current_path(will_it_work_for_me_path, only_path: true)
+      expect(page).to have_current_path(choose_a_certified_company_path, only_path: true)
       expect(page.get_rack_session['selected_answers']).to eql('phone' => { 'mobile_phone' => true, 'landline' => false })
     end
 
@@ -75,7 +75,7 @@ RSpec.describe 'When the user visits the select phone page' do
   end
 
   context 'with javascript enabled', js: true do
-    it 'redirects to the will it work for me page when user has a phone' do
+    it 'redirects to the idp picker page when user has a phone' do
       stub_federation
       given_a_session_with_document_evidence
 
@@ -85,7 +85,7 @@ RSpec.describe 'When the user visits the select phone page' do
       choose 'select_phone_form_smart_phone_true'
       click_button 'Continue'
 
-      expect(page).to have_current_path(will_it_work_for_me_path)
+      expect(page).to have_current_path(choose_a_certified_company_path)
       expect(page.get_rack_session['selected_answers']).to eql(
         'phone' => { 'mobile_phone' => true, 'smart_phone' => true },
         'documents' => { 'passport' => true, 'driving_licence' => true })

--- a/spec/features/user_visits_select_phone_page_spec.rb
+++ b/spec/features/user_visits_select_phone_page_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'When the user visits the select phone page' do
   end
 
   context 'with javascript disabled' do
-    it 'redirects to the idp picker page when user has a phone' do
+    it 'redirects to the age question page when user has a phone' do
       stub_federation_no_docs
       visit '/select-phone'
 
@@ -26,8 +26,30 @@ RSpec.describe 'When the user visits the select phone page' do
       choose 'select_phone_form_landline_false'
       click_button 'Continue'
 
-      expect(page).to have_current_path(choose_a_certified_company_path, only_path: true)
+      expect(page).to have_current_path(will_it_work_for_me_path, only_path: true)
       expect(page.get_rack_session['selected_answers']).to eql('phone' => { 'mobile_phone' => true, 'smart_phone' => true, 'landline' => false })
+    end
+
+    context 'for users on the age questions first journey' do
+      before(:each) do
+        page.set_rack_session(
+          show_age_question_first: true
+        )
+      end
+
+      it 'redirects to the idp picker page when user has a phone' do
+        stub_federation_no_docs
+        visit '/select-phone'
+
+        choose 'select_phone_form_mobile_phone_true'
+        choose 'select_phone_form_smart_phone_true'
+        choose 'select_phone_form_landline_false'
+        click_button 'Continue'
+
+        expect(page).to have_current_path(choose_a_certified_company_path, only_path: true)
+        expect(page.get_rack_session['selected_answers']).to eql('phone' => { 'mobile_phone' => true, 'smart_phone' => true, 'landline' => false })
+      end
+
     end
 
     it 'does not include apps if user doesnt know if their phone has apps' do
@@ -39,7 +61,7 @@ RSpec.describe 'When the user visits the select phone page' do
       choose 'select_phone_form_landline_false'
       click_button 'Continue'
 
-      expect(page).to have_current_path(choose_a_certified_company_path, only_path: true)
+      expect(page).to have_current_path(will_it_work_for_me_path, only_path: true)
       expect(page.get_rack_session['selected_answers']).to eql('phone' => { 'mobile_phone' => true, 'landline' => false })
     end
 
@@ -75,20 +97,40 @@ RSpec.describe 'When the user visits the select phone page' do
   end
 
   context 'with javascript enabled', js: true do
-    it 'redirects to the idp picker page when user has a phone' do
-      stub_federation
-      given_a_session_with_document_evidence
+    context 'for users on the age questions first journey' do
+      before(:each) do
+        page.set_rack_session(
+          show_age_question_first: true
+        )
+      end
 
+      it 'redirects to the idp picker page when user has a phone' do
+        stub_federation
+        given_a_session_with_document_evidence
+
+        visit '/select-phone'
+
+        choose 'select_phone_form_mobile_phone_true'
+        choose 'select_phone_form_smart_phone_true'
+        click_button 'Continue'
+
+        expect(page).to have_current_path(choose_a_certified_company_path)
+        expect(page.get_rack_session['selected_answers']).to eql(
+          'phone' => { 'mobile_phone' => true, 'smart_phone' => true },
+          'documents' => { 'passport' => true, 'driving_licence' => true })
+      end
+    end
+
+    it 'redirects to the age question page when user has a phone' do
+      stub_federation_no_docs
       visit '/select-phone'
 
       choose 'select_phone_form_mobile_phone_true'
       choose 'select_phone_form_smart_phone_true'
       click_button 'Continue'
 
-      expect(page).to have_current_path(choose_a_certified_company_path)
-      expect(page.get_rack_session['selected_answers']).to eql(
-        'phone' => { 'mobile_phone' => true, 'smart_phone' => true },
-        'documents' => { 'passport' => true, 'driving_licence' => true })
+      expect(page).to have_current_path(will_it_work_for_me_path, only_path: true)
+      expect(page.get_rack_session['selected_answers']).to eql('phone' => { 'mobile_phone' => true, 'smart_phone' => true })
     end
 
     it 'should display a validation message when user does not answer mobile phone question' do

--- a/spec/features/user_visits_why_might_this_not_work_for_me_page_spec.rb
+++ b/spec/features/user_visits_why_might_this_not_work_for_me_page_spec.rb
@@ -13,14 +13,6 @@ RSpec.describe 'When the user visits the why-might-this-not-work-for-me page' do
     expect(page).to have_css 'html[lang=cy]'
   end
 
-  context 'with javascript enabled', js: true do
-    it 'contains the choose certified company link with selected evidence params' do
-      visit '/why-might-this-not-work-for-me'
-
-      expect(page).to have_link "I’d like to try to verify my identity online", href: "/choose-a-certified-company"
-    end
-  end
-
   it 'includes other ways text' do
     visit '/why-might-this-not-work-for-me'
 
@@ -33,5 +25,13 @@ RSpec.describe 'When the user visits the why-might-this-not-work-for-me page' do
     visit '/why-might-this-not-work-for-me'
 
     expect_feedback_source_to_be(page, 'WHY_THIS_MIGHT_NOT_WORK_FOR_ME_PAGE')
+  end
+
+  it 'redirects to select documents page if user clicks try to verify link' do
+    visit why_might_this_not_work_for_me_path
+
+    click_link 'I’d like to try to verify my identity online'
+
+    expect(page).to have_current_path(select_documents_path)
   end
 end

--- a/spec/features/user_visits_why_might_this_not_work_for_me_page_spec.rb
+++ b/spec/features/user_visits_why_might_this_not_work_for_me_page_spec.rb
@@ -27,11 +27,28 @@ RSpec.describe 'When the user visits the why-might-this-not-work-for-me page' do
     expect_feedback_source_to_be(page, 'WHY_THIS_MIGHT_NOT_WORK_FOR_ME_PAGE')
   end
 
-  it 'redirects to select documents page if user clicks try to verify link' do
+  it 'redirects to IdP picker page if user clicks try to verify link' do
+    stub_federation
     visit why_might_this_not_work_for_me_path
 
     click_link 'I’d like to try to verify my identity online'
 
-    expect(page).to have_current_path(select_documents_path)
+    expect(page).to have_current_path(choose_a_certified_company_path)
+  end
+
+  context 'for users on the age questions first journey' do
+    before(:each) do
+      page.set_rack_session(
+        show_age_question_first: true
+      )
+    end
+
+    it 'redirects to select documents page if user clicks try to verify link' do
+      visit why_might_this_not_work_for_me_path
+
+      click_link 'I’d like to try to verify my identity online'
+
+      expect(page).to have_current_path(select_documents_path)
+    end
   end
 end

--- a/spec/features/user_visits_will_it_work_for_me_page_spec.rb
+++ b/spec/features/user_visits_will_it_work_for_me_page_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'When the user visits the will it work for me page' do
     expect(page).to have_css 'html[lang=cy]'
   end
 
-  it 'redirects to the select documents page when user is over 20 and is a uk resident' do
+  it 'redirects to IdP picker page when user is over 20 and is a uk resident' do
     stub_federation
     visit '/will-it-work-for-me'
 
@@ -26,7 +26,25 @@ RSpec.describe 'When the user visits the will it work for me page' do
     choose 'will_it_work_for_me_form_resident_last_12_months_true'
     click_button 'Continue'
 
-    expect(page).to have_current_path(select_documents_path)
+    expect(page).to have_current_path(choose_a_certified_company_path)
+  end
+
+  context 'for users on the age questions first journey' do
+    before(:each) do
+      page.set_rack_session(
+        show_age_question_first: true
+      )
+    end
+
+    it 'redirects to the select document page when user is over 20 and is a uk resident' do
+      visit '/will-it-work-for-me'
+
+      choose 'will_it_work_for_me_form_above_age_threshold_true'
+      choose 'will_it_work_for_me_form_resident_last_12_months_true'
+      click_button 'Continue'
+
+      expect(page).to have_current_path(select_documents_path)
+    end
   end
 
   it 'redirects to the why-might-this-not-work-for-me page when user is over 20 and has moved to the uk in the last 12 months' do

--- a/spec/features/user_visits_will_it_work_for_me_page_spec.rb
+++ b/spec/features/user_visits_will_it_work_for_me_page_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'When the user visits the will it work for me page' do
     expect(page).to have_css 'html[lang=cy]'
   end
 
-  it 'redirects to the choose-a-company page when user is over 20 and is a uk resident' do
+  it 'redirects to the select documents page when user is over 20 and is a uk resident' do
     stub_federation
     visit '/will-it-work-for-me'
 
@@ -26,7 +26,7 @@ RSpec.describe 'When the user visits the will it work for me page' do
     choose 'will_it_work_for_me_form_resident_last_12_months_true'
     click_button 'Continue'
 
-    expect(page).to have_current_path(choose_a_certified_company_path)
+    expect(page).to have_current_path(select_documents_path)
   end
 
   it 'redirects to the why-might-this-not-work-for-me page when user is over 20 and has moved to the uk in the last 12 months' do


### PR DESCRIPTION
This adds support for a flag in the session which if set will show the
'Age' questions first.  By default it isn't set - the next release will
make it the default, but it's necessary to do it in two steps to avoid
breaking journeys that are in flight at the time of the roll-out.