### PR TITLE
EID-208: Cleanup eIDAS tests

### DIFF
--- a/spec/api_test_helper.rb
+++ b/spec/api_test_helper.rb
@@ -163,6 +163,11 @@ module ApiTestHelper
         .to_return(body: response.to_json, status: 200)
   end
 
+  def stub_api_bad_request_response_to_country_authn_request
+    stub_request(:get, api_uri(country_authn_request_endpoint(default_session_id)))
+        .to_return(body: "", status: 500)
+  end
+
   def stub_api_returns_error(code)
     stub_request(:get, api_uri(idp_authn_request_endpoint(default_session_id)))
         .to_return(body: an_error_response(code).to_json, status: 500)

--- a/spec/features/user_visits_redirect_to_country_spec.rb
+++ b/spec/features/user_visits_redirect_to_country_spec.rb
@@ -19,10 +19,25 @@ RSpec.describe 'When the user visits the redirect to country page' do
     )
   end
 
+  def given_a_session_supporting_eidas
+    page.set_rack_session transaction_supports_eidas: true
+  end
+
   it 'should show something went wrong when visiting redirect to country page directly with session not supporting eidas' do
     given_a_session_not_supporting_eidas
 
     visit '/redirect-to-country'
+
+    expect(page).to have_content 'Sorry, something went wrong'
+  end
+
+  it 'should show something went wrong when visiting redirect to country directly without choosing a country' do
+    stub_api_bad_request_response_to_country_authn_request
+
+    given_a_session_supporting_eidas
+
+    visit '/redirect-to-country'
+
     expect(page).to have_content 'Sorry, something went wrong'
   end
 end


### PR DESCRIPTION
Import a test where a user lands directly on a redirect to country page
without first choosing a country from acceptance tests.

Authors: @timothyspence @adityapahuja