### PR TITLE
BAU: validate Verify JS and CSS with SRI

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,7 +2,7 @@
 <% content_for :page_title, ' - GOV.UK Verify - GOV.UK' %>
 
 <% content_for :head do %>
-  <!--[if gt IE 8]><!--><%= stylesheet_link_tag 'style' %><!--<![endif]-->
+  <!--[if gt IE 8]><!--><%= stylesheet_link_tag 'style', integrity: true %><!--<![endif]-->
   <!--[if IE 8]><%= stylesheet_link_tag 'style-ie8' %><![endif]-->
   <%= csrf_meta_tags %>
   <% if content_for?(:meta_refresh) %>
@@ -40,7 +40,7 @@
 
 <% content_for :body_end do %>
 
-  <%= javascript_include_tag 'application' %>
+  <%= javascript_include_tag 'application', integrity: true %>
   <%= render 'shared/fingerprint' %>
 
 <% end %>


### PR DESCRIPTION
The [Subresource Integrity specification](https://www.w3.org/TR/SRI/) adds a new `integrity` attribute to `<script>` and `<link>` elements that is a hash of the asset they point to. [sprockets-rails](https://github.com/rails/sprockets-rails) will now automatically generate this attribute if you supply an `integrity: true` parameter to either `javascript_include_tag` or `stylesheet_link_tag`, which this commit does. Browsers that support SRI can then hash the downloaded asset and check that it matches the hash specified in the integrity attribute.

The real benefit of SRI is for people using CDNs where you can’t be sure the assets haven’t been tampered with. In our case, it’s a cheap enough win that it’s probably worth doing it anyway as another barrier against MitM attacks. Browsers that [currently support this](http://caniuse.com/#feat=subresource-integrity) are Chrome and Firefox.

This doesn’t add the same attribute to the core JS / CSS provided by the toolkit or templates. That job has a wider scope than this and will require more evaluation.

Testing this in development mode won’t show the attribute as sprockets will only apply it outside of debug mode. To test locally, change `config.assets.debug` in development.rb to `false`. I haven’t added any tests around this as it’s a feature that’s [unit tested as part of sprockets-rails](https://github.com/rails/sprockets-rails/blob/be6930cc324829fb794277337f98ecdcf435457a/test/test_helper.rb#L441).