### PR TITLE
5065: Use Heroku Ruby buildpack

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -12,7 +12,7 @@ RAILS_ENV=production dotenv bundle exec rake tmp:clear
 # to heroku-buildback hardcoding where the manifest file should be
 cp public/assets/${BUILD_NUMBER}/.*.json public/assets/
 
-bundle exec pkgr package . --version="${BUILD_NUMBER}" --iteration=1 --name=front --dependencies=front-assets-${BUILD_NUMBER}
+bundle exec pkgr package . --buildpack=https://github.com/heroku/heroku-buildpack-ruby --version="${BUILD_NUMBER}" --iteration=1 --name=front --dependencies=front-assets-${BUILD_NUMBER} --env STACK=cedar-14
 fpm --name front-assets-${BUILD_NUMBER}\
     --version 1\
     -C public/assets\

--- a/packaging/postinst.sh
+++ b/packaging/postinst.sh
@@ -13,3 +13,6 @@ chown -R deployer:deployer /opt/front/log
 chown -R deployer:deployer /var/log/front
 chown -R deployer:deployer /opt/front/tmp
 chgrp deployer /etc/front
+
+# deployer needs to access to all those files under bundle which are owned by root
+find /opt/front/vendor/bundle \( -type d -exec chmod go+rx {} \; \) , \( -type f -exec chmod go+r {} \;  \)


### PR DESCRIPTION
Make pkgr use the current Heroku Ruby buildpack
Update postinst.sh to allow deployer to access files under
/opt/front/vendor/bundle as these files are owned by root

Authors: @adityapahuja @maurorappa @mmhmm