### PR TITLE
TT-942: set fixed width on Verify logo on mobile - sign-off refinement

### DIFF
--- a/app/assets/stylesheets/pages/_slides.scss
+++ b/app/assets/stylesheets/pages/_slides.scss
@@ -83,7 +83,7 @@
     }
 
     @include media(mobile) {
-      width: 40%;
+      width: 140px;
     }
   }
 


### PR DESCRIPTION
During sign-off it was decided the logo should have a fixed width to roughly match the font size and not use percentage sizing

Solo: @jakubmiarka