### PR TITLE
ZD22311: Show validation errors even when js-hidden

### DIFF
--- a/app/assets/stylesheets/helpers/_validation-message.scss
+++ b/app/assets/stylesheets/helpers/_validation-message.scss
@@ -15,3 +15,11 @@
     text-decoration: none;
   }
 }
+
+
+// Fields that were hidden by JS but marked
+// as validation errors should always be visible:
+.js-hidden.error {
+  display: block;
+  visibility: visible;
+}


### PR DESCRIPTION
Some users were seeing problems with the select-phone page where the JS
to show the conditional questions would not work. This left them in a
state where the form was invalid, but they were unable to fill in the
mandatory questions.

This ensures that we always show hidden questions when they are marked
as invalid.

@robinwhittleton - we think this might be best pushed upstream to govuk_elements. Not sure where to put it though.

Authors: @richardtowers @andrien.ricketts