### PR TITLE
bau: reset locale to english before examples

### DIFF
--- a/spec/features/user_encounters_error_page_spec.rb
+++ b/spec/features/user_encounters_error_page_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe 'user encounters error page' do
     set_session_cookies!
     stub_transactions_list
     stub_request(:get, api_federation_endpoint).and_return(status: 403)
-    visit sign_in_en_path
+    visit sign_in_path
     expect(page).to have_content "Sorry, something went wrong"
     expect(page).to have_link "register for an identity profile", href: "http://localhost:50130/test-rp"
     expect(page).to have_css "#piwik-custom-url", text: "errors/generic-error"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -47,6 +47,14 @@ RSpec.configure do |config|
     mocks.verify_doubled_constant_names = true
   end
 
+
+  # Limits the available syntax to the non-monkey patched syntax that is
+  # recommended. For more details, see:
+  #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
+  #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
+  #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
+  # config.disable_monkey_patching!
+
 # The settings below are suggested to provide a good initial experience
 # with RSpec, but feel free to customize to your heart's content.
 =begin
@@ -61,13 +69,6 @@ RSpec.configure do |config|
   # the `--only-failures` and `--next-failure` CLI options. We recommend
   # you configure your source control system to ignore this file.
   config.example_status_persistence_file_path = "spec/examples.txt"
-
-  # Limits the available syntax to the non-monkey patched syntax that is
-  # recommended. For more details, see:
-  #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
-  #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
-  #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
-  config.disable_monkey_patching!
 
   # Many RSpec users commonly either run the entire suite or an individual
   # file, and it's useful to allow more verbose output when running an
@@ -96,6 +97,9 @@ RSpec.configure do |config|
   # as the one that triggered the failure.
   Kernel.srand config.seed
 =end
+  config.before(:example) do
+    I18n.locale = :en if defined? I18n
+  end
 end
 
 $:.unshift File.expand_path('../../app/', __FILE__)


### PR DESCRIPTION
When hitting a path we set the locale using I18n to the correct locale for that path (:en or :cy), but because all our tests run in the same thread the locale was kept until we hit a different locale path in another example. 

As the _path helper uses the locale to choose an appropriate path we were seeing tests hit welsh routes when we were intending for english ones if the the example followed a welsh language example.