### PR TITLE
BAU: Run linters by default in Rake

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,4 +6,5 @@ require 'fileutils'
 
 Rails.application.load_tasks
 
+task spec: ['lint:ruby', 'lint:sass']
 task default: [:spec, 'jasmine:ci']

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,0 +1,40 @@
+namespace :lint do
+  desc 'lint ruby files'
+  task :ruby do
+    sh 'govuk-lint-ruby app config lib spec', verbose: false do |ok, _|
+      if ok
+        green('Ruby linting PASSED')
+      else
+        red('Ruby linting FAILED')
+        exit(1)
+      end
+    end
+  end
+
+  desc 'lint sass files'
+  task :sass do
+    scss_files = FileList.new do |fl|
+      fl.include('app/assets/stylesheets/*.scss')
+      fl.include('app/assets/stylesheets/*/*.scss')
+      fl.exclude('app/assets/stylesheets/vendor/*.scss')
+    end
+    sh 'govuk-lint-sass', *scss_files, verbose: false do |ok, _|
+      if ok
+        green('SASS linting PASSED')
+      else
+        red('SASS linting FAILED')
+        exit(1)
+      end
+    end
+  end
+
+private
+
+  def green(msg)
+    puts ENV['TERM'] ? "#{`tput setaf 2`}#{msg}#{`tput sgr0`}" : msg
+  end
+
+  def red(msg)
+    puts ENV['TERM'] ? "#{`tput setaf 1`}#{msg}#{`tput sgr0`}" : msg
+  end
+end

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -5,31 +5,7 @@
 export RAILS_ENV=test
 
 bundle check || bundle install
-bundle exec govuk-lint-ruby app config lib spec
-success=$?
-
-# govuk-lint-sass is very quiet. Setting the output colour
-# to red makes it more obvious when it fails, but we won't
-# try to when there isn't a $TERM (jenkins).
-if [ -t 1 ]; then
-  tput setaf 1
-fi
-
-# HACK: can't get govuk-lint's exclude option to work, so hacking around it with `find`
-scss_files=$(find app/assets/stylesheets -name *.scss | grep --invert-match 'vendor')
-
-bundle exec govuk-lint-sass $scss_files
-success=$((success || $?))
-if [ -t 1 ]; then
-  tput sgr0
-fi
-
-# Spec tests
-bundle exec rake spec
-success=$((success || $?))
-
-# JavaScript tests
-bundle exec rake jasmine:ci
+bundle exec rake
 success=$((success || $?))
 
 # Stub API tests


### PR DESCRIPTION
Currently, the linters are only run when explicitly called in the
`pre-commit.sh` script. We use Travis to provide us with feedback on
test status when reviewing pull requests but it only runs Rake. This
means we can miss linter errors when merging a PR which will proceed
to fail later in our build system.

Author: @vixus0