### PR TITLE
3262 feedback link with mapper

### DIFF
--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -4,11 +4,13 @@ class FeedbackController < ApplicationController
   def index
     @form = FeedbackForm.new({})
     flash['feedback_referer'] = request.referer
+    flash['feedback_source'] = params['feedback-source']
   end
 
   def submit
     @form = FeedbackForm.new(feedback_form_params)
     flash.keep('feedback_referer')
+    flash.keep('feedback_source')
     if @form.valid?
       session_id = session[:verify_session_id]
       if FEEDBACK_SERVICE.submit!(session_id, @form)

--- a/app/controllers/feedback_sent_controller.rb
+++ b/app/controllers/feedback_sent_controller.rb
@@ -3,6 +3,8 @@ class FeedbackSentController < ApplicationController
 
   def index
     flash.keep('email_provided')
+    flash.keep('feedback_source')
+    @link_back_to_verify = FeedbackSourceMapper.page_from_source(flash['feedback_source'], I18n.locale)
     @email_provided = flash['email_provided']
     @session_valid = session_validator.validate(cookies, session).ok?
     render

--- a/app/models/feedback_source_mapper.rb
+++ b/app/models/feedback_source_mapper.rb
@@ -1,0 +1,45 @@
+module FeedbackSourceMapper
+  PAGE_TO_SOURCE_MAPPINGS = {
+      'ABOUT_CERTIFIED_COMPANIES_PAGE' => 'about_certified_companies',
+      'ABOUT_CHOOSING_A_COMPANY_PAGE' => 'about_choosing_a_company',
+      'ABOUT_IDENTITY_ACCOUNTS_PAGE' => 'about_identity_accounts',
+      'ABOUT_PAGE' => 'about',
+      'CHOOSE_A_CERTIFIED_COMPANY_PAGE' => 'choose_a_certified_company',
+      'CERTIFIED_COMPANY_UNAVAILABLE_PAGE' => 'choose_a_certified_company',
+      'CONFIRM_YOUR_IDENTITY' => 'confirm_your_identity',
+      'CONFIRMATION_PAGE' => 'confirmation',
+      'FAILED_REGISTRATION_PAGE' => 'failed_registration',
+      'FAILED_SIGN_IN_PAGE' => 'failed_sign_in',
+      'CYCLE_3_PAGE' => 'further_information',
+      'OTHER_WAYS_PAGE' => 'other_ways_to_access_service',
+      'REDIRECT_TO_IDP_WARNING_PAGE' => 'redirect_to_idp_warning',
+      'MATCHING_ERROR_PAGE' => 'response_processing',
+      'SELECT_DOCUMENTS_PAGE' => 'select_documents',
+      'UNLIKELY_TO_VERIFY_PAGE' => 'unlikely_to_verify',
+      'SELECT_PHONE_PAGE' => 'select_phone',
+      'NO_MOBILE_PHONE' => 'no_mobile_phone',
+      'SIGN_IN_PAGE' => 'sign_in',
+      'START_PAGE' => 'start',
+      'COOKIES_INFO_PAGE' => 'cookies',
+      'FORGOT_COMPANY_PAGE' => 'forgot_company',
+      'PRIVACY_NOTICE_PAGE' => 'privacy_notice',
+      'WHY_COMPANIES_PAGE' => 'why_companies',
+      'WILL_IT_WORK_FOR_ME_PAGE' => 'will_it_work_for_me',
+      'MAY_NOT_WORK_IF_YOU_LIVE_OVERSEAS_PAGE' => 'may_not_work_if_you_live_overseas',
+      'WHY_THIS_MIGHT_NOT_WORK_FOR_ME_PAGE' => 'why_might_this_not_work_for_me',
+      'WILL_NOT_WORK_WITHOUT_UK_ADDRESS_PAGE' => 'will_not_work_without_uk_address'
+  }.freeze
+
+  def self.page_from_source(feedback_source, locale)
+    route_name = route_name_from(feedback_source)
+    '/' + I18n.translate('routes.' + route_name, locale: locale)
+  end
+
+  private_class_method def self.route_name_from(feedback_source)
+    if feedback_source && feedback_source.starts_with?('CHOOSE_A_CERTIFIED_COMPANY_ABOUT_')
+      'choose_a_certified_company'
+    else
+      PAGE_TO_SOURCE_MAPPINGS.fetch(feedback_source, 'start')
+    end
+  end
+end

--- a/app/views/feedback_sent/index.html.erb
+++ b/app/views/feedback_sent/index.html.erb
@@ -12,11 +12,8 @@
     <% if @session_valid %>
         <%= link_to t('hub.feedback_sent.session_valid_link'), @link_back_to_verify %>
     <% else %>
-        <%= t(
-            'hub.feedback_sent.session_not_valid',
-            link: link_to(t('hub.feedback_sent.session_not_valid_link'), 'https://www.gov.uk')
-          ).html_safe
-        %>
+        <%= t('hub.feedback_sent.session_not_valid') %>
+        <%= render partial: 'errors/transaction_list' %>
     <% end %>
   </p>
 </div>

--- a/app/views/feedback_sent/index.html.erb
+++ b/app/views/feedback_sent/index.html.erb
@@ -10,7 +10,7 @@
 
   <p>
     <% if @session_valid %>
-        <%= link_to t('hub.feedback_sent.session_valid_link'), start_path %>
+        <%= link_to t('hub.feedback_sent.session_valid_link'), @link_back_to_verify %>
     <% else %>
         <%= t(
             'hub.feedback_sent.session_not_valid',

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -340,7 +340,7 @@ cy:
       heading: Diolch am eich adborth
       message_email: Rydym wedi derbyn eich neges a byddwn yn ymateb cyn gynted â phosibl.
       session_valid_link: Dychwelyd i GOV.UK Verify
-      session_not_valid: Mae eich sesiwn wedi’i amseru allan. I sicrhau eich diogelwch, mae’n rhaid i chi %{link}.
+      session_not_valid: Mae eich sesiwn wedi’i amseru allan.
       session_not_valid_link: ddechrau eto
     certified_company_unavailable:
       title: Nid yw'r cwmni ardystiedig hwn ar gael

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -334,7 +334,7 @@ en:
       heading: Thank you for your feedback
       message_email: We've received your message, and we'll reply as soon as possible.
       session_valid_link: Return to GOV.UK Verify
-      session_not_valid: Your session has timed out. To ensure your security, you must %{link}.
+      session_not_valid: Your session has timed out.
       session_not_valid_link: start again
     certified_company_unavailable:
       title: This certified company is unavailable

--- a/spec/features/user_submits_feedback_page_spec.rb
+++ b/spec/features/user_submits_feedback_page_spec.rb
@@ -56,6 +56,52 @@ RSpec.feature 'When the user submits the feedback page' do
   context 'user session valid' do
     it 'should show user link back to start page' do
       set_session_and_session_cookies!
+      visit start_path
+      click_link I18n.t('feedback_link.feedback_form')
+
+      fill_in 'feedback_form_what', with: 'Using verify'
+      fill_in 'feedback_form_details', with: 'Some details'
+      choose 'feedback_form_reply_false'
+
+      click_button I18n.t('hub.feedback.send_message')
+      expect(page).to have_current_path(feedback_sent_path, only_path: true)
+      expect(page).to_not have_content(session_not_valid_link)
+      expect(page).to have_link I18n.t('hub.feedback_sent.session_valid_link'), href: start_path
+    end
+
+    it 'should show user link back to page the user came from' do
+      set_session_and_session_cookies!
+      visit select_documents_path
+      click_link I18n.t('feedback_link.feedback_form')
+
+      fill_in 'feedback_form_what', with: 'Using verify'
+      fill_in 'feedback_form_details', with: 'Some details'
+      choose 'feedback_form_reply_false'
+
+      click_button I18n.t('hub.feedback.send_message')
+      expect(page).to have_current_path(feedback_sent_path, only_path: true)
+      expect(page).to_not have_content(session_not_valid_link)
+      expect(page).to have_link I18n.t('hub.feedback_sent.session_valid_link'), href: select_documents_path
+    end
+
+    it 'should show user link back to start page if the user came from an error page' do
+      set_session_and_session_cookies!
+      visit about_path
+      visit '/404'
+      click_link I18n.t('feedback_link.feedback_form')
+
+      fill_in 'feedback_form_what', with: 'Using verify'
+      fill_in 'feedback_form_details', with: 'Some details'
+      choose 'feedback_form_reply_false'
+
+      click_button I18n.t('hub.feedback.send_message')
+      expect(page).to have_current_path(feedback_sent_path, only_path: true)
+      expect(page).to_not have_content(session_not_valid_link)
+      expect(page).to have_link I18n.t('hub.feedback_sent.session_valid_link'), href: start_path
+    end
+
+    it 'should show user link back to start page if the user directly visits the feedback page' do
+      set_session_and_session_cookies!
       visit feedback_path
 
       fill_in 'feedback_form_what', with: 'Using verify'
@@ -65,13 +111,14 @@ RSpec.feature 'When the user submits the feedback page' do
       click_button I18n.t('hub.feedback.send_message')
       expect(page).to have_current_path(feedback_sent_path, only_path: true)
       expect(page).to_not have_content(session_not_valid_link)
-      expect(page).to have_link I18n.t('hub.feedback_sent.session_valid_link')
+      expect(page).to have_link I18n.t('hub.feedback_sent.session_valid_link'), href: start_path
     end
 
-    it 'should show feedback sent in Welsh' do
+    it 'should show feedback sent in Welsh and have the appropriate link back to Verify' do
       set_session_and_session_cookies!
+      visit select_documents_cy_path
+      click_link I18n.t('feedback_link.feedback_form', locale: :cy)
 
-      visit feedback_cy_path
       fill_in 'feedback_form_what', with: 'Using verify'
       fill_in 'feedback_form_details', with: 'Some details'
       choose 'feedback_form_reply_false'
@@ -79,6 +126,7 @@ RSpec.feature 'When the user submits the feedback page' do
 
       expect(page).to have_title I18n.t('hub.feedback_sent.title', locale: :cy)
       expect(page).to have_css 'html[lang=cy]'
+      expect(page).to have_link I18n.t('hub.feedback_sent.session_valid_link', locale: :cy), href: select_documents_cy_path
     end
   end
 end

--- a/spec/features/user_submits_feedback_page_spec.rb
+++ b/spec/features/user_submits_feedback_page_spec.rb
@@ -1,10 +1,15 @@
 require 'feature_helper'
+require 'api_test_helper'
 
 RSpec.feature 'When the user submits the feedback page' do
   let(:session_not_valid_link) {
     I18n.t('hub.feedback_sent.session_not_valid', link: I18n.t('hub.feedback_sent.session_not_valid_link'))
   }
   context 'user session invalid' do
+    before(:each) do
+      stub_transactions_list
+    end
+
     it 'when user provides email should say message has been received and show invalid session link' do
       visit feedback_path
 
@@ -19,7 +24,7 @@ RSpec.feature 'When the user submits the feedback page' do
       expect(page).to have_current_path(feedback_sent_path, only_path: true)
       expect(page).to have_content(I18n.t('hub.feedback_sent.message_email'))
       expect(page).to have_content(session_not_valid_link)
-      expect(page).to have_link I18n.t('hub.feedback_sent.session_not_valid_link')
+      expect(page).to have_content I18n.t('errors.transaction_list.title')
     end
 
     it 'when user does not provide email should not say message has been sent and show invalid session link' do
@@ -33,7 +38,7 @@ RSpec.feature 'When the user submits the feedback page' do
       expect(page).to have_current_path(feedback_sent_path, only_path: true)
       expect(page).to_not have_content(I18n.t('hub.feedback_sent.message_email'))
       expect(page).to have_content(session_not_valid_link)
-      expect(page).to have_link I18n.t('hub.feedback_sent.session_not_valid_link')
+      expect(page).to have_content I18n.t('errors.transaction_list.title')
     end
 
     it 'when session has timed out should show invalid session link' do
@@ -49,7 +54,7 @@ RSpec.feature 'When the user submits the feedback page' do
 
       click_button I18n.t('hub.feedback.send_message')
       expect(page).to have_content(session_not_valid_link)
-      expect(page).to have_link I18n.t('hub.feedback_sent.session_not_valid_link')
+      expect(page).to have_content I18n.t('errors.transaction_list.title')
     end
   end
 

--- a/spec/models/feedback_source_mapper_spec.rb
+++ b/spec/models/feedback_source_mapper_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+require 'rails_helper'
+
+describe FeedbackSourceMapper do
+  it 'should map feedback source to corresponding english path' do
+    expect(FeedbackSourceMapper.page_from_source('CONFIRM_YOUR_IDENTITY', :en)).to eql(confirm_your_identity_path)
+    expect(FeedbackSourceMapper.page_from_source('ABOUT_IDENTITY_ACCOUNTS_PAGE', :en)).to eql(about_identity_accounts_path)
+  end
+
+  it 'should map company about feedback source to choose company page' do
+    expect(FeedbackSourceMapper.page_from_source('CHOOSE_A_CERTIFIED_COMPANY_ABOUT_SOME_IDP_PAGE', :en)).to eql(choose_a_certified_company_path)
+  end
+
+  it 'should map feedback source to corresponding welsh path' do
+    expect(FeedbackSourceMapper.page_from_source('CONFIRM_YOUR_IDENTITY', :cy)).to eql('/cadarnhau-eich-hunaniaeth')
+  end
+
+  it 'should map error feedback source to start page' do
+    expect(FeedbackSourceMapper.page_from_source('ERROR_PAGE', :en)).to eql(start_path)
+  end
+
+  it 'should map unknown feedback source to start page' do
+    expect(FeedbackSourceMapper.page_from_source('BLAH', :en)).to eql(start_path)
+  end
+
+  it 'should map missing feedback source to start page' do
+    expect(FeedbackSourceMapper.page_from_source(nil, :en)).to eql(start_path)
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -42,4 +42,5 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+  config.include Rails.application.routes.url_helpers
 end


### PR DESCRIPTION
Using a map to link feedback sources to corresponding paths after feedback has been submitted.

Authors: @DataMinerUK @phss