### PR TITLE
bau: return head 404 instead of redirection

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -3,7 +3,7 @@ class ErrorsController < ApplicationController
   def page_not_found
     respond_to do |format|
       format.html { render '404', status: 404 }
-      format.all { redirect_to '/404' }
+      format.all { head 404 }
     end
   end
 end


### PR DESCRIPTION
It is possible that some assets on the page might request invalid resources as
well. In this case it's better to return a head 404 rather than redirect.

@oswaldquek