### PR TITLE
TT-981: changed a link on the failed uplift page

### DIFF
--- a/app/views/failed_uplift/index.html.erb
+++ b/app/views/failed_uplift/index.html.erb
@@ -26,7 +26,8 @@
       <summary><span class="summary"><%= t 'hub.failed_uplift.try_another_summary' %></span></summary>
       <div class="panel panel-border-narrow">
         <p><%= t 'hub.failed_uplift.try_another_text', idp_name: @idp.display_name %></p>
-        <p><%= link_to t('hub.failed_uplift.start_again'), start_path, id: 'startAgain' %></p>
+        <p><%= link_to t('hub.failed_uplift.start_again'), about_choosing_a_company_path, id: 'startAgain' %></p>
+        
       </div>
     </details>
 

--- a/app/views/failed_uplift/index.html.erb
+++ b/app/views/failed_uplift/index.html.erb
@@ -27,7 +27,6 @@
       <div class="panel panel-border-narrow">
         <p><%= t 'hub.failed_uplift.try_another_text', idp_name: @idp.display_name %></p>
         <p><%= link_to t('hub.failed_uplift.start_again'), about_choosing_a_company_path, id: 'startAgain' %></p>
-        
       </div>
     </details>
 


### PR DESCRIPTION
The link to 'Find another company to verify you' changed from /start to /about-choosing-a-company.

Authors: @jakubmiarka @hugh-emerson