### PR TITLE
bau: don't set colours when TERM unset

### DIFF
--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -7,11 +7,16 @@ bundle exec govuk-lint-ruby app config lib spec
 success=$?
 
 # govuk-lint-sass is very quiet. Setting the output colour
-# to red makes it more obvious when it fails.
-tput setaf 1
+# to red makes it more obvious when it fails, but we won't
+# try to when there isn't a $TERM (jenkins).
+if [ -t 1 ]; then
+  tput setaf 1
+fi
 bundle exec govuk-lint-sass app/assets/stylesheets
 success=$((success || $?))
-tput sgr0
+if [ -t 1 ]; then
+  tput sgr0
+fi
 
 bundle exec rspec --exclude-pattern "spec/features/*_spec.rb"
 success=$((success || $?))


### PR DESCRIPTION
When the $TERM is not set, on jenkins,  we don't want to set terminal colours as tput will
error.