### PR TITLE
TT-664: Send requested LOA in page titles to Piwik

### DIFF
--- a/app/assets/javascripts/analytics.js
+++ b/app/assets/javascripts/analytics.js
@@ -20,7 +20,7 @@
 
     siteId = $('#piwik-site-id').text();
     customUrl = $('#piwik-custom-url').text();
-    enTitle = $('meta[name="verify|title"]').attr("content") + " - GOV.UK Verify - GOV.UK";
+    enTitle = $('meta[name="verify|title"]').attr("content");
 
     piwikAnalyticsQueue = [
       ['setDocumentTitle', enTitle ],

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,7 +1,8 @@
 module ApplicationHelper
   def page_title(title_key, locale_data = {})
+    en_title = t(title_key, locale_data.merge(locale: :en))
     content_for :page_title, t(title_key, locale_data)
-    content_for :page_title_in_english, t(title_key, locale_data.merge(locale: :en))
+    content_for :page_title_in_english, "#{en_title} - GOV.UK Verify - GOV.UK - #{session['requested_loa']}"
     content_for :head do
       tag('meta', name: 'verify|title', content: content_for(:page_title_in_english))
     end
@@ -28,7 +29,7 @@ module ApplicationHelper
         idsite: public_piwik.site_id,
         rec: 1,
         rand: Random.rand(2**32 - 1),
-        action_name: "#{content_for(:page_title_in_english)} - GOV.UK Verify - GOV.UK",
+        action_name: content_for(:page_title_in_english),
     }
     hash[:url] = piwik_custom_url if piwik_custom_url?
     hash.to_query

--- a/spec/features/users_browser_sends_client_side_analytics_spec.rb
+++ b/spec/features/users_browser_sends_client_side_analytics_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'When the user visits the start page' do
     it 'sends a page view to analytics' do
       expect(request_log).to receive(:log).with(
         hash_including(
-          'action_name' => 'Start - GOV.UK Verify - GOV.UK',
+          'action_name' => 'Start - GOV.UK Verify - GOV.UK - LEVEL_2',
           'idsite' => '5'
         )
       )
@@ -38,7 +38,7 @@ RSpec.describe 'When the user visits the start page' do
     it 'and in Welsh sends the page title in English to analytics' do
       expect(request_log).to receive(:log).with(
         hash_including(
-          'action_name' => 'Start - GOV.UK Verify - GOV.UK',
+          'action_name' => 'Start - GOV.UK Verify - GOV.UK - LEVEL_2',
           'idsite' => '5'
         )
       )
@@ -50,11 +50,10 @@ RSpec.describe 'When the user visits the start page' do
       stub_transactions_list
       expect(request_log).to receive(:log).with(
         hash_including(
-          'action_name' => 'Cookies Missing - GOV.UK Verify - GOV.UK',
+          'action_name' => 'Cookies Missing - GOV.UK Verify - GOV.UK - ',
           'url' => /cookies-not-found/
         )
       )
-
       visit '/start'
       expect(page).to have_content "If you can’t access GOV.UK Verify from a service, enable your cookies."
     end
@@ -72,7 +71,7 @@ RSpec.describe 'When the user visits the start page' do
       expect(image_src).to match(/idsite=5/)
       expect(image_src).to match(/rec=1/)
       expect(image_src).to match(/rand=\d+/)
-      expect(image_src).to match(/action_name=Start\+-\+GOV\.UK\+Verify\+-\+GOV\.UK/)
+      expect(image_src).to match(/action_name=Start\+-\+GOV\.UK\+Verify\+-\+GOV\.UK\+-\+LEVEL_2/)
       expect(image_src).to_not include('url')
     end
 
@@ -82,7 +81,7 @@ RSpec.describe 'When the user visits the start page' do
       noscript_image = page.find(:id, 'piwik-noscript-tracker')
       expect(noscript_image).to_not be_nil
       image_src = noscript_image['src']
-      expect(image_src).to match(/action_name=Start\+-\+GOV\.UK\+Verify\+-\+GOV\.UK/)
+      expect(image_src).to match(/action_name=Start\+-\+GOV\.UK\+Verify\+-\+GOV\.UK\+-\+LEVEL_2/)
     end
 
     it 'sends a page view with a custom url for error pages' do
@@ -96,7 +95,7 @@ RSpec.describe 'When the user visits the start page' do
       expect(image_src).to match(/idsite=5/)
       expect(image_src).to match(/rec=1/)
       expect(image_src).to match(/rand=\d+/)
-      expect(image_src).to match(/action_name=Cookies\+Missing\+-\+GOV\.UK\+Verify\+-\+GOV\.UK/)
+      expect(image_src).to match(/action_name=Cookies\+Missing\+-\+GOV\.UK\+Verify\+-\+GOV\.UK\+-\+/)
       expect(image_src).to match(/url=[^&]+cookies-not-found/)
     end
   end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -3,6 +3,26 @@ require 'rails_helper'
 RSpec.describe ApplicationHelper, type: :helper do
   Idp = Struct.new(:display_name, :tagline)
 
+  describe '#page_title' do
+    it 'should output English page title by default' do
+      helper.page_title('hub.start.title')
+      expect(helper.content_for(:page_title)).to eql I18n.t('hub.start.title')
+    end
+
+    it 'should output Welsh page title if locale specified' do
+      helper.page_title('hub.start.title', locale: :cy)
+      expect(helper.content_for(:page_title)).to eql I18n.t('hub.start.title', locale: 'cy')
+    end
+
+    it 'should always output English page title and level of assurance for analytics' do
+      title = "#{I18n.t('hub.start.title', locale: 'en')} - GOV.UK Verify - GOV.UK - LEVEL_1"
+      session['requested_loa'] = 'LEVEL_1'
+      helper.page_title('hub.start.title', locale: :cy)
+      expect(helper.content_for(:page_title_in_english)).to eql title
+      expect(helper.content_for(:head)).to eql "<meta name=\"verify|title\" content=\"#{title}\" />"
+    end
+  end
+
   describe '#idp_tagline' do
     it 'should output name and tagline if tagline is present' do
       idp_tagline = helper.idp_tagline(Idp.new('name', 'tag'))


### PR DESCRIPTION
We currently report the requested and achieved LOAs to Piwik via custom variables. However, attempting to partition user journeys by custom variables through the Piwik UI leads to Piwik only using a subset of all the data available. Until a more permanent solution is found, we can report the requested LOA along with the page title (action name in Piwik terms).

Author: @vixus0