### PR TITLE
5026: update cookie notice

### DIFF
--- a/app/views/static/cookies.cy.html.erb
+++ b/app/views/static/cookies.cy.html.erb
@@ -34,18 +34,13 @@ end %>
   </thead>
   <tbody>
     <tr>
-      <td><var>x-govuk-secure-cookie</var></td>
-      <td>When you’re trying to use a service on GOV.UK, this cookie makes sure that no other user can login with your information</td>
-      <td>When you close your browser window</td>
-    </tr>
-    <tr>
       <td><var>x_govuk_session_cookie</var></td>
       <td>This cookie contains randomly generated characters so we can identify you during your visit</td>
       <td>When you close your browser window</td>
     </tr>
     <tr>
       <td><var>_verify-frontend_session</var></td>
-      <td>This cookie is used to hold information regarding your session, including when you started your session, which government service you’re using, your answers to filter questions, and which certified company you select so that we can present information relevant to your choices. This information is secured so that only GOV.UK Verify can read it</td>
+      <td>When you’re trying to use a service on GOV.UK, this cookie makes sure that no other user can log in with your information. It is also used to hold information regarding your session, including when you started your session, which government service you’re using, your answers to filter questions, and which certified company you select so that we can present information relevant to your choices. This information is secured so that only GOV.UK Verify can read it</td>
       <td>When you close your browser window</td>
     </tr>
     <tr>

--- a/app/views/static/cookies.en.html.erb
+++ b/app/views/static/cookies.en.html.erb
@@ -34,18 +34,13 @@ end %>
   </thead>
   <tbody>
     <tr>
-      <td><var>x-govuk-secure-cookie</var></td>
-      <td>When you’re trying to use a service on GOV.UK, this cookie makes sure that no other user can login with your information</td>
-      <td>When you close your browser window</td>
-    </tr>
-    <tr>
       <td><var>x_govuk_session_cookie</var></td>
       <td>This cookie contains randomly generated characters so we can identify you during your visit</td>
       <td>When you close your browser window</td>
     </tr>
     <tr>
       <td><var>_verify-frontend_session</var></td>
-      <td>This cookie is used to hold information regarding your session, including when you started your session, which government service you’re using, your answers to filter questions, and which certified company you select so that we can present information relevant to your choices. This information is secured so that only GOV.UK Verify can read it</td>
+      <td>When you’re trying to use a service on GOV.UK, this cookie makes sure that no other user can log in with your information. It is also used to hold information regarding your session, including when you started your session, which government service you’re using, your answers to filter questions, and which certified company you select so that we can present information relevant to your choices. This information is secured so that only GOV.UK Verify can read it</td>
       <td>When you close your browser window</td>
     </tr>
     <tr>

--- a/spec/features/user_visits_cookies_page_spec.rb
+++ b/spec/features/user_visits_cookies_page_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe 'When the user visits the cookies page' do
   it 'displays the page in English' do
     visit '/cookies'
     expect(page).to have_content('GOV.UK puts small files (known as ‘cookies’) onto your computer to collect information about how you browse the site.')
-    expect(page).to have_content('x-govuk-secure-cookie')
     expect(page).to have_content('x_govuk_session_cookie')
     expect(page).to have_content('_verify-frontend_session')
     expect(page).to have_content('seen_cookie_message')


### PR DESCRIPTION
the cookie notice must be changed to reflect the removal of the secure cookie.

@gdsamit has reviewed the changes and has given it an OK.