### PR TITLE
TT-639: interstitial reporting value is reset when user selects an IDP

### DIFF
--- a/app/controllers/choose_a_certified_company_controller.rb
+++ b/app/controllers/choose_a_certified_company_controller.rb
@@ -13,6 +13,7 @@ class ChooseACertifiedCompanyController < ConfigurableJourneyController
   end
 
   def select_idp
+    selected_answer_store.store_selected_answers('interstitial', {})
     select_viewable_idp(params.fetch('entity_id')) do |decorated_idp|
       session[:selected_idp_was_recommended] = IDP_RECOMMENDATION_GROUPER.recommended?(decorated_idp.identity_provider, selected_evidence, current_identity_providers, current_transaction_simple_id)
       redirect_to next_page(has_one_doc_and_show_interstitial_question(decorated_idp))

--- a/app/controllers/choose_a_certified_company_variant_controller.rb
+++ b/app/controllers/choose_a_certified_company_variant_controller.rb
@@ -15,6 +15,7 @@ class ChooseACertifiedCompanyVariantController < ConfigurableJourneyController
   end
 
   def select_idp
+    selected_answer_store.store_selected_answers('interstitial', {})
     select_viewable_idp(params.fetch('entity_id')) do |decorated_idp|
       session[:selected_idp_was_recommended] = IDP_RECOMMENDATION_GROUPER.recommended?(decorated_idp.identity_provider, selected_evidence, current_identity_providers, current_transaction_simple_id)
       redirect_to next_page(has_one_doc_and_show_interstitial_question(decorated_idp))

--- a/spec/controllers/choose_a_certified_company_spec.rb
+++ b/spec/controllers/choose_a_certified_company_spec.rb
@@ -29,4 +29,13 @@ describe ChooseACertifiedCompanyController do
     end
     expect(subject).to render_template(:choose_a_certified_company_LOA2)
   end
+
+  it 'resets interstitial answer to no value when IDP is selected' do
+    set_session_and_cookies_with_loa('LEVEL_2')
+    session[:selected_answers] = { 'interstitial' => { 'interstitial_yes' => true } }
+
+    post :select_idp, params: { locale: 'en', entity_id: 'http://idcorp.com' }
+
+    expect(session[:selected_answers]['interstitial']).to eq({})
+  end
 end

--- a/spec/controllers/choose_a_certified_company_variant_spec.rb
+++ b/spec/controllers/choose_a_certified_company_variant_spec.rb
@@ -31,5 +31,14 @@ describe ChooseACertifiedCompanyVariantController do
       end
       expect(subject).to render_template(:choose_a_certified_company_LOA2)
     end
+
+    it 'resets interstitial answer to no value when IDP is selected' do
+      set_session_and_cookies_with_loa('LEVEL_2')
+      session[:selected_answers] = { 'interstitial' => { 'interstitial_yes' => true } }
+
+      post :select_idp, params: { locale: 'en', entity_id: 'http://idcorp.com' }
+
+      expect(session[:selected_answers]['interstitial']).to eq({})
+    end
   end
 end


### PR DESCRIPTION
- interstitial value was falsely being reported when user initially
chose one doc option, went to IDP and then navigated back and chose a
two doc IDP
- value is now reset everytime an IDP is picked

Authors: @NasAshrafThoughtworks @javindo