### PR TITLE
bau: Fix kill-service.sh to kill the stub api properly

### DIFF
--- a/kill-service.sh
+++ b/kill-service.sh
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
-if [ -a 'tmp/stub-api.pid' ]
+if [ -a './tmp/stub_api.pid' ]
 then
-  kill "$(cat tmp/stub-api.pid)"
+  xargs kill < ./tmp/stub_api.pid
+  rm ./tmp/stub_api.pid
 fi
 
-if [ -a 'tmp/puma.pid' ]
+if [ -a './tmp/puma.pid' ]
 then
-  kill "$(cat tmp/puma.pid)"
+  xargs kill < ./tmp/puma.pid
+  rm ./tmp/puma.pid
 fi
+

--- a/kill-service.sh
+++ b/kill-service.sh
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
+
 if [ -a './tmp/stub_api.pid' ]
 then
-  xargs kill < ./tmp/stub_api.pid
+  kill "$(< ./tmp/stub_api.pid)"
   rm ./tmp/stub_api.pid
 fi
 
 if [ -a './tmp/puma.pid' ]
 then
-  xargs kill < ./tmp/puma.pid
+  kill "$(< ./tmp/puma.pid)"
   rm ./tmp/puma.pid
 fi
 


### PR DESCRIPTION
pid file is stub_api.pid, not stub-api.pid.

Also removes a useless use of cat (replacing it with a probably useless
use of xargs, but hey-ho).

Authors: @richardtowers