### PR TITLE
bau: only use minimal config for ZDD

### DIFF
--- a/lib/tasks/zdd.rake
+++ b/lib/tasks/zdd.rake
@@ -1,13 +1,25 @@
 require 'fileutils'
 namespace :zdd do
+  def zdd_file
+    ENV.fetch('ZDD_LATCH') {
+      raise "ZDD_LATCH environment variable is unset!"
+    }
+  end
+
+  def wait_time
+    ENV.fetch('POLLING_WAIT_TIME') {
+      raise "POLLING_WAIT_TIME environment variable is unset!"
+    }
+  end
+
   desc 'set the service unavailable'
-  task set_unavailable: :environment do
-    FileUtils.touch(CONFIG.zdd_file)
-    sleep Integer(CONFIG.polling_wait_time)
+  task :set_unavailable do
+    FileUtils.touch(zdd_file)
+    sleep Integer(wait_time)
   end
 
   desc 'reset service availability'
-  task reset: :environment do
-    FileUtils.rm(CONFIG.zdd_file, force: true)
+  task :reset do
+    FileUtils.rm(zdd_file, force: true)
   end
 end


### PR DESCRIPTION
We occasionally run into a problem in some of our environments where we're missing
an envvar required for the service thats causes our zdd rake tasks to fail (as
they were dependent on the full Rails environment).

This currently requires some manual intervention before we can fix the
environment. By only using config that is required for ZDD we can mitigate the
impact of missing config on our build pipeline and hopefully remove these manual
steps form our process.