### PR TITLE
BAU: allow for changes in content without introducing new keys

### DIFF
--- a/app/views/about/certified_companies.html.erb
+++ b/app/views/about/certified_companies.html.erb
@@ -22,9 +22,6 @@
     <span class="summary"><%= t 'hub.about_certified_companies.summary' %></span>
   </summary>
   <div class="panel panel-border-narrow">
-    <p><%= t 'hub.about_certified_companies.details.p1' %></p>
-    <p><%= t 'hub.about_certified_companies.details.p2' %></p>
-    <p><%= t 'hub.about_certified_companies.details.p3' %></p>
-    <p><%= t 'hub.about_certified_companies.details.p4' %></p>
+    <%= t 'hub.about_certified_companies.details_html' %>
   </div>
 </details>

--- a/app/views/about/choosing_a_company.html.erb
+++ b/app/views/about/choosing_a_company.html.erb
@@ -4,8 +4,7 @@
 <div class="grid-row">
   <div class="column-two-thirds">
     <h1 class="heading-large"><%= t 'hub.about_choosing_a_company.heading' %></h1>
-    <p><%= t 'hub.about_choosing_a_company.p1' %></p>
-    <p><%= t 'hub.about_choosing_a_company.p2' %></p>
+    <%= t 'hub.about_choosing_a_company.content_html' %>
   </div>
 </div>
 <div class="actions">

--- a/app/views/about/identity_accounts.html.erb
+++ b/app/views/about/identity_accounts.html.erb
@@ -1,9 +1,7 @@
 <%= page_title 'hub.about_identity_accounts.title' %>
 <% content_for :feedback_source, 'ABOUT_IDENTITY_ACCOUNTS_PAGE' %>
 
-<p><%= t 'hub.about_identity_accounts.content.p1' %></p>
-<p><%= t 'hub.about_identity_accounts.content.p2' %></p>
-<p><%= t 'hub.about_identity_accounts.content.p3' %></p>
+<%= t 'hub.about_identity_accounts.content_html' %>
 
 <div class="actions">
   <%= button_link_to t('navigation.start_now'), about_choosing_a_company_path, id: 'next-button' %>

--- a/app/views/redirect_to_idp_warning/_recommended.html.erb
+++ b/app/views/redirect_to_idp_warning/_recommended.html.erb
@@ -2,5 +2,4 @@
     <%= idp.special_no_docs_instructions.html_safe %>
 <% end %>
 
-<p><%= t 'hub.redirect_to_idp_warning.recommended.p1', display_name: idp.display_name %></p>
-<p><%= t 'hub.redirect_to_idp_warning.recommended.p2' %></p>
+<%= t 'hub.redirect_to_idp_warning.recommended_html', display_name: idp.display_name %>

--- a/app/views/select_phone/no_mobile_phone.html.erb
+++ b/app/views/select_phone/no_mobile_phone.html.erb
@@ -4,9 +4,7 @@
 <div class="grid-row">
   <div class="column-two-thirds">
     <h1 class="heading-xlarge"><%= t 'hub.no_mobile_phone.heading' %></h1>
-
-    <p><%= t 'hub.no_mobile_phone.p1', other_ways_description: @other_ways_description %></p>
-    <p><%= t 'hub.no_mobile_phone.p2' %></p>
+    <%= t 'hub.no_mobile_phone.content_html', other_ways_description: @other_ways_description %>
 
     <%= render partial: 'shared/other_ways', locals: {other_ways_text: @other_ways_text, other_ways_description: @other_ways_description} %>
   </div>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -88,24 +88,25 @@ cy:
       ensure_privacy: Nid yw’r cwmni ardystiedig yn gwybod pa wasanaeth o’r llywodraeth rydych yn ei ddefnyddio ac nid yw’r adran o’r llywodraeth yn gwybod pa gwmni wnaeth ddilysu eich hunaniaeth. Mae hyn yn sicrhau eich preifatrwydd.
       no_charge: Nid oes tâl am y gwasanaeth hwn.
       summary: Sut y gall cwmnïau wirio hunaniaeth
-      details:
-        p1: Gall y cwmnïau hyn ddefnyddio eu data eu hunain, a gallant gael mynediad at ddata fel cofnodion credyd. Maent yn gallu gwirio bod gwybodaeth o basbortau a thrwyddedau gyrru yn gywir.
-        p2: Mae cwmnïau ardystiedig yn bodloni safonau preifatrwydd y llywodraeth, felly gallwch ymddiried ynddynt gyda’ch gwybodaeth bersonol. Ni fyddant yn rhannu neu werthu eich data at unrhyw ddibenion eraill heb eich caniatâd.
-        p3: Ni fydd unrhyw effaith ar eich sgôr credyd.
-        p4: Mae mwy nag un cwmni ardystiedig yn golygu eich bod chi’n dewis pwy sy’n dilysu eich hunaniaeth, ac mae’n golygu bod y system yn ei gyfanrwydd yn gryfach.
+      details_html: |
+        <p>Gall y cwmnïau hyn ddefnyddio eu data eu hunain, a gallant gael mynediad at ddata fel cofnodion credyd. Maent yn gallu gwirio bod gwybodaeth o basbortau a thrwyddedau gyrru yn gywir.</p>
+        <p>Mae cwmnïau ardystiedig yn bodloni safonau preifatrwydd y llywodraeth, felly gallwch ymddiried ynddynt gyda’ch gwybodaeth bersonol. Ni fyddant yn rhannu neu werthu eich data at unrhyw ddibenion eraill heb eich caniatâd.</p>
+        <p>Ni fydd unrhyw effaith ar eich sgôr credyd.</p>
+        <p>Mae mwy nag un cwmni ardystiedig yn golygu eich bod chi’n dewis pwy sy’n dilysu eich hunaniaeth, ac mae’n golygu bod y system yn ei gyfanrwydd yn gryfach.</p>
     about_identity_accounts:
       title: Am gyfrifon hunaniaeth
-      content:
-        p1: Mae dilysu eich hunaniaeth yn cymryd tua 10 munud.
-        p2: Yna bydd gennych gyfrif hunaniaeth gyda’ch cwmni ardystiedig.
-        p3: Gallwch fewngofnodi lle bynnag y byddwch yn gweld logo GOV.UK Verify.
+      content_html: |
+        <p>Mae dilysu eich hunaniaeth yn cymryd tua 10 munud.</p>
+        <p>Yna bydd gennych gyfrif hunaniaeth gyda’ch cwmni ardystiedig.</p>
+        <p>Gallwch fewngofnodi lle bynnag y byddwch yn gweld logo GOV.UK Verify.</p>
       summary: Ble allwch chi ddefnyddio eich cyfrif hunaniaeth
       details: "Mae GOV.UK Verify yn gynllun newydd ac mae gwasanaethau newydd yn ymuno drwy’r amser. Y gwasanaethau presennol yw:"
     about_choosing_a_company:
       title: Am ddewis cwmni
       heading: Dod o hyd i’r cwmni iawn i’ch dilysu chi
-      p1: Mae gan gwmnïau ardystiedig ffyrdd gwahanol o wirio hunaniaeth, er enghraifft trwy wirio dogfennau adnabod neu ddarparu ap.
-      p2: Byddwn nawr yn gofyn ychydig o gwestiynau i chi i edrych pa gwmnïau all eich dilysu.
+      content_html: |
+        <p>Mae gan gwmnïau ardystiedig ffyrdd gwahanol o wirio hunaniaeth, er enghraifft trwy wirio dogfennau adnabod neu ddarparu ap.</p>
+        <p>Byddwn nawr yn gofyn ychydig o gwestiynau i chi i edrych pa gwmnïau all eich dilysu.</p>
     select_documents:
       title: Dewiswch yr holl ddogfennau sydd gennych
       explanation: Mae cwmnïau ardystiedig yn defnyddio gwybodaeth o wahanol ddogfennau hunaniaeth i’ch dilysu.
@@ -150,8 +151,9 @@ cy:
           no_selection: Dylech ateb pob cwestiwn
     no_mobile_phone:
       heading: Ni fydd GOV.UK Verify yn gweithio i chi
-      p1: Rydych angen ffôn neu lechen i ddefnyddio GOV.UK Verify. Os nad oes gennych un o’r rhain, mae ffyrdd eraill y gallwch %{other_ways_description}.
-      p2: Os nad oes gennych basport neu drwydded yrru’r DU byddwch hefyd angen gosod app.
+      content_html: |
+        <p>Rydych angen ffôn neu lechen i ddefnyddio GOV.UK Verify. Os nad oes gennych un o’r rhain, mae ffyrdd eraill y gallwch %{other_ways_description}.</p>
+        <p>Os nad oes gennych basport neu drwydded yrru’r DU byddwch hefyd angen gosod app.</p>
     may_not_work_if_you_live_overseas:
       title: Efallai na fyddwch yn gallu cael eich hunaniaeth wedi’i ddilysu
       heading: Efallai na fyddwch yn gallu cael eich hunaniaeth wedi’i ddilysu
@@ -226,9 +228,9 @@ cy:
     redirect_to_idp_warning:
       title: "Byddwch nawr yn cael eich ailgyfeirio"
       continue_to_idp: Parhau i %{display_name}
-      recommended:
-        p1: Byddwch nawr yn dilysu eich hunaniaeth ar wefan %{display_name}.
-        p2: Byddant yn rhoi cyfrif hunaniaeth i chi y gallwch ei ddefnyddio ble bynnag rydych yn gweld logo GOV.UK Verify.
+      recommended_html: |
+        <p>Byddwch nawr yn dilysu eich hunaniaeth ar wefan %{display_name}.</p>
+        <p>Byddant yn rhoi cyfrif hunaniaeth i chi y gallwch ei ddefnyddio ble bynnag rydych yn gweld logo GOV.UK Verify.</p>
       non_recommended:
         requirements: "I gael eich dilysu gyda %{display_name}, byddwch angen:"
       other_ways_link: "ffyrdd eraill i %{transaction}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -85,24 +85,25 @@ en:
       ensure_privacy: The certified company doesn’t know which government service you’re accessing, and the government department doesn’t know which company verified your identity. This ensures your privacy.
       no_charge: There’s no charge for this service.
       summary: How companies can verify identities
-      details:
-        p1: These companies can use their own data, and they can access data like credit records. They’re able to check that information from passports and driving licences is correct.
-        p2: Certified companies meet government privacy standards, so you can trust them with your personal information. They won’t share or sell your data for any other purposes without your consent.
-        p3: There won’t be any effect on your credit score.
-        p4: More than one certified company means you choose who verifies your identity, and it means the system overall is stronger.
+      details_html: |
+        <p>These companies can use their own data, and they can access data like credit records. They’re able to check that information from passports and driving licences is correct.</p>
+        <p>Certified companies meet government privacy standards, so you can trust them with your personal information. They won’t share or sell your data for any other purposes without your consent.</p>
+        <p>There won’t be any effect on your credit score.</p>
+        <p>More than one certified company means you choose who verifies your identity, and it means the system overall is stronger.</p>
     about_identity_accounts:
       title: About identity accounts
-      content:
-        p1: Verifying your identity takes about 10 minutes.
-        p2: You’ll then have an identity account with your certified company.
-        p3: You can sign in wherever you see the GOV.UK Verify logo.
+      content_html: |
+        <p>Verifying your identity takes about 10 minutes.</p>
+        <p>You’ll then have an identity account with your certified company.</p>
+        <p>You can sign in wherever you see the GOV.UK Verify logo.</p>
       summary: Where you can use your identity account
       details: "GOV.UK Verify is a new scheme, and new services are joining all the time. The current services are:"
     about_choosing_a_company:
       title: About choosing a company
       heading: Finding the right company to verify you
-      p1: Certified companies have different ways to verify identities, for example by checking identity documents, or providing an app.
-      p2: We’ll now ask you some questions to check which companies can verify you.
+      content_html: |
+        <p>Certified companies have different ways to verify identities, for example by checking identity documents, or providing an app.</p>
+        <p>We’ll now ask you some questions to check which companies can verify you.</p>
     select_documents:
       title: Select all the documents you have
       explanation: Certified companies use information from different identity documents to verify you.
@@ -147,8 +148,9 @@ en:
           no_selection: Please answer all the questions
     no_mobile_phone:
       heading: GOV.UK Verify won’t work for you
-      p1: You need a phone or tablet to use GOV.UK Verify. If you don’t have either of these, there are other ways you can %{other_ways_description}.
-      p2: If you don’t have a passport or UK driving licence, you will also need to install an app.
+      content_html: |
+        <p>You need a phone or tablet to use GOV.UK Verify. If you don’t have either of these, there are other ways you can %{other_ways_description}.</p>
+        <p>If you don’t have a passport or UK driving licence, you will also need to install an app.</p>
     may_not_work_if_you_live_overseas:
       title: You might not be able to have your identity verified
       heading: You might not be able to have your identity verified
@@ -220,9 +222,9 @@ en:
     redirect_to_idp_warning:
       title: "You'll now be redirected"
       continue_to_idp: Continue to %{display_name}
-      recommended:
-        p1: You’ll now verify your identity on %{display_name}’s website.
-        p2: They’ll give you an identity account you can use wherever you see the GOV.UK Verify logo.
+      recommended_html: |
+        <p>You’ll now verify your identity on %{display_name}’s website.</p>
+        <p>They’ll give you an identity account you can use wherever you see the GOV.UK Verify logo.</p>
       non_recommended:
         requirements: "To be verified with %{display_name}, you’ll need:"
       other_ways_link: "other ways to %{transaction}"

--- a/spec/features/user_visits_redirect_to_idp_warning_page_spec.rb
+++ b/spec/features/user_visits_redirect_to_idp_warning_page_spec.rb
@@ -1,7 +1,6 @@
 require 'feature_helper'
 require 'api_test_helper'
 require 'piwik_test_helper'
-require 'i18n'
 
 RSpec.describe 'When the user visits the redirect to IDP warning page' do
   let(:originating_ip) { '<PRINCIPAL IP ADDRESS COULD NOT BE DETERMINED>' }
@@ -155,7 +154,7 @@ RSpec.describe 'When the user visits the redirect to IDP warning page' do
     given_a_session_with_no_document_answers
     visit '/redirect-to-idp-warning'
 
-    expect(page).to have_content I18n.t 'hub.redirect_to_idp_warning.recommended.p1', display_name: 'No Docs IDP'
+    expect(page).to have_content 'You’ll now verify your identity on No Docs IDP’s website.'
     expect(page).to have_content 'Additional IDP Instructions'
     expect(page).to have_link 'other ways to register for an identity profile', href: other_ways_to_access_service_path
   end
@@ -165,7 +164,7 @@ RSpec.describe 'When the user visits the redirect to IDP warning page' do
     given_a_session_with_non_uk_id_document_answers
     visit '/redirect-to-idp-warning'
 
-    expect(page).to have_content I18n.t 'hub.redirect_to_idp_warning.recommended.p1', display_name: 'Best ID'
+    expect(page).to have_content 'You’ll now verify your identity on Best ID’s website.'
     expect(page).to have_content 'Additional IDP Instructions'
     expect(page).to have_link 'other ways to register for an identity profile', href: other_ways_to_access_service_path
   end


### PR DESCRIPTION
In several content sections individual paragraphs are being internationalised. If in the future we change the number of paragraphs we’d have to rework the keys in the localisation. The current method also fixes both translations to the same number of paragraphs, which might not be ideal.

This commit migrates these content sections into extended _html sections in the YAML. It also changes a spec that was testing for text node equality: as Capybara’s output for the page lacks HTML tags the content of the YAML file wasn’t matching.