### PR TITLE
Tt 721

### DIFF
--- a/spec/controllers/choose_a_certified_company_controller_spec.rb
+++ b/spec/controllers/choose_a_certified_company_controller_spec.rb
@@ -82,27 +82,9 @@ describe ChooseACertifiedCompanyController do
       set_session_and_cookies_with_loa('LEVEL_2')
     end
 
-    it 'redirects to interstitial question when user has passport but no driving licence' do
-      session[:selected_answers] = {
-          'documents' => { 'passport' => true },
-          'phone' => { 'mobile_phone' => true }
-      }
-      post :select_idp, params: { locale: 'en', entity_id: 'http://idcorp.com' }
-      expect(subject).to redirect_to redirect_to_idp_question_path
-    end
-
     it 'redirects to interstitial question when user has GB driving licence but no passport' do
       session[:selected_answers] = {
           'documents' => { 'driving_licence' => true },
-          'phone' => { 'mobile_phone' => true }
-      }
-      post :select_idp, params: { locale: 'en', entity_id: 'http://idcorp.com' }
-      expect(subject).to redirect_to redirect_to_idp_question_path
-    end
-
-    it 'redirects to interstitial question when user has NI driving licence and passport' do
-      session[:selected_answers] = {
-          'documents' => { 'ni_driving_licence' => true, 'passport' => true },
           'phone' => { 'mobile_phone' => true }
       }
       post :select_idp, params: { locale: 'en', entity_id: 'http://idcorp.com' }

--- a/spec/controllers/choose_a_certified_company_controller_spec.rb
+++ b/spec/controllers/choose_a_certified_company_controller_spec.rb
@@ -69,17 +69,53 @@ describe ChooseACertifiedCompanyController do
       expect(subject).to redirect_to redirect_to_idp_warning_path
     end
 
-    it 'redirects to IDP question page when user has one doc and IDP flag is enabled' do
-      session[:selected_answers] = { 'documents' => { 'driving_licence' => true } }
-      post :select_idp, params: { locale: 'en', entity_id: 'http://idcorp.com' }
-
-      expect(subject).to redirect_to redirect_to_idp_question_path
-    end
-
     it 'returns 404 page if IDP is non-existent' do
       post :select_idp, params: { locale: 'en', entity_id: 'http://notanidp.com' }
 
       expect(response).to have_http_status :not_found
+    end
+  end
+
+
+  context 'redirect scenarios for one doc enabled IDP where user has only one document of evidence' do
+    before :each do
+      set_session_and_cookies_with_loa('LEVEL_2')
+    end
+
+    it 'redirects to interstitial question when user has passport but no driving licence' do
+      session[:selected_answers] = {
+          'documents' => { 'passport' => true },
+          'phone' => { 'mobile_phone' => true }
+      }
+      post :select_idp, params: { locale: 'en', entity_id: 'http://idcorp.com' }
+      expect(subject).to redirect_to redirect_to_idp_question_path
+    end
+
+    it 'redirects to interstitial question when user has GB driving licence but no passport' do
+      session[:selected_answers] = {
+          'documents' => { 'driving_licence' => true },
+          'phone' => { 'mobile_phone' => true }
+      }
+      post :select_idp, params: { locale: 'en', entity_id: 'http://idcorp.com' }
+      expect(subject).to redirect_to redirect_to_idp_question_path
+    end
+
+    it 'redirects to interstitial question when user has NI driving licence and passport' do
+      session[:selected_answers] = {
+          'documents' => { 'ni_driving_licence' => true, 'passport' => true },
+          'phone' => { 'mobile_phone' => true }
+      }
+      post :select_idp, params: { locale: 'en', entity_id: 'http://idcorp.com' }
+      expect(subject).to redirect_to redirect_to_idp_question_path
+    end
+
+    it 'redirects to warning page when user has two documents of evidence' do
+      session[:selected_answers] = {
+          'documents' => { 'driving_licence' => true, 'passport' => true },
+          'phone' => { 'mobile_phone' => true }
+      }
+      post :select_idp, params: { locale: 'en', entity_id: 'http://idcorp.com' }
+      expect(subject).to redirect_to redirect_to_idp_warning_path
     end
   end
 

--- a/spec/features/user_visits_select_documents_page_spec.rb
+++ b/spec/features/user_visits_select_documents_page_spec.rb
@@ -43,5 +43,13 @@ RSpec.feature 'When user visits document selection page' do
       expect(page).to have_current_path(other_identity_documents_path)
       expect(page.get_rack_session['selected_answers']).to eql('documents' => { 'passport' => false, 'driving_licence' => false, 'ni_driving_licence' => false })
     end
+
+    it 'should go to other documents page if user does not have UK passport and only has NI driving licence' do
+      choose 'select_documents_form_any_driving_licence_true'
+      check 'select_documents_form_ni_driving_licence'
+      choose 'select_documents_form_passport_false'
+      click_button 'Continue'
+      expect(page).to have_current_path(other_identity_documents_path)
+    end
   end
 end

--- a/stub/api/stub_api.rb
+++ b/stub/api/stub_api.rb
@@ -14,6 +14,11 @@ class StubApi < Sinatra::Base
         "simpleId":"stub-idp-one",
         "entityId":"http://example.com/stub-idp-one",
         "levelsOfAssurance": ["LEVEL_2"]
+     },
+     {
+      "simpleId":"stub-idp-one-doc-question",
+      "entityId":"http://example.com/stub-idp-one-doc-question",
+      "levelsOfAssurance": ["LEVEL_2"]
      }]'
   end
 

--- a/stub/api/stub_api.rb
+++ b/stub/api/stub_api.rb
@@ -14,11 +14,6 @@ class StubApi < Sinatra::Base
         "simpleId":"stub-idp-one",
         "entityId":"http://example.com/stub-idp-one",
         "levelsOfAssurance": ["LEVEL_2"]
-     },
-     {
-      "simpleId":"stub-idp-one-doc-question",
-      "entityId":"http://example.com/stub-idp-one-doc-question",
-      "levelsOfAssurance": ["LEVEL_2"]
      }]'
   end
 


### PR DESCRIPTION
Adding test coverage for scenarios that relate to a person having one document of evidence.  Also modified stub_api.rb so that it can show more than just the one stub-idp-one IDP.  While doing the story, we realised that the coverage for the select documents page needed to be improved to consider cases where only an NI driving licence was selected for document evidence.