### PR TITLE
BAU: Make pre-commit run specs through Rake

### DIFF
--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -2,6 +2,8 @@
 
 . scripts/deploy.sh
 
+export RAILS_ENV=test
+
 bundle check || bundle install
 bundle exec govuk-lint-ruby app config lib spec
 success=$?
@@ -22,12 +24,8 @@ if [ -t 1 ]; then
   tput sgr0
 fi
 
-# Unit tests
-bundle exec rspec --exclude-pattern "spec/features/*_spec.rb"
-success=$((success || $?))
-
-# Feature tests
-bundle exec rspec --pattern "spec/features/*_spec.rb"
+# Spec tests
+bundle exec rake spec
 success=$((success || $?))
 
 # JavaScript tests


### PR DESCRIPTION
Travis runs the spec tests through `rake` whereas the pre-commit script
(used for local dev and Jenkins) runs them directly via `rspec`. This
led to issues where the tests ran locally but failed on Travis. The
`RAILS_ENV` environment variable must be set to `test` for Rake to work.

Author: @vixus0