### PR TITLE
bau: fix firefox instances starting up for all tests

### DIFF
--- a/spec/feature_helper.rb
+++ b/spec/feature_helper.rb
@@ -13,17 +13,6 @@ if ENV['HEADLESS'] == 'true'
     headless.destroy
     exit exit_status if exit_status
   end
-else
-  # The javascript tests are written against firefox browser and depend on the
-  # system having firefox installed. Explicitly depend on Firefox in order to
-  # avoid tests failing because Selenium chooses another browser when there is
-  # no firefox installed in the system.
-  begin
-    Selenium::WebDriver.for :firefox
-  rescue Selenium::WebDriver::Error::WebDriverError => err
-    puts err.message
-    exit(1)
-  end
 end
 
 def current_time_in_millis


### PR DESCRIPTION
The check to force firefox in the feature tests had caused FF to start
on every test. This is super annoying, so we think we should just remove
the check for now.

Authors: @richardtowers @datamineruk

@chrisholmes @tunylund - discussion / premature merges welcome :trollface: 