### PR TITLE
BAU: Fix stub API paths (fixes #231)

### DIFF
--- a/stub/api/Gemfile.lock
+++ b/stub/api/Gemfile.lock
@@ -52,4 +52,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.13.1
+   1.13.2

--- a/stub/api/stub_api.rb
+++ b/stub/api/stub_api.rb
@@ -16,7 +16,7 @@ class StubApi < Sinatra::Base
     }'
   end
 
-  get '/api/session/federation' do
+  get '/api/session/:session_id/federation' do
     '{
       "idps":[{
         "simpleId":"stub-idp-one",
@@ -25,13 +25,13 @@ class StubApi < Sinatra::Base
     }'
   end
 
-  put '/api/session/select-idp' do
+  put '/api/session/:session_id/select-idp' do
     '{
       "encryptedEntityId":"not-blank"
     }'
   end
 
-  get '/api/session/idp-authn-request' do
+  get '/api/session/:session_id/idp-authn-request' do
     '{
       "location":"http://localhost:50300/test-saml",
       "samlRequest":"blah",
@@ -40,7 +40,7 @@ class StubApi < Sinatra::Base
     }'
   end
 
-  put '/api/session/idp-authn-response' do
+  put '/api/session/:session_id/idp-authn-response' do
     '{
       "idpResult":"blah",
       "isRegistration":false

--- a/stub/api/stub_api_spec.rb
+++ b/stub/api/stub_api_spec.rb
@@ -36,36 +36,36 @@ describe StubApi do
     end
   end
 
-  context '#get /api/session/federation' do
+  context '#get /api/session/:session_id/federation' do
     it 'should respond with valid FederationInfoResponse' do
-      get '/api/session/federation'
+      get '/api/session/session_id/federation'
       expect(last_response).to be_ok
       response = FederationInfoResponse.new(last_response_json)
       expect(response).to be_valid
     end
   end
 
-  context '#put /api/session/select-idp' do
+  context '#put /api/session/:session_id/select-idp' do
     it 'should respond with valid SelectIdpResponse' do
-      put '/api/session/select-idp'
+      put '/api/session/session_id/select-idp'
       expect(last_response).to be_ok
       response = SelectIdpResponse.new(last_response_json)
       expect(response).to be_valid
     end
   end
 
-  context '#get /api/session/idp-authn-request' do
+  context '#get /api/session/:session_id/idp-authn-request' do
     it 'should respond with valid OutboundSamlMessage' do
-      get '/api/session/idp-authn-request'
+      get '/api/session/session_id/idp-authn-request'
       expect(last_response).to be_ok
       response = OutboundSamlMessage.new(last_response_json)
       expect(response).to be_valid
     end
   end
 
-  context '#put /api/session/idp-authn-response' do
+  context '#put /api/session/:session_id/idp-authn-response' do
     it 'should respond with valid hash' do
-      put '/api/session/idp-authn-response'
+      put '/api/session/session_id/idp-authn-response'
       expect(last_response).to be_ok
       response = IdpAuthnResponse.new(last_response_json)
       expect(response).to be_valid


### PR DESCRIPTION
The session API endpoints pass session_id in as part of the URL now. (See [session_endpoints.rb](https://github.com/alphagov/verify-frontend/blob/d7543b566c614fc2f36643aec0f9ad88fc01fd2f/app/models/session_endpoints.rb)).
Updates the stub API to serve requests from these URLs now.

Authors: @richardtowers