### PR TITLE
3795: remove start form ZDD protection

### DIFF
--- a/app/controllers/start_controller.rb
+++ b/app/controllers/start_controller.rb
@@ -6,9 +6,6 @@ class StartController < ApplicationController
   end
 
   def request_post
-    if params['selection'].present?
-      params['start_form'] = { selection: params['selection'] }
-    end
     @form = StartForm.new(params['start_form'] || {})
     if @form.valid?
       if @form.registration?


### PR DESCRIPTION
The start form needed to cope with old parameters being passed in. Now that the new form is live and users of the old system have drained we can remove the mitigation code.