### PR TITLE
bau: add session id to raven user context

### DIFF
--- a/lib/store_session_id.rb
+++ b/lib/store_session_id.rb
@@ -6,7 +6,9 @@ class StoreSessionId
 
   def call(env)
     request = ActionDispatch::Request.new env
-    RequestStore.store[:session_id] = request.cookies[CookieNames::SESSION_ID_COOKIE_NAME]
+    session_id = request.cookies[CookieNames::SESSION_ID_COOKIE_NAME]
+    RequestStore.store[:session_id] = session_id
+    Raven.user_context(session_id: session_id)
     @app.call(env)
   end
 end

--- a/spec/lib/store_session_id_spec.rb
+++ b/spec/lib/store_session_id_spec.rb
@@ -1,15 +1,18 @@
 require 'spec_helper'
 require 'store_session_id'
 require 'rails_helper'
+require 'raven'
 
 describe StoreSessionId do
   it 'reads the session cookie from the users' do
+    session_id = 'foobarbaz'
     env = {
-      "HTTP_COOKIE" => "#{CookieNames::SESSION_ID_COOKIE_NAME}=foobarbaz;"
+      "HTTP_COOKIE" => "#{CookieNames::SESSION_ID_COOKIE_NAME}=#{session_id};"
     }
     app = double(:app)
     expect(app).to receive(:call).with(env)
     StoreSessionId.new(app).call(env)
-    expect(RequestStore.store[:session_id]).to eql 'foobarbaz'
+    expect(RequestStore.store[:session_id]).to eql session_id
+    expect(Raven.context.user[:session_id]).to eql session_id
   end
 end


### PR DESCRIPTION
When we send an error to sentry it would be helpful if we include the session id
as a parameter so that we can correlate it easily against other logs/errors.

Usually, we wouldn't have to do this ourselves with Raven as it usually includes
cookies with the error, but we have disabled this so that we don't leak the
user's secure cookie. To work around this we can set a user context containing
the session id.