### PR TITLE
TT-260: Fixing other documents page so it ignores stale answers from …

### DIFF
--- a/app/controllers/other_identity_documents_controller.rb
+++ b/app/controllers/other_identity_documents_controller.rb
@@ -7,7 +7,7 @@ class OtherIdentityDocumentsController < ApplicationController
     @form = OtherIdentityDocumentsForm.new(params['other_identity_documents_form'] || {})
     if @form.valid?
       report_to_analytics('Other Documents Next')
-      selected_answer_store.update_selected_answers('documents', @form.selected_answers)
+      selected_answer_store.store_selected_answers('documents', @form.selected_answers)
       redirect_to select_phone_path
     else
       flash.now[:errors] = @form.errors.full_messages.join(', ')

--- a/app/models/selected_answer_store.rb
+++ b/app/models/selected_answer_store.rb
@@ -7,14 +7,6 @@ class SelectedAnswerStore
     selected_answers[stage] = answers
   end
 
-  def update_selected_answers(stage, answers)
-    if selected_answers[stage].nil?
-      selected_answers[stage] = answers
-    else
-      selected_answers[stage].merge!(answers)
-    end
-  end
-
   def selected_answers
     @session[:selected_answers] ||= {}
   end

--- a/spec/features/user_visits_other_documents_page_test_spec.rb
+++ b/spec/features/user_visits_other_documents_page_test_spec.rb
@@ -2,35 +2,58 @@ require 'feature_helper'
 require 'api_test_helper'
 
 RSpec.feature 'When users visits other documents page' do
-  before(:each) do
-    set_session_and_session_cookies!
-    visit '/other-identity-documents'
+  context 'happy path' do
+    before(:each) do
+      set_session_and_session_cookies!
+      visit '/other-identity-documents'
+    end
+
+    it 'should show other documents content' do
+      expect(page).to have_content('Other identity documents')
+    end
+
+    it 'should show other documents content in Welsh' do
+      visit '/dogfennau-hunaniaeth-eraill'
+      expect(page).to have_content('Dogfennau hunaniaeth eraill')
+    end
+
+    it 'should go to select phone path and set selected answers when user has other identity documents' do
+      choose 'other_identity_documents_form_non_uk_id_document_true'
+      click_button 'Continue'
+      expect(page).to have_current_path(select_phone_path)
+      expect(page.get_rack_session['selected_answers']).to eql('documents' => { 'non_uk_id_document' => true })
+    end
+
+    it 'should go to select phone path and set selected answers when user does not have other identity documents' do
+      choose 'other_identity_documents_form_non_uk_id_document_false'
+      click_button 'Continue'
+      expect(page).to have_current_path(select_phone_path)
+      expect(page.get_rack_session['selected_answers']).to eql('documents' => { 'non_uk_id_document' => false })
+    end
+
+    it 'should show a feedback link' do
+      expect_feedback_source_to_be(page, 'OTHER_IDENTITY_DOCUMENTS_PAGE', '/other-identity-documents')
+    end
   end
 
-  it 'should show other documents content' do
-    expect(page).to have_content('Other identity documents')
-  end
+  context 'user has pressed back key and old select document answers have been retained when visiting other id page' do
+    before(:each) do
+      set_session_and_session_cookies!
+    end
 
-  it 'should show other documents content in Welsh' do
-    visit '/dogfennau-hunaniaeth-eraill'
-    expect(page).to have_content('Dogfennau hunaniaeth eraill')
-  end
+    let(:session_with_stale_select_documents_answers) {
+      {
+          selected_answers: { documents: { passport: true, driving_licence: true, ni_driving_licence: false } }
+      }
+    }
 
-  it 'should go to select phone path and set selected answers when user has other identity documents' do
-    choose 'other_identity_documents_form_non_uk_id_document_true'
-    click_button 'Continue'
-    expect(page).to have_current_path(select_phone_path)
-    expect(page.get_rack_session['selected_answers']).to eql('documents' => { 'non_uk_id_document' => true })
-  end
-
-  it 'should go to select phone path and set selected answers when user does not have other identity documents' do
-    choose 'other_identity_documents_form_non_uk_id_document_false'
-    click_button 'Continue'
-    expect(page).to have_current_path(select_phone_path)
-    expect(page.get_rack_session['selected_answers']).to eql('documents' => { 'non_uk_id_document' => false })
-  end
-
-  it 'should show a feedback link' do
-    expect_feedback_source_to_be(page, 'OTHER_IDENTITY_DOCUMENTS_PAGE', '/other-identity-documents')
+    it 'will only contain has non-uk id document and will ignore any stale form values for passport and licence' do
+      set_session!(session_with_stale_select_documents_answers)
+      visit '/other-identity-documents'
+      choose 'other_identity_documents_form_non_uk_id_document_true'
+      click_button 'Continue'
+      only_has_non_uk_doc = { 'documents' => { 'non_uk_id_document' => true } }
+      expect(page.get_rack_session['selected_answers']).to eql(only_has_non_uk_doc)
+    end
   end
 end

--- a/spec/models/selected_answer_store_spec.rb
+++ b/spec/models/selected_answer_store_spec.rb
@@ -40,28 +40,22 @@ RSpec.describe SelectedAnswerStore do
     expect(store.selected_evidence).to eql [:passport, :mobile_phone]
   end
 
-  it 'should update selected answers at a given stage when there are already selected answers' do
+
+  it 'should overwrite stale answers with new ones' do
     session = {}
-    document_answers = {
+    old_answers = {
         passport: true,
         driving_licence: false
     }
-    other_document_answers = {
-        nonukid: true
+    new_answers = {
+        non_uk_id_document: true
     }
-    store = SelectedAnswerStore.new(session)
-    store.store_selected_answers('documents', document_answers)
-    store.update_selected_answers('documents', other_document_answers)
-    expect(store.selected_evidence).to eql [:passport, :nonukid]
-  end
 
-  it 'should update selected answers at a given stage when there no selected answers' do
-    session = {}
-    other_document_answers = {
-        nonukid: true
-    }
     store = SelectedAnswerStore.new(session)
-    store.update_selected_answers('documents', other_document_answers)
-    expect(store.selected_evidence).to eql [:nonukid]
+    store.store_selected_answers('documents', old_answers)
+    store.store_selected_answers('documents', new_answers)
+
+    expect(session[:selected_answers]).to eql('documents' => new_answers)
+    expect(store.selected_answers).to eql('documents' => new_answers)
   end
 end


### PR DESCRIPTION
…pressing back key

In the user journey, the following scenario causes an error:
1. Select passport and licence
2. Click Continue
3. Click Back
4. Now on the select phone page click the hyperlink "I don't have either of these documents"
5. Select has non-UK id
6. Click continue.
7. Click options for has mobile phone, has yes for install apps

The result will show the same IDPs as if a person had passport, a driver's licence and non-uk
ID document.  This is because the "Back" press causes the session to retain old selected
answers (ie: passport and licence).  Clicking the hyperlink means that the values on the
select_documents page are not refreshed and any answers for "true" for passport and licence
are retained until the IDP picker is chosen.

In other_identity_documents_controller, we have changed the behaviour of the select_other_documents
method so that no matter how the user arrives at the Other Documents page, it will replace rather
than combine 'documents' answers that may have been provided through the visit to the select_documents
page.  The result is that when the IDP page is reached, any true values for passport or licence will
not appear in form answers and will therefore not appear in the evidence that is used to filter IDPs.

We have done two tests so far:
(1) A test for selected_answer_store to ensure that successive sets to 'documents' will mean the latest
set of answers will overwrite the previous set of answers
(2) A feature test that imitates the scenario of having stale select_document answers which should be
ignored after visiting the other_identity_documents page.

Authors: @kgarwood, @cobainc0