### PR TITLE
bau: Disable console logging of fingerprint diagnostics

### DIFF
--- a/app/assets/javascripts/verify_fingerprint.js
+++ b/app/assets/javascripts/verify_fingerprint.js
@@ -3,6 +3,9 @@
 (function(global) {
    'use strict';
 
+    // By default Fingerprint2 logs things to the console. This setting disables logging:
+    global.NODEBUG = null;
+
     // based on jQuery's param implementation https://github.com/jquery/jquery/blob/master/src/serialize.js
     function serialiseComponents(components) {
         var componentsToExclude = ['webgl'];


### PR DESCRIPTION
By default Fingerprint2 logs messages like "you don't have flash
installed, so skipping flash fingerprinting" to the user's console. This
message is not useful for the average user, and at worst may persuade
some users to install flash (horror).

Also, if someone needs to report an error to the support team and they
happen to be technical enough to send us the logs from the console this
will remove irrelevant noise from that report.

Authors: @adityapahuja @richardtowers