### PR TITLE
5072: report metrics around HTTP status code counts

### DIFF
--- a/config/initializers/metrics.rb
+++ b/config/initializers/metrics.rb
@@ -4,9 +4,14 @@ require 'metrics'
 if CONFIG.metrics_enabled
   event_source = ActiveSupport::Notifications
   statsd_client = Statsd.new(CONFIG.statsd_host, CONFIG.statsd_port).tap { |sd| sd.namespace = CONFIG.statsd_prefix }
-  controller_action_reporter = Metrics::ControllerActionReporter.new(statsd_client)
   event_subscriber = Metrics::EventSubscriber.new(event_source)
+
+  controller_action_reporter = Metrics::ControllerActionReporter.new(statsd_client)
   event_subscriber.subscribe(/process_action.action_controller/, controller_action_reporter)
+
+  response_status_reporter = Metrics::ResponseStatusReporter.new(statsd_client)
+  event_subscriber.subscribe(/process_action.action_controller/, response_status_reporter)
+
   api_request_reporter = Metrics::ApiRequestReporter.new(statsd_client)
   event_subscriber.subscribe(/api_request/, api_request_reporter)
 end

--- a/lib/metrics.rb
+++ b/lib/metrics.rb
@@ -1,5 +1,6 @@
 require 'metrics/api_request_reporter'
 require 'metrics/controller_action_reporter'
+require 'metrics/response_status_reporter'
 require 'metrics/event_subscriber'
 
 module Metrics

--- a/lib/metrics/response_status_reporter.rb
+++ b/lib/metrics/response_status_reporter.rb
@@ -1,0 +1,19 @@
+module Metrics
+  class ResponseStatusReporter
+    def initialize(statsd_client, logger = Rails.logger)
+      @statsd_client = statsd_client
+      @logger = logger
+    end
+
+    def report(_name, _start, _finish, _id, payload)
+      if payload[:path] != '/service-status'
+        begin
+          status_code = Integer(payload[:status])
+          @statsd_client.increment("#{status_code / 100}xx_responses")
+        rescue TypeError #status code is not a number
+          @logger.warn('unable to read status code from response')
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/metrics/response_status_reporter_spec.rb
+++ b/spec/lib/metrics/response_status_reporter_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper'
+require 'metrics/response_status_reporter'
+
+module Metrics
+  describe ResponseStatusReporter do
+    let(:statsd) { double(:statsd) }
+    let(:logger) { double(:logger) }
+    let(:reporter) { ResponseStatusReporter.new(statsd, logger) }
+
+    it 'should report 1xx responses as 1xx_responses' do
+      payload = { status: 110 }
+      expect(statsd).to receive(:increment).with("1xx_responses")
+      reporter.report('event_name', Time.now, Time.now, 'notification_id', payload)
+    end
+
+    it 'should report 2xx responses as 2xx_responses' do
+      payload = { status: 200 }
+      expect(statsd).to receive(:increment).with("2xx_responses")
+      reporter.report('event_name', Time.now, Time.now, 'notification_id', payload)
+    end
+
+    it 'should report 3xx responses as 3xx_responses' do
+      payload = { status: 303 }
+      expect(statsd).to receive(:increment).with("3xx_responses")
+      reporter.report('event_name', Time.now, Time.now, 'notification_id', payload)
+    end
+
+    it 'should report 4xx responses as 4xx_responses' do
+      payload = { status: 404 }
+      expect(statsd).to receive(:increment).with("4xx_responses")
+      reporter.report('event_name', Time.now, Time.now, 'notification_id', payload)
+    end
+
+    it 'should report 5xx responses as 5xx_responses' do
+      payload = { status: 505 }
+      expect(statsd).to receive(:increment).with("5xx_responses")
+      reporter.report('event_name', Time.now, Time.now, 'notification_id', payload)
+    end
+
+    it 'should not report the status code for responses missing code' do
+      payload = {}
+      expect(statsd).to_not receive(:increment)
+      expect(logger).to receive(:warn).with("unable to read status code from response")
+      reporter.report('event_name', Time.now, Time.now, 'notification_id', payload)
+    end
+
+    it 'should not report the status code for /service-status' do
+      payload = { path: '/service-status', status: 200 }
+      expect(statsd).to_not receive(:increment)
+      reporter.report('event_name', Time.now, Time.now, 'notification_id', payload)
+    end
+  end
+end


### PR DESCRIPTION
We would like to see the occurrences of different status codes in our responses
to users so that we can provide a visualisation relating to the health of our
system (count of 2xxs vs 3xxs vs 4xxs vs 5xxs).

I have used the statsd/notifications metric reporter system to provide these metrics