### PR TITLE
BAU: Rescue from KeyError when no session data retrieved

### DIFF
--- a/app/controllers/redirect_to_idp_warning_controller.rb
+++ b/app/controllers/redirect_to_idp_warning_controller.rb
@@ -51,11 +51,19 @@ private
       selected_idp_names << idp_name
       session[:selected_idp_names] = selected_idp_names
     end
-    FEDERATION_REPORTER.report_idp_registration(request, idp_name, selected_idp_names, selected_answer_store.selected_evidence, recommended?)
+    FEDERATION_REPORTER.report_idp_registration(request, idp_name, selected_idp_names, selected_answer_store.selected_evidence, recommended)
   end
 
-  def recommended?
-    session.fetch(:selected_idp_was_recommended)
+  def recommended
+    begin
+      if session.fetch(:selected_idp_was_recommended)
+        '(recommended)'
+      else
+        '(not recommended)'
+      end
+    rescue KeyError
+      '(idp recommendation key not set)'
+    end
   end
 
   def decorated_idp

--- a/app/models/analytics/federation_reporter.rb
+++ b/app/models/analytics/federation_reporter.rb
@@ -29,11 +29,10 @@ module Analytics
     end
 
     def report_idp_registration(request, idp_name, idp_name_history, evidence, recommended)
-      recommended_str = recommended ? '(recommended)' : '(not recommended)'
       list_of_evidence = evidence.sort.join(', ')
       @analytics_reporter.report_custom_variable(
         request,
-        "#{idp_name} was chosen for registration #{recommended_str} with evidence #{list_of_evidence}",
+        "#{idp_name} was chosen for registration #{recommended} with evidence #{list_of_evidence}",
         Analytics::CustomVariable.build(:idp_selection, idp_name_history.join(','))
       )
     end

--- a/spec/controllers/redirect_to_idp_warning_controller_spec.rb
+++ b/spec/controllers/redirect_to_idp_warning_controller_spec.rb
@@ -48,7 +48,7 @@ describe RedirectToIdpWarningController do
 
     it 'reports idp registration details to piwik' do
       bobs_identity_service_idp_name = "Bob’s Identity Service"
-      idp_was_recommended = true
+      idp_was_recommended = '(recommended)'
       evidence = { driving_licence: true, passport: true }
 
       session[:selected_idp] = bobs_identity_service
@@ -61,6 +61,25 @@ describe RedirectToIdpWarningController do
                                        [bobs_identity_service_idp_name],
                                        evidence.keys,
                                        idp_was_recommended)
+
+      subject
+    end
+
+    it 'reports idp registration and doesn\t error out if idp_was_recommended key not present' do
+      bobs_identity_service_idp_name = "Bob’s Identity Service"
+      idp_was_recommended = '(idp recommendation key not set)'
+      evidence = { driving_licence: true, passport: true }
+
+      session[:selected_idp] = bobs_identity_service
+      session[:selected_answers] = { 'documents' => evidence }
+      session.delete(:selected_idp_was_recommended)
+
+      expect(FEDERATION_REPORTER).to receive(:report_idp_registration)
+                                         .with(a_kind_of(ActionDispatch::Request),
+                                               bobs_identity_service_idp_name,
+                                               [bobs_identity_service_idp_name],
+                                               evidence.keys,
+                                               idp_was_recommended)
 
       subject
     end

--- a/spec/models/analytics/federation_reporter_spec.rb
+++ b/spec/models/analytics/federation_reporter_spec.rb
@@ -48,7 +48,7 @@ module Analytics
           "#{idp_name} was chosen for registration (recommended) with evidence passport",
           5 => ['IDP_SELECTION', idp_history_str]
         )
-        federation_reporter.report_idp_registration(request, idp_name, idp_history, %w(passport), true)
+        federation_reporter.report_idp_registration(request, idp_name, idp_history, %w(passport), '(recommended)')
       end
 
       it 'should report correctly if IdP was not recommended' do
@@ -58,7 +58,17 @@ module Analytics
             "#{idp_name} was chosen for registration (not recommended) with evidence passport",
             5 => ['IDP_SELECTION', idp_history_str]
           )
-        federation_reporter.report_idp_registration(request, idp_name, idp_history, %w(passport), false)
+        federation_reporter.report_idp_registration(request, idp_name, idp_history, %w(passport), '(not recommended)')
+      end
+
+      it 'should report correctly if IdP recommendation key not found in session' do
+        expect(analytics_reporter).to receive(:report_custom_variable)
+          .with(
+            request,
+            "#{idp_name} was chosen for registration (idp recommendation key not set) with evidence passport",
+            5 => ['IDP_SELECTION', idp_history_str]
+            )
+        federation_reporter.report_idp_registration(request, idp_name, idp_history, %w(passport), '(idp recommendation key not set)')
       end
 
       it 'should sort evidence' do
@@ -68,7 +78,7 @@ module Analytics
             "#{idp_name} was chosen for registration (recommended) with evidence driving_licence, passport",
             5 => ['IDP_SELECTION', idp_history_str]
           )
-        federation_reporter.report_idp_registration(request, idp_name, idp_history, %w(passport driving_licence), true)
+        federation_reporter.report_idp_registration(request, idp_name, idp_history, %w(passport driving_licence), '(recommended)')
       end
     end
 


### PR DESCRIPTION
We're seeing a few errors cropping up where no idp_was_recommended value
is available in the session. This can occur for a number of reasons, but
leads to an irrecoverable journey from the user perspective.

The point of failure is currently at the reporting stage, which should
not cause the entire request to fail, therefore the error is now being
rescued from and a message will be included in the reporting explaining
why and where it failed.