### PR TITLE
5482: AB test for IDP rankings

### DIFF
--- a/.env
+++ b/.env
@@ -13,6 +13,7 @@ RULES_DIRECTORY=stub/idp-rules
 RULES_DIRECTORY_B=stub/idp-rules-b
 RP_CONFIG=stub/relying_parties.yml
 IDP_CONFIG=stub/identity_providers.yml
+IDP_RANKINGS_CONFIG=stub/idp_rankings.yml
 CYCLE_THREE_ATTRIBUTES_DIRECTORY=stub/attributes
 AB_TEST_FILE=stub/ab_test.yml
 

--- a/app/models/display/identity_provider_display_decorator.rb
+++ b/app/models/display/identity_provider_display_decorator.rb
@@ -11,6 +11,10 @@ module Display
       idp_list.map { |idp| correlate_display_data(idp) }.select(&:viewable?).shuffle
     end
 
+    def decorate_collection_with_ranking(idp_list, ranking)
+      decorate_collection(idp_list).sort_by { |idp| ranking.rank_idp(idp.simple_id) }
+    end
+
     def decorate(idp)
       correlate_display_data(idp)
     end

--- a/app/models/display/idp_ranker.rb
+++ b/app/models/display/idp_ranker.rb
@@ -1,0 +1,32 @@
+
+module Display
+  class IdpRanker
+    def initialize(rankings)
+      @rankings = rankings.inject({}) do |acc, ranking|
+        profile = ranking['profile'].map(&:to_sym).to_set
+        acc[profile] = IdpRanking.new(ranking['rank'])
+        acc
+      end
+    end
+
+    def rank(evidence)
+      @rankings.fetch(evidence.to_set, IdpRanking.no_ordering)
+    end
+  end
+
+  class IdpRanking
+    attr_reader :idps
+
+    def initialize(idps)
+      @idps = idps
+    end
+
+    def self.no_ordering
+      IdpRanking.new([])
+    end
+
+    def rank_idp(idp)
+      @idps.find_index(idp) || @idps.size
+    end
+  end
+end

--- a/config/initializers/00_configuration.rb
+++ b/config/initializers/00_configuration.rb
@@ -4,6 +4,7 @@ CONFIG = Configuration.load! do
   option_string 'rp_display_locales', 'RP_DISPLAY_LOCALES'
   option_string 'cycle_3_display_locales', 'CYCLE_3_DISPLAY_LOCALES'
   option_string 'idp_display_locales', 'IDP_DISPLAY_LOCALES'
+  option_string 'idp_rankings_config', 'IDP_RANKINGS_CONFIG', allow_missing: true
   option_string 'session_cookie_duration', 'SESSION_COOKIE_DURATION_IN_HOURS', default: 2
   option_string 'api_host', 'API_HOST'
   option_string 'logo_directory', 'LOGO_DIRECTORY'

--- a/config/initializers/30_federation.rb
+++ b/config/initializers/30_federation.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 require 'yaml_loader'
 
 Rails.application.config.after_initialize do
@@ -11,6 +12,8 @@ Rails.application.config.after_initialize do
     CONFIG.logo_directory,
     CONFIG.white_logo_directory
   )
+  idp_rankings_config = CONFIG.idp_rankings_config && File.exist?(CONFIG.idp_rankings_config) ? YAML.load_file(CONFIG.idp_rankings_config) : {}
+  IDP_RANKER = Display::IdpRanker.new(idp_rankings_config.fetch('rankings', {}))
 
   # Cycle Three display
   CYCLE_THREE_DISPLAY_REPOSITORY = repository_factory.create_cycle_three_repository(CONFIG.cycle_3_display_locales)

--- a/spec/features/user_visits_choose_a_certified_company_page_spec.rb
+++ b/spec/features/user_visits_choose_a_certified_company_page_spec.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 require 'feature_helper'
 require 'api_test_helper'
 require 'i18n'
@@ -19,6 +20,20 @@ RSpec.describe 'When the user visits the choose a certified company page' do
       documents: { driving_licence: true },
       phone: { mobile_phone: true, landline: true }
     }
+  }
+
+  let(:abtest_answers) {
+    {
+      documents: { ni_driving_licence: true },
+      phone: { mobile_phone: true }
+    }
+  }
+
+  let(:given_a_session_with_abtest_answers) {
+    page.set_rack_session(
+      transaction_simple_id: 'test-rp',
+      selected_answers: abtest_answers,
+    )
   }
 
   let(:given_a_session_with_selected_answers) {
@@ -188,6 +203,51 @@ RSpec.describe 'When the user visits the choose a certified company page' do
       within('#non-matching-idps') do
         expect(page).to have_content('Choose Demo IDP', count: 1)
       end
+    end
+  end
+
+  context 'IDP Ranking AB testing' do
+    let(:given_an_abtest_with_control_group) {
+      set_cookies!(CookieNames::AB_TEST => CGI.escape({ 'idp_ranking' => 'idp_ranking_control' }.to_json))
+    }
+    let(:given_an_abtest_with_by_completion_group) {
+      set_cookies!(CookieNames::AB_TEST => CGI.escape({ 'idp_ranking' => 'idp_ranking_by_completion' }.to_json))
+    }
+
+    it 'will show IDPs in ranking order on by_completion path' do
+      given_a_session_with_abtest_answers
+      given_an_abtest_with_by_completion_group
+
+      visit choose_a_certified_company_path
+
+      within('#matching-idps') do
+        ranked_idps = all(:css, '.idp-option/button').map(&:value)
+        expect(ranked_idps).to eq(["Bob’s Identity Service", "Carol’s Secure ID", "IDCorp"])
+      end
+    end
+
+    xit 'will report control group to piwik' do
+      given_a_session_with_abtest_answers
+      given_an_abtest_with_control_group
+
+      visit choose_a_certified_company_path
+
+      piwik_request = {
+        '_cvar' => '{"6":["AB_TEST","idp_ranking_control"]}'
+      }
+      expect(a_request(:get, INTERNAL_PIWIK.url).with(query: hash_including(piwik_request))).to have_been_made.once
+    end
+
+    xit 'will report by completion group to piwik' do
+      given_a_session_with_abtest_answers
+      given_an_abtest_with_by_completion_group
+
+      visit choose_a_certified_company_path
+
+      piwik_request = {
+        '_cvar' => '{"6":["AB_TEST","idp_ranking_by_completion"]}'
+      }
+      expect(a_request(:get, INTERNAL_PIWIK.url).with(query: hash_including(piwik_request))).to have_been_made.once
     end
   end
 end

--- a/spec/features/user_visits_start_page_spec.rb
+++ b/spec/features/user_visits_start_page_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe 'When the user visits the start page' do
 
   it 'will not set ab_test cookie if already set' do
     set_session_and_session_cookies!
-    cookie_hash = create_cookie_hash.merge!(ab_test: CGI.escape({ 'about_companies' => 'about_companies_with_logo', 'idp_ordering' => 'idp_ordering_no', 'select_documents_v2' => 'select_documents_v2_control' }.to_json))
+    cookie_hash = create_cookie_hash.merge!(ab_test: CGI.escape({ 'about_companies' => 'about_companies_with_logo', 'idp_ordering' => 'idp_ordering_no', 'select_documents_v2' => 'select_documents_v2_control', 'idp_ranking' => 'idp_ranking_control' }.to_json))
     set_cookies!(cookie_hash)
     page.set_rack_session(transaction_simple_id: 'test-rp')
     visit '/start'

--- a/spec/models/display/identity_provider_display_decorator_spec.rb
+++ b/spec/models/display/identity_provider_display_decorator_spec.rb
@@ -79,7 +79,9 @@ module Display
 
         result = decorator.decorate_collection_with_ranking(idp_list, ranking)
 
-        expect(result.map(&:simple_id).first).to eql 'idp_three'
+        idps = result.map(&:simple_id)
+        expect(idps.first).to eql 'idp_three'
+        expect(idps[1..-1]).to include('idp_one', 'idp_two')
       end
 
       it 'returns a decorated IDP collection based on ranking with extra element' do

--- a/spec/models/display/identity_provider_display_decorator_spec.rb
+++ b/spec/models/display/identity_provider_display_decorator_spec.rb
@@ -1,4 +1,5 @@
 require 'active_support/core_ext/module/delegation'
+require 'models/display/idp_ranker'
 require 'models/display/identity_provider_display_decorator'
 require 'models/display/viewable_identity_provider'
 require 'models/display/not_viewable_identity_provider'
@@ -44,9 +45,54 @@ module Display
       expect(result).to eql []
     end
 
-    it "will return a non viewable if provided a nil value" do
+    it 'will return a non viewable if provided a nil value' do
       result = decorator.decorate(nil)
       expect(result).to be_a(NotViewableIdentityProvider)
+    end
+
+    describe 'decorated with ranking' do
+      let(:idp_list) { [idp(:idp_one), idp(:idp_two), idp(:idp_three)] }
+
+      before(:each) do
+        display_data = double(:display_data)
+        expect(repository).to receive(:fetch).at_least(:once).and_return display_data
+      end
+
+      it 'returns a decorated IDP collection based on ranking' do
+        ranking = Display::IdpRanking.new(%w(idp_two idp_three idp_one))
+
+        result = decorator.decorate_collection_with_ranking(idp_list, ranking)
+
+        expect(result.map(&:simple_id)).to eql %w(idp_two idp_three idp_one)
+      end
+
+      it 'returns a decorated IDP collection based on ranking with missing rank' do
+        ranking = Display::IdpRanking.new(%w(idp_two idp_one))
+
+        result = decorator.decorate_collection_with_ranking(idp_list, ranking)
+
+        expect(result.map(&:simple_id)).to eql %w(idp_two idp_one idp_three)
+      end
+
+      it 'returns a decorated IDP collection based on ranking only one rank' do
+        ranking = Display::IdpRanking.new(['idp_three'])
+
+        result = decorator.decorate_collection_with_ranking(idp_list, ranking)
+
+        expect(result.map(&:simple_id).first).to eql 'idp_three'
+      end
+
+      it 'returns a decorated IDP collection based on ranking with extra element' do
+        ranking = Display::IdpRanking.new(%w(idp_two idp_three idp_one idp_four))
+
+        result = decorator.decorate_collection_with_ranking(idp_list, ranking)
+
+        expect(result.map(&:simple_id)).to eql %w(idp_two idp_three idp_one)
+      end
+
+      def idp(id)
+        double(id, 'simple_id' => id.to_s, 'entity_id' => id.to_s)
+      end
     end
   end
 end

--- a/spec/models/display/idp_ranker_spec.rb
+++ b/spec/models/display/idp_ranker_spec.rb
@@ -1,0 +1,47 @@
+require 'display/idp_ranker'
+
+module Display
+  describe IdpRanker do
+    let(:ranker) {
+      IdpRanker.new([
+        { 'profile' => %w(doc1 doc2), 'rank' => %w(idpA idpB idpC) },
+        { 'profile' => ['doc1'], 'rank' => %w(idpC idpA idpD) },
+        { 'profile' => %w(doc2 doc3), 'rank' => %w(idpX idpY) }])
+    }
+
+    it 'should rank idps based on evidence' do
+      ranking = ranker.rank([:doc2, :doc3])
+
+      expect(ranking.idps).to eq(%w(idpX idpY))
+    end
+
+    it 'should rank idps based on evidence regardless of order' do
+      ranking = ranker.rank([:doc3, :doc2])
+
+      expect(ranking.idps).to eq(%w(idpX idpY))
+    end
+
+    it 'should return nil if no ranking found' do
+      ranking = ranker.rank([:doc3, :doc1])
+
+      expect(ranking.idps).to eql []
+    end
+  end
+
+  describe IdpRanking do
+    it 'should rank idp based on ranking' do
+      ranking = IdpRanking.new([:idpA, :idpC, :idpB])
+
+      expect(ranking.rank_idp(:idpA)).to eql 0
+      expect(ranking.rank_idp(:idpB)).to eql 2
+      expect(ranking.rank_idp(:idpC)).to eql 1
+    end
+
+    it 'should rank idp last if it doesnt appar in rakings' do
+      ranking = IdpRanking.new([:idpA, :idpC, :idpB])
+
+      expect(ranking.rank_idp(:idpX)).to eql 3
+      expect(ranking.rank_idp(:idpY)).to eql 3
+    end
+  end
+end

--- a/stub/ab_test.yml
+++ b/stub/ab_test.yml
@@ -19,6 +19,12 @@
 #
 
 experiments:
+  - idp_ranking:
+      alternatives:
+        - name: 'control'
+          percent: 90
+        - name: 'by_completion'
+          percent: 10
   - select_documents_v2:
       alternatives:
         - name: 'control'

--- a/stub/idp-rules/stub-idp-demo.yml
+++ b/stub/idp-rules/stub-idp-demo.yml
@@ -4,4 +4,5 @@ demo_profiles:
   - [ "driving_licence", "mobile_phone" ]
 non_recommended_profiles:
   - [ "driving_licence", "mobile_phone", "landline" ]
+  - [ "ni_driving_licence", "mobile_phone" ]
 send_hints: false

--- a/stub/idp-rules/stub-idp-three.yml
+++ b/stub/idp-rules/stub-idp-three.yml
@@ -1,4 +1,5 @@
 simpleIds: [ "stub-idp-three" ]
 recommended_profiles:
   - [ "passport", "driving_licence", "mobile_phone" ]
+  - [ "ni_driving_licence", "mobile_phone" ]
 non_recommended_profiles: []

--- a/stub/idp-rules/stub-idp-two.yml
+++ b/stub/idp-rules/stub-idp-two.yml
@@ -1,5 +1,6 @@
 simpleIds: [ "stub-idp-two" ]
-recommended_profiles: []
+recommended_profiles:
+  - [ "ni_driving_licence", "mobile_phone" ]
 non_recommended_profiles:
   - [ "driving_licence", "mobile_phone" ]
 send_hints: false

--- a/stub/idp_rankings.yml
+++ b/stub/idp_rankings.yml
@@ -1,0 +1,3 @@
+rankings:
+  - profile: [ "ni_driving_licence", "mobile_phone" ]
+    rank: ["stub-idp-two", "stub-idp-three", "stub-idp-one"]


### PR DESCRIPTION
Adds a ranking step to the Choose a Certified Company page. The ranking
is defined in verify-frontend-federation-config.

NOTE: we are still waiting for Olly's ranking data. Therefore we are
not sending requests to piwik!

We have test data in place to test it only in the Joint
environment.

Authors: @srinivasmurty @phss