### PR TITLE
refactor: use rp display data for reporting analytics

### DIFF
--- a/app/controllers/about_controller.rb
+++ b/app/controllers/about_controller.rb
@@ -3,7 +3,7 @@ class AboutController < ApplicationController
 
   def index
     FEDERATION_REPORTER.report_registration(
-      current_transaction_simple_id,
+      current_transaction,
       request
     )
   end

--- a/app/controllers/further_information_controller.rb
+++ b/app/controllers/further_information_controller.rb
@@ -21,7 +21,7 @@ class FurtherInformationController < ApplicationController
 
   def cancel
     FURTHER_INFORMATION_SERVICE.cancel(cookies)
-    FEDERATION_REPORTER.report_cycle_three_cancel(current_transaction_simple_id, request)
+    FEDERATION_REPORTER.report_cycle_three_cancel(current_transaction, request)
     redirect_to redirect_to_service_start_again_path
   end
 end

--- a/app/controllers/sign_in_controller.rb
+++ b/app/controllers/sign_in_controller.rb
@@ -8,7 +8,7 @@ class SignInController < ApplicationController
       unavailable_idps.map { |simple_id| IdentityProvider.new('simple_id' => simple_id, 'entity_id' => simple_id) }
     )
 
-    FEDERATION_REPORTER.report_sign_in(current_transaction_simple_id, request)
+    FEDERATION_REPORTER.report_sign_in(current_transaction, request)
     render 'index'
   end
 

--- a/app/models/analytics/federation_reporter.rb
+++ b/app/models/analytics/federation_reporter.rb
@@ -1,16 +1,15 @@
 module Analytics
   class FederationReporter
-    def initialize(federation_translator, analytics_reporter)
-      @federation_translator = federation_translator
+    def initialize(analytics_reporter)
       @analytics_reporter = analytics_reporter
     end
 
-    def report_sign_in(transaction_simple_id, request)
-      report_action(transaction_simple_id, request, 'The No option was selected on the introduction page')
+    def report_sign_in(current_transaction, request)
+      report_action(current_transaction, request, 'The No option was selected on the introduction page')
     end
 
-    def report_registration(transaction_simple_id, request)
-      report_action(transaction_simple_id, request, 'The Yes option was selected on the start page')
+    def report_registration(current_transaction, request)
+      report_action(current_transaction, request, 'The Yes option was selected on the start page')
     end
 
     def report_idp_registration(request, idp_name, idp_name_history, evidence, recommended)
@@ -34,20 +33,18 @@ module Analytics
       @analytics_reporter.report_custom_variable(request, 'Cycle3 submitted', cvar)
     end
 
-    def report_cycle_three_cancel(transaction_simple_id, request)
-      report_action(transaction_simple_id, request, 'Matching Outcome - Cancelled Cycle3')
+    def report_cycle_three_cancel(current_transaction, request)
+      report_action(current_transaction, request, 'Matching Outcome - Cancelled Cycle3')
     end
 
   private
 
-    def report_action(transaction_simple_id, request, action)
+    def report_action(current_transaction, request, action)
       begin
-        transaction_analytics_description = @federation_translator.translate(
-          "rps.#{transaction_simple_id}.analytics_description")
         @analytics_reporter.report_custom_variable(
           request,
           action,
-          Analytics::CustomVariable.build(:rp, transaction_analytics_description))
+          Analytics::CustomVariable.build(:rp, current_transaction.analytics_description))
       rescue Display::FederationTranslator::TranslationError => e
         Rails.logger.warn e
       end

--- a/app/models/display/rp_display_data.rb
+++ b/app/models/display/rp_display_data.rb
@@ -5,5 +5,6 @@ module Display
     content :name
     content :rp_name
     content :other_ways_text
+    content :analytics_description
   end
 end

--- a/config/initializers/piwik.rb
+++ b/config/initializers/piwik.rb
@@ -12,4 +12,4 @@ else
   ANALYTICS_REPORTER = Analytics::NullReporter.new
 end
 
-FEDERATION_REPORTER = Analytics::FederationReporter.new(FEDERATION_TRANSLATOR, ANALYTICS_REPORTER)
+FEDERATION_REPORTER = Analytics::FederationReporter.new(ANALYTICS_REPORTER)


### PR DESCRIPTION
Rather than calling the federation translator directly and having to encode
knowledge of the locales inside the analytics reporter we can pass in the
RpDisplayData object that is available for our transaction.

In addition, we now check the locale files for the RP's analytics description
on start up of the app so we shouldn't get into a state where it is missing.