### PR TITLE
bau: use middle to store session id for logging

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,6 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
   before_action :set_locale
-  before_filter :store_session_id
   before_filter :store_originating_ip
   before_action :validate_session
   after_action :store_locale_in_cookie, if: -> { request.method == 'GET' }
@@ -121,10 +120,6 @@ private
   def something_went_wrong_warn(exception)
     logger.warn(exception)
     render_error('something_went_wrong', :internal_server_error)
-  end
-
-  def store_session_id
-    RequestStore.store[:session_id] = request.cookies[CookieNames::SESSION_ID_COOKIE_NAME]
   end
 
   def store_originating_ip

--- a/config/initializers/store_session_id.rb
+++ b/config/initializers/store_session_id.rb
@@ -1,0 +1,2 @@
+require 'store_session_id'
+Rails.application.config.middleware.insert_before Rails::Rack::Logger, StoreSessionId

--- a/lib/store_session_id.rb
+++ b/lib/store_session_id.rb
@@ -1,0 +1,12 @@
+require 'cookie_names'
+class StoreSessionId
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    request = ActionDispatch::Request.new env
+    RequestStore.store[:session_id] = request.cookies[CookieNames::SESSION_ID_COOKIE_NAME]
+    @app.call(env)
+  end
+end

--- a/spec/lib/store_session_id_spec.rb
+++ b/spec/lib/store_session_id_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+require 'store_session_id'
+require 'rails_helper'
+
+describe StoreSessionId do
+  it 'reads the session cookie from the users' do
+    env = {
+      "HTTP_COOKIE" => "#{CookieNames::SESSION_ID_COOKIE_NAME}=foobarbaz;"
+    }
+    app = double(:app)
+    expect(app).to receive(:call).with(env)
+    StoreSessionId.new(app).call(env)
+    expect(RequestStore.store[:session_id]).to eql 'foobarbaz'
+  end
+end


### PR DESCRIPTION
The session is missing from some of our logs because it is only captured for
logstash when we reach the controller and after the CSRF check is performed.
This isn't helpful in some cases when trying to understand a user's journey and
session flows.

By switching to a middleware approach we can capture the session id before request
based logs are made.