### PR TITLE
TT671 - Fixed issue for disabling App Transparency AB test

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -14,18 +14,18 @@ window.GOVUK.shimLinksWithButtonRole.init();
 
 window.GOVUK.validation.init();
 window.GOVUK.selectDocuments.init();
-//window.GOVUK.selectPhone.init();
+window.GOVUK.selectPhone.init();
 window.GOVUK.willItWorkForMe.init();
 window.GOVUK.feedback.init();
 window.GOVUK.furtherInformation.init();
 window.GOVUK.interstitialQuestion.init();
 window.GOVUK.otherDocuments.init();
 
-abTest({
-  experiment: 'app_transparency',
-  routeA: window.GOVUK.selectPhone,
-  routeB: window.GOVUK.selectPhoneVariant
-})
+//abTest({
+//  experiment: 'app_transparency',
+//  routeA: window.GOVUK.selectPhone,
+//  routeB: window.GOVUK.selectPhoneVariant
+//})
 
 
 $(function () {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,6 @@ Rails.application.routes.draw do
 
   # You can have the root of your site routed with "root"
   # root 'welcome#index'
-
   POST_PICKER_EXPERIMENT = 'post_picker'.freeze
 
   report_to_piwik = -> (experiment_name, reported_alternative, transaction_id, request) {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,15 +5,11 @@ Rails.application.routes.draw do
   # You can have the root of your site routed with "root"
   # root 'welcome#index'
 
-  EXPERIMENT_NAME = 'app_transparency'.freeze
   POST_PICKER_EXPERIMENT = 'post_picker'.freeze
 
   report_to_piwik = -> (experiment_name, reported_alternative, transaction_id, request) {
     AbTest.report(experiment_name, reported_alternative, transaction_id, request)
   }
-
-  route_a = SelectRoute.new(EXPERIMENT_NAME, 'control')
-  route_b = SelectRoute.new(EXPERIMENT_NAME, 'variant')
 
   post_picker_a = SelectRoute.new(POST_PICKER_EXPERIMENT, 'control')
   post_picker_b = SelectRoute.new(POST_PICKER_EXPERIMENT, 'variant_logos')
@@ -58,16 +54,16 @@ Rails.application.routes.draw do
     get 'unlikely_to_verify', to: 'select_documents#unlikely_to_verify', as: :unlikely_to_verify
     get 'other_identity_documents', to: 'other_identity_documents#index', as: :other_identity_documents
     post 'other_identity_documents', to: 'other_identity_documents#select_other_documents', as: :other_identity_documents_submit
-    # get 'select_phone', to: 'select_phone#index', as: :select_phone
-    # post 'select_phone', to: 'select_phone#select_phone', as: :select_phone_submit
+    get 'select_phone', to: 'select_phone#index', as: :select_phone
+    post 'select_phone', to: 'select_phone#select_phone', as: :select_phone_submit
     get 'no_mobile_phone', to: 'select_phone#no_mobile_phone', as: :no_mobile_phone
     get 'will_it_work_for_me', to: 'will_it_work_for_me#index', as: :will_it_work_for_me
     post 'will_it_work_for_me', to: 'will_it_work_for_me#will_it_work_for_me', as: :will_it_work_for_me_submit
     get 'why_might_this_not_work_for_me', to: 'will_it_work_for_me#why_might_this_not_work_for_me', as: :why_might_this_not_work_for_me
     get 'may_not_work_if_you_live_overseas', to: 'will_it_work_for_me#may_not_work_if_you_live_overseas', as: :may_not_work_if_you_live_overseas
     get 'will_not_work_without_uk_address', to: 'will_it_work_for_me#will_not_work_without_uk_address', as: :will_not_work_without_uk_address
-    # get 'choose_a_certified_company', to: 'choose_a_certified_company#index', as: :choose_a_certified_company
-    # post 'choose_a_certified_company', to: 'choose_a_certified_company#select_idp', as: :choose_a_certified_company_submit
+    get 'choose_a_certified_company', to: 'choose_a_certified_company#index', as: :choose_a_certified_company
+    post 'choose_a_certified_company', to: 'choose_a_certified_company#select_idp', as: :choose_a_certified_company_submit
     get 'choose_a_certified_company_about', to: 'choose_a_certified_company#about', as: :choose_a_certified_company_about
     get 'why_companies', to: 'why_companies#index', as: :why_companies
     # get 'redirect_to_idp_warning', to: 'redirect_to_idp_warning#index', as: :redirect_to_idp_warning
@@ -101,22 +97,6 @@ Rails.application.routes.draw do
     post 'further_information', to: 'further_information#submit', as: :further_information_submit
     post 'further_information_cancel', to: 'further_information#cancel', as: :further_information_cancel
     post 'further_information_null_attribute', to: 'further_information#submit_null_attribute', as: :further_information_null_attribute_submit
-
-    constraints route_a do
-      get 'select_phone', to: 'select_phone#index', as: :select_phone
-      post 'select_phone', to: 'select_phone#select_phone', as: :select_phone_submit
-
-      get 'choose_a_certified_company', to: 'choose_a_certified_company#index', as: :choose_a_certified_company
-      post 'choose_a_certified_company', to: 'choose_a_certified_company#select_idp', as: :choose_a_certified_company_submit
-    end
-
-    constraints route_b do
-      get 'select_phone', to: 'select_phone_variant#index', as: :select_phone
-      post 'select_phone', to: 'select_phone_variant#select_phone', as: :select_phone_submit
-
-      get 'choose_a_certified_company', to: 'choose_a_certified_company_variant#index', as: :choose_a_certified_company
-      post 'choose_a_certified_company', to: 'choose_a_certified_company_variant#select_idp', as: :choose_a_certified_company_submit
-    end
 
     constraints post_picker_a_and_report_to_piwik do
       get 'redirect_to_idp_warning', to: 'redirect_to_idp_warning#index', as: :redirect_to_idp_warning

--- a/spec/constraints/select_route_spec.rb
+++ b/spec/constraints/select_route_spec.rb
@@ -9,16 +9,19 @@ describe SelectRoute do
   select_route = nil
   session = nil
 
+  before(:each) do
+    experiment_stub = MockExperiment.new
+    ab_test_stub = {
+        EXP_NAME => experiment_stub
+    }
+    stub_const('AB_TESTS', ab_test_stub)
+    # allow(AbTest).to receive(:report)
+  end
+
   context 'experiment tests' do
     before(:each) do
       select_route = SelectRoute.new(EXP_NAME, 'variant')
       session = {}
-      experiment_stub = MockExperiment.new
-      ab_test_stub = {
-          EXP_NAME => experiment_stub
-      }
-      stub_const('AB_TESTS', ab_test_stub)
-      allow(AbTest).to receive(:report)
     end
 
     it 'evaluates true when experiment and route both match' do
@@ -61,6 +64,7 @@ describe SelectRoute do
     end
 
     it 'execute ab_reporter when experiment matches' do
+      expect(experiment_stub).to receive(:alternative_name).with(ALTERNATIVE_NAME).and_return(ALTERNATIVE_NAME)
       session = { transaction_simple_id: 'test-rp' }
 
       cookies = create_ab_test_cookie(EXP_NAME, ALTERNATIVE_NAME)

--- a/spec/controllers/choose_a_certified_company_variant_controller_spec.rb
+++ b/spec/controllers/choose_a_certified_company_variant_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 require 'controller_helper'
 require 'api_test_helper'
 
-describe ChooseACertifiedCompanyVariantController do
+xdescribe ChooseACertifiedCompanyVariantController do
   before :each do
     stub_api_idp_list([{ 'simpleId' => 'stub-idp-loa1',
                          'entityId' => 'http://idcorp-loa1.com',

--- a/spec/controllers/select_phone_variant_controller_spec.rb
+++ b/spec/controllers/select_phone_variant_controller_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 require 'models/display/viewable_identity_provider'
 require 'api_test_helper'
 
-describe SelectPhoneVariantController do
+xdescribe SelectPhoneVariantController do
   VALID_PHONE_OPTION = { mobile_phone: 'true', smart_phone: 'true', landline: 'true' }.freeze
   INVALID_PHONE_OPTION = { mobile_phone: 'false', smart_phone: 'true' }.freeze
 

--- a/spec/features/user_visits_choose_a_certified_company_variant_page_spec.rb
+++ b/spec/features/user_visits_choose_a_certified_company_variant_page_spec.rb
@@ -2,7 +2,7 @@ require 'feature_helper'
 require 'api_test_helper'
 require 'i18n'
 
-describe 'When the user visits the choose a certified company page' do
+xdescribe 'When the user visits the choose a certified company page' do
   before(:each) do
     set_session_and_ab_session_cookies!('app_transparency' => 'app_transparency_variant')
     stub_api_idp_list

--- a/spec/features/user_visits_select_phone_variant_page_spec.rb
+++ b/spec/features/user_visits_select_phone_variant_page_spec.rb
@@ -2,7 +2,7 @@ require 'feature_helper'
 require 'api_test_helper'
 require 'uri'
 
-RSpec.describe 'When the user visits the select phone page' do
+RSpec.xdescribe 'When the user visits the select phone page' do
   let(:selected_answers) { { documents: { passport: true, driving_licence: true } } }
   let(:given_a_session_with_document_evidence) {
     page.set_rack_session(

--- a/stub/ab_test.yml
+++ b/stub/ab_test.yml
@@ -31,12 +31,6 @@ experiments:
           percent: 0
         - name: 'no_logo_privacy'
           percent: 0
-  - app_transparency:
-        alternatives:
-          - name: 'control'
-            percent: 80
-          - name: 'variant'
-            percent: 20
   - post_picker:
         alternatives:
           - name: 'control'


### PR DESCRIPTION
- App transparency test was disabled by setting the control to 100%.
This was fine for new users but if previous users aleady had the app
transparency cookie set to variant they still saw the variant page.
Remedied by removing the cookie and ab logic from routes.rb
- Controller/Feature tests for the variant pages have been commented out
as they will fail to run when no ab test routes present.
- The variant version of controllers/templates have not been removed as
a decision on which version to keep has not been made yet

Author: @NasAshrafThoughtworks