### PR TITLE
EID-153: Add a new endpoint country_response

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,5 @@ before_script:
 cache:
   directories:
     - $HOME/.phantomjs 
+addons:
+  firefox: "45.9.0esr"

--- a/app/controllers/authn_response_controller.rb
+++ b/app/controllers/authn_response_controller.rb
@@ -1,5 +1,5 @@
 class AuthnResponseController < SamlController
-  protect_from_forgery except: :idp_response
+  protect_from_forgery except: [:idp_response, :country_response]
 
   SIGNING_IN_STATE = 'SIGN_IN_WITH_IDP'.freeze
   REGISTERING_STATE = 'REGISTER_WITH_IDP'.freeze
@@ -24,6 +24,31 @@ class AuthnResponseController < SamlController
       redirect_to failed_uplift_path
     else
       report_to_analytics("Failure - #{user_state}")
+      redirect_to response.is_registration ? failed_registration_path : failed_sign_in_path
+    end
+  end
+
+  def country_response
+    if params['RelayState'].nil?
+      if session[:transaction_supports_eidas]
+        params['RelayState'] = session[:verify_session_id]
+      end
+    end
+
+    if params['RelayState'] != session[:verify_session_id]
+      raise Errors::WarningLevelError, "Relay state should match session id. Relay state was #{params['RelayState'].inspect}"
+    end
+
+    response = SESSION_PROXY.country_authn_response(session[:verify_session_id], params['SAMLResponse'], params['RelayState'])
+
+    case response.country_result
+    when 'SUCCESS'
+      redirect_to response.is_registration ? confirmation_path : response_processing_path
+    when 'CANCEL'
+      redirect_to response.is_registration ? failed_registration_path : start_path
+    when 'FAILED_UPLIFT'
+      redirect_to failed_uplift_path
+    else
       redirect_to response.is_registration ? failed_registration_path : failed_sign_in_path
     end
   end

--- a/app/controllers/test_saml_controller.rb
+++ b/app/controllers/test_saml_controller.rb
@@ -19,4 +19,15 @@ class TestSamlController < ApplicationController
 
     render 'idp_request'
   end
+
+  def country_request
+    @saml_request = params['SAMLRequest']
+    @relay_state = params['RelayState']
+    @registration = params['registration']
+    @language_hint = params['language']
+
+    @hints = blah.split('&').select { |x| x.starts_with? 'hint' }.map { |x| x.split('=')[1] }.join(', ')
+
+    render 'country_request'
+  end
 end

--- a/app/models/country_authn_response.rb
+++ b/app/models/country_authn_response.rb
@@ -1,0 +1,12 @@
+class CountryAuthnResponse < Api::Response
+  attr_reader :country_result, :is_registration, :loa_achieved
+  validates_presence_of :country_result
+  validates_inclusion_of :loa_achieved, in: ['LEVEL_1', 'LEVEL_2', nil]
+  validates_inclusion_of :is_registration, in: [true, false]
+
+  def initialize(hash)
+    @country_result = hash['countryResult']
+    @is_registration = hash['isRegistration']
+    @loa_achieved = hash['loaAchieved']
+  end
+end

--- a/app/models/session_endpoints.rb
+++ b/app/models/session_endpoints.rb
@@ -22,6 +22,7 @@ module SessionEndpoints
   SESSION_ID = 'sessionId'.freeze
   COUNTRIES_PATH_PREFIX = Pathname(COUNTRIES_PATH)
   COUNTRY_AUTHN_REQUEST_SUFFIX = 'country-authn-request'.freeze
+  COUNTRY_AUTHN_RESPONSE_SUFFIX = 'country-authn-response'.freeze
 
   def countries_endpoint(session_id)
     COUNTRIES_PATH_PREFIX.join(session_id).to_s
@@ -45,6 +46,10 @@ module SessionEndpoints
 
   def country_authn_request_endpoint(session_id)
     session_endpoint(session_id, COUNTRY_AUTHN_REQUEST_SUFFIX)
+  end
+
+  def country_authn_response_endpoint(session_id)
+    session_endpoint(session_id, COUNTRY_AUTHN_RESPONSE_SUFFIX)
   end
 
   def idp_authn_request_endpoint(session_id)

--- a/app/models/session_proxy.rb
+++ b/app/models/session_proxy.rb
@@ -82,6 +82,16 @@ class SessionProxy
     IdpAuthnResponse.validated_response(response)
   end
 
+  def country_authn_response(session_id, saml_response, relay_state)
+    body = {
+        PARAM_RELAY_STATE => relay_state,
+        PARAM_SAML_RESPONSE => saml_response,
+        PARAM_ORIGINATING_IP => originating_ip
+    }
+    response = @api_client.put(country_authn_response_endpoint(session_id), body)
+    CountryAuthnResponse.validated_response(response)
+  end
+
   def matching_outcome(session_id)
     response = @api_client.get(matching_outcome_endpoint(session_id))
     MatchingOutcomeResponse.validated_response(response).outcome

--- a/app/views/test_saml/index.html.erb
+++ b/app/views/test_saml/index.html.erb
@@ -49,3 +49,20 @@
     <%= hidden_field_tag('language', 'cy') %>
     <div><%= submit_tag 'saml-response-post-with-cy-language' %></div>
 <% end -%>
+<%= form_tag('/SAML2/SSO/EidasResponse/POST') do -%>
+    <%= hidden_field_tag('SAMLResponse', 'my-saml-response') %>
+    <%= hidden_field_tag('RelayState', params.fetch('session-id', session[:verify_session_id])) %>
+    <div><%= submit_tag 'saml-eidas-response-post' %></div>
+<% end -%>
+<%= form_tag('/SAML2/SSO/EidasResponse/POST') do -%>
+    <%= hidden_field_tag('SAMLResponse', 'my-saml-response') %>
+    <%= hidden_field_tag('RelayState', params.fetch('session-id', session[:verify_session_id])) %>
+    <%= hidden_field_tag('language', 'en') %>
+    <div><%= submit_tag 'saml-eidas-response-post-with-en-language' %></div>
+<% end -%>
+<%= form_tag('/SAML2/SSO/EidasResponse/POST') do -%>
+    <%= hidden_field_tag('SAMLResponse', 'my-saml-response') %>
+    <%= hidden_field_tag('RelayState', params.fetch('session-id', session[:verify_session_id])) %>
+    <%= hidden_field_tag('language', 'cy') %>
+    <div><%= submit_tag 'saml-eidas-response-post-with-cy-language' %></div>
+<% end -%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
 
   post 'SAML2/SSO' => 'authn_request#rp_request'
   post 'SAML2/SSO/Response/POST' => 'authn_response#idp_response'
+  post 'SAML2/SSO/EidasResponse/POST' => 'authn_response#country_response'
   match "/404", to: "errors#page_not_found", via: :all
 
   if %w(test development).include? Rails.env

--- a/spec/api_test_helper.rb
+++ b/spec/api_test_helper.rb
@@ -151,6 +151,18 @@ module ApiTestHelper
         .to_return(body: response.to_json, status: 200)
   end
 
+  def stub_api_country_authn_response(relay_state, response = { 'idpResult' => 'SUCCESS', 'isRegistration' => false })
+    authn_response_body = {
+        PARAM_SAML_RESPONSE => 'my-saml-response',
+        PARAM_RELAY_STATE => relay_state,
+        PARAM_ORIGINATING_IP => '<PRINCIPAL IP ADDRESS COULD NOT BE DETERMINED>'
+    }
+
+    stub_request(:put, api_uri(country_authn_response_endpoint(default_session_id)))
+        .with(body: authn_response_body)
+        .to_return(body: response.to_json, status: 200)
+  end
+
   def stub_api_returns_error(code)
     stub_request(:get, api_uri(idp_authn_request_endpoint(default_session_id)))
         .to_return(body: an_error_response(code).to_json, status: 500)

--- a/spec/features/user_sends_authn_response_spec.rb
+++ b/spec/features/user_sends_authn_response_spec.rb
@@ -100,4 +100,16 @@ RSpec.describe 'User returns from an IDP with an AuthnResponse' do
     expect(a_request(:get, INTERNAL_PIWIK.url)
                .with(query: hash_including('action_name' => 'Success - SIGN_IN_WITH_IDP at LOA LEVEL_2'))).to have_been_made.once
   end
+
+  it 'will redirect the user to /response-processing on successful sign in at the Country' do
+    stub_session
+    stub_matching_outcome
+    api_request = stub_api_country_authn_response(session_id, 'countryResult' => 'SUCCESS', 'isRegistration' => false, 'loaAchieved' => 'LEVEL_2')
+
+    visit("/test-saml?session-id=#{session_id}")
+    click_button 'saml-eidas-response-post'
+
+    expect(page).to have_current_path '/response-processing'
+    expect(api_request).to have_been_made.once
+  end
 end


### PR DESCRIPTION
Country response in authn response controller will be used to receive eIDAS Authn Response from a country proxy node and will be forwarded to a new endpoint in saml-proxy. This will enable saml-proxy to process eIDAS Authn Response in a different way compared to Verify Authn Response (e.g. verifying country's signature using metadata aggregator instead of federation metadata).

Authors: @adityapahuja @lamerexter @sfkamath