### PR TITLE
5226: Raise an error on startup if missing a secret

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -63,5 +63,7 @@ module VerifyFrontend
     # If you go back on our pages it remembers the disabled state, thus breaking the system.
     # We can turn this functionality off globally.
     config.action_view.automatically_disable_submit_tag = false
+
+    raise "Missing secret_key_base. Please make sure config/secrets.yml is valid." if Rails.application.secrets.secret_key_base.nil?
   end
 end


### PR DESCRIPTION
There was a short downtime on verify frontend due to a missing
configuration that needs to be put in place by hand. The error could
have been noticed sooner if the application would have raised an error
on the missing configuration.

Solo: @tunylund