### PR TITLE
5404: Only report to piwik on select documents page

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -71,16 +71,16 @@ class ApplicationController < ActionController::Base
   end
 
   def alternative_name
-    ab_test_cookie = Cookies.parse_json(cookies[CookieNames::AB_TEST])['select_documents']
-    if AB_TESTS['select_documents']
-      AB_TESTS['select_documents'].alternative_name(ab_test_cookie)
+    ab_test_cookie = Cookies.parse_json(cookies[CookieNames::AB_TEST])['select_documents_v2']
+    if AB_TESTS['select_documents_v2']
+      AB_TESTS['select_documents_v2'].alternative_name(ab_test_cookie)
     else
       'default'
     end
   end
 
   def is_in_b_group?
-    alternative_name == 'select_documents_new_questions_profile_change'
+    alternative_name == 'select_documents_v2_new_questions_profile_change'
   end
 
 private

--- a/app/controllers/select_documents_controller.rb
+++ b/app/controllers/select_documents_controller.rb
@@ -1,5 +1,7 @@
 class SelectDocumentsController < ApplicationController
   def index
+    reported_alternative = Cookies.parse_json(cookies[CookieNames::AB_TEST])['select_documents_v2']
+    AbTest.report('select_documents_v2', reported_alternative, request)
     @form = SelectDocumentsForm.new({}, form_attributes)
     @is_in_b_group = is_in_b_group?
   end

--- a/app/controllers/start_controller.rb
+++ b/app/controllers/start_controller.rb
@@ -13,9 +13,6 @@ class StartController < ApplicationController
         update_ab_test_cookie(experiment_selection_hash)
       end
     end
-
-    reported_alternative = Cookies.parse_json(cookies[CookieNames::AB_TEST])['select_documents']
-    AbTest.report('select_documents', reported_alternative, request)
   end
 
   def request_post

--- a/spec/features/user_visits_select_document_page_ab_test_spec.rb
+++ b/spec/features/user_visits_select_document_page_ab_test_spec.rb
@@ -2,7 +2,7 @@ require 'feature_helper'
 require 'api_test_helper'
 require 'cookie_names'
 
-RSpec.describe 'When the user visits the start page' do
+RSpec.describe 'When the user visits the select document page' do
   let(:simple_id) { 'stub-idp-one' }
   let(:idp_entity_id) { 'http://idcorp.com' }
 
@@ -13,15 +13,23 @@ RSpec.describe 'When the user visits the start page' do
     set_session_and_session_cookies!
   end
 
-  it 'reports custom variable to piwik for cohort a and does not show additional questions' do
-    set_cookies!(CookieNames::AB_TEST => CGI.escape({ 'select_documents' => 'select_documents_control' }.to_json))
+  it 'doesnt report custom variable on start page' do
+    set_cookies!(CookieNames::AB_TEST => CGI.escape({ 'select_documents_v2' => 'select_documents_v2_control' }.to_json))
     visit '/start'
     piwik_request = {
-        '_cvar' => '{"6":["AB_TEST","select_documents_control"]}'
+        '_cvar' => '{"6":["AB_TEST","select_documents_v2_control"]}'
     }
-    expect(a_request(:get, INTERNAL_PIWIK.url).with(query: hash_including(piwik_request))).to have_been_made.once
+    expect(a_request(:get, INTERNAL_PIWIK.url).with(query: hash_including(piwik_request))).to_not have_been_made
+  end
 
+  it 'reports custom variable to piwik for cohort a and does not show additional questions' do
+    set_cookies!(CookieNames::AB_TEST => CGI.escape({ 'select_documents_v2' => 'select_documents_v2_control' }.to_json))
     visit '/select-documents'
+    piwik_request = {
+        '_cvar' => '{"6":["AB_TEST","select_documents_v2_control"]}'
+    }
+
+    expect(a_request(:get, INTERNAL_PIWIK.url).with(query: hash_including(piwik_request))).to have_been_made.once
     expect(page).to_not have_content I18n.translate('hub.select_documents.question.uk_bank_account_details')
     expect(page).to_not have_content I18n.translate('hub.select_documents.question.debit_card')
     expect(page).to_not have_content I18n.translate('hub.select_documents.question.credit_card')
@@ -29,14 +37,13 @@ RSpec.describe 'When the user visits the start page' do
   end
 
   it 'reports custom variable to piwik for cohort b and does not show additional questions' do
-    set_cookies!(CookieNames::AB_TEST => CGI.escape({ 'select_documents' => 'select_documents_new_questions_profile_change' }.to_json))
-    visit '/start'
-    piwik_request = {
-        '_cvar' => '{"6":["AB_TEST","select_documents_new_questions_profile_change"]}'
-    }
-    expect(a_request(:get, INTERNAL_PIWIK.url).with(query: hash_including(piwik_request))).to have_been_made.once
-
+    set_cookies!(CookieNames::AB_TEST => CGI.escape({ 'select_documents_v2' => 'select_documents_v2_new_questions_profile_change' }.to_json))
     visit '/select-documents'
+    piwik_request = {
+        '_cvar' => '{"6":["AB_TEST","select_documents_v2_new_questions_profile_change"]}'
+    }
+
+    expect(a_request(:get, INTERNAL_PIWIK.url).with(query: hash_including(piwik_request))).to have_been_made.once
     expect(page).to have_content I18n.translate('hub.select_documents.question.uk_bank_account_details')
     expect(page).to have_content I18n.translate('hub.select_documents.question.debit_card')
     expect(page).to have_content I18n.translate('hub.select_documents.question.credit_card')

--- a/spec/features/user_visits_start_page_spec.rb
+++ b/spec/features/user_visits_start_page_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe 'When the user visits the start page' do
 
   it 'will not set ab_test cookie if already set' do
     set_session_and_session_cookies!
-    cookie_hash = create_cookie_hash.merge!(ab_test: CGI.escape({ 'about_companies' => 'about_companies_with_logo', 'idp_ordering' => 'idp_ordering_no', 'select_documents' => 'select_documents_control' }.to_json))
+    cookie_hash = create_cookie_hash.merge!(ab_test: CGI.escape({ 'about_companies' => 'about_companies_with_logo', 'idp_ordering' => 'idp_ordering_no', 'select_documents_v2' => 'select_documents_v2_control' }.to_json))
     set_cookies!(cookie_hash)
     page.set_rack_session(transaction_simple_id: 'test-rp')
     visit '/start'

--- a/stub/ab_test.yml
+++ b/stub/ab_test.yml
@@ -19,12 +19,12 @@
 #
 
 experiments:
-  - select_documents:
+  - select_documents_v2:
       alternatives:
         - name: 'control'
-          percent: 50
+          percent: 90
         - name: 'new_questions_profile_change'
-          percent: 50
+          percent: 10
   - about_companies:
       alternatives:
         - name: 'with_logo'


### PR DESCRIPTION
Since we were reporting to piwik on start page, the performance team was
getting unreliable results.

Author: @DataMinerUK @phss