### PR TITLE
5017: Use stub_const

### DIFF
--- a/spec/models/ab_test/ab_test_spec.rb
+++ b/spec/models/ab_test/ab_test_spec.rb
@@ -6,21 +6,21 @@ module AbTest
   describe AbTest do
     context '#alternative_name_for_experiment' do
       it 'should return the default when no experiment exists' do
-        ::AB_TESTS = {}.freeze
+        stub_const("AB_TESTS", {})
         alternative_name = subject.alternative_name_for_experiment('missing_experiment', 'alternative', 'default')
         expect(alternative_name).to eq('default')
       end
 
       it 'should return alternative name' do
         alternatives = { 'logos' => { 'alternatives' => [{ 'name' => 'yes', 'percent' => 75 }] } }
-        ::AB_TESTS = { 'logos' => Experiment.new(alternatives) }.freeze
+        stub_const("AB_TESTS", 'logos' => Experiment.new(alternatives))
         alternative_name = subject.alternative_name_for_experiment('logos', 'logos_yes', 'default')
         expect(alternative_name).to eq('logos_yes')
       end
 
       it 'should return first alternative name when given invalid alternative' do
         alternatives = { 'logos' => { 'alternatives' => [{ 'name' => 'yes', 'percent' => 75 }] } }
-        ::AB_TESTS = { 'logos' => Experiment.new(alternatives) }.freeze
+        stub_const("AB_TESTS", 'logos' => Experiment.new(alternatives))
         alternative_name = subject.alternative_name_for_experiment('logos', 'invalid', 'default')
         expect(alternative_name).to eq('logos_yes')
       end


### PR DESCRIPTION
Setting the const in test cases results in warnings in the logs. This approach fixes that.
We've used stub_const elsewhere to test code that uses const values.

Solo: @lloydnye