### PR TITLE
ZD33435 Ensure service name is lower cased

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -347,7 +347,7 @@ en:
       what_to_do_next_intro: "You can try the following:"
       what_to_do_next: "What to do next"
       problems_verifying_your_identity: Problems verifying your identity
-      continue_heading: "Continue to %{transaction_name}"
+      continue_heading: "Continue to %{other_ways_description}"
       continue_idp_text: "%{idp_name} was unable to verify your identity, but you can still submit your application."
       continue_text: "Continue to %{rp_name} to find out how."
       start_again: Find another company to verify you


### PR DESCRIPTION
By using the other_ways_description we ensure that the service name is
lower cased when prefixed with 'Continue'