### PR TITLE
TT-386: Piwik analytics ordering for IDP sign-in/register and LOA achieved

### DIFF
--- a/app/controllers/authn_response_controller.rb
+++ b/app/controllers/authn_response_controller.rb
@@ -14,8 +14,7 @@ class AuthnResponseController < SamlController
 
     case response.idp_result
     when 'SUCCESS'
-      report_to_analytics("Success - #{user_state}")
-      FEDERATION_REPORTER.report_loa_achieved(request, response.loa_achieved)
+      report_to_analytics("Success - #{user_state} at LOA #{response.loa_achieved}")
       redirect_to response.is_registration ? confirmation_path : response_processing_path
     when 'CANCEL'
       report_to_analytics("Cancel - #{user_state}")

--- a/app/models/analytics/federation_reporter.rb
+++ b/app/models/analytics/federation_reporter.rb
@@ -42,12 +42,6 @@ module Analytics
       report_action(current_transaction, request, 'Matching Outcome - Cancelled Cycle3')
     end
 
-    def report_loa_achieved(request, loa_achieved)
-      @analytics_reporter.report_custom_variable(
-        request, "LOA Achieved - #{loa_achieved}", Analytics::CustomVariable.build(:loa_achieved, loa_achieved)
-      )
-    end
-
   private
 
     def report_action(current_transaction, request, action)

--- a/lib/analytics/custom_variable.rb
+++ b/lib/analytics/custom_variable.rb
@@ -1,7 +1,6 @@
 module Analytics
   module CustomVariable
     CUSTOM_VARIABLES = {
-      loa_achieved: { name: 'LOA_ACHIEVED', index: 3 },
       loa_requested: { name: 'LOA_REQUESTED', index: 2 },
       rp: { name: 'RP', index: 1 },
       idp_selection: { name: 'IDP_SELECTION', index: 5 },

--- a/spec/features/user_sends_authn_response_spec.rb
+++ b/spec/features/user_sends_authn_response_spec.rb
@@ -32,7 +32,6 @@ RSpec.describe 'User returns from an IDP with an AuthnResponse' do
     api_request = stub_api_authn_response(session_id, 'idpResult' => 'SUCCESS', 'isRegistration' => true, 'loaAchieved' => 'LEVEL_2')
     stub_session
     stub_request(:get, INTERNAL_PIWIK.url).with(query: hash_including({}))
-    piwik_cvar_request = stub_piwik_report_loa_achieved('LEVEL_2')
 
     visit("/test-saml?session-id=#{session_id}")
     click_button 'saml-response-post'
@@ -40,8 +39,7 @@ RSpec.describe 'User returns from an IDP with an AuthnResponse' do
     expect(page).to have_current_path '/confirmation'
     expect(api_request).to have_been_made.once
     expect(a_request(:get, INTERNAL_PIWIK.url)
-      .with(query: hash_including('action_name' => 'Success - REGISTER_WITH_IDP'))).to have_been_made.once
-    expect(piwik_cvar_request).to have_been_made.once
+      .with(query: hash_including('action_name' => 'Success - REGISTER_WITH_IDP at LOA LEVEL_2'))).to have_been_made.once
   end
 
   it 'will redirect the user to /failed-registration when they cancel at the IDP' do
@@ -89,13 +87,13 @@ RSpec.describe 'User returns from an IDP with an AuthnResponse' do
     stub_session
     stub_matching_outcome
     api_request = stub_api_authn_response(session_id, 'idpResult' => 'SUCCESS', 'isRegistration' => false, 'loaAchieved' => 'LEVEL_2')
-    piwik_cvar_request = stub_piwik_report_loa_achieved('LEVEL_2')
 
     visit("/test-saml?session-id=#{session_id}")
     click_button 'saml-response-post'
 
     expect(page).to have_current_path '/response-processing'
     expect(api_request).to have_been_made.once
-    expect(piwik_cvar_request).to have_been_made.once
+    expect(a_request(:get, INTERNAL_PIWIK.url)
+               .with(query: hash_including('action_name' => 'Success - SIGN_IN_WITH_IDP at LOA LEVEL_2'))).to have_been_made.once
   end
 end

--- a/spec/models/analytics/federation_reporter_spec.rb
+++ b/spec/models/analytics/federation_reporter_spec.rb
@@ -35,19 +35,6 @@ module Analytics
       end
     end
 
-    describe '#report_loa_achieved' do
-      it 'should report the LOA achieved at the IDP' do
-        loa_achieved = 'LEVEL_1'
-        expect(analytics_reporter).to receive(:report_custom_variable)
-        .with(
-          request,
-          "LOA Achieved - #{loa_achieved}",
-          3 => ['LOA_ACHIEVED', loa_achieved]
-        )
-        federation_reporter.report_loa_achieved(request, loa_achieved)
-      end
-    end
-
     describe '#report_idp_registration' do
       idp_name = 'IDCorp'
       idp_history = ['Previous IdP', 'IDCorp']


### PR DESCRIPTION
Verify front-end reported to piwik the events 'successfully registered/signed-in with an IDP' followed by the 'LOA level Achieved'. Due to the asynchronous nature of the reporting mechanism these events would sometimes be sent in the wrong order .

This has been resolved by combing those two separate events into one.

The 'LOA Level Achieved' custom variable has subsequently been removed.