### PR TITLE
5078: make sure that link buttons have roles

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -49,4 +49,10 @@ module ApplicationHelper
   def idp_tagline(identity_provider)
     identity_provider.display_name + (identity_provider.tagline.nil? ? '' : ": #{identity_provider.tagline}")
   end
+
+  def button_link_to text, path, options = {}
+    options[:class] = [options[:class], 'button'].compact.join(' ')
+    options[:role] = 'button'
+    link_to text, path, options
+  end
 end

--- a/app/views/about/certified_companies.html.erb
+++ b/app/views/about/certified_companies.html.erb
@@ -6,7 +6,7 @@
 <p><%= t 'hub.about_certified_companies.no_charge' %></p>
 
 <div class="actions">
-  <%= link_to t('navigation.next'), about_identity_accounts_path, class: 'button', role: 'button', id: 'next-button' %>
+  <%= button_link_to t('navigation.next'), about_identity_accounts_path, id: 'next-button' %>
 </div>
 
 <details>

--- a/app/views/about/choosing_a_company.html.erb
+++ b/app/views/about/choosing_a_company.html.erb
@@ -9,5 +9,5 @@
   </div>
 </div>
 <div class="actions">
-  <%= link_to t('navigation.continue'), will_it_work_for_me_path, class: 'button', role: 'button', id: 'next-button' %>
+  <%= button_link_to t('navigation.continue'), will_it_work_for_me_path, id: 'next-button' %>
 </div>

--- a/app/views/about/identity_accounts.html.erb
+++ b/app/views/about/identity_accounts.html.erb
@@ -6,7 +6,7 @@
 <p><%= t 'hub.about_identity_accounts.content.p3' %></p>
 
 <div class="actions">
-  <%= link_to t('navigation.start_now'), about_choosing_a_company_path, class: 'button', role: 'button', id: 'next-button' %>
+  <%= button_link_to t('navigation.start_now'), about_choosing_a_company_path, id: 'next-button' %>
 </div>
 
 <details>

--- a/app/views/about/index.html.erb
+++ b/app/views/about/index.html.erb
@@ -5,5 +5,5 @@
 <p><%= t 'hub.about.its_secure' %></p>
 
 <div class="actions">
-  <%= link_to t('navigation.next'), about_certified_companies_path, class: 'button', role: 'button', id: 'next-button' %>
+  <%= button_link_to t('navigation.next'), about_certified_companies_path, id: 'next-button' %>
 </div>

--- a/app/views/confirmation/index.html.erb
+++ b/app/views/confirmation/index.html.erb
@@ -5,5 +5,5 @@
 <p><%= t 'hub.confirmation.message' %></p>
 <p><strong><%= t 'hub.confirmation.continue_to_rp', transaction_name: @transaction_name %></strong></p>
 <div class="actions">
-  <%= link_to t('navigation.continue'), response_processing_path, class: 'button', role: 'button', id:'next-button' %>
+  <%= button_link_to t('navigation.continue'), response_processing_path, id:'next-button' %>
 </div>

--- a/app/views/failed_registration/index_continue_on_failed_registration.html.erb
+++ b/app/views/failed_registration/index_continue_on_failed_registration.html.erb
@@ -9,7 +9,7 @@
 
     <p><%= t 'hub.failed_registration.continue_text', rp_name: @rp_name %></p>
 
-    <%= link_to t('navigation.continue'), redirect_to_service_error_path, class: 'button', role: 'button' %>
+    <%= button_link_to t('navigation.continue'), redirect_to_service_error_path %>
 
     <h2 class="heading-medium"><%= t 'hub.failed_registration.problems_verifying_your_identity' %></h2>
 

--- a/app/views/failed_sign_in/index.html.erb
+++ b/app/views/failed_sign_in/index.html.erb
@@ -6,6 +6,6 @@
     <h1 class="heading-xlarge"><%= t 'hub.failed_sign_in.heading', display_name: @idp.display_name %></h1>
 
     <%= t 'hub.failed_sign_in.reasons_html' %>
-    <%= link_to t('hub.failed_sign_in.start_again'), start_path, class: 'button', role: 'button', id: 'startAgain' %>
+    <%= button_link_to t('hub.failed_sign_in.start_again'), start_path, id: 'startAgain' %>
   </div>
 </div>

--- a/app/views/shared/_unavailable_idp_list.erb
+++ b/app/views/shared/_unavailable_idp_list.erb
@@ -8,7 +8,7 @@
               </div>
             </div>
 
-            <%= link_to t('hub.signin.select_idp', display_name: identity_provider.display_name), certified_company_unavailable_path(identity_provider.simple_id), class: 'button', role: 'button' %>
+            <%= button_link_to t('hub.signin.select_idp', display_name: identity_provider.display_name), certified_company_unavailable_path(identity_provider.simple_id) %>
           </div>
         </div>
       </div>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -13,4 +13,26 @@ RSpec.describe ApplicationHelper, type: :helper do
       expect(idp_tagline).to eq('name')
     end
   end
+
+  describe '#button_link_to' do
+    it 'should pass through the text and path to link_to' do
+      button = helper.button_link_to 'My text', '/my_path'
+      expect(button).to include('href="/my_path"')
+      expect(button).to include('My text')
+    end
+    it 'should always have a class and role of "button"' do
+      button = helper.button_link_to '', ''
+      expect(button).to include('class="button"')
+      expect(button).to include('role="button"')
+    end
+    it 'should append "button" to existing classes' do
+      button = helper.button_link_to '', '', class: 'test'
+      expect(button).to include('class="test button"')
+    end
+    it 'should overwrite existing roles with "button"' do
+      button = helper.button_link_to '', '', role: 'test'
+      expect(button).to include('role="button"')
+      expect(button).not_to include('role="test"')
+    end
+  end
 end


### PR DESCRIPTION
Creating a `button_link_to` helper reduces the chance that link buttons won’t have the correct role applied. If a `class` attribute is supplied it’ll append `button` to the existing one, but we’d only ever want a `role="button"` so that is overridden. Other parameters are passed straight through.