### PR TITLE
5078: make link buttons behave like buttons to assistive tech

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,7 +83,7 @@ GEM
       govuk_frontend_toolkit (>= 4.14.1)
       rails (>= 4.1.0)
       sass (>= 3.2.0)
-    govuk_frontend_toolkit (4.14.1)
+    govuk_frontend_toolkit (4.16.1)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
     govuk_template (0.18.0)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -7,8 +7,11 @@
 //= require jquery
 //= require jquery_ujs
 //= require govuk/selection-buttons
+//= require govuk/shim-links-with-button-role
 //= require_tree .
 //= require piwik
+
+window.GOVUK.shimLinksWithButtonRole.init();
 
 window.GOVUK.validation.init();
 window.GOVUK.selectDocuments.init();

--- a/app/views/about/certified_companies.html.erb
+++ b/app/views/about/certified_companies.html.erb
@@ -6,7 +6,7 @@
 <p><%= t 'hub.about_certified_companies.no_charge' %></p>
 
 <div class="actions">
-  <%= link_to t('navigation.next'), about_identity_accounts_path, class: 'button', id: 'next-button' %>
+  <%= link_to t('navigation.next'), about_identity_accounts_path, class: 'button', role: 'button', id: 'next-button' %>
 </div>
 
 <details>

--- a/app/views/about/choosing_a_company.html.erb
+++ b/app/views/about/choosing_a_company.html.erb
@@ -9,5 +9,5 @@
   </div>
 </div>
 <div class="actions">
-  <%= link_to t('navigation.continue'), will_it_work_for_me_path, class: 'button', id: 'next-button' %>
+  <%= link_to t('navigation.continue'), will_it_work_for_me_path, class: 'button', role: 'button', id: 'next-button' %>
 </div>

--- a/app/views/about/identity_accounts.html.erb
+++ b/app/views/about/identity_accounts.html.erb
@@ -6,7 +6,7 @@
 <p><%= t 'hub.about_identity_accounts.content.p3' %></p>
 
 <div class="actions">
-  <%= link_to t('navigation.start_now'), about_choosing_a_company_path, class: 'button', id: 'next-button' %>
+  <%= link_to t('navigation.start_now'), about_choosing_a_company_path, class: 'button', role: 'button', id: 'next-button' %>
 </div>
 
 <details>

--- a/app/views/about/index.html.erb
+++ b/app/views/about/index.html.erb
@@ -5,5 +5,5 @@
 <p><%= t 'hub.about.its_secure' %></p>
 
 <div class="actions">
-  <%= link_to t('navigation.next'), about_certified_companies_path, class: 'button', id: 'next-button' %>
+  <%= link_to t('navigation.next'), about_certified_companies_path, class: 'button', role: 'button', id: 'next-button' %>
 </div>

--- a/app/views/confirmation/index.html.erb
+++ b/app/views/confirmation/index.html.erb
@@ -5,5 +5,5 @@
 <p><%= t 'hub.confirmation.message' %></p>
 <p><strong><%= t 'hub.confirmation.continue_to_rp', transaction_name: @transaction_name %></strong></p>
 <div class="actions">
-  <%= link_to t('navigation.continue'), response_processing_path, class: 'button', id:'next-button' %>
+  <%= link_to t('navigation.continue'), response_processing_path, class: 'button', role: 'button', id:'next-button' %>
 </div>

--- a/app/views/failed_registration/index_continue_on_failed_registration.html.erb
+++ b/app/views/failed_registration/index_continue_on_failed_registration.html.erb
@@ -9,7 +9,7 @@
 
     <p><%= t 'hub.failed_registration.continue_text', rp_name: @rp_name %></p>
 
-    <%= link_to t('navigation.continue'), redirect_to_service_error_path, class: 'button' %>
+    <%= link_to t('navigation.continue'), redirect_to_service_error_path, class: 'button', role: 'button' %>
 
     <h2 class="heading-medium"><%= t 'hub.failed_registration.problems_verifying_your_identity' %></h2>
 

--- a/app/views/failed_sign_in/index.html.erb
+++ b/app/views/failed_sign_in/index.html.erb
@@ -6,6 +6,6 @@
     <h1 class="heading-xlarge"><%= t 'hub.failed_sign_in.heading', display_name: @idp.display_name %></h1>
 
     <%= t 'hub.failed_sign_in.reasons_html' %>
-    <%= link_to t('hub.failed_sign_in.start_again'), start_path, class: 'button', id: 'startAgain' %>
+    <%= link_to t('hub.failed_sign_in.start_again'), start_path, class: 'button', role: 'button', id: 'startAgain' %>
   </div>
 </div>

--- a/app/views/shared/_unavailable_idp_list.erb
+++ b/app/views/shared/_unavailable_idp_list.erb
@@ -8,7 +8,7 @@
               </div>
             </div>
 
-            <%= link_to t('hub.signin.select_idp', display_name: identity_provider.display_name), certified_company_unavailable_path(identity_provider.simple_id), class: 'button' %>
+            <%= link_to t('hub.signin.select_idp', display_name: identity_provider.display_name), certified_company_unavailable_path(identity_provider.simple_id), class: 'button', role: 'button' %>
           </div>
         </div>
       </div>


### PR DESCRIPTION
All links styled to look like buttons should have a `role="button"` attribute to correctly define to assistive tech what the expectation of their use is. To make sure that they behave as buttons to the user, we also add the spacebar-to-activate behaviour with Javascript.