### PR TITLE
BAU: Run stub-api on a different port to the real API

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ You can start the application without having any of the closed source components
 
 `./startup.sh --stub-api`
 
-This will start the frontend server running on http://localhost:50300/ and a stubbed API server on http://localhost:50190.
+This will start the frontend server running on http://localhost:50300/ and a stubbed API server on http://localhost:50191.
 
 To start a journey on the front end visit http://localhost:50300/test-saml and click `saml-post`.
 

--- a/startup.sh
+++ b/startup.sh
@@ -3,8 +3,9 @@
 
 if [ "$1" == '--stub-api' ]
 then
-  echo "Starting stub-api server on port 50190"
-  rackup --daemonize --port 50190 --pid tmp/stub_api.pid stub/stub_api_conf.ru
+  echo "Starting stub-api server on port 50191"
+  export API_HOST=http://localhost:50191
+  rackup --daemonize --port 50191 --pid tmp/stub_api.pid stub/stub_api_conf.ru
 fi
 
 bundle exec puma -e development -d -p 50300


### PR DESCRIPTION
This avoids problems where the real API tries to start on a port that's
already been grabbed by the stub API.

Solo: @richardtowers