### PR TITLE
3332: remove setting cookie for cycle 3 page routing

### DIFF
--- a/app/controllers/authn_request_controller.rb
+++ b/app/controllers/authn_request_controller.rb
@@ -15,21 +15,10 @@ class AuthnRequestController < ApplicationController
     set_secure_cookie(CookieNames::SECURE_COOKIE_NAME, response.secure_cookie)
     set_current_transaction_simple_id(response.transaction_simple_id)
 
-    enable_feature_flag_cookie!
-
     if params['journey_hint'].present?
       redirect_to confirm_your_identity_path
     else
       redirect_to start_path
     end
-  end
-
-  def enable_feature_flag_cookie!
-    cookies['x_front_test'] = {
-      value: '1idfoif2d',
-      expires: 2.hour.from_now,
-      httponly: true,
-      secure: Rails.configuration.x.cookies.secure
-    }
   end
 end

--- a/spec/features/user_sends_authn_request_spec.rb
+++ b/spec/features/user_sends_authn_request_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'user sends authn requests' do
       expect(cookie_value(CookieNames::SECURE_COOKIE_NAME)).not_to be_empty
 
       cookies = Capybara.current_session.driver.request.cookies
-      expected_cookies = CookieNames.session_cookies + ['_verify-frontend_session', CookieNames::VERIFY_FRONT_JOURNEY_HINT, 'x_front_test']
+      expected_cookies = CookieNames.session_cookies + ['_verify-frontend_session', CookieNames::VERIFY_FRONT_JOURNEY_HINT]
 
       expect(cookies.keys.to_set).to eql expected_cookies.to_set
     end


### PR DESCRIPTION
Reverts alphagov/verify-frontend#185

This is no longer necessary as we're not using the cookie for page routing any more.