### PR TITLE
BAU: Cookie mismatch is a bad request

### DIFF
--- a/app/models/session_validator/validation_failure.rb
+++ b/app/models/session_validator/validation_failure.rb
@@ -31,7 +31,7 @@ class SessionValidator
 
     def self.session_id_mismatch
       message = 'Session ID in cookie does not match value in session'
-      ValidationFailure.new(:something_went_wrong, :internal_server_error, message)
+      ValidationFailure.new(:something_went_wrong, :bad_request, message)
     end
 
     def initialize(type, status, message)

--- a/spec/features/user_visits_start_page_spec.rb
+++ b/spec/features/user_visits_start_page_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe 'When the user visits the start page' do
       set_session!(transaction_simple_id: 'test-rp', start_time: start_time_in_millis, verify_session_id: 'a mismatched value')
       visit '/start'
       expect(page).to have_content 'Sorry, something went wrong'
-      expect(page).to have_http_status :internal_server_error
+      expect(page).to have_http_status :bad_request
       expect(page).to have_link 'feedback', href: '/feedback?feedback-source=ERROR_PAGE'
     end
 


### PR DESCRIPTION
Discussion in code quality meeting came to consensus that this is a client error so should have a 400 series http response.

Solo: @lloydnye