### PR TITLE
3704 feedback sent page - localize routes and remove query params

### DIFF
--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -12,9 +12,8 @@ class FeedbackController < ApplicationController
     if @form.valid?
       session_id = cookies[CookieNames::SESSION_ID_COOKIE_NAME]
       if FEEDBACK_SERVICE.submit!(session_id, @form)
-        query_params = { "emailProvided" => @form.reply_required?, "sessionValid" => session_id.present? }
         flash['email_provided'] = @form.reply_required?
-        redirect_to feedback_sent_path(query_params)
+        redirect_to feedback_sent_path
       else
         @has_email_sending_error = true
         render :index

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -32,7 +32,7 @@ cy:
     redirect_to_service_start_again: ailgyfeirio-i-gwasanaeth/dechrau-eto
     redirect_to_service_error: ailgyfeirio-i-gwasanaeth/gwall
     feedback: adborth
-    feedback_sent: adborth-wedi'i-anfon
+    feedback_sent: adborth/adborth-wedi'i-anfon
     certified_company_unavailable: cwmni-ardystiedig-ddim-ar-gael/:company
     further_information: further-information-cy
     further_information_cancel: further-information-cy/cancel

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,7 +32,7 @@ en:
     redirect_to_service_start_again: redirect-to-service/start-again
     redirect_to_service_error: redirect-to-service/error
     feedback: feedback
-    feedback_sent: feedback-sent
+    feedback_sent: feedback/feedback-sent
     certified_company_unavailable: certified-company-unavailable/:company
     further_information: further-information
     further_information_cancel: further-information/cancel

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,6 +60,7 @@ Rails.application.routes.draw do
     get 'redirect_to_service_error' => 'redirect_to_service#error', as: :redirect_to_service_error
     get 'feedback', to: 'feedback#index', as: :feedback
     post 'feedback', to: 'feedback#submit', as: :feedback_submit
+    get 'feedback_sent', to: 'feedback_sent#index', as: :feedback_sent
     get 'certified_company_unavailable', to: 'certified_company_unavailable#index', as: :certified_company_unavailable
     post 'further_information', to: 'further_information#submit', as: :further_information_submit
     post 'further_information_cancel', to: 'further_information#cancel', as: :further_information_cancel
@@ -77,10 +78,6 @@ Rails.application.routes.draw do
     get 'further-information', to: 'further_information#index', as: :further_information
     get 'further-information-cy', to: 'further_information#index', as: :further_information_cy
   end
-
-  get 'feedback/feedback-sent', to: 'feedback_sent#index', as: :feedback_sent
-  get "adborth/adborth-wedi'i-anfon", to: 'feedback_sent#index'
-
 
   # Example of named route that can be invoked with purchase_url(id: product.id)
   #   get 'products/:id/purchase' => 'catalog#purchase', as: :purchase

--- a/spec/features/user_submits_feedback_page_spec.rb
+++ b/spec/features/user_submits_feedback_page_spec.rb
@@ -66,5 +66,18 @@ RSpec.feature 'When the user submits the feedback page' do
       expect(page).to_not have_content(session_not_valid_link)
       expect(page).to have_link I18n.t('hub.feedback_sent.session_valid_link')
     end
+
+    it 'should show feedback sent in Welsh' do
+      set_session_cookies!
+
+      visit feedback_cy_path
+      fill_in 'feedback_form_what', with: 'Using verify'
+      fill_in 'feedback_form_details', with: 'Some details'
+      choose 'feedback_form_reply_false'
+      click_button I18n.t('hub.feedback.send_message', locale: :cy)
+
+      expect(page).to have_title I18n.t('hub.feedback_sent.title', locale: :cy)
+      expect(page).to have_css 'html[lang=cy]'
+    end
   end
 end

--- a/spec/features/user_visits_feedback_page_spec.rb
+++ b/spec/features/user_visits_feedback_page_spec.rb
@@ -89,17 +89,6 @@ RSpec.feature 'When the user visits the feedback page' do
     expect(page).to have_css('.validation-message', text: I18n.t('hub.feedback.errors.no_selection'))
   end
 
-  it 'should pass email not provided to feedback sent page when successful' do
-    visit feedback_path
-
-    fill_in 'feedback_form_what', with: 'Verify my identity'
-    fill_in 'feedback_form_details', with: 'Some details'
-    choose 'feedback_form_reply_false'
-
-    click_button I18n.t('hub.feedback.send_message')
-    expect(current_url).to eql feedback_sent_url(emailProvided: false, sessionValid: false)
-  end
-
   it 'should report on the what box character limit', js: true do
     visit feedback_path
 
@@ -123,33 +112,6 @@ RSpec.feature 'When the user visits the feedback page' do
     fill_in 'feedback_form_details', with: details
     page.execute_script('$("#feedback_form_details").triggerHandler("txtinput")')
     expect(page).to have_content("#{long_text_limit - details.size}#{character_count_message_suffix}")
-  end
-
-  it 'should include email provided on feedback sent page when response requested' do
-    visit feedback_path
-
-    fill_in 'feedback_form_what', with: 'Verify my identity'
-    fill_in 'feedback_form_details', with: 'Some details'
-    choose 'feedback_form_reply_true'
-    fill_in 'feedback_form_name', with: 'Bob Smith'
-    fill_in 'feedback_form_email', with: 'bob@smith.com'
-
-    click_button I18n.t('hub.feedback.send_message')
-    expect(current_url).to eql feedback_sent_url(emailProvided: true, sessionValid: false)
-  end
-
-  context 'with session' do
-    it 'should pass email not provided to feedback sent page when successful' do
-      set_session_cookies!
-      visit feedback_path
-
-      fill_in 'feedback_form_what', with: 'Verify my identity'
-      fill_in 'feedback_form_details', with: 'Some details'
-      choose 'feedback_form_reply_false'
-
-      click_button I18n.t('hub.feedback.send_message')
-      expect(current_url).to eql feedback_sent_url(emailProvided: false, sessionValid: true)
-    end
   end
 
   it 'should not go to feedback sent page when a error with zendesk occurs' do


### PR DESCRIPTION
Query params are no longer required because we're using the flash cookie now.

Moves the feedback-sent route into the localized block. This is safe from a ZDD perspective because we've already deployed routes for both the english and welsh journeys.