### PR TITLE
5175: Add new hints for driving licences

### DIFF
--- a/app/models/hints_mapper.rb
+++ b/app/models/hints_mapper.rb
@@ -4,17 +4,22 @@ class HintsMapper
     'smart_phone' => 'apps',
     'landline' => 'landline',
     'passport' => 'ukpassport',
-    'driving_licence' => 'ukphotolicence',
+    'driving_licence' => 'ukphotolicence_gb',
+    'ni_driving_licence' => 'ukphotolicence_ni',
     'non_uk_id_document' => 'nonukid'
   }.freeze
 
   def self.map_answers_to_hints(answers_hash)
     result = Set.new
     answers = answers_hash.values.reduce(:merge)
+    no_licences = Set.new %w(not_ukphotolicence_gb not_ukphotolicence_ni)
     unless answers.nil?
       answers.each do |key, value|
         hint = create_hint(key, value)
         result << hint unless hint.nil?
+      end
+      if(no_licences.subset?(result))
+        result << 'not_ukphotolicence'
       end
     end
     result

--- a/spec/models/hints_mapper_spec.rb
+++ b/spec/models/hints_mapper_spec.rb
@@ -5,12 +5,22 @@ describe HintsMapper do
   it 'should produce a list of hints from answers hash' do
     answers_hash = {
       phone: { 'mobile_phone' => true, 'smart_phone' => false, 'landline' => true },
-      documents: { 'passport' => true, 'driving_licence' => true, 'non_uk_id_document' => false }
+      documents: { 'passport' => true, 'driving_licence' => true, 'ni_driving_licence' => true, 'non_uk_id_document' => false }
     }
 
     hints = HintsMapper.map_answers_to_hints(answers_hash)
 
-    expect(hints).to eql(%w(has_ukpassport has_ukphotolicence not_nonukid not_apps has_mobile has_landline).to_set)
+    expect(hints).to eql(%w(has_ukpassport has_ukphotolicence_gb has_ukphotolicence_ni not_nonukid not_apps has_mobile has_landline).to_set)
+  end
+
+  it 'should produce a list of hints for no licences from answers hash' do
+    answers_hash = {
+        documents: { 'driving_licence' => false, 'ni_driving_licence' => false }
+    }
+
+    hints = HintsMapper.map_answers_to_hints(answers_hash)
+
+    expect(hints).to eql(%w(not_ukphotolicence_gb not_ukphotolicence_ni not_ukphotolicence).to_set)
   end
 
   it 'should ignore unknown evidences' do


### PR DESCRIPTION
Introducing {has/not}_ukphotolicense_{gb/ni} to distinguish between gb and ni
licences.
Note that not_ukphotolicense is sent when user has selected NO to both gb and ni
licences but has_ukphotolicense is not sent when user has selected YES to both
gb and ni licences.

These changes will eventually be reverted when DCS can verify ni licences as
well.

@oswaldquek @sfkamath