### PR TITLE
Set a basic, lenient CSP header

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -33,8 +33,10 @@ module VerifyFrontend
 
     config.exceptions_app = self.routes
 
-    #remove default rails headers as they are added by reverse proxy
-    config.action_dispatch.default_headers.clear
+    # Apply a basic lenient Content Security Policy
+    config.action_dispatch.default_headers = {
+      'Content-Security-Policy' => "default-src 'self'; font-src data:; img-src 'self'; object-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'"
+    }
     RouteTranslator.config do |config|
       config.hide_locale = true
       config.available_locales = [:en, :cy]


### PR DESCRIPTION
Content-Security-Policy (CSP) is applied to restrict browser behavior to
the features used within the verify-frontend.

This policy is purposefully quite lenient, allowing any inline-scripts
to execute. We intend to add a reporting-uri in the future and iterate
our policy to further restrict browser behavior.

Specifically this policy only allows resources to be fetched from
'self' (origin of the document being served) it further restricts the
fonts to load using the 'data' scheme as they are provided from the
frontend_toolkit. We disallow embedding any object/applets. Scripts can
be loaded from self or as inline html, the same policy is applied to
stylesheets.