### PR TITLE
Fix Rails per-request constant reloading

### DIFF
--- a/config/initializers/cookie_validator.rb
+++ b/config/initializers/cookie_validator.rb
@@ -1,2 +1,5 @@
 session_cookie_duration_in_hours = CONFIG.session_cookie_duration
-COOKIE_VALIDATOR = CookieValidator.new(Integer(session_cookie_duration_in_hours))
+
+Rails.application.config.to_prepare do
+  COOKIE_VALIDATOR = CookieValidator.new(Integer(session_cookie_duration_in_hours))
+end

--- a/config/initializers/proxies.rb
+++ b/config/initializers/proxies.rb
@@ -1,14 +1,14 @@
 require 'originating_ip_store'
 API_HOST = CONFIG.api_host
 
-api_client = Api::Client.new(API_HOST, Api::ResponseHandler.new)
-
-SESSION_PROXY = SessionProxy.new(api_client, OriginatingIpStore)
-
-TRANSACTION_LISTER = Display::Rp::TransactionLister.new(
-  Display::Rp::TransactionsProxy.new(api_client),
-  Display::Rp::DisplayDataCorrelator.new(FEDERATION_TRANSLATOR)
-)
+Rails.application.config.to_prepare do
+  api_client = Api::Client.new(API_HOST, Api::ResponseHandler.new)
+  SESSION_PROXY = SessionProxy.new(api_client, OriginatingIpStore)
+  TRANSACTION_LISTER = Display::Rp::TransactionLister.new(
+    Display::Rp::TransactionsProxy.new(api_client),
+    Display::Rp::DisplayDataCorrelator.new(FEDERATION_TRANSLATOR)
+  )
+end
 
 Rails.application.config.after_initialize do
   IDENTITY_PROVIDER_DISPLAY_DECORATOR = Display::IdentityProviderDisplayDecorator.new(


### PR DESCRIPTION
In development mode, rails will unload certain constants
and reload certain files before each request. It does this to
reduce the cycle time required before a developer sees their
changes.

When classes are reloaded, existing values don't get their
class references updated to point at the new class (after all,
the class definition might have changed since the value
was created). If you hold on to a value having the type of
the unloaded class, Ruby will get confused when it tries to
reference constants defined on that class, since it no
longer exists.

We can work around this by creating our global values with
`to_prepare`, which runs a block before every request in
development mode, but just once in production mode.

Links:

https://github.com/rails/rails/blob/375d9a0a7fb329b0fbbd75a13e93e53a00520587/activesupport/lib/active_support/dependencies.rb#L444-L446

http://guides.rubyonrails.org/configuring.html