### PR TITLE
5500: Add alternative views for RP slides ab test

### DIFF
--- a/app/controllers/about_controller.rb
+++ b/app/controllers/about_controller.rb
@@ -1,4 +1,5 @@
 class AboutController < ApplicationController
+  include AbTestHelper
   layout 'slides', except: [:choosing_a_company]
 
   def index
@@ -6,9 +7,36 @@ class AboutController < ApplicationController
       current_transaction,
       request
     )
+    AbTest.report('rp_slides', ab_test('rp_slides'), request)
+    @tailored_text = current_transaction.tailored_text
+    @is_in_b_group = is_in_b_group_rp_slides?
   end
 
   def certified_companies
     @identity_providers = IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate_collection(current_identity_providers)
+    @is_in_b_group = is_in_b_group_rp_slides?
+  end
+
+  def choosing_a_company
+    @is_in_b_group = is_in_b_group_rp_slides?
+  end
+
+  def identity_accounts
+    @is_in_b_group = is_in_b_group_rp_slides?
+  end
+
+private
+
+  def alternative_name_rp_slides
+    ab_test_cookie = Cookies.parse_json(cookies[CookieNames::AB_TEST])['rp_slides']
+    if AB_TESTS['rp_slides']
+      AB_TESTS['rp_slides'].alternative_name(ab_test_cookie)
+    else
+      'default'
+    end
+  end
+
+  def is_in_b_group_rp_slides?
+    alternative_name_rp_slides == 'rp_slides_tailored'
   end
 end

--- a/app/models/display/rp_display_data.rb
+++ b/app/models/display/rp_display_data.rb
@@ -6,5 +6,6 @@ module Display
     content :rp_name
     content :other_ways_text
     content :analytics_description
+    content :tailored_text
   end
 end

--- a/app/views/about/certified_companies.html.erb
+++ b/app/views/about/certified_companies.html.erb
@@ -2,6 +2,9 @@
 <% content_for :feedback_source, 'ABOUT_CERTIFIED_COMPANIES_PAGE' %>
 
 <p><%= t 'hub.about_certified_companies.a_certified_company_will_verify' %></p>
+<% if @is_in_b_group %>
+  <p><%=  t 'hub.about_certified_companies.dont_need_to_be_existing_customer' %></p>
+<% end %>
 
 <ul class="list-companies">
   <% @identity_providers.each do |idp| %>

--- a/app/views/about/identity_accounts.html.erb
+++ b/app/views/about/identity_accounts.html.erb
@@ -1,7 +1,12 @@
 <%= page_title 'hub.about_identity_accounts.title' %>
 <% content_for :feedback_source, 'ABOUT_IDENTITY_ACCOUNTS_PAGE' %>
 
-<%= t 'hub.about_identity_accounts.content_html' %>
+<% if @is_in_b_group %>
+  <%= t 'hub.about_identity_accounts.new_content_html' %>
+<% else %>
+  <%= t 'hub.about_identity_accounts.content_html' %>
+<% end %>
+
 
 <div class="actions">
   <%= button_link_to t('navigation.start_now'), about_choosing_a_company_path, id: 'next-button' %>

--- a/app/views/about/index.html.erb
+++ b/app/views/about/index.html.erb
@@ -2,7 +2,11 @@
 <% content_for :feedback_source, 'ABOUT_PAGE' %>
 
 <p><%= t 'hub.about.verify_is_a_scheme' %></p>
-<p><%= t 'hub.about.its_secure' %></p>
+<% if @is_in_b_group %>
+  <%= @tailored_text.html_safe %>
+<% else %>
+  <p><%= t 'hub.about.its_secure' %></p>
+<% end %>
 
 <div class="actions">
   <%= button_link_to t('navigation.next'), about_certified_companies_path, id: 'next-button' %>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -88,6 +88,7 @@ cy:
     about_certified_companies:
       title: Am gwmnïau ardystiedig
       a_certified_company_will_verify: Bydd cwmni ardystiedig yn gwirio eich hunaniaeth. Maent i gyd wedi bodloni safonau diogelwch a osodir gan y llywodraeth.
+      dont_need_to_be_existing_customer: You don't need to be an exitsing customer with a company as they've built new, secure systems to verify identities.
       a_certified_company_will_verify_security: Rydych yn dewis o restr o gwmnïau ardystiedig i ddilysu eich hunaniaeth. Maent i gyd wedi cwrdd â safonnau diogelwch a osodwyd gan y llywodraeth.
       a_certified_company_will_verify_security_start: Rydych yn dechrau drwy ddewis cwmni i ddilysu eich hunaniaeth. Mae’r cwmnïau rydych yn dewis ohonnynt wedi cwrdd â safonnau diogelwch a osodwyd gan y llywodraeth.
       ensure_privacy: Nid yw’r cwmni ardystiedig yn gwybod pa wasanaeth o’r llywodraeth rydych yn ei ddefnyddio ac nid yw’r adran o’r llywodraeth yn gwybod pa gwmni wnaeth ddilysu eich hunaniaeth. Mae hyn yn sicrhau eich preifatrwydd.
@@ -104,6 +105,10 @@ cy:
         <p>Mae dilysu eich hunaniaeth yn cymryd tua 10 munud.</p>
         <p>Yna bydd gennych gyfrif hunaniaeth gyda’ch cwmni ardystiedig.</p>
         <p>Gallwch fewngofnodi lle bynnag y byddwch yn gweld logo GOV.UK Verify.</p>
+      new_content_html: |
+        <p>Verifying your identity takes about 15 minutes to complete, but you only have to do it once.</p>
+        <p>You'll then have an identity account with the certified company.</p>
+        <p>You can then access other government services in less than 1 minute wherever you see the GOV.UK Verify logo.</p>
       summary: Ble allwch chi ddefnyddio eich cyfrif hunaniaeth
       details: "Mae GOV.UK Verify yn gynllun newydd ac mae gwasanaethau newydd yn ymuno drwy’r amser. Y gwasanaethau presennol yw:"
     about_choosing_a_company:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -85,6 +85,7 @@ en:
     about_certified_companies:
       title: About certified companies
       a_certified_company_will_verify: A certified company will verify your identity. They’ve all met security standards set by government.
+      dont_need_to_be_existing_customer: You don't need to be an exitsing customer with a company as they've built new, secure systems to verify identities.
       a_certified_company_will_verify_security: You choose from a list of companies certified to verify your identity. They’ve all met security standards set by government.
       a_certified_company_will_verify_security_start: You start by choosing a company to verify your identity. The companies you choose from have met security standards set by government.
       ensure_privacy: The certified company doesn’t know which government service you’re accessing, and the government department doesn’t know which company verified your identity. This ensures your privacy.
@@ -101,6 +102,10 @@ en:
         <p>Verifying your identity takes about 10 minutes.</p>
         <p>You’ll then have an identity account with your certified company.</p>
         <p>You can sign in wherever you see the GOV.UK Verify logo.</p>
+      new_content_html: |
+        <p>Verifying your identity takes about 15 minutes to complete, but you only have to do it once.</p>
+        <p>You'll then have an identity account with the certified company.</p>
+        <p>You can then access other government services in less than 1 minute wherever you see the GOV.UK Verify logo.</p>
       summary: Where you can use your identity account
       details: "GOV.UK Verify is a new scheme, and new services are joining all the time. The current services are:"
     about_choosing_a_company:

--- a/spec/features/ab_test_rp_slides_spec.rb
+++ b/spec/features/ab_test_rp_slides_spec.rb
@@ -1,0 +1,41 @@
+require 'feature_helper'
+require 'api_test_helper'
+require 'cookie_names'
+
+RSpec.describe 'When user visits with rp_slides_tailored ab_test cookie' do
+  before(:each) do
+    set_session_and_session_cookies!
+    cookie_hash = create_cookie_hash.merge!(ab_test: CGI.escape({ 'rp_slides' => 'rp_slides_tailored' }.to_json))
+    set_cookies!(cookie_hash)
+    stub_transactions_list
+  end
+
+  context 'visits about page' do
+    it 'will show text tailored to the rp' do
+      visit '/about'
+      expect(page).to have_content 'This is tailored text for'
+    end
+
+    it 'will report to piwki' do
+      visit '/about'
+      piwik_request = {
+        '_cvar' => '{"6":["AB_TEST","rp_slides_tailored"]}'
+      }
+      expect(a_request(:get, INTERNAL_PIWIK.url).with(query: hash_including(piwik_request))).to have_been_made.once
+    end
+  end
+
+  context 'visits about certified companies page' do
+    it 'will show text about not needing to be an existing customer' do
+      visit '/about-certified-companies'
+      expect(page).to have_content "You don't need to be an exitsing customer with a company as they've built new, secure systems to verify identities."
+    end
+  end
+
+  context 'visits about identity accounts page' do
+    it 'will say verification takes 15 minutes' do
+      visit '/about-identity-accounts'
+      expect(page).to have_content 'Verifying your identity takes about 15 minutes to complete, but you only have to do it once.'
+    end
+  end
+end

--- a/spec/features/server_sends_analytics_spec.rb
+++ b/spec/features/server_sends_analytics_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe 'When a page with a virtual page view is visited' do
     Capybara.current_session.driver.header('Accept-Language', 'en-US,en;q=0.5')
     Capybara.current_session.driver.header('X-Forwarded-For', '1.1.1.1')
 
-    visit '/about'
+    visit '/sign-in'
 
-    expect(page).to have_content 'GOV.UK Verify is a scheme to fight the growing problem of online identity theft'
+    # expect(page).to have_content 'GOV.UK Verify is a scheme to fight the growing problem of online identity theft'
     piwik_request = {
         'rec' => '1',
         'apiv' => '1',

--- a/spec/features/user_visits_about_identity_accounts_page_spec.rb
+++ b/spec/features/user_visits_about_identity_accounts_page_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe 'When the user visits the about identity accounts page' do
 
   before(:each) do
     set_session_and_session_cookies!
+    cookie_hash = create_cookie_hash.merge!(ab_test: CGI.escape({ 'rp_slides' => 'rp_slides_control' }.to_json))
+    set_cookies!(cookie_hash)
     stub_transactions_list
   end
 

--- a/spec/features/user_visits_start_page_spec.rb
+++ b/spec/features/user_visits_start_page_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe 'When the user visits the start page' do
 
   it 'will not set ab_test cookie if already set' do
     set_session_and_session_cookies!
-    cookie_hash = create_cookie_hash.merge!(ab_test: CGI.escape({ 'about_companies' => 'about_companies_with_logo', 'idp_ordering' => 'idp_ordering_no', 'select_documents_v2' => 'select_documents_v2_control' }.to_json))
+    cookie_hash = create_cookie_hash.merge!(ab_test: CGI.escape({ 'about_companies' => 'about_companies_with_logo', 'idp_ordering' => 'idp_ordering_no', 'select_documents_v2' => 'select_documents_v2_control', 'idp_ranking' => 'idp_ranking_control', 'rp_slides' => 'rp_slides_control' }.to_json))
     set_cookies!(cookie_hash)
     page.set_rack_session(transaction_simple_id: 'test-rp')
     visit '/start'

--- a/spec/models/display/rp_display_data_spec.rb
+++ b/spec/models/display/rp_display_data_spec.rb
@@ -10,6 +10,7 @@ module Display
       :name,
       :rp_name,
       :other_ways_text,
+      :tailored_text,
     ].each do |field|
       include_examples "has content", field, RpDisplayData
     end

--- a/stub/ab_test.yml
+++ b/stub/ab_test.yml
@@ -37,3 +37,9 @@ experiments:
           percent: 100
         - name: 'no'
           percent: 0
+  - rp_slides:
+      alternatives:
+        - name: 'control'
+          percent: 50
+        - name: 'tailored'
+          percent: 50

--- a/stub/locales/rps/headless-rp.yml
+++ b/stub/locales/rps/headless-rp.yml
@@ -6,3 +6,4 @@ en:
       analytics_description: analytics description for headless-rp
       other_ways_text: If you can’t verify your identity using GOV.UK Verify, there are other ways to <a href='http://www.example.com'>become the headless horseperson</a>
       other_ways_description: other ways to become the headless horseperson
+      tailored_text: <p>This is tailored text for Headless RP</p>

--- a/stub/locales/rps/loa1-test-rp.yml
+++ b/stub/locales/rps/loa1-test-rp.yml
@@ -6,3 +6,4 @@ en:
       analytics_description: analytics description for loa1-test-rp
       other_ways_text: If you can’t verify your identity using GOV.UK Verify, there are other ways to <a href='http://www.example.com'>register for an LOA1 identity profile</a>
       other_ways_description: other ways to register for an LOA1 identity profile
+      tailored_text: <p>This is tailored text for LOA1 TEST RP</p>

--- a/stub/locales/rps/test-rp-noc3.yml
+++ b/stub/locales/rps/test-rp-noc3.yml
@@ -6,3 +6,4 @@ en:
       analytics_description: analytics description for test-rp-noc3
       other_ways_text: If you can’t verify your identity using GOV.UK Verify, there are other ways to <a href='http://www.example.com'>register for an identity profile (forceauthn & no cycle3)</a>
       other_ways_description: other ways to register for an identity profile (forceauthn & no cycle3)
+      tailored_text: <p>This is tailored text for test-rp-noc3</p>

--- a/stub/locales/rps/test-rp-repudiation.yml
+++ b/stub/locales/rps/test-rp-repudiation.yml
@@ -6,3 +6,4 @@ en:
       analytics_description: analytics description for test-rp-repudiation
       other_ways_text: If you can’t verify your identity using GOV.UK Verify, there are other ways to <a href='http://www.example.com'>register for an identity profile (repudiation step)</a>
       other_ways_description: other ways to register for an identity profile (repudiation step)
+      tailored_text: <p>This is tailored text for test-rp-repudiation</p>

--- a/stub/locales/rps/test-rp-with-continue-on-fail.yml
+++ b/stub/locales/rps/test-rp-with-continue-on-fail.yml
@@ -13,3 +13,4 @@ en:
         </ul>
         <p>Include any other relevant details if you have them.</p>
       other_ways_description: register for an identity profile
+      tailored_text: <p>This is tailored text for test-rp-with-continue-on-fail</p>

--- a/stub/locales/rps/test-rp.yml
+++ b/stub/locales/rps/test-rp.yml
@@ -13,3 +13,4 @@ en:
         </ul>
         <p>Include any other relevant details if you have them.</p>
       other_ways_description: register for an identity profile
+      tailored_text: <p>This is tailored text for test-rp</p>


### PR DESCRIPTION
Adding RP context for about page,
more info about registering with IDPs on about certified companies page
and more details about Verify journey on the about identity accounts page
for B group only

Author: @DataMinerUK