### PR TITLE
bau: route test analytics and test csp reporter via frontend

### DIFF
--- a/.env
+++ b/.env
@@ -15,7 +15,7 @@ IDP_CONFIG=stub/identity_providers.yml
 CYCLE_THREE_ATTRIBUTES_DIRECTORY=stub/attributes
 AB_TEST_FILE=stub/ab_test.yml
 
-PUBLIC_PIWIK_HOST=https://localhost:1235/piwik.php
+PUBLIC_PIWIK_HOST=http://localhost:50300/analytics
 INTERNAL_PIWIK_HOST=https://localhost:1235/piwik.php
 PIWIK_SITE_ID=1
 

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@
 
 .DS_Store
 /spec/pacts
+
+*~
+\#*#

--- a/app/controllers/test_analytics_controller.rb
+++ b/app/controllers/test_analytics_controller.rb
@@ -1,0 +1,19 @@
+require 'uri'
+
+class TestAnalyticsController < ApplicationController
+  skip_before_action :validate_session
+
+  def forward
+    if PUBLIC_PIWIK.enabled? && INTERNAL_PIWIK.enabled?
+      client = PoolingClient.new(INTERNAL_PIWIK.url, 'User-Agent' => request.user_agent)
+      uri = INTERNAL_PIWIK.url
+      uri.query = request.query_parameters.to_param
+      begin
+        client.get(uri)
+      rescue HTTP::ConnectionError => e
+        logger.error("Error connecting to analytics #{INTERNAL_PIWIK.url}: #{e}")
+      end
+    end
+    head :ok
+  end
+end

--- a/app/controllers/test_csp_reporter_controller.rb
+++ b/app/controllers/test_csp_reporter_controller.rb
@@ -1,0 +1,11 @@
+class TestCspReporterController < ApplicationController
+  skip_before_action :validate_session
+  skip_before_filter :verify_authenticity_token
+  skip_after_action :store_locale_in_cookie
+
+  def report
+    # dump request to logs and do nothing else
+    logger.info(request.body.read)
+    head :ok
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -40,15 +40,15 @@ module VerifyFrontend
       'X-XSS-Protection' => '1; mode=block',
       'X-Content-Type-Options' => 'nosniff',
       'Content-Security-Policy' => "default-src 'self'; " +
-                                    "font-src data:; " +
-                                    "img-src 'self'; " +
-                                    "object-src 'none'; " +
-                                    # the script digests are for the two inline scripts in govuk_template.gem:govuk_template.html.erb
-                                    # if the scripts in that file change, or more are added, use a command similar to
-                                    # this to generate the digests:
-                                    # `echo "'sha256-"$(echo -n "inline javascript text" | openssl dgst -sha256 -binary | openssl enc -base64)"'"`
-                                    "script-src 'self' 'unsafe-eval' 'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=' 'sha256-G29/qSW/JHHANtFhlrZVDZW1HOkCDRc78ggbqwwIJ2g=' 'unsafe-inline'; " +
-                                    "style-src 'self' 'unsafe-inline'"
+        "font-src data:; " +
+        "img-src 'self'; " +
+        "object-src 'none'; " +
+        # the script digests are for the two inline scripts in govuk_template.gem:govuk_template.html.erb
+        # if the scripts in that file change, or more are added, use a command similar to
+        # this to generate the digests:
+        # `echo "'sha256-"$(echo -n "inline javascript text" | openssl dgst -sha256 -binary | openssl enc -base64)"'"`
+        "script-src 'self' 'unsafe-eval' 'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=' 'sha256-G29/qSW/JHHANtFhlrZVDZW1HOkCDRc78ggbqwwIJ2g=' 'unsafe-inline'; " +
+        "style-src 'self' 'unsafe-inline'"
     }
     RouteTranslator.config do |config|
       config.hide_locale = true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,14 @@ Rails.application.routes.draw do
     post 'another-idp-endpoint' => 'test_saml#idp_request'
     get 'test-journey-hint' => 'test_journey_hint_cookie#index', as: :test_journey_hint
     post 'test-journey-hint' => 'test_journey_hint_cookie#set_cookie', as: :test_journey_hint_submit
+    # route analytics through frontend URI, as like prod, to not violate our csp policy
+    get 'analytics', to: 'test_analytics#forward'
+    # fake basic csp reporter so reports can be logged (in development.log)
+    # has to be routed through the frontend as currently Firefox requires the reporter
+    # to be hosted in the same place as the place serving the pages
+    # see: https://developer.mozilla.org/en-US/docs/Web/Security/CSP/CSP_policy_directives#report-uri
+    # to use, add ';report-uri http://127.0.0.1:50300/csp-reporter' to the end of the CSP header in application.rb
+    post 'csp-reporter', to: 'test_csp_reporter#report'
   end
 
   localized do


### PR DESCRIPTION
CSP errors were happening locally because Piwik requests were not
being routed via the frontend. Therefore, rewrite requests through to
local Piwik when running locally.

This also adds a test CSP reporter that can be turned on to view what
browsers are sending.  It's not enabled by default; see how to enable
it in routes.rb.  Interesting to note that we have to do this because
Firefox requires the CSP reporter to be on the same host/port as the
site.  Safari and Chrome are ok with it being a different host/port.

Also fixes the linting issues that I should have fixed before the last
PR :(

Pair: WillPa