### PR TITLE
TT-792: Fix bug to allow front end to report which idp was chosen for

### DIFF
--- a/app/controllers/redirect_to_idp_warning_variant_controller.rb
+++ b/app/controllers/redirect_to_idp_warning_variant_controller.rb
@@ -64,6 +64,10 @@ private
     FEDERATION_REPORTER.report_idp_registration(request, idp_name, selected_idp_names, selected_answer_store.selected_evidence, recommended?)
   end
 
+  def recommended?
+    session.fetch(:selected_idp_was_recommended)
+  end
+
   def decorated_idp
     @decorated_idp ||= IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate(selected_identity_provider)
   end

--- a/spec/api_test_helper.rb
+++ b/spec/api_test_helper.rb
@@ -160,6 +160,10 @@ module ApiTestHelper
     stub_request(:get, api_uri(idp_list_endpoint(default_session_id))).to_return(body: idps.to_json)
   end
 
+  def stub_api_select_idp
+    stub_request(:put, api_uri(select_idp_endpoint(default_session_id)))
+  end
+
   def stub_api_no_docs_idps
     idps = [
       { 'simpleId' => 'stub-idp-one', 'entityId' => 'http://idcorp.com', 'levelsOfAssurance' => %w(LEVEL_1 LEVEL_2) },

--- a/spec/controllers/redirect_to_idp_warning_controller_spec.rb
+++ b/spec/controllers/redirect_to_idp_warning_controller_spec.rb
@@ -1,26 +1,66 @@
 require 'rails_helper'
 require 'controller_helper'
 require 'api_test_helper'
+require 'piwik_test_helper'
 
 describe RedirectToIdpWarningController do
-  subject { get :index, params: { locale: 'en' } }
-
   before :each do
     set_session_and_cookies_with_loa('LEVEL_2')
     session[:selected_idp_was_recommended] = [true, false].sample
   end
 
-  it 'renders idp warning page when idp has been selected' do
-    session[:selected_idp] = { 'simple_id' => 'stub-idp-two',
-                               'entity_id' => 'http://idcorp.com',
-                               'levels_of_assurance' => %w(LEVEL_1 LEVEL_2) }
+  context 'renders' do
+    subject { get :index, params: { locale: 'en' } }
 
-    expect(subject).to render_template(:index)
+    it 'idp warning page when idp has been selected' do
+      session[:selected_idp] = { 'simple_id' => 'stub-idp-two',
+                                 'entity_id' => 'http://idcorp.com',
+                                 'levels_of_assurance' => %w(LEVEL_1 LEVEL_2) }
+
+      expect(subject).to render_template(:index)
+    end
+
+    it 'error page when no idp selected' do
+      session[:selected_idp] = {}
+
+      expect(subject).to render_template('errors/something_went_wrong')
+    end
   end
 
-  it 'shows error page when no idp selected' do
-    session[:selected_idp] = {}
+  context 'continuing to idp' do
+    bobs_identity_service = { 'simple_id' => 'stub-idp-two',
+                              'entity_id' => 'http://idcorp.com',
+                              'levels_of_assurance' => %w(LEVEL_1 LEVEL_2) }
+    before :each do
+      stub_api_select_idp
+      stub_request(:get, INTERNAL_PIWIK.url).with(query: hash_including({}))
+    end
 
-    expect(subject).to render_template('errors/something_went_wrong')
+    subject { post :continue, params: { locale: 'en' } }
+
+    it 'redirects to idp website' do
+      session[:selected_idp] = bobs_identity_service
+
+      expect(subject).to redirect_to redirect_to_idp_path
+    end
+
+    it 'reports idp registration details to piwik' do
+      bobs_identity_service_idp_name = "Bob’s Identity Service"
+      idp_was_recommended = true
+      evidence = { driving_licence: true, passport: true }
+
+      session[:selected_idp] = bobs_identity_service
+      session[:selected_answers] = { 'documents' => evidence }
+      session[:selected_idp_was_recommended] = idp_was_recommended
+
+      expect(FEDERATION_REPORTER).to receive(:report_idp_registration)
+                                 .with(a_kind_of(ActionDispatch::Request),
+                                       bobs_identity_service_idp_name,
+                                       [bobs_identity_service_idp_name],
+                                       evidence.keys,
+                                       idp_was_recommended)
+
+      subject
+    end
   end
 end

--- a/spec/controllers/redirect_to_idp_warning_variant_controller_spec.rb
+++ b/spec/controllers/redirect_to_idp_warning_variant_controller_spec.rb
@@ -1,9 +1,12 @@
 require 'rails_helper'
 require 'controller_helper'
 require 'api_test_helper'
+require 'piwik_test_helper'
 
 describe RedirectToIdpWarningVariantController do
   before :each do
+    stub_api_select_idp
+    stub_request(:get, INTERNAL_PIWIK.url).with(query: hash_including({}))
     set_session_and_cookies_with_loa('LEVEL_2')
     session[:selected_idp_was_recommended] = [true, false].sample
   end
@@ -41,6 +44,43 @@ describe RedirectToIdpWarningVariantController do
       session[:selected_idp] = {}
 
       expect(subject).to render_template('errors/something_went_wrong')
+    end
+  end
+
+  context 'continuing to idp' do
+    bobs_identity_service = { 'simple_id' => 'stub-idp-two',
+                              'entity_id' => 'http://idcorp.com',
+                              'levels_of_assurance' => %w(LEVEL_1 LEVEL_2) }
+    before :each do
+      stub_api_select_idp
+      stub_request(:get, INTERNAL_PIWIK.url).with(query: hash_including({}))
+    end
+
+    subject { post :continue, params: { locale: 'en' } }
+
+    it 'redirects to idp website' do
+      session[:selected_idp] = bobs_identity_service
+
+      expect(subject).to redirect_to redirect_to_idp_path
+    end
+
+    it 'reports idp registration details to piwik' do
+      bobs_identity_service_idp_name = "Bob’s Identity Service"
+      idp_was_recommended = true
+      evidence = { driving_licence: true, passport: true }
+
+      session[:selected_idp] = bobs_identity_service
+      session[:selected_answers] = { 'documents' => evidence }
+      session[:selected_idp_was_recommended] = idp_was_recommended
+
+      expect(FEDERATION_REPORTER).to receive(:report_idp_registration)
+                                 .with(a_kind_of(ActionDispatch::Request),
+                                       bobs_identity_service_idp_name,
+                                       [bobs_identity_service_idp_name],
+                                       evidence.keys,
+                                       idp_was_recommended)
+
+      subject
     end
   end
 end


### PR DESCRIPTION
registration

- a method in the variant version of a controller was accidentally
removed in the last release which is used to determine whether user
chose an recommended or non recommended idp when reporting to piwik
- this resulted in a NoSuchMethod error causing the idp regisrtation not
to be reported t piwik
- restoring this method remedies the idp registration reporting