### PR TITLE
TT-356 Update selected answer store for other identity documents

### DIFF
--- a/app/controllers/other_identity_documents_controller.rb
+++ b/app/controllers/other_identity_documents_controller.rb
@@ -7,7 +7,7 @@ class OtherIdentityDocumentsController < ApplicationController
     @form = OtherIdentityDocumentsForm.new(params['other_identity_documents_form'] || {})
     if @form.valid?
       report_to_analytics('Other Documents Next')
-      selected_answer_store.store_selected_answers('documents', @form.selected_answers)
+      selected_answer_store.update_selected_answers('documents', @form.selected_answers)
       redirect_to select_phone_path
     else
       flash.now[:errors] = @form.errors.full_messages.join(', ')

--- a/app/models/selected_answer_store.rb
+++ b/app/models/selected_answer_store.rb
@@ -7,6 +7,14 @@ class SelectedAnswerStore
     selected_answers[stage] = answers
   end
 
+  def update_selected_answers(stage, answers)
+    if selected_answers[stage].nil?
+      selected_answers[stage] = answers
+    else
+      selected_answers[stage].merge!(answers)
+    end
+  end
+
   def selected_answers
     @session[:selected_answers] ||= {}
   end

--- a/spec/models/selected_answer_store_spec.rb
+++ b/spec/models/selected_answer_store_spec.rb
@@ -39,4 +39,29 @@ RSpec.describe SelectedAnswerStore do
     store.store_selected_answers('phone', phone_answers)
     expect(store.selected_evidence).to eql [:passport, :mobile_phone]
   end
+
+  it 'should update selected answers at a given stage when there are already selected answers' do
+    session = {}
+    document_answers = {
+        passport: true,
+        driving_licence: false
+    }
+    other_document_answers = {
+        nonukid: true
+    }
+    store = SelectedAnswerStore.new(session)
+    store.store_selected_answers('documents', document_answers)
+    store.update_selected_answers('documents', other_document_answers)
+    expect(store.selected_evidence).to eql [:passport, :nonukid]
+  end
+
+  it 'should update selected answers at a given stage when there no selected answers' do
+    session = {}
+    other_document_answers = {
+        nonukid: true
+    }
+    store = SelectedAnswerStore.new(session)
+    store.update_selected_answers('documents', other_document_answers)
+    expect(store.selected_evidence).to eql [:nonukid]
+  end
 end


### PR DESCRIPTION
Author: @DataMinerUK

This fixes the issue with hints and ensures evidence is the same for all groups in the AB test