### PR TITLE
bau: don't send 404 messages to sentry

### DIFF
--- a/lib/support/raven/logger.rb
+++ b/lib/support/raven/logger.rb
@@ -31,9 +31,13 @@ module Support
 
       class RavenWriter
         def write(msg = nil)
-          unless msg.nil? || msg.is_a?(ActionController::RoutingError) || message_is_raven_log?(msg)
+          unless msg.nil? || message_is_404?(msg) || message_is_raven_log?(msg)
             ::Raven.capture_exception(msg)
           end
+        end
+
+        def message_is_404?(message)
+          message.is_a?(ActionController::RoutingError) || (message.is_a?(String) && message.start_with?("ActionController::RoutingError"))
         end
 
         def message_is_raven_log?(message)

--- a/spec/lib/support/raven/logger_spec.rb
+++ b/spec/lib/support/raven/logger_spec.rb
@@ -18,6 +18,12 @@ describe Support::Raven::Logger do
       logger.error(error)
     end
 
+    it 'will not send routing messages to sentry' do
+      error = 'ActionController::RoutingError (No route matches [GET] "/favicon.ico")'
+      expect(Raven).to_not receive(:capture_exception).with(error)
+      logger.error(error)
+    end
+
     it 'will send non-exceptions to sentry after inspection' do
       msg = double(:message)
       inspected = double(:inspected)


### PR DESCRIPTION
We currently hook up sentry to the raven logger to capture exceptions and error
messages.

Rails is currently logging 404s as errrors using the string representation of
the error (not just the exception).

As 404s are not something we can usually action this change will stop them from
being sent to Sentry.