### PR TITLE
3342: stop nesting nullable attribute form

### DIFF
--- a/app/views/further_information/index.html.erb
+++ b/app/views/further_information/index.html.erb
@@ -36,18 +36,18 @@
           </div>
         </details>
         </div>
-        <% if @cycle_three_attribute.allows_nullable? %>
-          <div class="form-group">
-            <%= form_tag(further_information_null_attribute_submit_path) do %>
-              <%= button_tag t('hub.further_information.null_attribute', cycle_three_name: @cycle_three_attribute.name),
-                             id: 'cycle_three_null_attribute_link', class: 'button-link', role: 'link' %>
-            <% end %>
-          </div>
-        <% end %>
         <div class="form-group">
           <%= f.submit t('navigation.continue'), id: 'continue-button', class: 'button' %>
         </div>
       </fieldset>
+    <% end %>
+    <% if @cycle_three_attribute.allows_nullable? %>
+      <div class="form-group">
+        <%= form_tag(further_information_null_attribute_submit_path) do %>
+          <%= button_tag t('hub.further_information.null_attribute', cycle_three_name: @cycle_three_attribute.name),
+            id: 'cycle_three_null_attribute_link', class: 'button-link', role: 'link' %>
+        <% end %>
+      </div>
     <% end %>
     <div class="cancel-process">
       <%= form_tag(further_information_cancel_path) do %>

--- a/spec/features/user_visits_further_information_page_spec.rb
+++ b/spec/features/user_visits_further_information_page_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe 'user visits further information page' do
     expect(cancel_request).to have_been_made
   end
 
-  it 'will submit empty cycle 3 attribute when user clicks the no attribute link' do
+  it 'will submit empty cycle 3 attribute when user clicks the no attribute link', js: true do
     piwik_request = stub_piwik_cycle_three('NullableAttribute')
     stub_cycle_three_attribute_request('NullableAttribute')
     stub_request = stub_cycle_three_value_submit('')


### PR DESCRIPTION
The nullable attribute form was being nested within the main input form which
was causing it to be overriden. Unfortunately, this was not caught by the non-js tests.

This change moves the button to below the continue button and above the
cancellation button.