### PR TITLE
TT-732: Get Transactions from Config - implementation changes

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,6 @@
 SESSION_COOKIE_DURATION_IN_HOURS=2
-API_HOST=http://localhost:50190
+IDA_FRONTEND_HOST=http://localhost:50190
+CONFIG_API_HOST=https://localhost:50243
 RP_DISPLAY_LOCALES=stub/locales/rps
 CYCLE_3_DISPLAY_LOCALES=stub/locales/cycle3
 IDP_DISPLAY_LOCALES=stub/locales/idps

--- a/.env
+++ b/.env
@@ -1,6 +1,6 @@
 SESSION_COOKIE_DURATION_IN_HOURS=2
 IDA_FRONTEND_HOST=http://localhost:50190
-CONFIG_API_HOST=https://localhost:50243
+CONFIG_API_HOST=http://localhost:50240
 RP_DISPLAY_LOCALES=stub/locales/rps
 CYCLE_3_DISPLAY_LOCALES=stub/locales/cycle3
 IDP_DISPLAY_LOCALES=stub/locales/idps

--- a/.env.test
+++ b/.env.test
@@ -1,4 +1,5 @@
-API_HOST=http://api.com:50190
+IDA_FRONTEND_HOST=http://api.com:50190
+CONFIG_API_HOST=http://api.com:50240
 METRICS_ENABLED=false
 
 PUBLIC_PIWIK_HOST=http://localhost:4242/piwik.php

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,7 +22,7 @@ class ApplicationController < ActionController::Base
   prepend RedirectWithSeeOther
 
   def transactions_list
-    DATA_CORRELATOR.correlate(Display::Rp::TransactionsProxy.new(API_CLIENT).transactions)
+    DATA_CORRELATOR.correlate(Display::Rp::TransactionsProxy.new(CONFIG_API_CLIENT).transactions)
   end
 
   def loa1_transactions_list

--- a/app/models/api/client.rb
+++ b/app/models/api/client.rb
@@ -10,21 +10,21 @@ module Api
 
     def get(path, options = {})
       response = log_request(path, 'get') do
-        client.get(uri(path), options)
+        client.get(path, options)
       end
       @response_handler.handle_response(response.status, 200, response.to_s)
     end
 
     def post(path, body, options = {}, expected_status = 201)
       response = log_request(path, 'post') do
-        client.post(uri(path), body, options)
+        client.post(path, body, options)
       end
       @response_handler.handle_response(response.status, expected_status, response.to_s)
     end
 
     def put(path, body, options = {})
       response = log_request(path, 'put') do
-        client.put(uri(path), body, options)
+        client.put(path, body, options)
       end
       @response_handler.handle_response(response.status, 200, response.to_s)
     end
@@ -37,10 +37,6 @@ module Api
       ActiveSupport::Notifications.instrument('api_request', path: path, method: method) do
         yield
       end
-    end
-
-    def uri(path)
-      '/api' + path
     end
   end
 end

--- a/app/models/display/rp/display_data_correlator.rb
+++ b/app/models/display/rp/display_data_correlator.rb
@@ -15,12 +15,11 @@ module Display
       end
 
       def correlate(data)
-        transactions = data.fetch('transactions')
-        transactions_name_homepage = filter_transactions(transactions, @rps_name_homepage).map do |transaction|
+        transactions_name_homepage = filter_transactions(data, @rps_name_homepage).map do |transaction|
           name = translate_name(transaction)
-          Transaction.new(name, transaction.fetch('homepage'), transaction.fetch('loaList'))
+          Transaction.new(name, transaction.fetch('serviceHomepage'), transaction.fetch('loaList'))
         end
-        transactions_name_only = filter_transactions(transactions, @rps_name_only).map do |transaction|
+        transactions_name_only = filter_transactions(data, @rps_name_only).map do |transaction|
           name = translate_name(transaction)
           Transaction.new(name, nil, transaction.fetch('loaList'))
         end

--- a/app/models/display/rp/transactions_proxy.rb
+++ b/app/models/display/rp/transactions_proxy.rb
@@ -6,7 +6,7 @@ module Display
       end
 
       def transactions
-        @api_client.get('/transactions')
+        @api_client.get('/config/transactions/enabled')
       end
     end
   end

--- a/app/models/session_endpoints.rb
+++ b/app/models/session_endpoints.rb
@@ -1,5 +1,5 @@
 module SessionEndpoints
-  PATH = '/session'.freeze
+  PATH = '/api/session'.freeze
   PATH_PREFIX = Pathname(PATH)
   IDP_LIST_SUFFIX = 'idp-list'.freeze
   SELECT_IDP_SUFFIX = 'select-idp'.freeze
@@ -18,7 +18,7 @@ module SessionEndpoints
   PARAM_ENTITY_ID = 'entityId'.freeze
   PARAM_REGISTRATION = 'registration'.freeze
   PARAM_CYCLE_THREE_VALUE = 'value'.freeze
-  COUNTRIES_PATH = '/countries'.freeze
+  COUNTRIES_PATH = '/api/countries'.freeze
   SESSION_ID = 'sessionId'.freeze
   COUNTRIES_PATH_PREFIX = Pathname(COUNTRIES_PATH)
   COUNTRY_AUTHN_REQUEST_SUFFIX = 'country-authn-request'.freeze

--- a/config/initializers/00_configuration.rb
+++ b/config/initializers/00_configuration.rb
@@ -7,7 +7,8 @@ CONFIG = Configuration.load! do
   option_string 'idp_display_locales', 'IDP_DISPLAY_LOCALES'
   option_string 'country_display_locales', 'COUNTRY_DISPLAY_LOCALES'
   option_string 'session_cookie_duration', 'SESSION_COOKIE_DURATION_IN_HOURS', default: 2
-  option_string 'api_host', 'API_HOST'
+  option_string 'ida_frontend_host', 'IDA_FRONTEND_HOST'
+  option_string 'config_api_host', 'CONFIG_API_HOST'
   option_string 'logo_directory', 'LOGO_DIRECTORY'
   option_string 'white_logo_directory', 'WHITE_LOGO_DIRECTORY'
   option_string 'zdd_file', 'ZDD_LATCH'

--- a/config/initializers/20_api_proxies.rb
+++ b/config/initializers/20_api_proxies.rb
@@ -1,6 +1,7 @@
 require 'originating_ip_store'
 
 Rails.application.config.after_initialize do
-  API_CLIENT = Api::Client.new(CONFIG.api_host, Api::ResponseHandler.new)
-  SESSION_PROXY = SessionProxy.new(API_CLIENT, OriginatingIpStore)
+  IDA_FRONTEND_CLIENT = Api::Client.new(CONFIG.ida_frontend_host, Api::ResponseHandler.new)
+  SESSION_PROXY = SessionProxy.new(IDA_FRONTEND_CLIENT, OriginatingIpStore)
+  CONFIG_API_CLIENT = Api::Client.new(CONFIG.config_api_host, Api::ResponseHandler.new)
 end

--- a/spec/controllers/about_spec.rb
+++ b/spec/controllers/about_spec.rb
@@ -6,7 +6,7 @@ describe AboutController do
   let(:identity_provider_display_decorator) { double(:IdentityProviderDisplayDecorator) }
 
   before(:each) do
-    stub_request(:get, CONFIG.api_host + '/api/transactions')
+    stub_request(:get, CONFIG.config_api_host + '/config/transactions/enabled')
     stub_api_idp_list
   end
 

--- a/spec/features/redirects_with_see_other_spec.rb
+++ b/spec/features/redirects_with_see_other_spec.rb
@@ -2,7 +2,7 @@ require 'feature_helper'
 require 'api_test_helper'
 describe 'pages redirect with see other', type: :request do
   it 'sets a see other for redirects' do
-    stub_request(:post, api_uri('session')).to_return(body: stub_api_session.to_json, status: 201)
+    stub_request(:post, ida_frontend_api_uri('session')).to_return(body: stub_api_session.to_json, status: 201)
     stub_api_saml_endpoint
     post '/SAML2/SSO', params: { 'SAMLRequest' => 'my-saml-request', 'RelayState' => 'my-relay-state' }
     expect(response.status).to eql 303

--- a/spec/features/user_encounters_error_page_spec.rb
+++ b/spec/features/user_encounters_error_page_spec.rb
@@ -2,8 +2,8 @@ require 'feature_helper'
 require 'api_test_helper'
 
 RSpec.describe 'user encounters error page' do
-  let(:api_saml_endpoint) { api_uri('session') }
-  let(:api_select_idp_endpoint) { api_uri(select_idp_endpoint(default_session_id)) }
+  let(:api_saml_endpoint) { ida_frontend_api_uri('api/session') }
+  let(:api_select_idp_endpoint) { ida_frontend_api_uri(select_idp_endpoint(default_session_id)) }
 
   it 'will present the user with a list of transactions' do
     stub_transactions_list
@@ -85,7 +85,7 @@ RSpec.describe 'user encounters error page' do
 
     it 'will present session error page when session error occurs in upstream systems' do
       error_body = { id: '0', type: 'SESSION_ERROR' }
-      stub_request(:post, api_uri('session')).to_return(body: error_body.to_json, status: 400)
+      stub_request(:post, ida_frontend_api_uri('api/session')).to_return(body: error_body.to_json, status: 400)
       visit('/test-saml')
       click_button 'saml-post'
       expect(page).to have_content "You need to start again"
@@ -96,7 +96,7 @@ RSpec.describe 'user encounters error page' do
 
     it 'will present a session timeout error page when the API returns session timeout' do
       error_body = { id: '0', type: 'SESSION_TIMEOUT' }
-      stub_request(:post, api_uri('session')).to_return(body: error_body.to_json, status: 400)
+      stub_request(:post, ida_frontend_api_uri('api/session')).to_return(body: error_body.to_json, status: 400)
       visit('/test-saml')
       click_button 'saml-post'
       expect(page).to have_content "Your session has timed out"

--- a/spec/features/user_sends_authn_request_spec.rb
+++ b/spec/features/user_sends_authn_request_spec.rb
@@ -4,7 +4,7 @@ require 'models/session_proxy'
 require 'piwik_test_helper'
 
 describe 'user sends authn requests' do
-  let(:api_saml_endpoint) { api_uri('session') }
+  let(:api_saml_endpoint) { ida_frontend_api_uri('api/session') }
 
   context 'and it is received successfully' do
     let(:session_start_time) { DateTime.now }

--- a/spec/features/user_visits_choose_a_country_page_spec.rb
+++ b/spec/features/user_visits_choose_a_country_page_spec.rb
@@ -154,15 +154,15 @@ RSpec.describe 'When the user visits the choose a country page' do
     expect(page).to have_current_path('/a-country-page')
 
     # And API is called (and policy records the country selected by the user)
-    expect(a_request(:post, api_uri(select_country_endpoint("my-session-id-cookie", "NL")))).to have_been_made.once
+    expect(a_request(:post, ida_frontend_api_uri(select_country_endpoint("my-session-id-cookie", "NL")))).to have_been_made.once
   end
 
   def select_country_endpoint(session_id, country_code)
-    '/countries/' + session_id + '/' + country_code
+    '/api/countries/' + session_id + '/' + country_code
   end
 
   def stub_select_country_request
-    stub_request(:post, api_uri(select_country_endpoint("my-session-id-cookie", "NL")))
+    stub_request(:post, ida_frontend_api_uri(select_country_endpoint("my-session-id-cookie", "NL")))
         .to_return(body: '')
   end
 end

--- a/spec/features/user_visits_further_information_page_spec.rb
+++ b/spec/features/user_visits_further_information_page_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe 'user visits further information page' do
     # a journey with an rp that does not allow nullable cycle 3 attributes.
     # We are doing this by hacking the response from  the api to return different cycle 3 attributes on loading the page
     # so that we generate a link for capybara and submitting where nullable is not allowed.
-    matching_attribute_request = stub_request(:get, api_uri(cycle_three_endpoint(default_session_id)))
+    matching_attribute_request = stub_request(:get, ida_frontend_api_uri(cycle_three_endpoint(default_session_id)))
         .to_return(body: { name: 'NullableAttribute' }.to_json)
         .to_return(body: { name: 'DrivingLicenceNumber' }.to_json)
     stub_transactions_list

--- a/spec/features/user_visits_sign_in_page_spec.rb
+++ b/spec/features/user_visits_sign_in_page_spec.rb
@@ -34,9 +34,9 @@ RSpec.describe 'user selects an IDP on the sign in page' do
     expect(page).to have_content("relay state is 'a-relay-state'")
     expect(page).to have_content("registration is 'false'")
     expect(cookie_value('verify-front-journey-hint')).to_not be_nil
-    expect(a_request(:put, api_uri(select_idp_endpoint(default_session_id)))
+    expect(a_request(:put, ida_frontend_api_uri(select_idp_endpoint(default_session_id)))
              .with(body: { 'entityId' => idp_entity_id, 'originatingIp' => originating_ip, 'registration' => false })).to have_been_made.once
-    expect(a_request(:get, api_uri(idp_authn_request_endpoint(default_session_id)))
+    expect(a_request(:get, ida_frontend_api_uri(idp_authn_request_endpoint(default_session_id)))
              .with(headers: { 'X_FORWARDED_FOR' => originating_ip })).to have_been_made.once
     expect(stub_piwik_request('action_name' => "Sign In - #{idp_display_name}")).to have_been_made.once
   end

--- a/spec/models/api/client_spec.rb
+++ b/spec/models/api/client_spec.rb
@@ -16,39 +16,39 @@ module Api
 
     context '#get' do
       it 'sets cookies if provided them' do
-        stub_request(:get, "#{host}/api#{path}").with(headers: { cookie: /COOKIE_NAME=some-val/ }).and_return(status: 200, body: '{}')
+        stub_request(:get, "#{host}#{path}").with(headers: { cookie: /COOKIE_NAME=some-val/ }).and_return(status: 200, body: '{}')
         expect(response_handler).to receive(:handle_response).with(HTTP::Response::Status[200], 200, '{}').and_return(response_body)
         response = api_client.get(path, cookies: { 'COOKIE_NAME' => 'some-val' })
-        expect(a_request(:get, "#{host}/api#{path}").with(headers: { cookie: /COOKIE_NAME=some-val/ })).to have_been_made.once
+        expect(a_request(:get, "#{host}#{path}").with(headers: { cookie: /COOKIE_NAME=some-val/ })).to have_been_made.once
         expect(response).to eql response_body
       end
 
       it 'set params if provided them' do
-        stub_request(:get, "#{host}/api#{path}").with(query: { 'param1' => 'value1' }).and_return(status: 200, body: '{}')
+        stub_request(:get, "#{host}#{path}").with(query: { 'param1' => 'value1' }).and_return(status: 200, body: '{}')
         expect(response_handler).to receive(:handle_response).with(HTTP::Response::Status[200], 200, '{}').and_return(response_body)
         response = api_client.get(path, params: { 'param1' => 'value1' })
-        expect(a_request(:get, "#{host}/api#{path}").with(query: { 'param1' => 'value1' })).to have_been_made.once
+        expect(a_request(:get, "#{host}#{path}").with(query: { 'param1' => 'value1' })).to have_been_made.once
         expect(response).to eql response_body
       end
 
       it 'returns a JSON result when successful' do
-        stub_request(:get, "#{host}/api#{path}").and_return(status: 200, body: '{}')
+        stub_request(:get, "#{host}#{path}").and_return(status: 200, body: '{}')
         expect(response_handler).to receive(:handle_response).with(HTTP::Response::Status[200], 200, '{}').and_return(response_body)
         response = api_client.get(path)
-        expect(a_request(:get, "#{host}/api#{path}")).to have_been_made.once
+        expect(a_request(:get, "#{host}#{path}")).to have_been_made.once
         expect(response).to eql response_body
       end
     end
 
     context '#post' do
-      let(:receive_request) { stub_request(:post, "#{host}/api#{path}").with(body: request_body) }
+      let(:receive_request) { stub_request(:post, "#{host}#{path}").with(body: request_body) }
 
       context 'successful post' do
         it 'takes a hash and posts it as JSON and returns json result' do
           receive_request.and_return(status: 201, body: '{}')
           expect(response_handler).to receive(:handle_response).with(HTTP::Response::Status[201], 201, '{}').and_return(response_body)
           response = api_client.post(path, request_body)
-          expect(a_request(:post, "#{host}/api#{path}").with(body: request_body)).to have_been_made.once
+          expect(a_request(:post, "#{host}#{path}").with(body: request_body)).to have_been_made.once
           expect(response).to eq response_body
         end
       end
@@ -60,20 +60,20 @@ module Api
         api_client.post(path, request_body)
         api_client.post(path, request_body)
         api_client.post(path, request_body)
-        expect(a_request(:post, "#{host}/api#{path}").with(headers: { 'User-Agent' => 'Verify Frontend Micro Service Client' }))
+        expect(a_request(:post, "#{host}#{path}").with(headers: { 'User-Agent' => 'Verify Frontend Micro Service Client' }))
           .to have_been_made.times(4)
       end
     end
 
     context '#put' do
-      let(:receive_request) { stub_request(:put, "#{host}/api#{path}").with(body: request_body) }
+      let(:receive_request) { stub_request(:put, "#{host}#{path}").with(body: request_body) }
 
       context 'successful put' do
         it 'takes a hash and puts it as JSON and returns json result' do
           receive_request.and_return(status: 200, body: '{}')
           expect(response_handler).to receive(:handle_response).with(HTTP::Response::Status[200], 200, '{}').and_return(response_body)
           response = api_client.put(path, request_body)
-          expect(a_request(:put, "#{host}/api#{path}").with(body: request_body)).to have_been_made.once
+          expect(a_request(:put, "#{host}#{path}").with(body: request_body)).to have_been_made.once
           expect(response).to eq response_body
         end
       end
@@ -92,7 +92,7 @@ module Api
         end
 
         it 'logs API gets' do
-          stub_request(:get, "#{host}/api#{path}").and_return(status: 200, body: '{}')
+          stub_request(:get, "#{host}#{path}").and_return(status: 200, body: '{}')
           expect(response_handler).to receive(:handle_response).with(HTTP::Response::Status[200], 200, '{}').and_return(response_body)
 
           payload = notification_payload_for { api_client.get(path) }
@@ -101,7 +101,7 @@ module Api
         end
 
         it 'logs API puts' do
-          stub_request(:put, "#{host}/api#{path}").with(body: request_body).and_return(status: 200, body: '{}')
+          stub_request(:put, "#{host}#{path}").with(body: request_body).and_return(status: 200, body: '{}')
           expect(response_handler).to receive(:handle_response).with(HTTP::Response::Status[200], 200, '{}').and_return(response_body)
 
           payload = notification_payload_for { api_client.put(path, request_body) }
@@ -110,7 +110,7 @@ module Api
         end
 
         it 'logs API posts' do
-          stub_request(:post, "#{host}/api#{path}").with(body: request_body).and_return(status: 201, body: '{}')
+          stub_request(:post, "#{host}#{path}").with(body: request_body).and_return(status: 201, body: '{}')
           expect(response_handler).to receive(:handle_response).with(HTTP::Response::Status[201], 201, '{}').and_return(response_body)
 
           payload = notification_payload_for { api_client.post(path, request_body) }

--- a/spec/models/display/rp/display_data_correlator_spec.rb
+++ b/spec/models/display/rp/display_data_correlator_spec.rb
@@ -42,14 +42,12 @@ module Display
       end
 
       it 'returns the transactions with display name and homepage in the order listed in the relying_parties_config' do
-        transaction_data = {
-            'transactions' => [
-                { 'simpleId' => public_simple_id, 'homepage' => homepage, 'loaList' => public_simple_id_loa },
-                { 'simpleId' => public_simple_id_2, 'homepage' => homepage_2, 'loaList' => public_simple_id_2_loa },
-                { 'simpleId' => public_simple_id_3, 'homepage' => homepage_3, 'loaList' => public_simple_id_3_loa },
-                { 'simpleId' => public_simple_id_4, 'homepage' => homepage_4, 'loaList' => public_simple_id_4_loa },
-            ]
-        }
+        transaction_data = [
+              { 'simpleId' => public_simple_id, 'serviceHomepage' => homepage, 'loaList' => public_simple_id_loa },
+              { 'simpleId' => public_simple_id_2, 'serviceHomepage' => homepage_2, 'loaList' => public_simple_id_2_loa },
+              { 'simpleId' => public_simple_id_3, 'serviceHomepage' => homepage_3, 'loaList' => public_simple_id_3_loa },
+              { 'simpleId' => public_simple_id_4, 'serviceHomepage' => homepage_4, 'loaList' => public_simple_id_4_loa },
+        ]
         correlator = DisplayDataCorrelator.new(translator, [public_simple_id_4, public_simple_id_2, public_simple_id, public_simple_id_3], [])
         actual_result = correlator.correlate(transaction_data)
         expected_result = DisplayDataCorrelator::Transactions.new(
@@ -64,12 +62,10 @@ module Display
       end
 
       it 'translates and filters the transactions according to the relying_parties config' do
-        transaction_data = {
-          'transactions' => [
-            { 'simpleId' => public_simple_id, 'homepage' => homepage, 'loaList' => public_simple_id_loa },
-            { 'simpleId' => private_simple_id, 'loaList' => private_simple_id_loa }
-          ]
-        }
+        transaction_data = [
+          { 'simpleId' => public_simple_id, 'serviceHomepage' => homepage, 'loaList' => public_simple_id_loa },
+          { 'simpleId' => private_simple_id, 'loaList' => private_simple_id_loa }
+        ]
 
         actual_result = display_data_correlator.correlate(transaction_data)
         expected_result = DisplayDataCorrelator::Transactions.new(

--- a/spec/models/session_proxy_spec.rb
+++ b/spec/models/session_proxy_spec.rb
@@ -8,7 +8,7 @@ X_FORWARDED_FOR = 'X-Forwarded-For'.freeze
 describe SessionProxy do
   let(:api_client) { double(:api_client) }
   let(:originating_ip_store) { double(:originating_ip_store) }
-  let(:path) { '/session' }
+  let(:path) { '/api/session' }
   let(:session_id) { 'my-session-id' }
   let(:cookies) {
     {
@@ -98,7 +98,7 @@ describe SessionProxy do
     let(:api_response) { countries_json }
 
     it 'should retrieve countries' do
-      expect(api_client).to receive(:get).with('/countries/my-session-id').and_return(api_response)
+      expect(api_client).to receive(:get).with('/api/countries/my-session-id').and_return(api_response)
 
       response = session_proxy.get_countries(session_id)
       expect(response.countries.count).to eq(2)

--- a/startup.sh
+++ b/startup.sh
@@ -4,7 +4,8 @@
 if [ "$1" == '--stub-api' ]
 then
   echo "Starting stub-api server on port 50199"
-  export API_HOST=http://localhost:50199
+  export IDA_FRONTEND_HOST=http://localhost:50199
+  export CONFIG_API_HOST=http://localhost:50199
   (
   export BUNDLE_GEMFILE=stub/api/Gemfile
   bundle check || bundle install

--- a/stub/api/stub_api.rb
+++ b/stub/api/stub_api.rb
@@ -48,29 +48,19 @@ class StubApi < Sinatra::Base
     }'
   end
 
-  get '/api/transactions' do
-    '{
-      "public":[{
+   get '/config/transactions/enabled' do
+    '[{
         "simpleId":"test-rp",
         "entityId":"http://example.com/test-rp",
-        "homepage":"http://example.com/test-rp",
+        "serviceHomepage":"http://example.com/test-rp",
         "loaList":["LEVEL_2"]
-      }],
-      "private":[],
-      "transactions":[{
-        "simpleId":"test-rp",
-        "entityId":"http://example.com/test-rp",
-        "homepage":"http://example.com/test-rp",
-        "loaList":["LEVEL_2"]
-        },
-        {
-          "simpleId": "loa1-test-rp",
-          "entityId": "http://example.com/test-rp-loa1",
-          "homepage":"http://example.com/test-rp-loa1",
-          "loaList":["LEVEL_1","LEVEL_2"]
-        }
-      ]
-    }'
+      },
+      {
+        "simpleId": "loa1-test-rp",
+        "entityId": "http://example.com/test-rp-loa1",
+        "serviceHomepage":"http://example.com/test-rp-loa1",
+        "loaList":["LEVEL_1","LEVEL_2"]
+      }]'
   end
 
   get '/api/countries/blah' do

--- a/stub/api/stub_api_spec.rb
+++ b/stub/api/stub_api_spec.rb
@@ -73,13 +73,12 @@ describe StubApi do
     end
   end
 
-  context '#get /api/transactions' do
+  context '#get /config/transactions/enabled' do
     it 'should respond with valid hash' do
-      get '/api/transactions'
+      get '/config/transactions/enabled'
       expect(last_response).to be_ok
       response = last_response_json
-      expect(response['public']).to be_an(Array)
-      expect(response['private']).to be_an(Array)
+      expect(response).to be_an(Array)
     end
   end
 


### PR DESCRIPTION
[TT-732](https://govukverify.atlassian.net/browse/TT-732): Get Transactions directly from Config

Make the verify-frontend talk to Config service directly, instead of going via ida-frontend.

**Note:** This has to go **after** [app-config PR-15](https://github.digital.cabinet-office.gov.uk/gds/verify-frontend-app-config/pull/15) and [webops PR-3656](https://github.digital.cabinet-office.gov.uk/gds/ida-webops/pull/3656)

Authors: @jakubmiarka @MichaelWalker @hugh-emerson 