### PR TITLE
Revert "TT-963: update tests to stub and use the transaction entity id"

### DIFF
--- a/app/models/config_endpoints.rb
+++ b/app/models/config_endpoints.rb
@@ -4,7 +4,6 @@ module ConfigEndpoints
   IDP_LIST_SUFFIX = 'idps/idp-list'.freeze
 
   def idp_list_endpoint(transaction_id)
-    transaction_id_query_parameter = { transactionEntityId: transaction_id }.to_query
-    PATH_PREFIX.join(IDP_LIST_SUFFIX).to_s + "?#{transaction_id_query_parameter}"
+    PATH_PREFIX.join(IDP_LIST_SUFFIX).to_s + "?transactionEntityId=#{transaction_id}"
   end
 end

--- a/spec/api_test_helper.rb
+++ b/spec/api_test_helper.rb
@@ -95,7 +95,6 @@ module ApiTestHelper
   def stub_api_session(options = {})
     {
         'transactionSimpleId' => 'test-rp',
-        'transactionEntityId' => 'http://www.test-rp.gov.uk/SAML2/MD',
         'sessionStartTime' => '32503680000000',
         'sessionId' => default_session_id,
         'idps' => [{ 'simpleId' => 'stub-idp-one', 'entityId' => 'http://idcorp.com', 'levelsOfAssurance' => %w(LEVEL_1 LEVEL_2) }],
@@ -179,7 +178,7 @@ module ApiTestHelper
   end
 
   def stub_api_idp_list(idps = default_idps)
-    stub_request(:get, config_api_uri(idp_list_endpoint(default_transaction_entity_id))).to_return(body: idps.to_json)
+    stub_request(:get, config_api_uri(idp_list_endpoint(default_transaction_id))).to_return(body: idps.to_json)
   end
 
   def stub_api_select_idp
@@ -204,10 +203,6 @@ private
 
   def default_transaction_id
     'test-rp'
-  end
-
-  def default_transaction_entity_id
-    'http://www.test-rp.gov.uk/SAML2/MD'
   end
 
   def default_idps

--- a/spec/controller_helper.rb
+++ b/spec/controller_helper.rb
@@ -4,7 +4,6 @@ def set_session_and_cookies_with_loa(loa_requested)
   session[:requested_loa] = loa_requested
   session[:verify_session_id] = 'my-session-id-cookie'
   session[:transaction_simple_id] = 'test-rp'
-  session[:transaction_entity_id] = 'http://www.test-rp.gov.uk/SAML2/MD'
   session[:start_time] = DateTime.now.to_i * 1000
   cookies[CookieNames::SESSION_COOKIE_NAME] = 'my-session-cookie'
   cookies[CookieNames::SESSION_ID_COOKIE_NAME] = 'my-session-id-cookie'

--- a/spec/feature_helper.rb
+++ b/spec/feature_helper.rb
@@ -149,8 +149,7 @@ private
     { transaction_simple_id: 'test-rp',
       start_time: start_time_in_millis,
       verify_session_id: default_session_id,
-      requested_loa: 'LEVEL_2',
-      transaction_entity_id: 'http://www.test-rp.gov.uk/SAML2/MD'
+      requested_loa: 'LEVEL_2'
     }
   end
 end

--- a/spec/models/session_proxy_spec.rb
+++ b/spec/models/session_proxy_spec.rb
@@ -34,7 +34,6 @@ describe SessionProxy do
           'sessionId' => session_id,
           'sessionStartTime' => 'my-session-start-time',
           'transactionSimpleId' => 'transaction-simple-id',
-          'transactionEntityId' => 'http://www.test-rp.gov.uk/SAML2/MD',
           'idps' => [{ 'simpleId' => 'stub-idp-one', 'entityId' => 'http://idcorp.com' }],
           'levelsOfAssurance' => %w(LEVEL_1 LEVEL_2),
           'transactionSupportsEidas' => false
@@ -67,7 +66,7 @@ describe SessionProxy do
       expect(originating_ip_store).to receive(:get).and_return(ip_address)
       expect {
         session_proxy.create_session('my-saml-request', 'my-relay-state')
-      }.to raise_error Api::Response::ModelError, "Session can't be blank, Transaction simple can't be blank, Levels of assurance can't be blank, Transaction entity can't be blank, Transaction supports eidas is not included in the list"
+      }.to raise_error Api::Response::ModelError, "Session can't be blank, Transaction simple can't be blank, Levels of assurance can't be blank, Transaction supports eidas is not included in the list"
     end
   end
 

--- a/stub/api/stub_api.rb
+++ b/stub/api/stub_api.rb
@@ -95,7 +95,6 @@ private
       \"sessionId\":\"blah\",
       \"sessionStartTime\":32503680000000,
       \"transactionSimpleId\":\"test-rp\",
-      \"transactionEntityId\":\"http://www.test-rp.gov.uk/SAML2/MD\",
       \"levelsOfAssurance\":[\"#{level_of_assurance}\"],
       \"transactionSupportsEidas\": true
     }"


### PR DESCRIPTION
Reverts alphagov/verify-frontend#344

Temporarily to confirm this is the cause of staging failure