### PR TITLE
3795: form helper for custom check boxes

### DIFF
--- a/app/views/feedback/index.html.erb
+++ b/app/views/feedback/index.html.erb
@@ -62,8 +62,8 @@
                 <% if @form.errors.include?(:reply)%>
                   <span class="error-message"><%= @form.errors[:reply].first %></span>
                 <% end %>
-                <%= f.block_label :reply, true, t('hub.feedback.questions.reply_option_yes'), {required: true, data: { msg: t('hub.feedback.errors.reply')}} %>
-                <%= f.block_label :reply, false, t('option.no'), {required: true, data: { msg: t('hub.feedback.errors.reply')}} %>
+                <%= f.custom_radio_button :reply, true, t('hub.feedback.questions.reply_option_yes'), {required: true, data: { msg: t('hub.feedback.errors.reply')}} %>
+                <%= f.custom_radio_button :reply, false, t('option.no'), {required: true, data: { msg: t('hub.feedback.errors.reply')}} %>
               <% end %>
             </fieldset>
 

--- a/app/views/further_information/index.html.erb
+++ b/app/views/further_information/index.html.erb
@@ -37,13 +37,9 @@
         </details>
         </div>
         <% if @form.allows_nullable? %>
-          <%= f.label :null_attibute, {class: 'block-label'} do %>
-              <%= f.check_box :null_attribute, {class: 'js-no-docs'}, 'true', 'false' %>
-              <span>
-                  <span class="inner">&nbsp;</span>
-                </span>
-              <%= t 'hub.further_information.null_attribute', cycle_three_name: @attribute.name %>
-          <% end %>
+          <div class="form-group">
+            <%= f.custom_check_box :null_attribute, {}, true, false, t('hub.further_information.null_attribute', cycle_three_name: @attribute.name) %>
+          </div>
         <% end %>
         <div class="form-group">
           <%= f.submit t('navigation.continue'), id: 'continue-button', class: 'button' %>

--- a/app/views/select_documents/index.html.erb
+++ b/app/views/select_documents/index.html.erb
@@ -20,33 +20,27 @@
               <fieldset class="inline">
                 <legend class="visually-hidden">1. <%= t 'hub.select_documents.question.driving_licence'%></legend>
                 <span aria-hidden="true">1. <%= t 'hub.select_documents.question.driving_licence'%></span>
-                <%= f.block_label :driving_licence, true, t('hub.select_documents.documents_option_yes') %>
-                <%= f.block_label :driving_licence, false, t('option.no') %>
+                <%= f.custom_radio_button :driving_licence, true, t('hub.select_documents.documents_option_yes') %>
+                <%= f.custom_radio_button :driving_licence, false, t('option.no') %>
               </fieldset>
             </div>
             <div class="form-group">
               <fieldset class="inline">
                 <legend class="visually-hidden">2. <%= t 'hub.select_documents.question.passport'%></legend>
                 <span aria-hidden="true">2. <%= t 'hub.select_documents.question.passport'%></span>
-                <%= f.block_label :passport, true, t('hub.select_documents.documents_option_yes') %>
-                <%= f.block_label :passport, false, t('option.no') %>
+                <%= f.custom_radio_button :passport, true, t('hub.select_documents.documents_option_yes') %>
+                <%= f.custom_radio_button :passport, false, t('option.no') %>
               </fieldset>
             </div>
             <div class="form-group">
               <fieldset class="inline">
                 <legend class="visually-hidden">3. <%= t 'hub.select_documents.question.non_uk_id_document'%></legend>
                 <span aria-hidden="true">3. <%= t 'hub.select_documents.question.non_uk_id_document'%></span>
-                <%= f.block_label :non_uk_id_document, true, t('hub.select_documents.documents_option_yes') %>
-                <%= f.block_label :non_uk_id_document, false, t('option.no') %>
+                <%= f.custom_radio_button :non_uk_id_document, true, t('hub.select_documents.documents_option_yes') %>
+                <%= f.custom_radio_button :non_uk_id_document, false, t('option.no') %>
               </fieldset>
             </div>
-            <%= f.label :no_documents, {class: 'block-label'} do %>
-              <%= f.check_box :no_documents, {class: 'js-no-docs'}, 'true', 'false' %>
-              <span>
-                <span class="inner">&nbsp;</span>
-              </span>
-              <%= t 'hub.select_documents.question.no_documents' %>
-            <% end %>
+            <%= f.custom_check_box :no_documents, {class: 'js-no-docs'}, true, false, t('hub.select_documents.question.no_documents') %>
           </fieldset>
         <% end %>
 

--- a/app/views/select_phone/index.html.erb
+++ b/app/views/select_phone/index.html.erb
@@ -16,8 +16,8 @@
         <%= content_tag :div, class: form_question_class do %>
             <fieldset class="inline">
               <legend class="visually-hidden"><%= t 'hub.select_phone.question.mobile_phone' %></legend>
-              <%= f.block_label :mobile_phone, true, t('hub.select_phone.question.mobile_phone_option_yes') %>
-              <%= f.block_label :mobile_phone, false, t('option.no') %>
+              <%= f.custom_radio_button :mobile_phone, true, t('hub.select_phone.question.mobile_phone_option_yes') %>
+              <%= f.custom_radio_button :mobile_phone, false, t('option.no') %>
             </fieldset>
         <% end %>
 
@@ -27,16 +27,16 @@
                 <%= t 'hub.select_phone.question.smart_phone' %>
                 <span class="form-hint"><%= t 'hub.select_phone.question.smart_phone_subtitle' %></span>
               </legend>
-              <%= f.block_label :smart_phone, true, t('hub.select_phone.question.smart_phone_option_yes') %>
-              <%= f.block_label :smart_phone, false, t('option.no') %>
-              <%= f.block_label :smart_phone, 'do_not_know', t('option.unknown') %>
+              <%= f.custom_radio_button :smart_phone, true, t('hub.select_phone.question.smart_phone_option_yes') %>
+              <%= f.custom_radio_button :smart_phone, false, t('option.no') %>
+              <%= f.custom_radio_button :smart_phone, 'do_not_know', t('option.unknown') %>
             </fieldset>
         <% end %>
         <%= content_tag :div, id: 'landline-question', class: hidden_form_question_class do %>
             <fieldset class="inline">
               <legend><%= t 'hub.select_phone.question.landline' %></legend>
-              <%= f.block_label :landline, true, t('hub.select_phone.question.landline_option_yes') %>
-              <%= f.block_label :landline, false, t('option.no') %>
+              <%= f.custom_radio_button :landline, true, t('hub.select_phone.question.landline_option_yes') %>
+              <%= f.custom_radio_button :landline, false, t('option.no') %>
             </fieldset>
         <% end %>
 

--- a/app/views/start/index.html.erb
+++ b/app/views/start/index.html.erb
@@ -14,8 +14,8 @@
 
   <%= content_tag :div, class: flash[:errors] ? "form-group error" : "form-group" do %>
     <fieldset>
-      <%= f.block_label :selection, true, t('hub.start.answer_yes'), {required: true, data: { msg: t('hub.start.error_message')}} %>
-      <%= f.block_label :selection, false, t('hub.start.answer_no'), {required: true, data: { msg: t('hub.start.error_message')}} %>
+      <%= f.custom_radio_button :selection, true, t('hub.start.answer_yes'), {required: true, data: { msg: t('hub.start.error_message')}} %>
+      <%= f.custom_radio_button :selection, false, t('hub.start.answer_no'), {required: true, data: { msg: t('hub.start.error_message')}} %>
     </fieldset>
   <% end %>
 

--- a/app/views/will_it_work_for_me/index.html.erb
+++ b/app/views/will_it_work_for_me/index.html.erb
@@ -13,23 +13,23 @@
         <%= content_tag :div, class: form_question_class do %>
             <fieldset class="inline">
               <legend><%= t 'hub.will_it_work_for_me.question.above_age_threshold' %></legend>
-              <%= f.block_label :above_age_threshold, true, t('hub.will_it_work_for_me.question.option_yes') %>
-              <%= f.block_label :above_age_threshold, false, t('option.no') %>
+              <%= f.custom_radio_button :above_age_threshold, true, t('hub.will_it_work_for_me.question.option_yes') %>
+              <%= f.custom_radio_button :above_age_threshold, false, t('option.no') %>
             </fieldset>
         <% end %>
         <%= content_tag :div, class: form_question_class do %>
             <fieldset class="inline">
               <legend><%= t 'hub.will_it_work_for_me.question.resident_last_12_months' %></legend>
-              <%= f.block_label :resident_last_12_months, true, t('hub.will_it_work_for_me.question.option_yes') %>
-              <%= f.block_label :resident_last_12_months, false, t('option.no') %>
+              <%= f.custom_radio_button :resident_last_12_months, true, t('hub.will_it_work_for_me.question.option_yes') %>
+              <%= f.custom_radio_button :resident_last_12_months, false, t('option.no') %>
             </fieldset>
         <% end %>
         <%= content_tag :div, id: :not_resident_reason, class: hidden_form_question_class do %>
             <fieldset class="inline">
               <legend><%= t 'hub.will_it_work_for_me.question.not_resident_reason.title' %></legend>
-              <%= f.block_label :not_resident_reason, 'MovedRecently', t('hub.will_it_work_for_me.question.option_yes') %>
-              <%= f.block_label :not_resident_reason, 'AddressButNotResident', t('hub.will_it_work_for_me.question.not_resident_reason.not_resident') %>
-              <%= f.block_label :not_resident_reason, 'NoAddress', t('hub.will_it_work_for_me.question.not_resident_reason.no_address') %>
+              <%= f.custom_radio_button :not_resident_reason, 'MovedRecently', t('hub.will_it_work_for_me.question.option_yes') %>
+              <%= f.custom_radio_button :not_resident_reason, 'AddressButNotResident', t('hub.will_it_work_for_me.question.not_resident_reason.not_resident') %>
+              <%= f.custom_radio_button :not_resident_reason, 'NoAddress', t('hub.will_it_work_for_me.question.not_resident_reason.no_address') %>
             </fieldset>
         <% end %>
 

--- a/lib/verify_form_builder.rb
+++ b/lib/verify_form_builder.rb
@@ -1,11 +1,18 @@
 class VerifyFormBuilder < ActionView::Helpers::FormBuilder
-  # Our custom radio button implementation. Workarounds:
+  # Our custom radio / checkbox implementation. Workarounds:
   # 1. empty onclick attribute for iOS5 support
   # 2. blank space in the inner span to let JAWS-on-IE read the following text
-  def block_label key, value, text, attributes = {}
+  def custom_radio_button key, value, text, attributes = {}
     label "#{key}_#{value.to_s.parameterize}", class: 'block-label', onclick: '' do
-      radio = radio_button key, value, attributes
-      "#{radio} <span><span class=\"inner\">&nbsp;</span></span> #{text}".html_safe
+      input = radio_button key, value, attributes
+      "#{input} <span><span class=\"inner\">&nbsp;</span></span> #{text}".html_safe
+    end
+  end
+
+  def custom_check_box key, attributes, true_value, false_value, text
+    label key, class: 'block-label', onclick: '' do
+      input = check_box key, attributes, true_value, false_value
+      "#{input} <span><span class=\"inner\">&nbsp;</span></span> #{text}".html_safe
     end
   end
 end

--- a/spec/lib/verify_form_builder_spec.rb
+++ b/spec/lib/verify_form_builder_spec.rb
@@ -8,27 +8,51 @@ describe VerifyFormBuilder do
     template.extend(ActionView::Helpers::FormHelper)
     template.extend(ActionView::Helpers::FormOptionsHelper)
   }
-  it 'creates the block label radio button with value set on object and is checked when matches object' do
+  it 'creates the custom radio button with value set on object and is checked when matches object' do
     foo = double(:foo)
     expect(foo).to receive(:a).and_return 'b'
     form_builder = VerifyFormBuilder.new('foo', foo, template, {})
-    expected_radio_button = '<label class="block-label" onclick="" for="foo_a_b"><input type="radio" value="b" checked="checked" name="foo[a]" id="foo_a_b" /> <span><span class="inner">&nbsp;</span></span> c</label>'
-    expect(form_builder.block_label(:a, 'b', 'c', {})).to eql expected_radio_button
+    expected_html = '<label class="block-label" onclick="" for="foo_a_b"><input type="radio" value="b" checked="checked" name="foo[a]" id="foo_a_b" /> <span><span class="inner">&nbsp;</span></span> c</label>'
+    expect(form_builder.custom_radio_button(:a, 'b', 'c', {})).to eql expected_html
   end
 
-  it 'creates the block label radio button with value set on object but is unchecked when does not match object' do
+  it 'creates the custom radio button with value set on object but is unchecked when does not match object' do
     foo = double(:foo)
     expect(foo).to receive(:a).and_return 'd'
     form_builder = VerifyFormBuilder.new('foo', foo, template, {})
-    expected_radio_button = '<label class="block-label" onclick="" for="foo_a_b"><input type="radio" value="b" name="foo[a]" id="foo_a_b" /> <span><span class="inner">&nbsp;</span></span> c</label>'
-    expect(form_builder.block_label(:a, 'b', 'c', {})).to eql expected_radio_button
+    expected_html = '<label class="block-label" onclick="" for="foo_a_b"><input type="radio" value="b" name="foo[a]" id="foo_a_b" /> <span><span class="inner">&nbsp;</span></span> c</label>'
+    expect(form_builder.custom_radio_button(:a, 'b', 'c', {})).to eql expected_html
   end
 
-  it 'allows us to set html attributes' do
+  it 'allows us to set html attributes against a custom radio button' do
     foo = double(:foo)
     expect(foo).to receive(:a).and_return nil
     form_builder = VerifyFormBuilder.new('foo', foo, template, {})
-    expected_radio_button = '<label class="block-label" onclick="" for="foo_a_b"><input required="required" type="radio" value="b" name="foo[a]" id="foo_a_b" /> <span><span class="inner">&nbsp;</span></span> c</label>'
-    expect(form_builder.block_label(:a, 'b', 'c', required: true)).to eql expected_radio_button
+    expected_html = '<label class="block-label" onclick="" for="foo_a_b"><input required="required" type="radio" value="b" name="foo[a]" id="foo_a_b" /> <span><span class="inner">&nbsp;</span></span> c</label>'
+    expect(form_builder.custom_radio_button(:a, 'b', 'c', required: true)).to eql expected_html
+  end
+
+  it 'creates the custom check box with value set on object and is checked when matches object' do
+    foo = double(:foo)
+    expect(foo).to receive(:a).and_return 'b'
+    form_builder = VerifyFormBuilder.new('foo', foo, template, {})
+    expected_html = '<label class="block-label" onclick="" for="foo_a"><input name="foo[a]" type="hidden" value="c" /><input type="checkbox" value="b" checked="checked" name="foo[a]" id="foo_a" /> <span><span class="inner">&nbsp;</span></span> d</label>'
+    expect(form_builder.custom_check_box(:a, {}, 'b', 'c', 'd')).to eql expected_html
+  end
+
+  it 'creates the custom check box with value set on object but is unchecked when does not match object' do
+    foo = double(:foo)
+    expect(foo).to receive(:a).and_return 'd'
+    form_builder = VerifyFormBuilder.new('foo', foo, template, {})
+    expected_html = '<label class="block-label" onclick="" for="foo_a"><input name="foo[a]" type="hidden" value="c" /><input type="checkbox" value="b" name="foo[a]" id="foo_a" /> <span><span class="inner">&nbsp;</span></span> d</label>'
+    expect(form_builder.custom_check_box(:a, {}, 'b', 'c', 'd')).to eql expected_html
+  end
+
+  it 'allows us to set html attributes against a custom check box' do
+    foo = double(:foo)
+    expect(foo).to receive(:a).and_return nil
+    form_builder = VerifyFormBuilder.new('foo', foo, template, {})
+    expected_html = '<label class="block-label" onclick="" for="foo_a"><input name="foo[a]" type="hidden" value="c" /><input required="required" type="checkbox" value="b" name="foo[a]" id="foo_a" /> <span><span class="inner">&nbsp;</span></span> d</label>'
+    expect(form_builder.custom_check_box(:a, { required: true }, 'b', 'c', 'd')).to eql expected_html
   end
 end


### PR DESCRIPTION
Repeat the work done for custom radios for custom check boxes. The standard `check_box` helper has a different argument order to `radio_button`; I’ve mirrored that but could be persuaded to match `radio_button`’s argument order.