### PR TITLE
BAU: point cookies message at Verify

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,6 +10,13 @@
   <% end %>
 <% end %>
 
+<% content_for :cookie_message do %>
+  <p>
+    <%= t 'cookie_message.message' %>
+    <%= link_to t('cookie_message.link'), cookies_path %>
+  </p>
+<% end %>
+
 <% content_for :content do %>
   <main id="content">
     <div class="grid-row">

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -45,6 +45,9 @@ cy:
   option:
     "no": "Na"
     unknown: Ddim yn gwybod
+  cookie_message:
+    message: GOV.UK Verify uses cookies to make the site simpler.
+    link: Find out more about cookies
   translation_in_progress_banner:
     message: Mae GOV.UK Verify wrthi’n cael ei gyfieithu i’r Gymraeg. Rydym yn cyfieithu tudalennau bob wythnos rhwng nawr a diwedd mis Ebrill. Mae eich %{feedback_link} yn ein helpu i wella’r cyfieithiad.
     feedback: adborth

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -45,6 +45,9 @@ en:
   option:
     "no": "No"
     unknown: I don’t know
+  cookie_message:
+    message: GOV.UK Verify uses cookies to make the site simpler.
+    link: Find out more about cookies
   feedback_link:
     message: Use the %{href} to ask a question, report a problem or suggest an improvement
     feedback_form: feedback form


### PR DESCRIPTION
The current cookies banner points at GOV.UK’s cookies page, but should point at Verify’s. This also enables Welsh translation.