### PR TITLE
bau: log session cookie size if it's large

### DIFF
--- a/app/models/session_validator.rb
+++ b/app/models/session_validator.rb
@@ -5,7 +5,8 @@ class SessionValidator
       MissingCookiesValidator.new,
       SessionIdCookieValidator.new,
       TransactionSimpleIdPresence.new,
-      SessionStartTimeValidator.new(session_duration)
+      SessionStartTimeValidator.new(session_duration),
+      CookieSizeValidator.new
     ]
   end
 

--- a/app/models/session_validator/cookie_size_validator.rb
+++ b/app/models/session_validator/cookie_size_validator.rb
@@ -1,0 +1,10 @@
+class SessionValidator
+  class CookieSizeValidator
+    def validate(_cookies, session)
+      # an approximation of how big the session cookie values are
+      session_cookie_size = session.to_hash.flatten.to_s.length
+      Rails.logger.error("Session cookie is large: #{session_cookie_size}") if session_cookie_size > 3096 # 3Kb
+      SuccessfulValidation
+    end
+  end
+end


### PR DESCRIPTION
We store a lot of stuff in the session cookie. This commits add code
to log a warning if it's getting too large.  Without going too deep
into Rails we can log an approximation of the size, at a slightly
lower threshold.

Perhaps we can move this into the ApplicationController; I don't mind
too much as long as we can have some sort of visibility of this
becoming an issue.

Pair: WillPa