### PR TITLE
bau: fix CookieNames constants warning

### DIFF
--- a/lib/store_session_id.rb
+++ b/lib/store_session_id.rb
@@ -1,4 +1,3 @@
-require 'cookie_names'
 class StoreSessionId
   def initialize(app)
     @app = app


### PR DESCRIPTION
The cookies names were being re-evaluated during the jasmine run due to this
require statement and spewing warnings we'd rather avoid.