### PR TITLE
Remove Rails authenticity_token from SAML forms

### DIFF
--- a/app/views/redirect_to_idp/index.html.erb
+++ b/app/views/redirect_to_idp/index.html.erb
@@ -6,7 +6,7 @@
       <div class="application-notice info-notice">
         <p><%= t('hub.redirect_to_idp.description')%></p>
       </div>
-      <%= form_tag(@request.location, class: 'js-auto-submit') do %>
+      <%= form_tag(@request.location, class: 'js-auto-submit', authenticity_token: false, enforce_utf8: false) do %>
           <%= hidden_field_tag 'SAMLRequest', @request.saml_request %>
           <%= hidden_field_tag 'RelayState', @request.relay_state %>
           <%= hidden_field_tag 'registration', @request.registration %>

--- a/app/views/redirect_to_service/redirect_to_service.html.erb
+++ b/app/views/redirect_to_service/redirect_to_service.html.erb
@@ -7,7 +7,7 @@
       <div class="application-notice info-notice">
         <p><%= t('hub.redirect_to_service.no_javascript') %></p>
       </div>
-      <%= form_tag(@response_for_rp.location, class: 'js-auto-submit') do %>
+      <%= form_tag(@response_for_rp.location, class: 'js-auto-submit', authenticity_token: false, enforce_utf8: false) do %>
           <%= hidden_field_tag 'SAMLResponse', @response_for_rp.saml_message %>
           <% if @response_for_rp.relay_state %>
             <%= hidden_field_tag 'RelayState', @response_for_rp.relay_state %>

--- a/app/views/shared/_continue_to_idp_form.html.erb
+++ b/app/views/shared/_continue_to_idp_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_tag({}, {id: 'post-to-idp', class: 'hidden'}) do %>
+<%= form_tag({}, {id: 'post-to-idp', class: 'hidden', authenticity_token: false, enforce_utf8: false}) do %>
     <input name=SAMLRequest type=hidden>
     <input name=RelayState type=hidden>
     <input name=registration type=hidden>


### PR DESCRIPTION
SAML forms generally only include SAMLRequest and RelayState, with the
exception of our extensions (registration, hints) we shouldn't go beyond
these standard form parameters.

Rails includes an authenticity_token to prevent cross-site request
forgery however in this case the form 'action' is a separate domain
beyond our control so csrf tokens like this are not useful.

Rails docs say the utf8 ✓

 > enforces browsers to properly respect your form's character encoding

Given the content of these forms is generated and not user submitted we
can be confident that we don't place any unicode characters in there.
Generally the bodies of these forms are base64 encoded XML so there is
very little room for unicode characters in any case.