### PR TITLE
Stub api calls

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,6 +65,7 @@ group :development do
 end
 
 group :test, :development do
+  gem 'rspec', '~> 3.4.0'
   gem 'rspec-rails', '~> 3.4.0'
   gem 'capybara', '~> 2.6'
   gem 'capybara-puma'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -187,6 +187,10 @@ GEM
     route_translator (4.3.0)
       actionpack (>= 3.2, < 5.0)
       activesupport (>= 3.2, < 5.0)
+    rspec (3.4.0)
+      rspec-core (~> 3.4.0)
+      rspec-expectations (~> 3.4.0)
+      rspec-mocks (~> 3.4.0)
     rspec-core (3.4.4)
       rspec-support (~> 3.4.0)
     rspec-expectations (3.4.0)
@@ -309,6 +313,7 @@ DEPENDENCIES
   rails-i18n (~> 4.0)
   request_store
   route_translator (~> 4.2)
+  rspec (~> 3.4.0)
   rspec-rails (~> 3.4.0)
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)

--- a/README.md
+++ b/README.md
@@ -10,13 +10,16 @@ Once you’ve cloned this then `bundle` will install the requirements.
 
 ## Running the application
 
-`./startup.sh`
+You can start the application without having any of the closed source components installed with:
 
-This will start the server running on http://localhost:50300/ .
+`./startup.sh --stub-api`
 
-Without cookies this won’t do much; for the time being you’ll need to start a journey on the existing system until you get to the old frontend’s start page. This will give you the cookies you need for localhost.
+This will start the frontend server running on http://localhost:50300/ and a stubbed API server on http://localhost:50190.
 
-If you don’t have ida-sample-rp running you can get to the start page on the new frontend by visiting http://localhost:50300/test-saml and clicking on saml-post.
+To start a journey on the front end visit http://localhost:50300/test-saml and click `saml-post`.
+
+If you're on the Verify team and have the rest of the federation running locally you should omit the `--stub-api` argument
+and start your journey from the test-rp.
 
 ## Running the tests
 

--- a/app/views/test_saml/index.html.erb
+++ b/app/views/test_saml/index.html.erb
@@ -11,6 +11,6 @@
 <% end -%>
 <%= form_tag('/SAML2/SSO/Response/POST') do -%>
     <%= hidden_field_tag('SAMLResponse', 'my-saml-response') %>
-    <%= hidden_field_tag('RelayState', params['session-id']) %>
+    <%= hidden_field_tag('RelayState', params.fetch('session-id', cookies[CookieNames::SESSION_ID_COOKIE_NAME])) %>
     <div><%= submit_tag 'saml-response-post' %></div>
 <% end -%>

--- a/kill-service.sh
+++ b/kill-service.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+if [ -a 'tmp/stub-api.pid' ]
+then
+  kill "$(cat tmp/stub-api.pid)"
+fi
+
 if [ -a 'tmp/puma.pid' ]
 then
   kill "$(cat tmp/puma.pid)"

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -18,11 +18,20 @@ if [ -t 1 ]; then
   tput sgr0
 fi
 
+# Unit tests
 bundle exec rspec --exclude-pattern "spec/features/*_spec.rb"
 success=$((success || $?))
+
+# Feature tests
 bundle exec rspec --pattern "spec/features/*_spec.rb"
 success=$((success || $?))
+
+# JavaScript tests
 bundle exec rake spec:javascripts
+success=$((success || $?))
+
+# Stub API tests
+bundle exec rspec --pattern stub/**/*_spec.rb
 success=$((success || $?))
 
 if [ -t 1 ]; then

--- a/startup.sh
+++ b/startup.sh
@@ -1,3 +1,10 @@
 #!/usr/bin/env bash
 ./kill-service.sh
+
+if [ "$1" == '--stub-api' ]
+then
+  echo "Starting stub-api server on port 50190"
+  rackup --daemonize --port 50190 --pid tmp/stub_api.pid stub/stub_api_conf.ru
+fi
+
 bundle exec puma -e development -d -p 50300

--- a/stub/stub_api.rb
+++ b/stub/stub_api.rb
@@ -37,6 +37,13 @@ class StubApi < Sinatra::Base
     }'
   end
 
+  put '/api/session/idp-authn-response' do
+    '{
+      "idpResult":"blah",
+      "isRegistration":false
+    }'
+  end
+
   get '/api/transactions' do
     '{
       "public":[{

--- a/stub/stub_api.rb
+++ b/stub/stub_api.rb
@@ -1,0 +1,51 @@
+#!/usr/bin/env ruby
+
+require 'sinatra'
+
+class StubApi < Sinatra::Base
+  post '/api/session' do
+    status 201
+    '{
+      "sessionId":"blah",
+      "secureCookie":"blah",
+      "sessionStartTime":32503680000000,
+      "transactionSimpleId":"test-rp"
+    }'
+  end
+
+  get '/api/session/federation' do
+    '{
+      "idps":[{
+        "simpleId":"stub-idp-one",
+        "entityId":"http://example.com/stub-idp-one"
+      }]
+    }'
+  end
+
+  put '/api/session/select-idp' do
+    '{
+      "encryptedEntityId":"not-blank"
+    }'
+  end
+
+  get '/api/session/idp-authn-request' do
+    '{
+      "location":"http://www.example.com",
+      "samlRequest":"blah",
+      "relayState":"whatever",
+      "registration":false
+    }'
+  end
+
+  get '/api/transactions' do
+    '{
+      "public":[{
+        "simpleId":"test-rp",
+        "entityId":"http://example.com/test-rp",
+        "homepage":"http://example.com/test-rp"
+      }],
+      "private":[]
+    }'
+  end
+end
+

--- a/stub/stub_api_conf.ru
+++ b/stub/stub_api_conf.ru
@@ -1,0 +1,3 @@
+require './stub/stub_api'
+
+run StubApi

--- a/stub/stub_api_spec.rb
+++ b/stub/stub_api_spec.rb
@@ -10,6 +10,7 @@ require_relative '../app/models/identity_provider'
 require_relative '../app/models/federation_info_response'
 require_relative '../app/models/select_idp_response'
 require_relative '../app/models/outbound_saml_message'
+require_relative '../app/models/idp_authn_response'
 
 describe StubApi do
   include Rack::Test::Methods
@@ -54,6 +55,15 @@ describe StubApi do
       get '/api/session/idp-authn-request'
       expect(last_response).to be_ok
       response = OutboundSamlMessage.new(last_response_json)
+      expect(response).to be_valid
+    end
+  end
+
+  context '#put /api/session/idp-authn-response' do
+    it 'should respond with valid hash' do
+      put '/api/session/idp-authn-response'
+      expect(last_response).to be_ok
+      response = IdpAuthnResponse.new(last_response_json)
       expect(response).to be_valid
     end
   end

--- a/stub/stub_api_spec.rb
+++ b/stub/stub_api_spec.rb
@@ -1,0 +1,70 @@
+require 'json'
+require 'rspec'
+require 'rack/test'
+require './stub/stub_api'
+
+require 'active_model'
+require_relative '../app/models/api/response'
+require_relative '../app/models/session_response'
+require_relative '../app/models/identity_provider'
+require_relative '../app/models/federation_info_response'
+require_relative '../app/models/select_idp_response'
+require_relative '../app/models/outbound_saml_message'
+
+describe StubApi do
+  include Rack::Test::Methods
+
+  def app
+    StubApi
+  end
+
+  def last_response_json
+   JSON.parse(last_response.body)
+  end
+
+  context '#post /api/session' do
+    it 'should respond with valid SessionResponse' do
+      post '/api/session'
+      expect(last_response).to be_created
+      response = SessionResponse.new(last_response_json)
+      expect(response).to be_valid
+    end
+  end
+
+  context '#get /api/session/federation' do
+    it 'should respond with valid FederationInfoResponse' do
+      get '/api/session/federation'
+      expect(last_response).to be_ok
+      response = FederationInfoResponse.new(last_response_json)
+      expect(response).to be_valid
+    end
+  end
+
+  context '#put /api/session/select-idp' do
+    it 'should respond with valid SelectIdpResponse' do
+      put '/api/session/select-idp'
+      expect(last_response).to be_ok
+      response = SelectIdpResponse.new(last_response_json)
+      expect(response).to be_valid
+    end
+  end
+
+  context '#get /api/session/idp-authn-request' do
+    it 'should respond with valid OutboundSamlMessage' do
+      get '/api/session/idp-authn-request'
+      expect(last_response).to be_ok
+      response = OutboundSamlMessage.new(last_response_json)
+      expect(response).to be_valid
+    end
+  end
+
+  context '#get /api/transactions' do
+    it 'should respond with valid hash' do
+      get '/api/transactions'
+      expect(last_response).to be_ok
+      response = last_response_json
+      expect(response['public']).to be_an(Array)
+      expect(response['private']).to be_an(Array)
+    end
+  end
+end


### PR DESCRIPTION
**Don't merge yet - wants discussion**

This moves the experimental `richardTowers/mock-verify-hub` code into verify-frontend proper. There are some basic unit tests which hopefully should be enough (just about) to prevent the stub-api from diverging from the real API. See the changes to the README to get an idea of how it would work.

The main reason we'd want to do this is to give non-verify developers an easy way to run the frontend on their machines. At the moment this isn't possible because (for now) there's still closed-source code running behind the API.

Feedback on whether this is the best way to do this / the right place for the code / a good idea in the first place welcome.