### PR TITLE
bau: Fix a test that seems to depend on resolution

### DIFF
--- a/spec/feature_helper.rb
+++ b/spec/feature_helper.rb
@@ -16,6 +16,12 @@ if ENV['HEADLESS'] == 'true'
   end
 end
 
+RSpec.configure do |config|
+  config.before(:each, js: true) do
+    page.driver.browser.manage.window.resize_to(1280, 1024)
+  end
+end
+
 def current_time_in_millis
   DateTime.now.to_i * 1000
 end


### PR DESCRIPTION
This tests was failing consistently for me when firefox was popping up
on my laptop screen. I had a play around with screen resolutions and it
looks like the test fails on low resolutions and passes on high
resolutions. I think this is due to a bug (?) in Capybara / Selenium
where it can't click on an element that is "below the fold".

This fix is definitely a hack. Better suggestions welcome.

Solo: @richardtowers