### PR TITLE
Bau: Improve windows support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -84,7 +84,7 @@ gem 'request_store', '~> 1.3.1'
 gem 'zendesk_api'
 gem 'email_validator'
 
-platforms :x64_mingw_23 do
+platforms :mswin, :mingw, :x64_mingw do
   gem 'windows-pr'
   gem 'win32-process'
   gem 'tzinfo-data'

--- a/Gemfile
+++ b/Gemfile
@@ -83,3 +83,9 @@ gem 'logstash-logger'
 gem 'request_store', '~> 1.3.1'
 gem 'zendesk_api'
 gem 'email_validator'
+
+platforms :x64_mingw_23 do
+  gem 'windows-pr'
+  gem 'win32-process'
+  gem 'tzinfo-data'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -371,13 +371,16 @@ DEPENDENCIES
   statsd-ruby (~> 1.3.0)
   therubyracer
   thin
+  tzinfo-data
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
   webmock
+  win32-process
+  windows-pr
   zendesk_api
 
 RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.13.0
+   1.13.2

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -8,4 +8,4 @@ stdout_redirect 'log/puma.stdout', 'log/puma.stderr', true
 
 bind 'unix://tmp/puma.sock'
 
-workers 2
+workers 2 unless Gem.win_platform?


### PR DESCRIPTION
Puma doesn't support multiple workers on windows. Gem config file needed
3 extra dependencies for windows.

Puma also doesn't support being run in daemon mode, which means that
./startup.sh doesn't work. It's possible to work around this by manually
running puma without the daemonize flag.

Authors: @niyi @richardtowers