### PR TITLE
Tt 809 - Changing one doc IDP and fixing bug from TT-721

### DIFF
--- a/app/assets/javascripts/interstitial_question.js
+++ b/app/assets/javascripts/interstitial_question.js
@@ -12,17 +12,8 @@
         },
 
         setInterstitialQuestionDetailsVisibility: function () {
-            if (interstitialQuestion.hasAnsweredNo()) {
-                interstitialQuestion.interstitialQuestionDetails.removeClass('hidden');
-                interstitialQuestion.interstitialQuestionDetails.addClass('form-group-error');
-            } else {
-                interstitialQuestion.interstitialQuestionDetails.addClass('hidden');
-                interstitialQuestion.interstitialQuestionDetails.removeClass('form-group-error');
-            }
-        },
-        hasAnsweredNo: function () {
-            var input = $('input[name="interstitial_question_form[interstitial_question_result]"]:checked');
-            return input.length === 1 && input.val() === 'false';
+            interstitialQuestion.interstitialQuestionDetails.addClass('hidden');
+            interstitialQuestion.interstitialQuestionDetails.removeClass('form-group-error');
         }
     };
 

--- a/app/controllers/redirect_to_idp_question_controller.rb
+++ b/app/controllers/redirect_to_idp_question_controller.rb
@@ -21,6 +21,7 @@ class RedirectToIdpQuestionController < ApplicationController
   end
 
   def idp_wont_work_for_you
+    @idp = decorated_idp
     render 'idp_wont_work_for_you'
   end
 

--- a/spec/features/user_visits_redirect_to_idp_question_page_spec.rb
+++ b/spec/features/user_visits_redirect_to_idp_question_page_spec.rb
@@ -49,6 +49,12 @@ RSpec.describe 'When the user visits the redirect to IDP question page' do
     expect(page.get_rack_session['selected_answers']).to eql(expected_answers)
   end
 
+  it 'goes to "idp-wont-work-for-you" page if the user answers no to the interstitial question and javascript is enabled', js: true do
+    choose 'interstitial_question_form_interstitial_question_result_false', allow_label_click: true
+    click_button 'Continue'
+    expect(page).to have_title(I18n.t('hub.idp_wont_work_for_you_one_doc.title'))
+  end
+
   it 'displays an error message when user does not answer the question when javascript is turned off' do
     click_button 'Continue'
 
@@ -56,19 +62,7 @@ RSpec.describe 'When the user visits the redirect to IDP question page' do
     expect(page).to have_content('Please answer the question')
   end
 
-  context 'react appropriately when user fills in form', js: true do
-    it 'should not say we cannot verify you when user selects yes' do
-      choose 'interstitial_question_form_interstitial_question_result_true', allow_label_click: true
-      expect(page).to_not have_content('may not be able to verify you')
-    end
-
-    it 'should say we may not be able to verify you when user selects no' do
-      choose 'interstitial_question_form_interstitial_question_result_false', allow_label_click: true
-      expect(page).to have_content('may not be able to verify you')
-    end
-  end
-
-  context 'javascript validation', js: true do
+  context 'when the form is invalid', js: true do
     it 'should display validation message if no selection is made' do
       click_button 'Continue'
       expect(page).to have_content('Please answer the question')

--- a/spec/features/user_visits_redirect_to_idp_question_page_spec.rb
+++ b/spec/features/user_visits_redirect_to_idp_question_page_spec.rb
@@ -26,14 +26,12 @@ RSpec.describe 'When the user visits the redirect to IDP question page' do
   end
 
   it 'displays interstitial question' do
-    expect(page).to have_content('Verifying with FancyPants')
     expect(page).to have_content('I have a question for you in English')
   end
 
   it 'displays interstitial question in Welsh' do
     visit '/ailgyfeirio-i-gwestiwn-idp'
 
-    expect(page).to have_content('Dilysu gyda Welsh FancyPants')
     expect(page).to have_content('I have a question for you in Welsh')
     expect(page).to have_css 'html[lang=cy]'
   end

--- a/stub/locales/idps/stub-idp-one-doc-question.yml
+++ b/stub/locales/idps/stub-idp-one-doc-question.yml
@@ -25,7 +25,6 @@ en:
       interstitial_question: |
         <p>I have a question for you in English</p>
         <h2 class="heading-medium">Are you sure you want to continue?</h2>
-        <p>We are mean and will not let you</p>
       interstitial_explanation: |
         <p>OneDocIdp will not work for you.</p>
 cy:
@@ -54,6 +53,5 @@ cy:
       interstitial_question: |
         <p>I have a question for you in Welsh</p>
         <h2 class="heading-medium">Are you sure you want to continue?</h2>
-        <p>We are mean and will not let you</p>
       interstitial_explanation: |
         <p>OneDocIdp will not work for you in Welsh</p>

--- a/stub/locales/idps/stub-idp-one-doc-question.yml
+++ b/stub/locales/idps/stub-idp-one-doc-question.yml
@@ -1,25 +1,22 @@
 en:
   idps:
     stub-idp-one-doc-question:
-      name: "FancyPants"
-      tagline: "a really fancy pants identity provider"
+      name: "OneDocIdp"
+      tagline: "shows an interstitial page when the user only has one doc"
       about: |
-          <p>FancyPants is the premier identity proofing service around.</p>
-          <ul>
-            <li>Identity</li>
-            <li>Verification</li>
-          </ul>
-          <ol>
-            <li>Tell us about yourself</li>
-            <li>Create a password</li>
-          </ol>
-          <p>Once you get verified you can transact with online government services.</p>
+          <p>
+            OneDocIdp is a test provider that is able to verify identity
+            based on one piece of document evidence.  Its main purpose is to
+            provide an example of an IDP that has an interstitial question.
+            It will work if you have a mobile phone and have either just a passport
+            or just a driving licence.
+          </p>
       requirements:
         - a UK passport
         - a UK photocard driving licence
       contact_details: |
         <p>
-          <strong id="stub-idp-one-contact-details">100 IDCorp Lane</strong>
+          <strong id="stub-idp-one-contact-details">100 OneDocIdp Street</strong>
           <br/>Telephone: 0123456789
           <br/>Monday to Friday, 8am to 8pm
           <br/>Saturday and Sunday, 8am to 5pm
@@ -30,23 +27,25 @@ en:
         <h2 class="heading-medium">Are you sure you want to continue?</h2>
         <p>We are mean and will not let you</p>
       interstitial_explanation: |
-        <p>FancyPants will not work for you.</p>
+        <p>OneDocIdp will not work for you.</p>
 cy:
   idps:
     stub-idp-one-doc-question:
-      name: "Welsh FancyPants"
+      name: "Welsh OneDocInterstitialIdp"
+      tagline: "shows an interstitial page when the user only has one doc (Welsh)"
       about: |
-           <p>FancyPants is the premier identity proofing service around.</p>
-           <ul>
-             <li>Identity</li>
-             <li>Verification</li>
-           </ul>
+          <p>
+            OneDocIdp is a test provider that is able to verify identity
+            based on one piece of document evidence.  Its main purpose is to
+            provide an example of an IDP that has an interstitial question.
+            It will work if you have a mobile phone and have either just a passport
+            or just a driving licence.
+          </p>
       requirements:
-        - a UK passport
-        - a UK photocard driving licence
+        - must have a mobile phone and either a UK passport or a driving licence
       contact_details: |
         <p>
-          <strong id="stub-idp-one-contact-details">100 IDCorp Lane</strong>
+          <strong id="stub-idp-one-contact-details">100 OneDocIdp Street</strong>
           <br/>Telephone: 0123456789
           <br/>Monday to Friday, 8am to 8pm
           <br/>Saturday and Sunday, 8am to 5pm
@@ -57,4 +56,4 @@ cy:
         <h2 class="heading-medium">Are you sure you want to continue?</h2>
         <p>We are mean and will not let you</p>
       interstitial_explanation: |
-        <p>FancyPants will not work for you in Welsh</p>
+        <p>OneDocIdp will not work for you in Welsh</p>


### PR DESCRIPTION
In the course of fixing TT-809, I discovered a bug that was in the redirect_to_idp_question controller where the idp name was not being made available to the view idp_wont_work_for_you.html.erb.  This has been fixed.

The redirect_to_ip_question page has been modified so that when user clicks "No" on the interstitial question, there is no warning that appears under the radio button.  Much of the text for this already appears after the Continue button so the same warning by the radio button was eliminated.  Removing the text made it necessary to change some of the tests.

The text for the stub-idp-one-doc-question was also changed to make it more informative.

