### PR TITLE
TT-1119: Fixes for scrolling event and piwik action name

### DIFF
--- a/app/assets/javascripts/piwik_idp_picker_tracking.js
+++ b/app/assets/javascripts/piwik_idp_picker_tracking.js
@@ -18,14 +18,20 @@
         };
     });
 
-    var eventAction = canSeeAllButtons() ? 'All' : numberOfVisibleButtons.toString();
+    if(canSeeAllButtons()){
+        var eventAction = 'All';
+    }
+    else if (numberOfVisibleButtons === 0) {
+        var eventAction = 'None';
+    } 
+    else {
+        var eventAction = numberOfVisibleButtons.toString();
+    }
 
     _paq.push(['trackEvent', 'Engagement', eventAction, 'IDP visibility']);
 
-
-    $(window).scroll(function() {
+    $(window).one('scroll', function() {
         _paq.push(['trackEvent', 'Engagement', 'Picker scroll', 'scrolled']);
-        $(window).off('scroll');
     })
 
 })(window);


### PR DESCRIPTION
Bugs were idenitifed with scrolling event firing more than once. Also, due to Piwik bug event action names having "0" were considered as null. Changing that to null.

Authors: @jakubmiarka @michaelwalker