### PR TITLE
bau: Check for transaction simple id presence

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -38,7 +38,7 @@ class ApplicationController < ActionController::Base
   end
 
   def validate_cookies
-    validation = cookie_validator.validate(cookies)
+    validation = cookie_validator.validate(cookies, session)
     unless validation.ok?
       logger.info(validation.message)
       render_error(validation.type, validation.status)

--- a/app/models/cookie_validator.rb
+++ b/app/models/cookie_validator.rb
@@ -4,11 +4,12 @@ class CookieValidator
       NoCookiesValidator.new,
       MissingCookiesValidator.new,
       SessionIdCookieValidator.new,
+      TransactionSimpleIdPresence.new,
       SessionStartTimeCookieValidator.new(session_duration)
     ]
   end
 
-  def validate(cookies)
-    @validators.lazy.map { |validator| validator.validate(cookies) }.detect { |result| !result.ok? } || SuccessfulValidation
+  def validate(cookies, session)
+    @validators.lazy.map { |validator| validator.validate(cookies, session) }.detect(&:bad?) || SuccessfulValidation
   end
 end

--- a/app/models/cookie_validator/missing_cookies_validator.rb
+++ b/app/models/cookie_validator/missing_cookies_validator.rb
@@ -1,6 +1,6 @@
 class CookieValidator
   class MissingCookiesValidator
-    def validate(cookies)
+    def validate(cookies, _session)
       missing_cookies = []
       if start_time_cookie_missing?(cookies)
         missing_cookies << ::CookieNames::SESSION_STARTED_TIME_COOKIE_NAME

--- a/app/models/cookie_validator/no_cookies_validator.rb
+++ b/app/models/cookie_validator/no_cookies_validator.rb
@@ -1,6 +1,6 @@
 class CookieValidator
   class NoCookiesValidator
-    def validate(cookies)
+    def validate(cookies, _session)
       if all_cookies_missing?(cookies)
         ValidationFailure.no_cookies
       else

--- a/app/models/cookie_validator/session_id_cookie_validator.rb
+++ b/app/models/cookie_validator/session_id_cookie_validator.rb
@@ -1,7 +1,7 @@
 class CookieValidator
   class SessionIdCookieValidator
     NO_CURRENT_SESSION = 'no-current-session'.freeze
-    def validate(cookies)
+    def validate(cookies, _session)
       session_id = cookies[::CookieNames::SESSION_ID_COOKIE_NAME]
       if session_id == NO_CURRENT_SESSION
         ValidationFailure.deleted_session

--- a/app/models/cookie_validator/session_start_time_cookie_validator.rb
+++ b/app/models/cookie_validator/session_start_time_cookie_validator.rb
@@ -4,7 +4,7 @@ class CookieValidator
       @session_duration = session_duration
     end
 
-    def validate(cookies)
+    def validate(cookies, _session)
       start_time_cookie_value = cookies[::CookieNames::SESSION_STARTED_TIME_COOKIE_NAME]
       begin
         session_start_time_s = Integer(start_time_cookie_value) / 1000

--- a/app/models/cookie_validator/transaction_simple_id_presence.rb
+++ b/app/models/cookie_validator/transaction_simple_id_presence.rb
@@ -1,0 +1,12 @@
+class CookieValidator
+  class TransactionSimpleIdPresence
+    ERROR_MESSAGE = "Transaction simple ID can not be found in the user's session".freeze
+    def validate(_cookies, session)
+      if session.include?(:transaction_simple_id)
+        SuccessfulValidation
+      else
+        ValidationFailure.something_went_wrong(ERROR_MESSAGE)
+      end
+    end
+  end
+end

--- a/app/models/cookie_validator/validation.rb
+++ b/app/models/cookie_validator/validation.rb
@@ -3,5 +3,9 @@ class CookieValidator
     def ok?
       true
     end
+
+    def bad?
+      !ok?
+    end
   end
 end

--- a/app/models/cookie_validator/validation_failure.rb
+++ b/app/models/cookie_validator/validation_failure.rb
@@ -1,5 +1,5 @@
 class CookieValidator
-  class ValidationFailure
+  class ValidationFailure < Validation
     def self.something_went_wrong(message)
       ValidationFailure.new(:something_went_wrong, :internal_server_error, message)
     end

--- a/spec/feature_helper.rb
+++ b/spec/feature_helper.rb
@@ -66,6 +66,7 @@ end
 def set_session_cookies!
   cookie_hash = create_cookie_hash
   set_cookies!(cookie_hash)
+  page.set_rack_session(transaction_simple_id: 'test-rp')
   cookie_hash
 end
 

--- a/spec/features/redirects_with_see_other_spec.rb
+++ b/spec/features/redirects_with_see_other_spec.rb
@@ -1,11 +1,10 @@
 require 'feature_helper'
+require 'api_test_helper'
 describe 'pages redirect with see other', type: :request do
   it 'sets a see other for redirects' do
-    cookie_hash = create_cookie_hash
-    cookie_hash.each do |k, v|
-      cookies[k] = v
-    end
-    post '/start', 'selection' => 'true'
+    stub_federation
+    stub_api_saml_endpoint
+    post '/SAML2/SSO', 'SAMLRequest' => 'my-saml-request', 'RelayState' => 'my-relay-state'
     expect(response.status).to eql 303
   end
 end


### PR DESCRIPTION
We've had a few journeys  occur where after a user submits a duplicate SAML
message (perhaps after hitting the back and forwards button) they are treated
with an error message, but after a refresh are able to continue on for a few
pages despite their session missing a transaction simple id.

We want users to be see errors page as soon as they see an unhealthy state
so this PR introduces a check for the user's transaction simple as part of our
exisitng cookie validation. If the simple id is missing then the user will see
the standard something went wrong page.