### PR TITLE
5057: Revert all commits adding "(position x of n)"

### DIFF
--- a/app/controllers/choose_a_certified_company_controller.rb
+++ b/app/controllers/choose_a_certified_company_controller.rb
@@ -1,17 +1,14 @@
 class ChooseACertifiedCompanyController < ApplicationController
   def index
+    grouped_identity_providers = IDP_RECOMMENDATION_GROUPER.group_by_recommendation(selected_evidence, current_identity_providers, current_transaction_simple_id)
     @recommended_idps = IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate_collection(grouped_identity_providers.recommended)
     @non_recommended_idps = IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate_collection(grouped_identity_providers.non_recommended)
   end
 
   def select_idp
     select_viewable_idp(params.fetch('entity_id')) do |decorated_idp|
-      recommended = IDP_RECOMMENDATION_GROUPER.recommended?(decorated_idp.identity_provider, selected_evidence, current_identity_providers, current_transaction_simple_id)
-      session[:selected_idp_was_recommended] = recommended
-
-      store_selected_idp_index
-      store_num_of_idps(recommended)
-
+      session[:selected_idp_was_recommended] =
+        IDP_RECOMMENDATION_GROUPER.recommended?(decorated_idp.identity_provider, selected_evidence, current_identity_providers, current_transaction_simple_id)
       redirect_to redirect_to_idp_warning_path
     end
   end
@@ -26,26 +23,5 @@ class ChooseACertifiedCompanyController < ApplicationController
     else
       render 'errors/404', status: 404
     end
-  end
-
-private
-
-  def grouped_identity_providers
-    @grouped_identity_providers ||= IDP_RECOMMENDATION_GROUPER.group_by_recommendation(selected_evidence, current_identity_providers, current_transaction_simple_id)
-  end
-
-  def store_selected_idp_index
-    raw_index = params['selected_idp_position']
-    begin
-      flash[:selected_idp_position] = Integer(raw_index)
-    rescue TypeError, ArgumentError
-      Rails.logger.warn('Could not parse selected_idp_position as an Integer.')
-    end
-  end
-
-  def store_num_of_idps(recommended)
-    # This is the count of idps in the group the user clicked (recommended or non-recommended)
-    # It's used to report to piwik that the user clicked e.g. "index 2 of 4"
-    flash[:idp_count] = recommended ? grouped_identity_providers.recommended.count : grouped_identity_providers.non_recommended.count
   end
 end

--- a/app/controllers/redirect_to_idp_warning_controller.rb
+++ b/app/controllers/redirect_to_idp_warning_controller.rb
@@ -3,9 +3,6 @@ class RedirectToIdpWarningController < ApplicationController
   helper_method :user_has_no_docs_or_foreign_id_only?, :other_ways_description
 
   def index
-    flash.keep(:selected_idp_position)
-    flash.keep(:idp_count)
-
     @idp = decorated_idp
     if @idp.viewable?
       @recommended = recommended?
@@ -54,15 +51,7 @@ private
       selected_idp_names << idp_name
       session[:selected_idp_names] = selected_idp_names
     end
-    FEDERATION_REPORTER.report_idp_registration(
-      request,
-      idp_name,
-      selected_idp_names,
-      selected_answer_store.selected_evidence,
-      recommended?,
-      flash[:selected_idp_position],
-      flash[:idp_count]
-    )
+    FEDERATION_REPORTER.report_idp_registration(request, idp_name, selected_idp_names, selected_answer_store.selected_evidence, recommended?)
   end
 
   def recommended?

--- a/app/models/analytics/federation_reporter.rb
+++ b/app/models/analytics/federation_reporter.rb
@@ -12,13 +12,13 @@ module Analytics
       report_action(current_transaction, request, 'The Yes option was selected on the start page')
     end
 
-    def report_idp_registration(request, idp_name, idp_name_history, evidence, recommended, idp_position, num_of_idps)
+    def report_idp_registration(request, idp_name, idp_name_history, evidence, recommended)
       cvars = Analytics::CustomVariable.build(:register_idp, idp_name).merge(
         Analytics::CustomVariable.build(:idp_selection, idp_name_history.join(',')))
 
       recommended_str = recommended ? '(recommended)' : '(not recommended)'
       list_of_evidence = evidence.sort.join(', ')
-      action = "#{idp_name} was chosen for registration #{recommended_str} (position #{idp_position || '-'} of #{num_of_idps || '-'}) with evidence #{list_of_evidence}"
+      action = "#{idp_name} was chosen for registration #{recommended_str} with evidence #{list_of_evidence}"
 
       @analytics_reporter.report_custom_variable(request, action, cvars)
     end

--- a/app/views/choose_a_certified_company/_idp_option.html.erb
+++ b/app/views/choose_a_certified_company/_idp_option.html.erb
@@ -15,6 +15,5 @@
                      value: identity_provider.display_name
       %>
       <%= hidden_field_tag 'entity_id', identity_provider.entity_id, id: nil %>
-      <%= hidden_field_tag 'selected_idp_position', index + 1, id: nil %>
   <% end %>
 </div>

--- a/app/views/choose_a_certified_company/index.html.erb
+++ b/app/views/choose_a_certified_company/index.html.erb
@@ -15,8 +15,8 @@
     </div>
   </div>
   <div id="matching-idps">
-    <% @recommended_idps.each_with_index do |identity_provider, index| %>
-      <%= render partial: 'idp_option', locals: {recommended: true, identity_provider: identity_provider, index: index} %>
+    <% @recommended_idps.each do |identity_provider| %>
+      <%= render partial: 'idp_option', locals: {recommended: true, identity_provider: identity_provider} %>
     <% end %>
   </div>
   <% if @non_recommended_idps.any? %>
@@ -34,8 +34,8 @@
           <span class="summary"><%= t 'hub.choose_a_certified_company.show_all_companies' %></span>
         </summary>
         <div class="panel panel-border-narrow">
-          <% @non_recommended_idps.each_with_index do |identity_provider, index| %>
-            <%= render partial: 'idp_option', locals: {recommended: false, identity_provider: identity_provider, index: index} %>
+          <% @non_recommended_idps.each do |identity_provider| %>
+            <%= render partial: 'idp_option', locals: {recommended: false, identity_provider: identity_provider} %>
           <% end %>
         </div>
       </details>

--- a/spec/features/idp_selections_reported_to_piwik_spec.rb
+++ b/spec/features/idp_selections_reported_to_piwik_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'When the user selects an IDP' do
   }
 
   let(:idcorp_registration_piwik_request) {
-    stub_piwik_idp_registration('IDCorp', 3, selected_answers: selected_answers, recommended: true)
+    stub_piwik_idp_registration('IDCorp', selected_answers: selected_answers, recommended: true)
   }
 
   let(:originating_ip) { '<PRINCIPAL IP ADDRESS COULD NOT BE DETERMINED>' }
@@ -46,7 +46,6 @@ RSpec.describe 'When the user selects an IDP' do
   it 'appends the IdP name on subsequent selections' do
     idcorp_piwik_request = idcorp_registration_piwik_request
     idcorp_and_bobs_piwik_request = stub_piwik_idp_registration('Bob’s Identity Service',
-                                                                1,
                                                                 selected_answers: selected_answers,
                                                                 recommended: false,
                                                                 idp_list: 'IDCorp,Bob’s Identity Service'
@@ -66,7 +65,7 @@ RSpec.describe 'When the user selects an IDP' do
 
   it 'truncates IdP names' do
     idps = %w(A B C D E)
-    idcorp_piwik_request = stub_piwik_idp_registration('IDCorp', 3, recommended: true, selected_answers: selected_answers, idp_list: idps.join(','))
+    idcorp_piwik_request = stub_piwik_idp_registration('IDCorp', recommended: true, selected_answers: selected_answers, idp_list: idps.join(','))
     page.set_rack_session(selected_idp_names: idps)
     visit '/choose-a-certified-company'
     click_button 'Choose IDCorp'

--- a/spec/features/user_visits_redirect_to_idp_warning_page_spec.rb
+++ b/spec/features/user_visits_redirect_to_idp_warning_page_spec.rb
@@ -59,12 +59,6 @@ RSpec.describe 'When the user visits the redirect to IDP warning page' do
     )
   }
 
-  def stub_registration_piwik_report(selected_answers, recommended)
-    # Tests in this file register without picking an IdP on choose-a-certified-company first.
-    # This means that the position of the IdP the user clicked is not in flash, so (index - of -) should be reported.
-    stub_piwik_idp_registration('IDCorp', '-', idp_position: '-', selected_answers: selected_answers, recommended: recommended)
-  end
-
   before(:each) do
     set_session_and_session_cookies!
   end
@@ -110,7 +104,7 @@ RSpec.describe 'When the user visits the redirect to IDP warning page' do
     select_idp_stub_request
     stub_session_idp_authn_request(originating_ip, location, false)
 
-    piwik_registration_virtual_page = stub_registration_piwik_report(selected_answers, true)
+    piwik_registration_virtual_page = stub_piwik_idp_registration('IDCorp', selected_answers: selected_answers, recommended: true)
 
     click_button 'Continue to IDCorp'
 
@@ -129,7 +123,7 @@ RSpec.describe 'When the user visits the redirect to IDP warning page' do
     select_idp_stub_request
     stub_session_idp_authn_request(originating_ip, location, false)
 
-    piwik_registration_virtual_page = stub_registration_piwik_report(selected_answers, false)
+    piwik_registration_virtual_page = stub_piwik_idp_registration('IDCorp', selected_answers: selected_answers)
 
     click_button 'Continue to IDCorp'
 
@@ -180,7 +174,8 @@ RSpec.describe 'When the user visits the redirect to IDP warning page' do
 
   context 'with JS enabled', js: true do
     it 'will redirect the user to the IDP on Continue' do
-      piwik_registration_virtual_page = stub_registration_piwik_report(selected_answers, true)
+      piwik_registration_virtual_page = stub_piwik_idp_registration('IDCorp', selected_answers: selected_answers, recommended: true)
+      stub_piwik_idp_registration('IDCorp')
       stub_federation
       given_a_session_with_document_answers
       visit '/redirect-to-idp-warning'
@@ -202,6 +197,7 @@ RSpec.describe 'When the user visits the redirect to IDP warning page' do
     end
 
     it 'will redirect the user to the IDP without sending hints when they are disabled' do
+      stub_piwik_idp_registration('IDCorp')
       stub_federation
       given_a_session_with_a_hints_disabled_idp
       visit '/redirect-to-idp-warning'

--- a/spec/models/analytics/federation_reporter_spec.rb
+++ b/spec/models/analytics/federation_reporter_spec.rb
@@ -32,33 +32,33 @@ module Analytics
         expect(analytics_reporter).to receive(:report_custom_variable)
           .with(
             request,
-            "#{idp_name} was chosen for registration (recommended) (position 1 of 5) with evidence passport",
+            "#{idp_name} was chosen for registration (recommended) with evidence passport",
             2 => ['REGISTER_IDP', idp_name],
             5 => ['IDP_SELECTION', idp_history_str]
           )
-        federation_reporter.report_idp_registration(request, idp_name, idp_history, %w(passport), true, 1, 5)
+        federation_reporter.report_idp_registration(request, idp_name, idp_history, %w(passport), true)
       end
 
       it 'should report correctly if IdP was not recommended' do
         expect(analytics_reporter).to receive(:report_custom_variable)
           .with(
             request,
-            "#{idp_name} was chosen for registration (not recommended) (position 2 of 4) with evidence passport",
+            "#{idp_name} was chosen for registration (not recommended) with evidence passport",
             2 => ['REGISTER_IDP', idp_name],
             5 => ['IDP_SELECTION', idp_history_str]
           )
-        federation_reporter.report_idp_registration(request, idp_name, idp_history, %w(passport), false, 2, 4)
+        federation_reporter.report_idp_registration(request, idp_name, idp_history, %w(passport), false)
       end
 
-      it 'should sort evidence and skip nil indices' do
+      it 'should sort evidence' do
         expect(analytics_reporter).to receive(:report_custom_variable)
           .with(
             request,
-            "#{idp_name} was chosen for registration (recommended) (position - of -) with evidence driving_licence, passport",
+            "#{idp_name} was chosen for registration (recommended) with evidence driving_licence, passport",
             2 => ['REGISTER_IDP', idp_name],
             5 => ['IDP_SELECTION', idp_history_str]
           )
-        federation_reporter.report_idp_registration(request, idp_name, idp_history, %w(passport driving_licence), true, nil, nil)
+        federation_reporter.report_idp_registration(request, idp_name, idp_history, %w(passport driving_licence), true)
       end
     end
 

--- a/spec/piwik_test_helper.rb
+++ b/spec/piwik_test_helper.rb
@@ -1,11 +1,11 @@
-def stub_piwik_idp_registration(idp_name, idp_count, idp_position: '\d', selected_answers: {}, recommended: false, idp_list: idp_name)
+def stub_piwik_idp_registration(idp_name, selected_answers: {}, recommended: false, idp_list: idp_name)
   recommended_str = recommended ? 'recommended' : 'not recommended'
   evidence = selected_answers.values.flat_map { |answer_set|
     answer_set.select { |_, v| v }.map { |item| item[0] }
   }.sort.join(', ')
   piwik_request = {
     '_cvar' => "{\"2\":[\"REGISTER_IDP\",\"#{idp_name}\"],\"5\":[\"IDP_SELECTION\",\"#{idp_list}\"]}",
-    'action_name' => match(/#{idp_name} was chosen for registration \(#{recommended_str}\) \(position #{idp_position} of #{idp_count}\) with evidence #{evidence}/),
+    'action_name' => "#{idp_name} was chosen for registration (#{recommended_str}) with evidence #{evidence}",
   }
   stub_request(:get, INTERNAL_PIWIK.url).with(query: hash_including(piwik_request))
 end


### PR DESCRIPTION
This was needed to gather data on whether IdPs at the top of the list
are selected more often than those further down. We have enough data to
be confident that it does now, so this extra logging is no longer
required.

We'd leave it in place, but having such a large number of permutations
for this virtual page title confuses the piwik UI, and that will be
annoying for the analytics team. More seriously, the page title we
modified is used for calculating the success rate in demo periods. We're
not sure if the change might have skewed the results a bit, so we'd like
to go back to the old format for the next demo period.

If we need similar behaviour in the future (which we probably will) we
should have a bit more of a think about where to put it and what the
effect on the piwik UI will be. Considerations:

* It would be nice not to have to store anything in flash in the code.
  We could just as easily log this page title on the picker page, not
  the redirect-to-idp-warning page.
* Page titles with a high number of permutations will mess up the piwik UI

Also note: once this commit merges to master we will need to make the
corresponding change to ida-hub-acceptance-tests to stop asserting that
the position is logged.

This commit reverts the following:

* "5057: Rename index to position" (112e42ae17636307bc848612b2c3b69ae05f5619)
* "5057: cache the result of grouped_identity_providers" (9b90f0bb97b3dbbdc14af65b01bf2e472e55fb6a)
* "5057: Use `Integer(thing)` instead of `thing.to_i if thing =~ /\d+/" (9f9293a859c982e2a996ec855c533dae2c79530a)
* "5057: Add flash.keep to RedirectToIdpWarningController#index" (fe2292439095254123c14a38e6dbe673253952da)
* "5057: Refactor feature tests check for registration piwik report" (6df98338cb28c23bb0716119c7778a15952b47f0)
* "5057: Add number of idps to idp selected piwik report" (eacc5879546803af904713bebc6e7edc4328430e)
* "5057: Send position of chosen IdP to piwik" (c7611af1abf2d044452cd39fd3e7ae0c84904fef)

Solo: @richardtowers