### PR TITLE
BAU: Make session keys consistently symbols

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -183,10 +183,10 @@ private
   end
 
   def is_loa1?
-    session['requested_loa'] == 'LEVEL_1'
+    session[:requested_loa] == 'LEVEL_1'
   end
 
   def is_loa2?
-    session['requested_loa'] == 'LEVEL_2'
+    session[:requested_loa] == 'LEVEL_2'
   end
 end

--- a/app/controllers/authn_response_controller.rb
+++ b/app/controllers/authn_response_controller.rb
@@ -9,7 +9,7 @@ class AuthnResponseController < SamlController
       raise Errors::WarningLevelError, "Relay state should match session id. Relay state was #{params['RelayState'].inspect}"
     end
 
-    response = SESSION_PROXY.idp_authn_response(session['verify_session_id'], params['SAMLResponse'], params['RelayState'])
+    response = SESSION_PROXY.idp_authn_response(session[:verify_session_id], params['SAMLResponse'], params['RelayState'])
     user_state = response.is_registration ? REGISTERING_STATE : SIGNING_IN_STATE
 
     case response.idp_result

--- a/app/controllers/choose_a_country_controller.rb
+++ b/app/controllers/choose_a_country_controller.rb
@@ -3,11 +3,11 @@ class ChooseACountryController < ApplicationController
   before_action :ensure_session_eidas_supported
 
   def choose_a_country
-    setup_countries(session['verify_session_id'])
+    setup_countries(session[:verify_session_id])
   end
 
   def choose_a_country_submit
-    session_id = session['verify_session_id']
+    session_id = session[:verify_session_id]
     setup_countries(session_id)
 
     country = params[:country]

--- a/app/controllers/further_information_controller.rb
+++ b/app/controllers/further_information_controller.rb
@@ -1,12 +1,12 @@
 class FurtherInformationController < ApplicationController
   def index
-    session_id = session['verify_session_id']
+    session_id = session[:verify_session_id]
     @cycle_three_attribute = FURTHER_INFORMATION_SERVICE.get_attribute_for_session(session_id).new({})
     @transaction_name = current_transaction.name
   end
 
   def submit
-    session_id = session['verify_session_id']
+    session_id = session[:verify_session_id]
     cycle_three_attribute_class = FURTHER_INFORMATION_SERVICE.get_attribute_for_session(session_id)
     @cycle_three_attribute = cycle_three_attribute_class.new(params['cycle_three_attribute'])
     if @cycle_three_attribute.valid?
@@ -20,14 +20,14 @@ class FurtherInformationController < ApplicationController
   end
 
   def cancel
-    session_id = session['verify_session_id']
+    session_id = session[:verify_session_id]
     FURTHER_INFORMATION_SERVICE.cancel(session_id)
     FEDERATION_REPORTER.report_cycle_three_cancel(current_transaction, request)
     redirect_to redirect_to_service_start_again_path
   end
 
   def submit_null_attribute
-    session_id = session['verify_session_id']
+    session_id = session[:verify_session_id]
     cycle_three_attribute_class = FURTHER_INFORMATION_SERVICE.get_attribute_for_session(session_id)
     if cycle_three_attribute_class.allows_nullable?
       FURTHER_INFORMATION_SERVICE.submit(session_id, '')

--- a/app/controllers/redirect_to_idp_controller.rb
+++ b/app/controllers/redirect_to_idp_controller.rb
@@ -1,6 +1,6 @@
 class RedirectToIdpController < ApplicationController
   def index
-    saml_message = SESSION_PROXY.idp_authn_request(session['verify_session_id'])
+    saml_message = SESSION_PROXY.idp_authn_request(session[:verify_session_id])
     @request = IdentityProviderRequest.new(
       saml_message,
       selected_identity_provider.simple_id,

--- a/app/controllers/redirect_to_idp_warning_controller.rb
+++ b/app/controllers/redirect_to_idp_warning_controller.rb
@@ -26,7 +26,7 @@ class RedirectToIdpWarningController < ConfigurableJourneyController
     idp = decorated_idp
     if idp.viewable?
       select_registration(idp)
-      outbound_saml_message = SESSION_PROXY.idp_authn_request(session['verify_session_id'])
+      outbound_saml_message = SESSION_PROXY.idp_authn_request(session[:verify_session_id])
       idp_request = IdentityProviderRequest.new(
         outbound_saml_message,
         selected_identity_provider.simple_id,
@@ -40,7 +40,7 @@ class RedirectToIdpWarningController < ConfigurableJourneyController
 private
 
   def select_registration(idp)
-    SESSION_PROXY.select_idp(session['verify_session_id'], idp.entity_id, true)
+    SESSION_PROXY.select_idp(session[:verify_session_id], idp.entity_id, true)
     set_journey_hint(idp.entity_id)
     register_idp_selections(idp.display_name)
   end

--- a/app/controllers/redirect_to_service_controller.rb
+++ b/app/controllers/redirect_to_service_controller.rb
@@ -25,13 +25,9 @@ private
   def redirect_to_service(title_key, transition_heading_key, is_error: false)
     @title = title_key
     @response_for_rp = if is_error
-                         SESSION_PROXY.error_response_for_rp(
-                           session['verify_session_id'],
-                         )
+                         SESSION_PROXY.error_response_for_rp(session[:verify_session_id])
                        else
-                         SESSION_PROXY.response_for_rp(
-                           session['verify_session_id'],
-                         )
+                         SESSION_PROXY.response_for_rp(session[:verify_session_id])
                        end
     @rp_name = current_transaction.rp_name
     @transition_message = t(transition_heading_key, rp_name: @rp_name)

--- a/app/controllers/response_processing_controller.rb
+++ b/app/controllers/response_processing_controller.rb
@@ -3,7 +3,7 @@ class ResponseProcessingController < ApplicationController
 
   def index
     @rp_name = current_transaction.rp_name
-    outcome = SESSION_PROXY.matching_outcome(session['verify_session_id'])
+    outcome = SESSION_PROXY.matching_outcome(session[:verify_session_id])
     case outcome
     when MatchingOutcomeResponse::GOTO_HUB_LANDING_PAGE
       report_to_analytics('Matching Outcome - Hub Landing')

--- a/app/controllers/sign_in_controller.rb
+++ b/app/controllers/sign_in_controller.rb
@@ -23,7 +23,7 @@ class SignInController < ApplicationController
   def select_idp_ajax
     select_viewable_idp(params.fetch('entityId')) do |decorated_idp|
       sign_in(decorated_idp.entity_id, decorated_idp.display_name)
-      outbound_saml_message = SESSION_PROXY.idp_authn_request(session['verify_session_id'])
+      outbound_saml_message = SESSION_PROXY.idp_authn_request(session[:verify_session_id])
       provider_request = IdentityProviderRequest.new(
         outbound_saml_message,
         selected_identity_provider.simple_id,
@@ -36,7 +36,7 @@ class SignInController < ApplicationController
 private
 
   def sign_in(entity_id, display_name)
-    SESSION_PROXY.select_idp(session['verify_session_id'], entity_id)
+    SESSION_PROXY.select_idp(session[:verify_session_id], entity_id)
     set_journey_hint(entity_id)
     FEDERATION_REPORTER.report_sign_in_idp_selection(request, display_name)
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,7 +1,7 @@
 module ApplicationHelper
   def page_title(title_key, locale_data = {})
     en_title = [t(title_key, locale_data.merge(locale: :en)), 'GOV.UK Verify', 'GOV.UK']
-    en_title << session['requested_loa'] if session['requested_loa']
+    en_title << session[:requested_loa] if session[:requested_loa]
     content_for :page_title, t(title_key, locale_data)
     content_for :page_title_in_english, en_title.join(' - ')
     content_for :head do


### PR DESCRIPTION
We currently use a mix of strings and symbols to refer to the same
Rails session values which is confusing. Symbols feel somewhat more
appropriate for defining session keys as Ruby hashes typically use
symbols for keys.

Author: @vixus0