### PR TITLE
BAU: Tidy up countries method calls

### DIFF
--- a/app/controllers/choose_a_country_controller.rb
+++ b/app/controllers/choose_a_country_controller.rb
@@ -3,11 +3,12 @@ class ChooseACountryController < ApplicationController
   before_action :ensure_session_eidas_supported
 
   def choose_a_country
-    setup_countries
+    setup_countries(session['verify_session_id'])
   end
 
   def choose_a_country_submit
-    session_id = setup_countries
+    session_id = session['verify_session_id']
+    setup_countries(session_id)
 
     country = params[:country]
     if country.empty?
@@ -16,18 +17,15 @@ class ChooseACountryController < ApplicationController
       return
     end
 
-    SESSION_PROXY.set_selected_country(session_id, country)
+    SESSION_PROXY.select_a_country(session_id, country)
 
     redirect_to '/redirect-to-country'
   end
 
 private
 
-  def setup_countries
-    session_id = session['verify_session_id']
-    response = SESSION_PROXY.get_countries(session_id)
-    countries_map = response.map { |country| Country.from_api(country) }
-    @countries = COUNTRY_DISPLAY_DECORATOR.decorate_collection(countries_map)
-    session_id
+  def setup_countries(session_id)
+    countries_map = SESSION_PROXY.get_countries(session_id)
+    @countries = COUNTRY_DISPLAY_DECORATOR.decorate_collection(countries_map.countries)
   end
 end

--- a/app/controllers/redirect_to_country_controller.rb
+++ b/app/controllers/redirect_to_country_controller.rb
@@ -1,4 +1,7 @@
 class RedirectToCountryController < ApplicationController
+  before_action :validate_session
+  before_action :ensure_session_eidas_supported
+
   def index
   end
 end

--- a/app/models/country_response.rb
+++ b/app/models/country_response.rb
@@ -1,0 +1,15 @@
+class CountryResponse < Api::Response
+  attr_reader :countries
+  validate :consistent_countries
+
+  def initialize(response)
+    @countries = response.map { |country| Country.from_api(country) }
+  end
+
+  def consistent_countries
+    return if @countries.empty?
+    if @countries.none?(&:valid?)
+      errors.add(:countries, 'are malformed')
+    end
+  end
+end

--- a/app/models/session_endpoints.rb
+++ b/app/models/session_endpoints.rb
@@ -24,6 +24,10 @@ module SessionEndpoints
     COUNTRIES_PATH_PREFIX.join(session_id).to_s
   end
 
+  def select_a_country_endpoint(session_id, suffix)
+    COUNTRIES_PATH_PREFIX.join(session_id, suffix).to_s
+  end
+
   def session_endpoint(session_id, suffix)
     PATH_PREFIX.join(session_id, suffix).to_s
   end

--- a/app/models/session_proxy.rb
+++ b/app/models/session_proxy.rb
@@ -31,13 +31,14 @@ class SessionProxy
   end
 
   def get_countries(session_id)
-    @api_client.get(countries_endpoint(session_id))
+    response = @api_client.get(countries_endpoint(session_id))
+    CountryResponse.validated_response(response)
   end
 
-  def set_selected_country(session_id, country)
+  def select_a_country(session_id, country)
     # Call into Policy to change state
     # POST /api/countries (NL)
-    @api_client.post("/countries/#{session_id}/#{country}", '', {}, 200)
+    @api_client.post(select_a_country_endpoint(session_id, country), '', {}, 200)
   end
 
   def select_idp(session_id, entity_id, registration = false)

--- a/spec/features/user_visits_redirect_to_country_spec.rb
+++ b/spec/features/user_visits_redirect_to_country_spec.rb
@@ -1,0 +1,28 @@
+require 'feature_helper'
+require 'api_test_helper'
+require 'i18n'
+
+RSpec.describe 'When the user visits the redirect to country page' do
+  before(:each) do
+    set_session_and_session_cookies!
+    stub_transactions_list
+  end
+
+  def no_eidas_session
+    'no-eidas-session'
+  end
+
+  def given_a_session_not_supporting_eidas
+    page.set_rack_session(
+      verify_session_id: no_eidas_session,
+      transaction_supports_eidas: false
+    )
+  end
+
+  it 'should show something went wrong when visiting redirect to country page directly with session not supporting eidas' do
+    given_a_session_not_supporting_eidas
+
+    visit '/redirect-to-country'
+    expect(page).to have_content 'Sorry, something went wrong'
+  end
+end

--- a/spec/models/session_proxy_spec.rb
+++ b/spec/models/session_proxy_spec.rb
@@ -101,17 +101,31 @@ describe SessionProxy do
       expect(api_client).to receive(:get).with('/countries/my-session-id').and_return(api_response)
 
       response = session_proxy.get_countries(session_id)
-      expect(response).to match_array countries_json
+      expect(response.countries.count).to eq(2)
+      response.countries.each do |country|
+        case country.simple_id
+        when 'ES'
+          expect(country).to have_attributes(simple_id: 'ES',
+                                             entity_id: 'http://spainEnitity.es',
+                                             enabled: true)
+        when 'NL'
+          expect(country).to have_attributes(simple_id: 'NL',
+                                             entity_id: 'http://netherlandsEnitity.nl',
+                                             enabled: false)
+        else
+          fail('Invalid list of countries')
+        end
+      end
     end
   end
 
   describe('#idp_authn_request') do
     it 'should get an IDP authn request' do
       authn_request = {
-          'location' => 'some-location',
-          'samlRequest' => 'a-saml-request',
-          'relayState' => 'relay-state',
-          'registration' => false
+        'location' => 'some-location',
+        'samlRequest' => 'a-saml-request',
+        'relayState' => 'relay-state',
+        'registration' => false
       }
       ip_address = '1.1.1.1'
       expect(api_client).to receive(:get)


### PR DESCRIPTION
- Updated setup_countries not to return session id to avoid causing confusion.
- Updated get_countries method to validate response and returns a list of country objects.
- Replaced hard coded URL with API endpoint in select_a_country method.
- Updated redirect to country page to stop non-eIDAS users from visiting this page.

Solo: @adityapahuja