### PR TITLE
GH295: Tidy up some controller tests

### DIFF
--- a/spec/controllers/choose_a_certified_company_variant_spec.rb
+++ b/spec/controllers/choose_a_certified_company_variant_spec.rb
@@ -4,25 +4,7 @@ require 'spec_helper'
 require 'api_test_helper'
 
 describe ChooseACertifiedCompanyVariantController do
-  let(:identity_provider_display_decorator) { double(:IdentityProviderDisplayDecorator) }
-  let(:repository) { double(:repository) }
-  let(:display_data) { double(:display_data) }
-
-  render_views
   subject { get :index, params: { locale: 'en' } }
-
-  LOARecommended = Struct.new(
-    :identity_provider,
-    :display_data,
-    :logo_path,
-    :white_logo_path
-  ) do
-    delegate :entity_id, to: :identity_provider
-    delegate :simple_id, to: :identity_provider
-    delegate :model_name, to: :identity_provider
-    delegate :to_key, to: :identity_provider
-    delegate :display_name, :about_content, :requirements, :special_no_docs_instructions, :no_docs_requirement, :contact_details, :interstitial_question, :mobile_app_installation, :tagline, to: :display_data
-  end
 
   context 'Level of Assurance 1' do
     before(:each) do
@@ -32,66 +14,22 @@ describe ChooseACertifiedCompanyVariantController do
                          { 'simpleId' => 'stub-idp-loa2',
                            'entityId' => 'http://idcorp.com',
                            'levelsOfAssurance' => ['LEVEL_2'] }])
-
-      loa_identity_provider = IdentityProvider.new('simpleId' => 'stub-idp-loa1',
-                                                   'entityId' => 'http://idcorp.com',
-                                                   'levelsOfAssurance' => %w(LEVEL_1 LEVEL_2))
-
-      stub_const('IDENTITY_PROVIDER_DISPLAY_DECORATOR', identity_provider_display_decorator)
-
-      loa_recommended = LOARecommended.new(loa_identity_provider, display_data, 'idp-logos/barclays.png', 'idp-logos-white/barclays.png')
-
-      expect(identity_provider_display_decorator).to receive(:decorate_collection) { |idps|
-        expect(idps.first).to have_attributes(simple_id: loa_identity_provider.simple_id,
-                                              entity_id: loa_identity_provider.entity_id,
-                                              levels_of_assurance: loa_identity_provider.levels_of_assurance)
-      }.and_return([loa_recommended])
-      expect(display_data).to receive(:display_name).at_least(1).times.and_return('stub')
     end
 
-    context 'renders LOA1 template' do
-      it 'when LEVEL_1 is the requested LOA' do
-        set_session_and_cookies_with_loa('LEVEL_1')
-
-        expect(subject).to render_template(:choose_a_certified_company_LOA1)
-        expect(subject).to_not render_template(:choose_a_certified_company_LOA2)
-        expect(response.body).to have_css('button[name="stub-idp-loa1"]')
+    it 'renders the LOA1 template with LOA1 IDPs when LEVEL_1 is the requested LOA' do
+      set_session_and_cookies_with_loa('LEVEL_1')
+      expect(IDENTITY_PROVIDER_DISPLAY_DECORATOR).to receive(:decorate_collection) do |idps|
+        idps.each { |idp| expect(idp.levels_of_assurance).to include 'LEVEL_1' }
       end
+      expect(subject).to render_template(:choose_a_certified_company_LOA1)
     end
 
-    context 'mobile app installation message' do
-      before(:each) do
-        set_session_and_cookies_with_loa('LEVEL_1')
+    it 'renders the certified companies LOA2 template when LEVEL_2 is the requested LOA' do
+      set_session_and_cookies_with_loa('LEVEL_2')
+      expect(IDENTITY_PROVIDER_DISPLAY_DECORATOR).to receive(:decorate_collection).twice do |idps|
+        idps.each { |idp| expect(idp.levels_of_assurance).to include 'LEVEL_2' }
       end
-
-      it 'is rendered when IDP requires app installation' do
-        session[:reluctant_mob_installation] = true
-        expect(display_data).to receive(:mobile_app_installation).at_least(1).times.and_return('You will need to install an app')
-
-        subject
-
-        expect(response.body).to include("You will need to install an app")
-      end
-
-      it 'is not rendered when IDP does not require app installation' do
-        session[:reluctant_mob_installation] = false
-        expect(display_data).not_to receive(:mobile_app_installation)
-
-        subject
-      end
+      expect(subject).to render_template(:choose_a_certified_company_LOA2)
     end
-  end
-
-  it 'renders the certified companies LOA2 template when LEVEL_2 is the requested LOA' do
-    stub_api_idp_list([{ 'simpleId' => 'stub-idp-loa1',
-                         'entityId' => 'http://idcorp.com',
-                         'levelsOfAssurance' => %w(LEVEL_1 LEVEL_2) },
-                       { 'simpleId' => 'stub-idp-loa2',
-                         'entityId' => 'http://idcorp.com',
-                         'levelsOfAssurance' => ['LEVEL_2'] }])
-
-    set_session_and_cookies_with_loa('LEVEL_2')
-    expect(subject).to render_template(:choose_a_certified_company_LOA2)
-    expect(subject).to_not render_template(:choose_a_certified_company_LOA1)
   end
 end

--- a/spec/controllers/confirmation_spec.rb
+++ b/spec/controllers/confirmation_spec.rb
@@ -4,62 +4,19 @@ require 'spec_helper'
 require 'models/display/viewable_identity_provider'
 
 describe ConfirmationController do
-  let(:identity_provider_display_decorator) { double(:IdentityProviderDisplayDecorator) }
-  let(:repository) { double(:repository) }
-  let(:display_data) { double(:display_data) }
-  entity_id = 'http://idcorp.com'
-  simple_id = 'stub-idp-loa'
-  levels_of_assurance = %w(LEVEL_1 LEVEL_2)
-  transaction_simple_id = 'test-rp'
-
   subject { get :index, params: { locale: 'en' } }
 
   before(:each) do
-    session[:selected_idp] = { 'entity_id' => entity_id, 'simple_id' => simple_id, 'levels_of_assurance' => levels_of_assurance }
-    session[:transaction_simple_id] = transaction_simple_id
-
-    stub_const('IDENTITY_PROVIDER_DISPLAY_DECORATOR', stub_identity_provider_display_decorator(identity_provider_display_decorator, simple_id, entity_id, levels_of_assurance))
-    stub_const('RP_DISPLAY_REPOSITORY', stub_rp_display_repository(transaction_simple_id))
+    session[:selected_idp] = { 'entity_id' => 'http://idcorp.com', 'simple_id' => 'stub-idp-one', 'levels_of_assurance' => %w(LEVEL_1 LEVEL_2) }
   end
 
   it 'renders the confirmation LOA1 template when LEVEL_1 is the requested LOA' do
     set_session_and_cookies_with_loa('LEVEL_1')
-
     expect(subject).to render_template(:confirmation_LOA1)
-    expect(subject).to_not render_template(:confirmation_LOA2)
   end
 
   it 'renders the confirmation LOA2 template when LEVEL_2 is the requested LOA' do
     set_session_and_cookies_with_loa('LEVEL_2')
-
     expect(subject).to render_template(:confirmation_LOA2)
-    expect(subject).to_not render_template(:confirmation_LOA1)
   end
-end
-
-
-def stub_identity_provider_display_decorator(identity_provider_display_decorator, simple_id, entity_id, levels_of_assurance)
-  loa_identity_provider = IdentityProvider.new('simpleId' => simple_id,
-                                               'entityId' => entity_id,
-                                               'levelsOfAssurance' => levels_of_assurance)
-
-  viewable_identity_provider_stub = Display::ViewableIdentityProvider.new(loa_identity_provider, display_data, 'idp-logos/barclays.png', 'idp-logos-white/barclays.png')
-
-  expect(identity_provider_display_decorator).to receive(:decorate) { |identity_provider|
-    expect(identity_provider).to have_attributes(simple_id: simple_id,
-                                                 entity_id: entity_id,
-                                                 levels_of_assurance: levels_of_assurance)
-  }.and_return(viewable_identity_provider_stub)
-  expect(viewable_identity_provider_stub).to receive(:display_name).and_return('idp-display-name')
-
-  identity_provider_display_decorator
-end
-
-def stub_rp_display_repository(transaction_simple_data)
-  current_transaction = ''
-
-  def current_transaction.name
-    'Test-RP'
-  end
-  { transaction_simple_data => current_transaction }
 end

--- a/spec/controllers/select_phone_controller_spec.rb
+++ b/spec/controllers/select_phone_controller_spec.rb
@@ -1,109 +1,61 @@
 require 'rails_helper'
 require 'controller_helper'
 require 'spec_helper'
-require 'models/display/viewable_identity_provider'
 require 'api_test_helper'
+require 'piwik_test_helper'
+require 'models/display/viewable_identity_provider'
 
 describe SelectPhoneController do
-  VALID_PHONE = { mobile_phone: 'true', smart_phone: 'true', landline: 'true' }.freeze
-  INVALID_PHONE = { mobile_phone: 'false', smart_phone: 'true' }.freeze
-
-  let(:piwik_reporter) { double(:Reporter) }
-  let(:eligibility_checker) { double(:Checker) }
+  valid_phone_evidence = { mobile_phone: 'true', smart_phone: 'true', landline: 'true' }.freeze
+  invalid_phone_evidence = { mobile_phone: 'false', smart_phone: 'true' }.freeze
 
   before(:each) do
     set_session_and_cookies_with_loa('LEVEL_1')
-    stub_const('ANALYTICS_REPORTER', piwik_reporter)
-    stub_const('IDP_ELIGIBILITY_CHECKER', eligibility_checker)
-
-    stub_api_idp_list([{ 'simpleId' => 'stub-idp-loa1',
-                         'entityId' => 'http://idcorp.com',
-                         'levelsOfAssurance' => %w(LEVEL_1 LEVEL_2) },
-                       { 'simpleId' => 'stub-idp-loa2',
-                         'entityId' => 'http://idcorp.com',
-                         'levelsOfAssurance' => ['LEVEL_2'] }])
+    session[:selected_answers] = { 'documents' => { driving_licence: true, passport: true } }
+    stub_piwik_request
   end
 
-  context 'Redirects:' do
-    context 'when form is valid' do
-      subject { post :select_phone, params: { locale: 'en', select_phone_form: VALID_PHONE } }
+  context 'when form is valid' do
+    subject { post :select_phone, params: { locale: 'en', select_phone_form: valid_phone_evidence } }
 
-      before(:each) do
-        expect(piwik_reporter).to receive(:report)
-      end
+    it 'redirects to choose certified company page when eligible IDPs exist' do
+      stub_api_idp_list([{ 'simpleId' => 'stub-idp-one',
+                           'entityId' => 'http://idcorp.com',
+                           'levelsOfAssurance' => %w(LEVEL_2) }])
 
-      it 'redirects to choose certified company page when eligible IDPs exist' do
-        expect(eligibility_checker).to receive(:any?).with([:mobile_phone, :smart_phone, :landline], anything).and_return(true)
-
-        expect(subject).to redirect_to('/choose-a-certified-company')
-      end
-
-      it 'redirects to no mobile phone page when no eligible IDPs' do
-        expect(eligibility_checker).to receive(:any?).with([:mobile_phone, :smart_phone, :landline], anything).and_return(false)
-
-        expect(subject).to redirect_to('/no-mobile-phone')
-      end
+      expect(ANALYTICS_REPORTER).to receive(:report).with(anything, 'Phone Next')
+      expect(subject).to redirect_to('/choose-a-certified-company')
     end
 
-    context 'when form is invalid' do
-      subject { post :select_phone, params: { locale: 'en', select_phone_form: INVALID_PHONE } }
+    it 'redirects to no mobile phone page when no eligible IDPs' do
+      stub_api_idp_list([{ 'simpleId' => 'stub-idp-four',
+                           'entityId' => 'http://idcorp.com',
+                           'levelsOfAssurance' => %w(LEVEL_2) }])
 
-      it 'renders iitself' do
-        expect(subject).to render_template(:index)
-      end
+      expect(ANALYTICS_REPORTER).to receive(:report).with(anything, 'Phone Next')
+      expect(subject).to redirect_to('/no-mobile-phone')
+    end
+
+    it 'captures form values in session cookie' do
+      stub_api_idp_list
+      expect(subject).to redirect_to('/choose-a-certified-company')
+      expect(session[:selected_answers]['phone']).to eq(mobile_phone: true, smart_phone: true, landline: true)
     end
   end
 
-  context 'Analytics and Session:' do
-    context 'when form is valid' do
-      subject { post :select_phone, params: { locale: 'en', select_phone_form: VALID_PHONE } }
+  context 'when form is invalid' do
+    subject { post :select_phone, params: { locale: 'en', select_phone_form: invalid_phone_evidence } }
 
-      before(:each) do
-        expect(eligibility_checker).to receive(:any?)
-      end
-
-      it 'reports to Pwik' do
-        expect(piwik_reporter).to receive(:report).with(anything, 'Phone Next')
-
-        subject
-      end
-
-      it 'captures form values in session cookie' do
-        expect(piwik_reporter).to receive(:report).with(any_args)
-
-        subject
-
-        expect(session[:selected_answers]["phone"]).to eq(mobile_phone: true, smart_phone: true, landline: true)
-      end
-
-      it 'does not store flash errors' do
-        expect(piwik_reporter).to receive(:report).with(any_args)
-        subject
-
-        expect(flash[:errors]).to be_nil
-      end
+    it 'renders itself' do
+      expect(subject).to render_template(:index)
     end
 
-    context 'when form is invalid' do
-      subject { post :select_phone, params: { locale: 'en', select_phone_form: INVALID_PHONE } }
+    it 'does not capture form values in session cookie' do
+      expect(session[:selected_answers]['phone']).to eq(nil)
+    end
 
-      it 'does not report to Pwik' do
-        expect(piwik_reporter).not_to receive(:report)
-
-        subject
-      end
-
-      it 'does not capture form values in session cookie' do
-        subject
-
-        expect(session[:selected_answers]).to eq(nil)
-      end
-
-      it 'stores flash errors' do
-        subject
-
-        expect(flash[:errors]).not_to be_empty
-      end
+    it 'does not report to Piwik' do
+      expect(ANALYTICS_REPORTER).not_to receive(:report)
     end
   end
 end

--- a/spec/features/user_visits_choose_a_certified_company_variant_page_spec.rb
+++ b/spec/features/user_visits_choose_a_certified_company_variant_page_spec.rb
@@ -29,11 +29,6 @@ describe 'When the user visits the choose a certified company page' do
     )
   }
 
-
-  let(:given_a_session_with_two_docs_selected_answers) {
-    given_a_session_with_selected_answers
-  }
-
   let(:given_a_session_without_selected_answers) {
     page.set_rack_session(
       transaction_simple_id: 'test-rp',
@@ -112,9 +107,7 @@ describe 'When the user visits the choose a certified company page' do
   end
 
   it 'redirects to the redirect warning page when selecting a recommended IDP' do
-    entity_id = 'http://idcorp.com'
     given_a_session_with_selected_answers
-    stub_api_idp_list([{ 'simpleId' => 'stub-idp-one', 'entityId' => entity_id, 'levelsOfAssurance' => %w(LEVEL_1 LEVEL_2) }])
     visit '/choose-a-certified-company'
 
     within('#matching-idps') do
@@ -122,7 +115,7 @@ describe 'When the user visits the choose a certified company page' do
     end
 
     expect(page).to have_current_path(redirect_to_idp_warning_path)
-    expect(page.get_rack_session_key('selected_idp')).to include('entity_id' => entity_id, 'simple_id' => 'stub-idp-one', 'levels_of_assurance' => %w(LEVEL_1 LEVEL_2))
+    expect(page.get_rack_session_key('selected_idp')).to include('entity_id' => 'http://idcorp.com', 'simple_id' => 'stub-idp-one', 'levels_of_assurance' => %w(LEVEL_1 LEVEL_2))
     expect(page.get_rack_session_key('selected_idp_was_recommended')).to eql true
   end
 
@@ -161,7 +154,7 @@ describe 'When the user visits the choose a certified company page' do
     end
 
     it 'redirects to the warning page without additional question for two docs' do
-      given_a_session_with_two_docs_selected_answers
+      given_a_session_with_selected_answers
       visit '/choose-a-certified-company'
 
       within('#matching-idps') do


### PR DESCRIPTION
See issue #295 

We were unnecessarily stubbing/mocking parts of the application in our
controller tests. Instead, we should be using existing fixtures and let
the Rails app handle initialising constants etc.

I've also removed `render_views` from all the controller tests and no
longer assert on the contents of the rendered view. That
should only be done in feature tests.

Author: @vixus0