### PR TITLE
BAU: cope with broken JS in some situations

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,7 +41,7 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.4.0)
     archive-tar-minitar (0.5.2)
-    arel (7.1.1)
+    arel (7.1.2)
     arr-pm (0.0.10)
       cabin (> 0)
     ast (2.2.0)
@@ -110,7 +110,7 @@ GEM
     govuk_frontend_toolkit (4.16.1)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_template (0.18.1)
+    govuk_template (0.18.2)
       rails (>= 3.1)
     hashdiff (0.3.0)
     hashie (3.4.4)
@@ -156,7 +156,7 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
     mini_portile2 (2.1.0)
-    minitest (5.9.0)
+    minitest (5.9.1)
     mixlib-log (1.7.1)
     mixlib-shellout (1.6.1)
     multi_json (1.11.2)
@@ -284,7 +284,7 @@ GEM
     sprockets (3.7.0)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
-    sprockets-rails (3.1.1)
+    sprockets-rails (3.2.0)
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
@@ -380,4 +380,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.12.5
+   1.13.0


### PR DESCRIPTION
[govuk_template 0.18.2](https://github.com/alphagov/govuk_template/releases/tag/v0.18.2) adds the ability for the styling to recover in the event that external JS has failed to load. These scenarios are rare but potentially problematic.