### PR TITLE
BAU: Specify Firefox binary for Selenium

### DIFF
--- a/spec/feature_helper.rb
+++ b/spec/feature_helper.rb
@@ -28,6 +28,12 @@ Capybara.configure do |config|
   config.server = :puma
 end
 
+Capybara.register_driver :selenium do |app|
+  require 'selenium/webdriver'
+  Selenium::WebDriver::Firefox::Binary.path = ENV['FIREFOX_PATH'] || Selenium::WebDriver::Firefox::Binary.path
+  Capybara::Selenium::Driver.new(app, browser: :firefox)
+end
+
 module FeatureHelper
   def current_time_in_millis
     DateTime.now.to_i * 1000


### PR DESCRIPTION
- Setting the FIREFOX_PATH env var to point to a specific `firefox-bin`
  will force Selenium to use that in its web driver tests.
- This allows you to have the current Firefox installed in Applications
  and kept up to date alongside an older version (probably 47.0.1)
  somewhere else.

Author: @vixus0