### PR TITLE
TT-1065: bugfix for JS syntax

### DIFF
--- a/app/assets/javascripts/ab_test_selector.js
+++ b/app/assets/javascripts/ab_test_selector.js
@@ -2,7 +2,7 @@ function abTest(experimentDetails) {
 
   try {
     if (document.cookie.indexOf("ab_test") >= 0) {
-      const abCookie = JSON.parse(getCookie("ab_test"))
+      var abCookie = JSON.parse(getCookie("ab_test"))
 
       var routes = { 'control': experimentDetails.control.route}
 


### PR DESCRIPTION
[JIRA TT-1065](https://govukverify.atlassian.net/browse/TT-1065)

Replacing const keyword with var to work in IE<11.

Solo: @jakubmiarka