### PR TITLE
5090: Add proxy config option for zendesk

### DIFF
--- a/config/initializers/00_configuration.rb
+++ b/config/initializers/00_configuration.rb
@@ -26,6 +26,7 @@ CONFIG = Configuration.load! do
   option_string 'zendesk_url', 'ZENDESK_URL'
   option_string 'zendesk_username', 'ZENDESK_USERNAME'
   option_string 'zendesk_token', 'ZENDESK_TOKEN'
+  option_string 'zendesk_proxy', 'ZENDESK_PROXY', allow_missing: true
   option_string 'rp_config', 'RP_CONFIG'
   option_string 'idp_config', 'IDP_CONFIG'
   option_string 'cycle_three_attributes_directory', 'CYCLE_THREE_ATTRIBUTES_DIRECTORY'

--- a/config/initializers/feedback.rb
+++ b/config/initializers/feedback.rb
@@ -9,6 +9,9 @@ else
     config.url = CONFIG.zendesk_url
     config.username = CONFIG.zendesk_username
     config.token = CONFIG.zendesk_token
+    if CONFIG.zendesk_proxy
+      config.client_options[:proxy] = { uri: CONFIG.zendesk_proxy }
+    end
   end
   ZENDESK_CLIENT = ZendeskClient.new(client, Rails.logger)
 end


### PR DESCRIPTION
We want to be able to make external calls via a proxy.
This change allows us to set a proxy for zendesk connections.
The value is optional so no existing configuration will continue to work.

Solo: lloydnye