### PR TITLE
3843: Move service name out of the button

### DIFF
--- a/app/views/confirmation/index.html.erb
+++ b/app/views/confirmation/index.html.erb
@@ -3,6 +3,7 @@
 
 <h1 class="heading-large"><%= t 'hub.confirmation.heading', display_name: @idp_name %></h1>
 <p><%= t 'hub.confirmation.message' %></p>
+<p><strong><%= t 'hub.confirmation.continue_to_rp', transaction_name: @transaction_name %></strong></p>
 <div class="actions">
-  <%= link_to @transaction_name.capitalize, response_processing_path, class: 'button', id:'next-button' %>
+  <%= link_to t('navigation.continue'), response_processing_path, class: 'button', id:'next-button' %>
 </div>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -234,7 +234,8 @@ cy:
       need_to_signin_again: Er mwyn %{transaction_name}, mae angen i chi lofnodi i mewn eto gyda’ch cwmni ardystiedig. Nid oes angen i chi gofrestru eto.
     confirmation:
       title: Mae eich hunaniaeth wedi cael ei ddilysu
-      message: Gallwch nawr fewngofnodi ble bynnag rydych yn gweld logo GOV.UK Verify logo
+      message: You can sign in wherever you see the GOV.UK Verify logo.
+      continue_to_rp: "You can now %{transaction_name}."
       heading: Mae "%{display_name} wedi dilysu eich hunaniaeth"
     failed_registration:
       title: Methu dilysu eich hunaniaeth

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -228,7 +228,8 @@ en:
       need_to_signin_again: In order to %{transaction_name}, you need to sign in again with your certified company. You don’t need to register again.
     confirmation:
       title: Your identity has been verified
-      message: You can now sign in wherever you see the GOV.UK Verify logo
+      message: You can sign in wherever you see the GOV.UK Verify logo.
+      continue_to_rp: "You can now %{transaction_name}."
       heading: "%{display_name} has verified your identity"
     failed_registration:
       title: Unable to verify your identity

--- a/spec/features/user_visits_confirmation_page_spec.rb
+++ b/spec/features/user_visits_confirmation_page_spec.rb
@@ -39,11 +39,6 @@ RSpec.describe 'When user visits the confirmation page' do
     expect(page).to have_css('html[lang=en]')
   end
 
-  it 'displays link button to Continue' do
-    visit '/confirmation'
-    expect(page).to have_link(I18n.t('navigation.continue'), href: response_processing_path)
-  end
-
   it 'sends user to response-processing page when they click the link' do
     stub_matching_outcome
     visit '/confirmation'

--- a/spec/features/user_visits_confirmation_page_spec.rb
+++ b/spec/features/user_visits_confirmation_page_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe 'When user visits the confirmation page' do
     expect_feedback_source_to_be(page, 'CONFIRMATION_PAGE')
     expect(page).to have_title("#{I18n.t('hub.confirmation.title')} - GOV.UK Verify - GOV.UK")
     expect(page).to have_text(I18n.t('hub.confirmation.message'))
+    expect(page).to have_text(I18n.t('hub.confirmation.continue_to_rp', transaction_name: 'register for an identity profile'))
   end
 
   it 'displays the IDP name' do
@@ -38,15 +39,15 @@ RSpec.describe 'When user visits the confirmation page' do
     expect(page).to have_css('html[lang=en]')
   end
 
-  it 'displays link button with Transaction name' do
+  it 'displays link button to Continue' do
     visit '/confirmation'
-    expect(page).to have_link(I18n.t('rps.test-rp.name').capitalize, href: response_processing_path)
+    expect(page).to have_link(I18n.t('navigation.continue'), href: response_processing_path)
   end
 
   it 'sends user to response-processing page when they click the link' do
     stub_matching_outcome
     visit '/confirmation'
-    click_link I18n.t('rps.test-rp.name').capitalize
+    click_link I18n.t('navigation.continue')
     expect(page).to have_current_path(response_processing_path)
   end
 end


### PR DESCRIPTION
Feedback from services is that the button can be too big, depending on
the service name. 

Suggestion from UX folks is to replace the service name by 'Continue' on the button and introduce a new paragraph that informs the user can proceed to the service.

Authors: @adityapahuja @phss