### PR TITLE
bau: add COOKIE_NOT_FOUND_PAGE page source

### DIFF
--- a/app/models/feedback_source_mapper.rb
+++ b/app/models/feedback_source_mapper.rb
@@ -9,6 +9,7 @@ class FeedbackSourceMapper
       'CERTIFIED_COMPANY_UNAVAILABLE_PAGE' => 'choose_a_certified_company',
       'CONFIRM_YOUR_IDENTITY' => 'confirm_your_identity',
       'CONFIRMATION_PAGE' => 'confirmation',
+      'COOKIE_NOT_FOUND_PAGE' => nil,
       'ERROR_PAGE' => 'start',
       'FAILED_REGISTRATION_PAGE' => 'failed_registration',
       'FAILED_SIGN_IN_PAGE' => 'failed_sign_in',
@@ -43,6 +44,8 @@ class FeedbackSourceMapper
     route_name = route_name_from(feedback_source)
     if route_name =~ /https?:.*/
       route_name
+    elsif route_name.nil?
+      return
     else
       '/' + I18n.translate('routes.' + route_name, locale: locale)
     end

--- a/spec/features/user_visits_feedback_page_spec.rb
+++ b/spec/features/user_visits_feedback_page_spec.rb
@@ -1,7 +1,29 @@
 require 'feature_helper'
+require 'api_test_helper'
 
 RSpec.feature 'When the user visits the feedback page' do
   let(:long_text_limit) { FeedbackForm::LONG_TEXT_LIMIT }
+
+  it 'should go to the session timed out when feedback source is COOKIE_NOT_FOUND_PAGE' do
+    stub_transactions_list
+    visit '/start'
+    expect(page).to have_content 'If you can’t access GOV.UK Verify from a service, enable your cookies.'
+    expect(page).to have_http_status :forbidden
+    expect(page).to have_link 'feedback', href: '/feedback?feedback-source=COOKIE_NOT_FOUND_PAGE'
+
+    click_link 'feedback form'
+
+    expect(page).to have_content('Send your feedback to GOV.UK Verify')
+
+    fill_in 'feedback_form_what', with: 'Verify my identity'
+    fill_in 'feedback_form_details', with: 'Some details'
+    choose 'feedback_form_reply_false', allow_label_click: true
+
+    click_button I18n.t('hub.feedback.send_message')
+
+    expect(page).to have_title(I18n.t('hub.feedback_sent.title'))
+    expect(page).to have_content('Your session has timed out.')
+  end
 
   it 'should link back to the product page when user came from the product page' do
     visit '/feedback?feedback-source=PRODUCT_PAGE'

--- a/spec/features/user_visits_start_page_spec.rb
+++ b/spec/features/user_visits_start_page_spec.rb
@@ -32,11 +32,11 @@ RSpec.describe 'When the user visits the start page' do
     it 'will display the no cookies error when all cookies are missing' do
       allow(Rails.logger).to receive(:info)
       expect(Rails.logger).to receive(:info).with("No session cookies can be found").at_least(:once)
-      visit "/start"
-      expect(page).to have_content "If you can’t access GOV.UK Verify from a service, enable your cookies."
+      visit '/start'
+      expect(page).to have_content 'If you can’t access GOV.UK Verify from a service, enable your cookies.'
       expect(page).to have_http_status :forbidden
       expect(page).to have_link 'feedback', href: '/feedback?feedback-source=COOKIE_NOT_FOUND_PAGE'
-      expect(page).to have_link "register for an identity profile", href: "http://localhost:50130/test-rp"
+      expect(page).to have_link 'register for an identity profile', href: 'http://localhost:50130/test-rp'
     end
 
     it 'will display the generic error when start time is missing from session' do


### PR DESCRIPTION
https://github.com/alphagov/verify-frontend/blob/7379b463065c0d9f52413daa012c3fbc2e1ea2f8/spec/features/user_visits_start_page_spec.rb#L38
shows that there is a COOKIE_NOT_FOUND_PAGE page source. This commit adds it to
the feedback_source_mapper.rb. It doesn't map to any url as no cookies means no
session, so the 'Your session has timed out' text should show after the
submission of feedback. This is reflected in the new test added in
user_visits_feedback_page_spec.rb.

@oswaldquek