### PR TITLE
BAU: reduce js payload

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -5,7 +5,6 @@
 //= require details.polyfill
 
 //= require jquery
-//= require jquery_ujs
 //= require jquery.validate
 //= require govuk/selection-buttons
 //= require_tree .

--- a/spec/features/user_visits_select_phone_page_spec.rb
+++ b/spec/features/user_visits_select_phone_page_spec.rb
@@ -49,7 +49,6 @@ RSpec.describe 'When the user visits the select phone page' do
         expect(page).to have_current_path(choose_a_certified_company_path, only_path: true)
         expect(page.get_rack_session['selected_answers']).to eql('phone' => { 'mobile_phone' => true, 'smart_phone' => true, 'landline' => false })
       end
-
     end
 
     it 'does not include apps if user doesnt know if their phone has apps' do


### PR DESCRIPTION
This is shipped with jquery-rails: it binds Rails’s helper methods through to the frontend. We’re not using any of the helpers currently and I don’t see us using them in future (we have dedicated per-page Javascript for that).

This saves us 25Kb unminified and un-gzipped.

(also included - a trivial fix for a lint failure)