### PR TITLE
5175: Send not_ukphotolicense as well...

### DIFF
--- a/app/models/hints_mapper.rb
+++ b/app/models/hints_mapper.rb
@@ -12,7 +12,7 @@ class HintsMapper
   def self.map_answers_to_hints(answers_hash)
     result = Set.new
     answers = answers_hash.values.reduce(:merge)
-    no_licences = Set.new %w(not_ukphotolicence_gb not_ukphotolicence_ni)
+    no_licences = Set.new %w(not_ukphotolicence_gb)
     unless answers.nil?
       answers.each do |key, value|
         hint = create_hint(key, value)

--- a/spec/models/hints_mapper_spec.rb
+++ b/spec/models/hints_mapper_spec.rb
@@ -23,6 +23,16 @@ describe HintsMapper do
     expect(hints).to eql(%w(not_ukphotolicence_gb not_ukphotolicence_ni not_ukphotolicence).to_set)
   end
 
+  it 'should produce not_ukphotolicense_gb and not_ukphotolicense hints when answers indicate NO GB licence' do
+    answers_hash = {
+        documents: { 'driving_licence' => false }
+    }
+
+    hints = HintsMapper.map_answers_to_hints(answers_hash)
+
+    expect(hints).to eql(%w(not_ukphotolicence_gb not_ukphotolicence).to_set)
+  end
+
   it 'should ignore unknown evidences' do
     answers_hash = { phone: { dummy_evidence: true } }
 


### PR DESCRIPTION
...when user has selected NO to GB licence. This is to ensure backwards
compatability as not_ukphotolicense is currently being sent in this case.

solo: @oswaldquek