### PR TITLE
TT-811: remove logo from redirect to service pages

### DIFF
--- a/app/assets/stylesheets/helpers/_verify-logo.scss
+++ b/app/assets/stylesheets/helpers/_verify-logo.scss
@@ -13,7 +13,13 @@
 
 .slides,
 .no-right-hand-logo {
-  ~ .verify-logo-right,
+  ~ .verify-logo-right {
+    display: none;
+  }
+}
+
+.slides,
+.no-right-hand-logo {
   // use the "+" selector to support IE6
   + .feedback-link + .verify-logo-right,
   + .verify-logo-right {

--- a/app/views/redirect_to_service/redirect_to_service.html.erb
+++ b/app/views/redirect_to_service/redirect_to_service.html.erb
@@ -1,6 +1,6 @@
 <%= page_title @title %>
 
-<div class="content-inner js-hidden">
+<div class="content-inner js-hidden no-right-hand-logo">
   <div class="grid-row">
     <div class="column-two-thirds">
       <h1 class="heading-large"><%= t('hub.redirect_to_service.heading') %></h1>
@@ -18,10 +18,8 @@
   </div>
 </div>
 
-<div class="grid-row response-processing js-show">
-  <div class="column-two-thirds">
-    <h1 class="heading-large"><%= @transition_message %></h1>
-    <p><%= t('hub.redirect_to_service.please_wait') %></p>
-    <%= image_tag 'loading.gif', alt: t('hub.redirect_to_service.loading'), class: 'loading' %>
-  </div>
+<div class="grid-row response-processing js-show no-right-hand-logo">
+  <h1 class="heading-large"><%= @transition_message %></h1>
+  <p><%= t('hub.redirect_to_service.please_wait') %></p>
+  <%= image_tag 'loading.gif', alt: t('hub.redirect_to_service.loading'), class: 'loading' %>
 </div>

--- a/app/views/response_processing/index.html.erb
+++ b/app/views/response_processing/index.html.erb
@@ -1,10 +1,8 @@
 <%= page_title 'hub.response_processing.title' %>
 <% content_for :meta_refresh, '2' %>
 
-<div class="grid-row response-processing">
-  <div class="column-two-thirds">
-    <h1 class="heading-large"><%= t('hub.response_processing.heading', rp_name: @rp_name) %></h1>
-    <p><%= t('hub.response_processing.bear_with_us') %></p>
-    <%= image_tag 'loading.gif', alt: 'Loading animation', class: 'loading' %>
-  </div>
+<div class="grid-row response-processing no-right-hand-logo">
+  <h1 class="heading-large"><%= t('hub.response_processing.heading', rp_name: @rp_name) %></h1>
+  <p><%= t('hub.response_processing.bear_with_us') %></p>
+  <%= image_tag 'loading.gif', alt: 'Loading animation', class: 'loading' %>
 </div>


### PR DESCRIPTION
We don't want the logo to appear on the redirect page at the end of the user's journey through Verify because they feel like they have returned to the RP at this point. So this commit hides the logo on that page (actually comprised of two views) and reverts the two-thirds width change.

Author: @hugh-emerson, @MichaelWalker 