### PR TITLE
Tt 563: Streamlining behaviour of failed_registration and won’t work pages

### DIFF
--- a/app/views/failed_registration/index_continue_on_failed_registration.html.erb
+++ b/app/views/failed_registration/index_continue_on_failed_registration.html.erb
@@ -5,7 +5,10 @@
   <div class="column-two-thirds">
     <h1 class="heading-large"><%= t('hub.failed_registration.continue_heading', transaction_name: @transaction.name) %></h1>
 
-    <p><%= t 'hub.failed_registration.continue_idp_text', idp_name: @idp.display_name %></p>
+    <p>
+      <%= t 'hub.failed_registration.continue_idp_text', idp_name: @idp.display_name %>
+      <%= @transaction.other_ways_text.html_safe %>
+    </p>
 
     <p><%= t 'hub.failed_registration.continue_text', rp_name: @transaction.rp_name %></p>
 

--- a/app/views/will_it_work_for_me/why_might_this_not_work_for_me.html.erb
+++ b/app/views/will_it_work_for_me/why_might_this_not_work_for_me.html.erb
@@ -24,8 +24,11 @@
     <p><%= t 'hub.why_might_this_not_work_for_me.youll_also_need' %></p>
 
     <p><%= link_to t('hub.why_might_this_not_work_for_me.try_to_verify'), select_documents_path, id: 'verify-identity-online' %></p>
+    <h2 class="heading-medium"><%= t 'hub.other_ways_heading', other_ways_description: @other_ways_description %></h2>
+    <div class="other-ways-to-complete-transaction">
+      <%= @other_ways_text.html_safe %>
+    </div>
 
 
-    <%= render partial: 'shared/other_ways', locals: { other_ways_text: @other_ways_text, other_ways_description: @other_ways_description } %>
   </div>
 </div>

--- a/app/views/will_it_work_for_me/will_not_work_without_uk_address.html.erb
+++ b/app/views/will_it_work_for_me/will_not_work_without_uk_address.html.erb
@@ -6,7 +6,11 @@
     <h1 class="heading-large"><%= t 'hub.will_not_work_without_uk_address.heading' %></h1>
 
     <p><%= t 'hub.will_not_work_without_uk_address.explanation' %></p>
-
-    <%= render partial: 'shared/other_ways', locals: { other_ways_text: @other_ways_text, other_ways_description: @other_ways_description } %>
+    <h2 class="heading-medium"><%= t 'hub.other_ways_heading', other_ways_description: @other_ways_description %></h2>
+    <div class="other-ways-to-complete-transaction">
+      <p>
+      <%= @other_ways_text.html_safe %>
+      </p>
+    </div>
   </div>
 </div>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -242,10 +242,12 @@ cy:
       mobile_phone_contract: cytundeb ffôn symudol
       registered_to_vote: rydych wedi cofrestru i bleidleisio
       youll_also_need: Byddwch hefyd angen pasport y DU neu drwydded yrru’r DU.
+      if_verify_doesnt_work_there_is_still_a_way: You may try to use GOV.UK Verify may not verify your identity.
     will_not_work_without_uk_address:
       title: Ni fydd GOV.UK Verify yn gweithio i chi
       heading: Ni fydd GOV.UK Verify yn gweithio i chi
       explanation: Rydych angen cyfeiriad presennol yn y DU i gael eich hunaniaeth wedi’i ddilysu.
+      verify_wont_work_but_there_is_still_a_way: GOV.UK Verify can't verify your identity because it needs you to have at least a UK address.  %{other_ways_text}
     choose_a_certified_company:
       title: Dewiswch gwmni ardystiedig
       heading: Dewiswch gwmni
@@ -353,7 +355,7 @@ cy:
       what_to_do_next: "Beth i’w wneud nesaf"
       problems_verifying_your_identity: Problemau gyda dilysu eich hunaniaeth
       continue_heading: "Mynd ymlaen i %{transaction_name}"
-      continue_idp_text: "Roedd %{idp_name} yn methu dilysu eich hunaniaeth, ond gallwch ddal i anfon eich cais."
+      continue_idp_text: "Roedd %{idp_name} yn methu dilysu eich hunaniaeth."
       continue_text: "Mynd ymlaen i %{rp_name} i ddarganfod sut."
       start_again: Dod o hyd i gwmni arall i’ch gwirio
       other_ways_summary: "Gweld ffyrdd eraill o %{other_ways_description}"

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -242,7 +242,6 @@ cy:
       mobile_phone_contract: cytundeb ffôn symudol
       registered_to_vote: rydych wedi cofrestru i bleidleisio
       youll_also_need: Byddwch hefyd angen pasport y DU neu drwydded yrru’r DU.
-      if_verify_doesnt_work_there_is_still_a_way: You may try to use GOV.UK Verify may not verify your identity.
     will_not_work_without_uk_address:
       title: Ni fydd GOV.UK Verify yn gweithio i chi
       heading: Ni fydd GOV.UK Verify yn gweithio i chi

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -348,7 +348,7 @@ en:
       what_to_do_next: "What to do next"
       problems_verifying_your_identity: Problems verifying your identity
       continue_heading: "Continue to %{transaction_name}"
-      continue_idp_text: "%{idp_name} was unable to verify your identity, but you can still submit your application."
+      continue_idp_text: "%{idp_name} was unable to verify your identity."
       continue_text: "Continue to %{rp_name} to find out how."
       start_again: Find another company to verify you
       other_ways_summary: "View other ways to %{other_ways_description}"

--- a/spec/controllers/will_it_work_for_me_response_spec.rb
+++ b/spec/controllers/will_it_work_for_me_response_spec.rb
@@ -40,7 +40,6 @@ describe WillItWorkForMeController do
                      'renders the select documents page when users meet minimum age and are residents',
                      PROCEED_TO_SELECT_DOCUMENT_ANSWERS,
                      :select_documents_path
-
   end
 
   context 'when form is invalid' do
@@ -52,6 +51,4 @@ describe WillItWorkForMeController do
       expect(flash[:errors]).not_to be_empty
     end
   end
-
-
 end

--- a/spec/controllers/will_it_work_for_me_response_spec.rb
+++ b/spec/controllers/will_it_work_for_me_response_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+require 'controller_helper'
+require 'will_it_work_for_me_examples'
+
+describe WillItWorkForMeController do
+  PROCEED_TO_SELECT_DOCUMENT_ANSWERS = { above_age_threshold: 'true', resident_last_12_months: 'true', not_resident_reason: 'noAddress' }.freeze
+  NOT_OLD_ENOUGH_ANSWERS = { above_age_threshold: 'false', resident_last_12_months: 'true', not_resident_reason: 'MovedRecently' }.freeze
+  MOVED_TO_UK_LAST_YEAR_ANSWERS = { above_age_threshold: 'true', resident_last_12_months: 'false', not_resident_reason: 'MovedRecently' }.freeze
+  NON_RESIDENT_ANSWERS = { above_age_threshold: 'true', resident_last_12_months: 'false', not_resident_reason: 'AddressButNotResident' }.freeze
+  NO_UK_ADDRESS_ANSWERS = { above_age_threshold: 'true', resident_last_12_months: 'false', not_resident_reason: 'NoAddress' }.freeze
+  INVALID_FORM_ANSWERS = { above_age_threshold: 'true' }.freeze
+
+  context 'valid form' do
+    include_examples 'will_it_work_for_me',
+                     'redirects to might not work for you if moved in recently',
+                     'when user has moved to the UK in the last year',
+                     MOVED_TO_UK_LAST_YEAR_ANSWERS,
+                     :why_might_this_not_work_for_me_path
+
+    include_examples 'will_it_work_for_me',
+                     'redirects to might not work for you if underage',
+                     'when user is less than 20 yrs old',
+                     NOT_OLD_ENOUGH_ANSWERS,
+                     :why_might_this_not_work_for_me_path
+
+    include_examples 'will_it_work_for_me',
+                     'redirects to the will not work page if user has no UK address',
+                     'renders the verify will not work information page',
+                     NO_UK_ADDRESS_ANSWERS,
+                     :will_not_work_without_uk_address_path
+
+    include_examples 'will_it_work_for_me',
+                     'redirects to overseas page if user has UK address but does not live in the UK',
+                     'renders the verify may not work information page',
+                     NON_RESIDENT_ANSWERS,
+                     :may_not_work_if_you_live_overseas_path
+
+    include_examples 'will_it_work_for_me',
+                     'redirects to overseas page if user has UK address but does not live in the UK',
+                     'renders the select documents page when users meet minimum age and are residents',
+                     PROCEED_TO_SELECT_DOCUMENT_ANSWERS,
+                     :select_documents_path
+
+  end
+
+  context 'when form is invalid' do
+    subject { post :will_it_work_for_me, params: { locale: 'en', will_it_work_for_me_form: INVALID_FORM_ANSWERS } }
+
+    it 'stores flash errors' do
+      set_session_and_cookies_with_loa('LEVEL_1')
+      expect(subject).to render_template(:index)
+      expect(flash[:errors]).not_to be_empty
+    end
+  end
+
+
+end

--- a/spec/features/user_visits_will_not_work_without_uk_address_page_spec.rb
+++ b/spec/features/user_visits_will_not_work_without_uk_address_page_spec.rb
@@ -9,10 +9,7 @@ RSpec.describe 'When the user visits the will-not-work-without-uk-address page' 
 
   it 'includes other ways text' do
     visit '/will-not-work-without-uk-address'
-
-    expect(page).to have_content('If you can’t verify your identity using GOV.UK Verify, you can register for an identity profile here')
-    expect(page).to have_content('register for an identity profile')
-    expect(page).to have_link 'here', href: 'http://www.example.com'
+    expect(page).to have_content('You need a current UK address to get your identity verified')
   end
 
   it 'includes the appropriate feedback source' do

--- a/spec/support/will_it_work_for_me_examples.rb
+++ b/spec/support/will_it_work_for_me_examples.rb
@@ -1,0 +1,20 @@
+require 'piwik_test_helper'
+
+shared_examples 'will_it_work_for_me' do |test_context, form_answer_description, form_variables, redirect_path|
+  let(:session_proxy) {double(:session_proxy)}
+
+  before(:each) do
+    set_session_and_cookies_with_loa('LEVEL_1')
+    session[:selected_idp] = { 'entity_id' => 'http://idcorp.com', 'simple_id' => 'stub-idp-one', 'levels_of_assurance' => %w(LEVEL_1 LEVEL_2) }
+    session[:selected_idp_was_recommended] = true
+    stub_piwik_request
+  end
+
+  context test_context do
+    subject {post :will_it_work_for_me, params: {locale: 'en', will_it_work_for_me_form: form_variables}}
+    it "should redirect to #{redirect_path} on #{form_answer_description}" do
+      expect(ANALYTICS_REPORTER).to receive(:report).with(any_args)
+      expect(subject).to redirect_to(send(redirect_path))
+    end
+  end
+end

--- a/spec/support/will_it_work_for_me_examples.rb
+++ b/spec/support/will_it_work_for_me_examples.rb
@@ -1,7 +1,7 @@
 require 'piwik_test_helper'
 
 shared_examples 'will_it_work_for_me' do |test_context, form_answer_description, form_variables, redirect_path|
-  let(:session_proxy) {double(:session_proxy)}
+  let(:session_proxy) { double(:session_proxy) }
 
   before(:each) do
     set_session_and_cookies_with_loa('LEVEL_1')
@@ -11,7 +11,7 @@ shared_examples 'will_it_work_for_me' do |test_context, form_answer_description,
   end
 
   context test_context do
-    subject {post :will_it_work_for_me, params: {locale: 'en', will_it_work_for_me_form: form_variables}}
+    subject { post :will_it_work_for_me, params: { locale: 'en', will_it_work_for_me_form: form_variables } }
     it "should redirect to #{redirect_path} on #{form_answer_description}" do
       expect(ANALYTICS_REPORTER).to receive(:report).with(any_args)
       expect(subject).to redirect_to(send(redirect_path))

--- a/stub/locales/rps/test-rp-with-continue-on-fail.yml
+++ b/stub/locales/rps/test-rp-with-continue-on-fail.yml
@@ -4,13 +4,6 @@ en:
       name: register for an identity profile
       rp_name: Test RP
       analytics_description: analytics description for test-rp
-      other_ways_text: |
-        <p>If you can’t verify your identity using GOV.UK Verify, you can register for an identity profile <a href="http://www.example.com">here</a>.</p>
-        <p>Tell us your:</p>
-        <ul>
-         <li>name</li>
-         <li>age</li>
-        </ul>
-        <p>Include any other relevant details if you have them.</p>
-      other_ways_description: register for an identity profile
+      other_ways_text: <p>You can still print, sign and return your  <a href="http://www.example.com">declaration</a>.</p>
+      other_ways_description: sign your declaration
       tailored_text: <p>This is tailored text for test-rp-with-continue-on-fail</p>

--- a/stub/locales/rps/test-rp-with-continue-on-fail.yml
+++ b/stub/locales/rps/test-rp-with-continue-on-fail.yml
@@ -4,6 +4,6 @@ en:
       name: register for an identity profile
       rp_name: Test RP
       analytics_description: analytics description for test-rp
-      other_ways_text: <p>You can still print, sign and return your  <a href="http://www.example.com">declaration</a>.</p>
+      other_ways_text: <p>You can still continue to complete your transaction.</p>
       other_ways_description: sign your declaration
       tailored_text: <p>This is tailored text for test-rp-with-continue-on-fail</p>


### PR DESCRIPTION
Code changes mainly focus on two themes: streamlining the appearance of failed_registration and will_not_work_without_uk_address views for rps with continue-on-fail and to improve the tests that exercise the controller that routes to the will_not_work_without_uk_address view.

Changing views and message properties
Much of this story has related to designing UI messages that can be parameterised by properties of the relying party and still provide a uniform look to Verify’s web pages that show how it may not, will not or has not verified a user’s identity.  Changes to the UI messages sometimes had a side effect of appearing on some of these pages which were not the focus of the story.  

More broadly, there is an emerging design issue about how fine-grained you can make some UI messages so that it can work with different RPs and across the different variations of pages that do not relate to positively verifying someone.  Further thought is needed to produce new stories which can be used to better streamline the content of will_not_work_without_uk_address, why_might_this_not_work_for_me, may_not_work_if_you_live_oversease and failed_registration pages, both for rps that allow continue after fail and for rps that do not.

Improving tests for will_it_work_for_me_controller
The story provided an opportunity to develop controller tests that relate to will_it_work_for_me_controller, which determines whether users will see the will_not_work_without_uk_address view file.  As well as developing a collection of tests that exercise the routing options for this controller, we decided to rework the tests to use rspec’s include_examples template mechanism.

Some of the feature tests were changed so they relied less on looking for long pieces of text that are brittle when UI messages get changed.

Authors: @kgarwood, @vixus0, @cobainc0