### PR TITLE
bau: return 404.html for all non matching routes

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,6 +1,9 @@
 class ErrorsController < ApplicationController
   skip_before_action :validate_session
   def page_not_found
-    render '404', status: 404
+    respond_to do |format|
+      format.html { render '404', status: 404 }
+      format.all { redirect_to '/404' }
+    end
   end
 end


### PR DESCRIPTION
Not all non matching routes were returning our 404.html. A request like
/doesnotexist.html would, but not /doesnotexist.{png,jpeg} - which would return
a 500 internal server error page. This commit enables ErrorsController to deal
with requests with weird/unknown/not-applicable mime types and returns our
normal 404.html.

Unfortunately doing format.all { render '404', status: 404 } in the
ErrorsController didn't work - it would still return the 500 internal server
error page - hence the redirection to '/404'.

@oswaldquek