### PR TITLE
BAU: stop Rails 5 automatically disabling submit buttons

### DIFF
--- a/app/views/start/index.html.erb
+++ b/app/views/start/index.html.erb
@@ -23,7 +23,7 @@
 
   <div class="form-group-tight">
     <div class="actions">
-      <input class="button" id="next-button" type="submit" value="<%= t 'hub.start.continue' %>" />
+      <%= f.submit t('hub.start.continue'), class: 'button', id: 'next-button' %>
     </div>
   </div>
 <% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -45,5 +45,10 @@ module VerifyFrontend
     # by default rails wraps invalid inputs with <div class="field_with_errors">
     # we have our own way of styling errors, so we don't need this behaviour:
     config.action_view.field_error_proc = Proc.new { |html_tag| html_tag }
+
+    # Rails 5 automatically disables submit buttons after they’ve bee clicked on once.
+    # If you go back on our pages it remembers the disabled state, thus breaking the system.
+    # We can turn this functionality off globally.
+    config.action_view.automatically_disable_submit_tag = false
   end
 end

--- a/spec/features/user_visits_start_page_spec.rb
+++ b/spec/features/user_visits_start_page_spec.rb
@@ -18,6 +18,12 @@ RSpec.describe 'When the user visits the start page' do
     expect(page).to have_css 'html[lang=cy]'
   end
 
+  it 'will not automatically disable the continue button on submit' do
+    set_session_and_session_cookies!
+    visit '/start'
+    expect(page).to_not have_css '#next-button[data-disable-with]'
+  end
+
   context 'when there is an error' do
     before(:each) do
       stub_transactions_list


### PR DESCRIPTION
Rails 5 automatically disables submit buttons after they’ve been clicked on once. If you go back on our pages it remembers the disabled state, thus breaking the system. We can turn this functionality off globally.