### PR TITLE
bau: tune CSP directive

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -35,7 +35,7 @@ module VerifyFrontend
 
     # Apply a basic lenient Content Security Policy
     config.action_dispatch.default_headers = {
-      'Content-Security-Policy' => "default-src 'self'; font-src data:; img-src 'self'; object-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'"
+      'Content-Security-Policy' => "default-src 'self'; font-src data:; img-src 'self' data:; object-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'"
     }
     RouteTranslator.config do |config|
       config.hide_locale = true


### PR DESCRIPTION
We were seeing an issue with the existing CSP directive in staging,
this was due to our piwik.js loading an image from a data: URI which
was disallowed.

This fix has been tested locally in both Chrome and Firefox with
tweaked PIWIK_HOST to point to the same host/port as the frontend (as
happens in prod).  When running locally with piwik on a different port
etc the CSP difrective will still be violated => we should consider
what to do with CSP when running locally.

Pair: WillPa