### PR TITLE
bau: skip funky banner on jenkins

### DIFF
--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -25,10 +25,12 @@ success=$((success || $?))
 bundle exec rake spec:javascripts
 success=$((success || $?))
 
-if [ $success -eq 0 ]
-then
-  funky_pass_banner
-else
-  funky_fail_banner
+if [ -t 1 ]; then
+  if [ $success -eq 0 ]
+  then
+    funky_pass_banner
+  else
+    funky_fail_banner
+  fi
 fi
-
+exit $success


### PR DESCRIPTION
If $TERM is undefined then we should skip the funky banner as this might cause
the build to fail.

Also, we should return the exit code using $success