### PR TITLE
TT-811 adjustments

### DIFF
--- a/app/assets/stylesheets/helpers/_verify-logo.scss
+++ b/app/assets/stylesheets/helpers/_verify-logo.scss
@@ -5,10 +5,9 @@
 
   .verify-logo-right {
     position: absolute;
-    right: 0;
+    right: -20px;
     top: 80px;
-    width: 33.333%;
-    text-align: center;
+    width: 33.33333%;
   }
 }
 

--- a/app/assets/stylesheets/pages/_redirect-to-idp-warning.scss
+++ b/app/assets/stylesheets/pages/_redirect-to-idp-warning.scss
@@ -4,9 +4,10 @@
     @include inline-block;
     padding: 0 20px 0 20px;
     width: 50%;
+    box-sizing: border-box;
 
     @include media (tablet) {
-      width: 24%;
+      max-width: 200px;
     }
   }
 

--- a/app/views/redirect_to_idp_warning/logos.html.erb
+++ b/app/views/redirect_to_idp_warning/logos.html.erb
@@ -17,8 +17,8 @@
     <% end %>
     <div class="logos-container">
       <ul class="list-logos">
-        <li class="verify"><%= image_tag @idp.logo_path, alt: '' %></li>
-        <li><%= image_tag 'govuk-verify-small-black-text-400X200.png', alt: 'GOV.UK VERIFY' %></li>
+        <li class="verify"><%= image_tag @idp.logo_path, alt: '' %></li><!--
+     --><li><%= image_tag 'govuk-verify-small-black-text-400X200.png', alt: 'GOV.UK VERIFY' %></li>
       </ul>
     </div>
 

--- a/app/views/sign_in/index.html.erb
+++ b/app/views/sign_in/index.html.erb
@@ -2,8 +2,13 @@
 <% content_for :feedback_source, 'SIGN_IN_PAGE' %>
 
 <%= link_to t('navigation.back'), start_path, class: 'link-back' %>
-<h1 class="heading-large"><%= t 'hub.signin.heading' %></h1>
-<p><%= t 'hub.signin.registration_message_html', href: link_to(t('hub.signin.about_link'), about_path) %></p>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <h1 class="heading-large"><%= t 'hub.signin.heading' %></h1>
+    <p><%= t 'hub.signin.registration_message_html', href: link_to(t('hub.signin.about_link'), about_path) %></p>
+  </div>
+</div>
 
 <div class="grid-row js-continue-to-idp" data-location="<%= url_for(controller: 'sign_in', action: 'select_idp_ajax', locale: I18n.locale)  %>">
   <%= render partial: 'shared/idp_list', locals: {identity_providers: @identity_providers} %>


### PR DESCRIPTION
Move header on sign-in page into two-thirds width column. Left-align logo to match the language options text.

Also adjust logo widths on redirect-to-idp-warning page

Authors: @hugh-emerson