### PR TITLE
bau: add csp checksums

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -39,7 +39,16 @@ module VerifyFrontend
       'X-Frame-Options' => 'DENY',
       'X-XSS-Protection' => '1; mode=block',
       'X-Content-Type-Options' => 'nosniff',
-      'Content-Security-Policy' => "default-src 'self'; font-src data:; img-src 'self'; object-src 'none'; script-src 'self' 'unsafe-eval' 'unsafe-inline'; style-src 'self' 'unsafe-inline'"
+      'Content-Security-Policy' => "default-src 'self'; " +
+                                    "font-src data:; " +
+                                    "img-src 'self'; " +
+                                    "object-src 'none'; " +
+                                    # the script digests are for the two inline scripts in govuk_template.gem:govuk_template.html.erb
+                                    # if the scripts in that file change, or more are added, use a command similar to
+                                    # this to generate the digests:
+                                    # `echo "'sha256-"$(echo -n "inline javascript text" | openssl dgst -sha256 -binary | openssl enc -base64)"'"`
+                                    "script-src 'self' 'unsafe-eval' 'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=' 'sha256-G29/qSW/JHHANtFhlrZVDZW1HOkCDRc78ggbqwwIJ2g=' 'unsafe-inline'; " +
+                                    "style-src 'self' 'unsafe-inline'"
     }
     RouteTranslator.config do |config|
       config.hide_locale = true


### PR DESCRIPTION
Also add script to generate checksums of inline JS, and add them to the
policy.

Tested with reporting in latest Firefox, Chrome & Safari

Pair: WillPa / DavidK