### PR TITLE
bau: Add bundle install to startup.sh

### DIFF
--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -2,7 +2,7 @@
 
 . scripts/deploy.sh
 
-bundle
+bundle check || bundle install
 bundle exec govuk-lint-ruby app config lib spec
 success=$?
 

--- a/startup.sh
+++ b/startup.sh
@@ -5,7 +5,9 @@ if [ "$1" == '--stub-api' ]
 then
   echo "Starting stub-api server on port 50199"
   export API_HOST=http://localhost:50199
+  BUNDLE_GEMFILE=stub/api/Gemfile bundle install
   BUNDLE_GEMFILE=stub/api/Gemfile bundle exec rackup  --daemonize --port 50199 --pid tmp/stub_api.pid stub/api/stub_api_conf.ru
 fi
 
+bundle install
 bundle exec puma -e development -d -p 50300

--- a/startup.sh
+++ b/startup.sh
@@ -5,9 +5,12 @@ if [ "$1" == '--stub-api' ]
 then
   echo "Starting stub-api server on port 50199"
   export API_HOST=http://localhost:50199
-  BUNDLE_GEMFILE=stub/api/Gemfile bundle install
-  BUNDLE_GEMFILE=stub/api/Gemfile bundle exec rackup  --daemonize --port 50199 --pid tmp/stub_api.pid stub/api/stub_api_conf.ru
+  (
+  export BUNDLE_GEMFILE=stub/api/Gemfile
+  bundle check || bundle install
+  bundle exec rackup  --daemonize --port 50199 --pid tmp/stub_api.pid stub/api/stub_api_conf.ru
+  )
 fi
 
-bundle install
+bundle check || bundle install
 bundle exec puma -e development -d -p 50300


### PR DESCRIPTION
This adds a few 100ms to the time taken to run the script, but it
ensures that you don't get the horrible "you need to run bundle install"
error.

Authors: @richardtowers