### PR TITLE
3717: return IDPs from profile fitlers in sets

### DIFF
--- a/app/models/idp_eligibility/filter.rb
+++ b/app/models/idp_eligibility/filter.rb
@@ -2,7 +2,7 @@ module IdpEligibility
   class Filter
     def filter_idps(profile_filter, evidence, enabled_idps)
       filtered_idps = profile_filter.idps_for(evidence)
-      enabled_idps.select { |idp| filtered_idps.include?(idp.simple_id) }
+      enabled_idps.select { |idp| filtered_idps.include?(idp.simple_id) }.to_set
     end
   end
 end

--- a/spec/features/user_visits_choose_a_certified_company_page_spec.rb
+++ b/spec/features/user_visits_choose_a_certified_company_page_spec.rb
@@ -195,7 +195,7 @@ RSpec.describe 'When the user visits the choose a certified company page' do
       visit choose_a_certified_company_path
 
       within('#non-matching-idps') do
-        expect(page).to have_content('Choose Demo IDP')
+        expect(page).to have_content('Choose Demo IDP', count: 1)
       end
     end
   end

--- a/spec/models/idp_eligibility/filter_spec.rb
+++ b/spec/models/idp_eligibility/filter_spec.rb
@@ -11,7 +11,7 @@ module IdpEligibility
       rules = double(:rules)
       expect(rules).to receive(:idps_for).with(evidence).and_return(['idp_one'])
       filtered_idps = Filter.new.filter_idps(rules, evidence, enabled_idps)
-      expect(filtered_idps).to eql [idp_one]
+      expect(filtered_idps).to eql [idp_one].to_set
     end
   end
 end

--- a/spec/models/idp_eligibility/recommendation_grouper_spec.rb
+++ b/spec/models/idp_eligibility/recommendation_grouper_spec.rb
@@ -8,15 +8,15 @@ module IdpEligibility
   describe RecommendationGrouper do
     let(:idp_one) { double(:idp_one, simple_id: 'idp') }
     let(:idp_two) { double(:idp_one, simple_id: 'idp2') }
-    let(:singleton_idp) { [idp_one] }
+    let(:singleton_idp) { [idp_one].to_set }
     let(:transaction_simple_id) { 'a-transaction' }
     let(:blacklisted_transaction_simple_id) { 'blacklisted-transaction' }
     let(:passport_profile) { Profile.new([:passport]) }
     let(:driving_licence_profile) { Profile.new([:driving_licence]) }
-    let(:mobile_phone_profile) { Profile.new([:mobile_phone]) }
+    let(:demo_profile) { Profile.new([:mobile_phone, :driving_licence]) }
     let(:recommended_profile_filter) { ProfileFilter.new('idp' => [passport_profile]) }
     let(:non_recommended_profile_filter) { ProfileFilter.new('idp' => [driving_licence_profile], 'idp2' => [passport_profile]) }
-    let(:demo_profile_filter) { ProfileFilter.new('idp' => [mobile_phone_profile]) }
+    let(:demo_profile_filter) { ProfileFilter.new('idp' => [demo_profile]) }
     let(:transaction_blacklist) { [blacklisted_transaction_simple_id] }
     let(:grouper) { RecommendationGrouper.new(recommended_profile_filter, non_recommended_profile_filter, demo_profile_filter, transaction_blacklist) }
 
@@ -37,13 +37,13 @@ module IdpEligibility
 
       it 'should return true when profile is in IDP demo profiles' do
         enabled_idps = singleton_idp
-        user_docs = [:mobile_phone]
+        user_docs = [:mobile_phone, :driving_licence]
         expect(grouper.recommended?(idp_one, user_docs, enabled_idps, transaction_simple_id)).to eql(true)
       end
 
       it 'should return false when profile is in IdP demo profiles but the transaction does not allow demos' do
         enabled_idps = singleton_idp
-        user_docs = [:mobile_phone]
+        user_docs = [:mobile_phone, :driving_licence]
         expect(grouper.recommended?(idp_one, user_docs, enabled_idps, blacklisted_transaction_simple_id)).to eql(false)
       end
     end
@@ -55,46 +55,46 @@ module IdpEligibility
         user_docs = [:passport]
         grouped_idps = grouper.group_by_recommendation(user_docs, singleton_idp, transaction_simple_id)
         expect(grouped_idps.recommended).to eql(singleton_idp)
-        expect(grouped_idps.non_recommended).to eql([])
+        expect(grouped_idps.non_recommended).to eql(Set.new)
       end
 
       it 'should return non-recommended idps' do
         enabled_idps = multiple_idps
         user_docs = [:driving_licence]
         grouped_idps = grouper.group_by_recommendation(user_docs, enabled_idps, transaction_simple_id)
-        expect(grouped_idps.recommended).to eql([])
-        expect(grouped_idps.non_recommended).to eql([idp_one])
+        expect(grouped_idps.recommended).to eql(Set.new)
+        expect(grouped_idps.non_recommended).to eql(singleton_idp)
       end
 
       it 'should return recommended and non-recommended idps' do
         enabled_idps = multiple_idps
         user_docs = [:passport, :driving_licence]
         grouped_idps = grouper.group_by_recommendation(user_docs, enabled_idps, transaction_simple_id)
-        expect(grouped_idps.recommended).to eql([idp_one])
-        expect(grouped_idps.non_recommended).to eql([idp_two])
+        expect(grouped_idps.recommended).to eql([idp_one].to_set)
+        expect(grouped_idps.non_recommended).to eql([idp_two].to_set)
       end
 
       it 'should return an empty list when no enabled idps' do
         enabled_idps = []
         user_docs = [:passport]
         grouped_idps = grouper.group_by_recommendation(user_docs, enabled_idps, transaction_simple_id)
-        expect(grouped_idps.recommended).to eql([])
-        expect(grouped_idps.non_recommended).to eql([])
+        expect(grouped_idps.recommended).to eql([].to_set)
+        expect(grouped_idps.non_recommended).to eql([].to_set)
       end
 
       it 'should add demo profiles to recommended' do
         enabled_idps = singleton_idp
-        user_docs = [:mobile_phone]
+        user_docs = [:driving_licence, :mobile_phone]
         grouped_idps = grouper.group_by_recommendation(user_docs, enabled_idps, transaction_simple_id)
-        expect(grouped_idps.recommended).to eql([idp_one])
+        expect(grouped_idps.recommended).to eql([idp_one].to_set)
         expect(grouped_idps.non_recommended).to be_empty
       end
 
       it 'should not add demo profiles to recommended when rp is blacklisted' do
         enabled_idps = singleton_idp
-        user_docs = [:mobile_phone]
+        user_docs = [:driving_licence, :mobile_phone]
         grouped_idps = grouper.group_by_recommendation(user_docs, enabled_idps, blacklisted_transaction_simple_id)
-        expect(grouped_idps.non_recommended).to eql([idp_one])
+        expect(grouped_idps.non_recommended).to eql([idp_one].to_set)
         expect(grouped_idps.recommended).to be_empty
       end
     end

--- a/stub/idp-rules/stub-idp-demo.yml
+++ b/stub/idp-rules/stub-idp-demo.yml
@@ -2,5 +2,6 @@ simpleIds: [ "stub-idp-demo" ]
 recommended_profiles: []
 demo_profiles:
   - [ "driving_licence", "mobile_phone" ]
-non_recommended_profiles: []
+non_recommended_profiles:
+  - [ "driving_licence", "mobile_phone", "landline" ]
 send_hints: false


### PR DESCRIPTION
IDPs returned from profile filters are not being returned as a Set. This has caused
a problem for sessions from a RP where we do not want demos to be enabled as
the IDP was appearing twice as it had both demo and non-recommended profiles
defined so was introduced in both lists that were joined.