### PR TITLE
TT225 - Added analytic to record when the "Yes, but I prefer not to" option is chosen on select phone page

### DIFF
--- a/app/models/select_phone_variant_form.rb
+++ b/app/models/select_phone_variant_form.rb
@@ -20,6 +20,11 @@ class SelectPhoneVariantForm
         answers[attr] = result == 'true' || result == 'reluctant_yes'
       end
     end
+
+    if public_send(:smart_phone) == 'reluctant_yes'
+      answers[:smart_phone_prefer_not_to] = true
+    end
+
     answers
   end
 

--- a/app/models/select_phone_variant_form.rb
+++ b/app/models/select_phone_variant_form.rb
@@ -21,7 +21,7 @@ class SelectPhoneVariantForm
       end
     end
 
-    if public_send(:smart_phone) == 'reluctant_yes'
+    if smart_phone == 'reluctant_yes'
       answers[:smart_phone_prefer_not_to] = true
     end
 

--- a/spec/models/select_phone_variant_form_spec.rb
+++ b/spec/models/select_phone_variant_form_spec.rb
@@ -87,7 +87,7 @@ describe SelectPhoneVariantForm do
         smart_phone: 'reluctant_yes'
       )
       answers = form.selected_answers
-      expect(answers).to eql(mobile_phone: true, smart_phone: true)
+      expect(answers).to eql(mobile_phone: true, smart_phone: true, smart_phone_prefer_not_to: true)
     end
   end
 


### PR DESCRIPTION
- this will allow us to determine if a user actually chose an IDP that required an app to be installed despite originally preferring not to
- analytic is set in the evidence using the identifier smart_phone_prefer_not_to (adding this to the evidence doesn't affect IDP rules matching)