### PR TITLE
BAU: update JS to follow new GOV.UK module pattern

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,7 +83,7 @@ GEM
       govuk_frontend_toolkit (>= 4.12.0)
       rails (>= 4.1.0)
       sass (>= 3.2.0)
-    govuk_frontend_toolkit (4.12.0)
+    govuk_frontend_toolkit (4.14.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
     govuk_template (0.18.0)
@@ -103,7 +103,7 @@ GEM
     i18n (0.7.0)
     inflection (1.0.0)
     jasmine-core (2.4.1)
-    jasmine-rails (0.12.3)
+    jasmine-rails (0.12.6)
       jasmine-core (>= 1.3, < 3.0)
       phantomjs (>= 1.9)
       railties (>= 3.2.0)
@@ -237,7 +237,7 @@ GEM
       rack-protection (~> 1.4)
       tilt (>= 1.3, < 3)
     spring (1.6.3)
-    sprockets (3.6.3)
+    sprockets (3.7.0)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.1.1)
@@ -323,5 +323,8 @@ DEPENDENCIES
   webmock
   zendesk_api
 
+RUBY VERSION
+   ruby 2.3.0p0
+
 BUNDLED WITH
-   1.11.2
+   1.12.5

--- a/app/assets/javascripts/analytics.js
+++ b/app/assets/javascripts/analytics.js
@@ -1,5 +1,7 @@
-(function () {
-   'use strict';
+(function(global) {
+    'use strict';
+    var GOVUK = global.GOVUK || {};
+    var $ = global.jQuery;
 
     function setPiwikVisitorIdCookie () {
         var visitor_id = this.getVisitorId();
@@ -34,5 +36,5 @@
       piwikAnalyticsQueue.unshift(['setCustomUrl', customUrl]);
     }
 
-    window._paq = piwikAnalyticsQueue;
-})();
+    global._paq = piwikAnalyticsQueue;
+})(window);

--- a/app/assets/javascripts/auto_submit_form.js
+++ b/app/assets/javascripts/auto_submit_form.js
@@ -1,11 +1,13 @@
-//= require 'jquery'
-
-(function () {
+(function(global) {
   'use strict';
-  if(!window.GOVUK) { window.GOVUK = {}; }
-  window.GOVUK.autoSubmitForm = {
+  var GOVUK = global.GOVUK || {};
+  var $ = global.jQuery;
+
+  GOVUK.autoSubmitForm = {
     attach: function () {
       $('form.js-auto-submit').submit();
     }
   };
-})();
+
+  global.GOVUK = GOVUK;
+})(window);

--- a/app/assets/javascripts/continue_to_idp.js
+++ b/app/assets/javascripts/continue_to_idp.js
@@ -1,14 +1,9 @@
-(function () {
+(function(global) {
   "use strict";
+  var GOVUK = global.GOVUK || {};
+  var $ = global.jQuery;
 
-  var root = this,
-    $ = root.jQuery;
-
-  if(typeof root.GOVUK === 'undefined') { root.GOVUK = {}; }
-
-  root.GOVUK.signin = {
-    init: function () {
-    },
+  GOVUK.signin = {
     attach: function () {
       var $container = $('.js-continue-to-idp');
       $container.on('submit', '.js-idp-form', function (e) {
@@ -53,4 +48,5 @@
     }
   };
 
-}).call(this);
+  global.GOVUK = GOVUK;
+})(window);

--- a/app/assets/javascripts/feedback.js
+++ b/app/assets/javascripts/feedback.js
@@ -1,10 +1,9 @@
 //= require vendor/jquery.inputevent
 
-(function () {
+(function(global) {
   "use strict";
-  var root = this,
-    $ = root.jQuery;
-  if(typeof root.GOVUK === 'undefined') { root.GOVUK = {}; }
+  var GOVUK = global.GOVUK || {};
+  var $ = global.jQuery;
 
   /**
    * The reply radios need special treatment because unlike
@@ -62,5 +61,7 @@
     }
   };
 
-  root.GOVUK.feedback = feedback;
-}).call(this);
+  GOVUK.feedback = feedback;
+
+  global.GOVUK = GOVUK;
+})(window);

--- a/app/assets/javascripts/further_information.js
+++ b/app/assets/javascripts/further_information.js
@@ -1,14 +1,14 @@
-
-(function () {
+(function(global) {
   "use strict";
-  var root = this,
-    $ = root.jQuery;
-  if(typeof root.GOVUK === 'undefined') { root.GOVUK = {}; }
+  var GOVUK = global.GOVUK || {};
+  var $ = global.jQuery;
 
-  root.GOVUK.furtherInformation = {
+  GOVUK.furtherInformation = {
     init: function () {
       this.$form = $('#further-information');
       this.$form.validate();
     }
   };
-}).call(this);
+
+  global.GOVUK = GOVUK;
+})(window);

--- a/app/assets/javascripts/select_documents.js
+++ b/app/assets/javascripts/select_documents.js
@@ -1,8 +1,7 @@
-(function () {
+(function(global) {
   "use strict"
-  var root = this,
-      $ = root.jQuery;
-  if(typeof root.GOVUK === 'undefined') { root.GOVUK = {}; }
+  var GOVUK = global.GOVUK || {};
+  var $ = global.jQuery;
 
   var selectDocuments = {
     markAllAsNo: function() {
@@ -66,5 +65,7 @@
     }
   };
 
-  root.GOVUK.selectDocuments = selectDocuments;
-}).call(this);
+  GOVUK.selectDocuments = selectDocuments;
+
+  global.GOVUK = GOVUK;
+})(window);

--- a/app/assets/javascripts/select_phone.js
+++ b/app/assets/javascripts/select_phone.js
@@ -1,8 +1,7 @@
-(function () {
+(function(global) {
   "use strict";
-  var root = this,
-    $ = root.jQuery;
-  if(typeof root.GOVUK === 'undefined') { root.GOVUK = {}; }
+  var GOVUK = global.GOVUK || {};
+  var $ = global.jQuery;
 
   var selectPhone = {
     toggleSecondaryQuestion: function() {
@@ -47,5 +46,7 @@
     }
   };
 
-  root.GOVUK.selectPhone = selectPhone;
-}).call(this);
+  GOVUK.selectPhone = selectPhone;
+
+  global.GOVUK = GOVUK;
+})(window);

--- a/app/assets/javascripts/validation.js
+++ b/app/assets/javascripts/validation.js
@@ -1,5 +1,7 @@
-(function () {
+(function(global) {
   "use strict";
+  var GOVUK = global.GOVUK || {};
+  var $ = global.jQuery;
 
   function placeRadioErrorMessages($error, $element) {
     $error.addClass('validation-message form-group');
@@ -13,12 +15,7 @@
     $error.children('a').focus();
   }
 
-  var root = this,
-    $ = root.jQuery;
-
-  if(typeof root.GOVUK === 'undefined') { root.GOVUK = {}; }
-
-  root.GOVUK.validation = {
+  GOVUK.validation = {
     radiosValidation: {
       focusInvalid: false,
       errorElement: 'a',
@@ -54,4 +51,5 @@
     }
   };
 
-}).call(this);
+  global.GOVUK = GOVUK;
+})(window);

--- a/app/assets/javascripts/verify_fingerprint.js
+++ b/app/assets/javascripts/verify_fingerprint.js
@@ -1,13 +1,13 @@
 //= require fingerprint2
 
-(function (exports) {
+(function(global) {
    'use strict';
 
     // based on jQuery's param implementation https://github.com/jquery/jquery/blob/master/src/serialize.js
     function serialiseComponents(components) {
         var componentsToExclude = ['webgl'];
         var r = [];
-        jQuery.each(components, function() {
+        global.jQuery.each(components, function() {
             if(componentsToExclude.indexOf(this.key) == -1) {
                 r[r.length] = encodeURIComponent(this.key) + "=" + encodeURIComponent(this.value);
             }
@@ -23,5 +23,5 @@
         });
     }
 
-    exports.reportFingerprint = reportFingerprint;
-})(this);
+    global.reportFingerprint = reportFingerprint;
+})(window);

--- a/app/assets/javascripts/will_it_work_for_me.js
+++ b/app/assets/javascripts/will_it_work_for_me.js
@@ -1,9 +1,7 @@
-(function () {
+(function(global) {
     "use strict";
-    var root = this, $ = root.jQuery;
-    if (typeof root.GOVUK === 'undefined') {
-        root.GOVUK = {};
-    }
+    var GOVUK = global.GOVUK || {};
+    var $ = global.jQuery;
 
     var willItWorkForMe = {
         init: function () {
@@ -50,5 +48,7 @@
         }
     };
 
-    root.GOVUK.willItWorkForMe = willItWorkForMe;
-}).call(this);
+    GOVUK.willItWorkForMe = willItWorkForMe;
+
+    global.GOVUK = GOVUK;
+})(window);

--- a/spec/javascripts/auto_submit_form_spec.js
+++ b/spec/javascripts/auto_submit_form_spec.js
@@ -1,3 +1,4 @@
+//= require jquery
 //= require 'auto_submit_form'
 
 describe('auto', function () {
@@ -17,14 +18,14 @@ describe('auto', function () {
   it('should leave ordinary forms alone', function () {
     $dom = $('<form><input type="submit"></form>');
     $(document.body).append($dom);
-    window.GOVUK.autoSubmitForm.attach();
+    GOVUK.autoSubmitForm.attach();
     expect(formSpy).not.toHaveBeenCalled();
   });
 
   it('should immediately submit auto-submitting forms', function () {
     $dom = $('<form class="js-auto-submit"><input type="submit"></form>');
     $(document.body).append($dom);
-    window.GOVUK.autoSubmitForm.attach();
+    GOVUK.autoSubmitForm.attach();
     expect(formSpy).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
[govuk_frontend_toolkit](https://github.com/alphagov/govuk_frontend_toolkit) has a [new module pattern](https://github.com/alphagov/govuk_frontend_toolkit/pull/290). Our JS should match the standard where possible for simplicity. This commit updates govuk_frontend_toolkit to the latest version and brings our JS in line.

It also updates jasmine_rails to the latest point version, which fixes a potential memory leak issue.