### PR TITLE
TT-1078: Made sign-in IDP picker page consistent on mobile

### DIFF
--- a/app/assets/stylesheets/pages/_company.scss
+++ b/app/assets/stylesheets/pages/_company.scss
@@ -58,12 +58,19 @@
   left: 0;
 }
 
-.company-logo-inner img {
-  max-width: 100%;
+.company-logo-inner {
+  img,
+  input[type="image"] {
+    max-width: 100%;
+  }
 }
 
 .company .button {
   margin: 0 0 20px;
+
+  @include media (mobile) {
+    width: 65%;
+  }
 }
 
 .company dialog .button {

--- a/app/views/shared/_idp_list.erb
+++ b/app/views/shared/_idp_list.erb
@@ -1,14 +1,14 @@
   <% identity_providers.each_with_index do |identity_provider, idx| %>
+    <%= form_for(identity_provider, url: sign_in_submit_path, html: {class: 'idp-option js-idp-form', id: nil}) do |f| %>
+      <%= hidden_field_tag 'entity_id', identity_provider.entity_id, id: nil, class: 'js-entity-id' %>
       <div class="column-one-third company-wrapper <%= idx % 3 == 0 ? 'clear-left' : nil %>">
         <div class="company">
           <div class="company-inner">
             <div class="company-logo">
               <div class="company-logo-inner">
-                <%= image_tag identity_provider.logo_path, alt: idp_tagline(identity_provider) %>
+                <%= image_submit_tag(identity_provider.logo_path, alt: idp_tagline(identity_provider)) %>
               </div>
             </div>
-
-            <%= form_for(identity_provider, url: sign_in_submit_path, html: {class: 'idp-option js-idp-form', id: nil}) do |f| %>
                 <% button_text = local_assigns.fetch(:non_repudiation, false) ? 'hub.signin.sign_in_idp' : 'hub.signin.select_idp' %>
                 <%= f.button t(button_text, display_name: identity_provider.display_name),
                              class: 'button',
@@ -17,9 +17,8 @@
                              type: 'submit',
                              value: identity_provider.display_name
                 %>
-                <%= hidden_field_tag 'entity_id', identity_provider.entity_id, id: nil, class: 'js-entity-id' %>
-            <% end %>
           </div>
         </div>
       </div>
+    <% end %>
   <% end %>

--- a/app/views/shared/_unavailable_idp_list.erb
+++ b/app/views/shared/_unavailable_idp_list.erb
@@ -4,7 +4,7 @@
           <div class="company-inner">
             <div class="company-logo">
               <div class="company-logo-inner">
-                <%= image_tag identity_provider.logo_path, alt: idp_tagline(identity_provider) %>
+                <%= link_to image_tag(identity_provider.logo_path, alt: idp_tagline(identity_provider)), certified_company_unavailable_path(identity_provider.simple_id) %>
               </div>
             </div>
 

--- a/spec/features/user_submits_start_page_form_spec.rb
+++ b/spec/features/user_submits_start_page_form_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'when user submits start page form' do
     expect(current_path).to eq('/sign-in')
     expect(page).to have_content 'Who do you have an identity account with?'
     expect(page).to have_content 'IDCorp'
-    expect(page).to have_css('img[src="/stub-logos/stub-idp-one.png"]')
+    expect(page).to have_css('.company-logo input[src="/stub-logos/stub-idp-one.png"]')
     expect(page).to have_link 'Back', href: '/start'
     expect_feedback_source_to_be(page, 'SIGN_IN_PAGE', '/sign-in')
     expect(page).to have_link 'start now', href: '/about'

--- a/spec/features/user_visits_confirm_your_identity_page_spec.rb
+++ b/spec/features/user_visits_confirm_your_identity_page_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe 'When the user visits the confirm-your-identity page' do
       visit '/sign-in'
       first('.available-languages').click_link('Cymraeg')
       expect(page).to have_current_path('/mewngofnodi')
-      click_button 'IDCorp'
+      click_button 'Ddewis Welsh IDCorp'
 
       visit '/test-saml'
       click_button 'saml-post-journey-hint'


### PR DESCRIPTION
Made logos clickable and used same styles on mobile devices for button. Also updated tests to click the correct button.

Solo: @jakubmiarka