### PR TITLE
BAU: Automatically install dep changes in pre-commit

### DIFF
--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -2,6 +2,7 @@
 
 . scripts/deploy.sh
 
+bundle
 bundle exec govuk-lint-ruby app config lib spec
 success=$?
 


### PR DESCRIPTION
This automates the manual step of installing changed dependencies,
saving a few back and forth commands. With no dependencies changed, it
doesn't add noticable time to the build.

Solo: @lloydnye