### PR TITLE
5024: Generate static assets separately

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -22,7 +22,7 @@ Rails.application.configure do
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
-  config.serve_static_files = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier
@@ -72,5 +72,6 @@ Rails.application.configure do
   #Cookie Configuration
   config.x.cookies.secure = true
 
-  config.assets.prefix = '/assets'
+  build_number_file = File.expand_path('../../.build-number', __dir__)
+  config.assets.prefix = "/assets/#{File.read(build_number_file).chomp}"
 end

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -4,7 +4,19 @@ bundle
 export HEADLESS=true
 export DISPLAY=:0
 ./pre-commit.sh
+echo ${BUILD_NUMBER} > .build-number
 RAILS_ENV=production dotenv bundle exec rake assets:precompile
 RAILS_ENV=production dotenv bundle exec rake tmp:clear
 
-bundle exec pkgr package . --version="${BUILD_NUMBER}" --iteration=1 --name=front
+# We need to copy the manifest file to the root of the public/assets dir due
+# to heroku-buildback hardcoding where the manifest file should be
+cp public/assets/${BUILD_NUMBER}/.*.json public/assets/
+
+bundle exec pkgr package . --version="${BUILD_NUMBER}" --iteration=1 --name=front --dependencies=front-assets-${BUILD_NUMBER}
+fpm --name front-assets-${BUILD_NUMBER}\
+    --version 1\
+    -C public/assets\
+    --prefix /opt/front-assets\
+    -s dir\
+    -t deb\
+    ${BUILD_NUMBER}/


### PR DESCRIPTION
Separated assets from front package so we can install assets before
installing app package, to prevent 404s of assets during deployment.

Front package depends on front-assets, in order to guarantee being
installed.

Authors: @joerayme @tunylund @phss