### PR TITLE
BAU: Remove use of have_not_been_made

### DIFF
--- a/spec/features/user_visits_sign_in_page_spec.rb
+++ b/spec/features/user_visits_sign_in_page_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe 'user selects an IDP on the sign in page' do
       when_i_select_an_idp
 
       expect(page).to have_content(I18n.translate('errors.page_not_found.title'))
-      expect(a_piwik_request).to have_not_been_made
+      expect(a_piwik_request.with(query: hash_including({}))).to have_been_made.once
       expect(page.get_rack_session['selected_idp']).to be_nil
     end
   end


### PR DESCRIPTION
have_not_been_made does not match requests as expected. It requires the very specific request to have been made in order to fail.
The actual page here does make a request to Piwik (because the user hits the sign in page), so I have changed the test to show that.

Solo: @lloydnye