### PR TITLE
3580: log API server errors at warn

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,6 +13,7 @@ class ApplicationController < ActionController::Base
   rescue_from StandardError, with: :something_went_wrong unless Rails.env == 'development'
   rescue_from Errors::WarningLevelError, with: :something_went_wrong_warn
   rescue_from Api::SessionError, with: :session_error
+  rescue_from Api::UpstreamError, with: :something_went_wrong_warn
   rescue_from Api::SessionTimeoutError, with: :session_timeout
 
   prepend RedirectWithSeeOther

--- a/app/models/api/response_handler.rb
+++ b/app/models/api/response_handler.rb
@@ -13,13 +13,13 @@ module Api
     def handle_error(body, status)
       json = parse_json(body, status) || {}
       error_message = message(status, json)
-      case json.fetch('type', 'NONE')
+      case json.fetch('type') { raise Error, error_message }
       when SessionError::TYPE
         raise SessionError, error_message
       when SessionTimeoutError::TYPE
         raise SessionTimeoutError, error_message
       else
-        raise Error, error_message
+        raise UpstreamError, error_message
       end
     end
 

--- a/app/models/api/upstream_error.rb
+++ b/app/models/api/upstream_error.rb
@@ -1,0 +1,4 @@
+module Api
+  class UpstreamError < StandardError
+  end
+end

--- a/spec/features/user_encounters_error_page_spec.rb
+++ b/spec/features/user_encounters_error_page_spec.rb
@@ -64,6 +64,18 @@ RSpec.describe 'user encounters error page' do
     expect(page.status_code).to eq(500)
   end
 
+  it 'will present something went wrong when parsable upstream error occurs and not log error' do
+    expect(Raven).to_not receive(:capture_exception)
+    expect(Rails.logger).to_not receive(:error)
+    error_body = { id: '0', type: 'SERVER_ERROR' }
+    stub_request(:post, api_saml_endpoint).and_return(status: 500, body: error_body.to_json)
+    stub_transactions_list
+    visit '/test-saml'
+    click_button "saml-post"
+    expect(page).to have_content "Sorry, something went wrong"
+    expect(page.status_code).to eq(500)
+  end
+
   it 'will present session error page when session error occurs in upstream systems' do
     set_session_cookies!
     error_body = { id: '0', type: 'SESSION_ERROR' }


### PR DESCRIPTION
If an error/problem occurs upstream within the Hub we receive a formatted
error message. As our upstream services also log their errors it shouldn't
be necessary to log them at a high level at the FE so I have changed it to only
log if it sees a message in an unexpected format (missing a type field).

Connection and Timeout errors will still be logged at error.