### PR TITLE
TT-988: Implement grouping by taxon for timeout page.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,6 +8,7 @@ class ApplicationController < ActionController::Base
   before_action :set_locale
   before_action :store_originating_ip
   after_action :store_locale_in_cookie, if: -> { request.method == 'GET' }
+  helper_method :transaction_taxon_list
   helper_method :transactions_list
   helper_method :loa1_transactions_list
   helper_method :loa2_transactions_list
@@ -20,6 +21,10 @@ class ApplicationController < ActionController::Base
   rescue_from Api::SessionTimeoutError, with: :session_timeout
 
   prepend RedirectWithSeeOther
+
+  def transaction_taxon_list
+    TRANSACTION_TAXON_CORRELATOR.correlate(CONFIG_PROXY.transactions)
+  end
 
   def transactions_list
     DATA_CORRELATOR.correlate(CONFIG_PROXY.transactions)

--- a/app/models/display/rp/transaction_taxon_correlator.rb
+++ b/app/models/display/rp/transaction_taxon_correlator.rb
@@ -1,0 +1,82 @@
+module Display
+  module Rp
+    class TransactionTaxonCorrelator
+      Transaction = Struct.new(:name, :taxon, :homepage, :loa_list)
+      Taxon = Struct.new(:name, :transactions)
+
+      def initialize(translator)
+        @translator = translator
+        @other_services_translation = @translator.translate('errors.transaction_list.other_services')
+      end
+
+      def correlate(data)
+        transaction_list = map_to_transactions(data)
+        transaction_list = sort_transactions(transaction_list)
+        taxon_groups = group_by_taxon(transaction_list)
+        taxons = sort_taxons(taxon_groups)
+        return taxons
+
+      rescue KeyError => e
+        Rails.logger.error e
+        []
+      end
+
+    private
+
+      def map_to_transactions(data)
+        data.map do |item|
+          name = translate_name(item)
+          homepage = item.fetch('serviceHomepage', nil)
+          # if there's no homepage, move the transaction down to the 'Other service' taxon
+          taxon = homepage.nil? ? @other_services_translation : translate_taxon(item)
+          loa_list = item.fetch('loaList')
+          Transaction.new(name, taxon, homepage, loa_list)
+        end
+      end
+
+      def sort_transactions(transactions)
+        # Prioritise transactions with a homepage, and then sort alphabetically.
+        transactions.sort do |x, y|
+          if x.homepage.nil? && !y.homepage.nil?
+            1
+          elsif !x.homepage.nil? && y.homepage.nil?
+            -1
+          else
+            x.name.casecmp(y.name)
+          end
+        end
+      end
+
+      def sort_taxons(taxons)
+        # Sort alphabetically, except putting 'Other services' at the bottom of the list.
+        taxons.sort do |x, y|
+          if x.name === @other_services_translation
+            1
+          elsif y.name === @other_services_translation
+            -1
+          else
+            x.name.casecmp(y.name)
+          end
+        end
+      end
+
+      def translate_name(transaction)
+        simple_id = transaction.fetch('simpleId')
+        @translator.translate("rps.#{simple_id}.name")
+      end
+
+      def translate_taxon(transaction)
+        simple_id = transaction.fetch('simpleId')
+        @translator.translate("rps.#{simple_id}.taxon_name")
+      rescue Display::FederationTranslator::TranslationError
+        @other_services_translation
+      end
+
+      def group_by_taxon(transactions)
+        transactions
+            .group_by { |transaction| transaction[:taxon] }
+            .map { |name, taxon_transactions| Taxon.new(name, taxon_transactions) }
+      end
+    end
+  end
+end

--- a/app/views/errors/_transaction_list.html.erb
+++ b/app/views/errors/_transaction_list.html.erb
@@ -1,15 +1,19 @@
-<% transactions = transactions_list %>
-<% if transactions.any? %>
-    <h2 class="heading-medium"><%= t 'errors.transaction_list.title' %></h2>
-    <ul class="list-bullet list">
-      <% transactions.name_homepage.each do |transaction| -%>
-          <li><%= link_to transaction.name, transaction.homepage %></li>
-      <% end %>
-      <% transactions.name_only.each do |transaction| -%>
+<% taxons = transaction_taxon_list %>
+<% if taxons.any? %>
+  <h2 class="heading-medium"><%= t 'errors.transaction_list.title' %></h2>
+  <% taxons.each do |taxon| %>
+    <h3 class="heading-small"><%= taxon.name %></h3>
+    <ul class="list">
+      <% taxon.transactions.each do |transaction| %>
         <li>
-          <%= transaction.name %>
-          <p class="form-hint"><%= t 'errors.transaction_list.hint' %></p>
+          <% if transaction.homepage %>
+            <%= link_to transaction.name, transaction.homepage %>
+          <% else %>
+            <%= transaction.name %>
+            <p class="form-hint"><%= t 'errors.transaction_list.hint' %></p>
+          <% end %>
         </li>
       <% end %>
     </ul>
+  <% end %>
 <% end %>

--- a/config/initializers/30_federation.rb
+++ b/config/initializers/30_federation.rb
@@ -27,6 +27,7 @@ Rails.application.config.after_initialize do
   rps_name_and_homepage = RP_CONFIG['transaction_type']['display_name_and_homepage'] || []
   rps_name_only = RP_CONFIG['transaction_type']['display_name_only'] || []
   DATA_CORRELATOR = Display::Rp::DisplayDataCorrelator.new(federation_translator, rps_name_and_homepage, rps_name_only)
+  TRANSACTION_TAXON_CORRELATOR = Display::Rp::TransactionTaxonCorrelator.new(federation_translator)
 
   # IDP Config
   IDP_CONFIG = YAML.load_file(CONFIG.idp_config)

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -477,6 +477,7 @@ cy:
     transaction_list:
       title: Dod o hyd i’r gwasanaeth rydych yn ei ddefnyddio i ddechrau eto
       hint: Dilynnwch y cyfarwyddiadau rydych wedi’u derbyn.
+      other_services: Other services
     cookie_expired:
       title: Mae eich sesiwn wedi amseru allan
       feedback_message: Defnyddiwch yr %{feedback_link} i ofyn cwestiwn, hysbysu problem neu awgrymu gwelliant.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -472,6 +472,7 @@ en:
     transaction_list:
       title: Find the service you were using to start again
       hint: Follow the instructions you received.
+      other_services: Other services
     cookie_expired:
       title: Your session has timed out
       feedback_message: Use the %{feedback_link} to ask a question, report a problem or suggest an improvement.

--- a/spec/features/user_encounters_error_page_spec.rb
+++ b/spec/features/user_encounters_error_page_spec.rb
@@ -18,10 +18,10 @@ RSpec.describe 'user encounters error page' do
   it 'will present the user with no list of transactions if we cant read the errors' do
     allow(Rails.logger).to receive(:error)
     expect(Rails.logger).to receive(:error).with(kind_of(KeyError)).at_least(:once)
-    bad_transactions_json = {
+    bad_transactions_json = [
         'public' => [{ 'homepage' => 'http://localhost:50130/test-rp' }],
         'private' => []
-    }
+    ]
     stub_request(:post, api_saml_endpoint).to_return(status: 500)
     stub_request(:get, api_transactions_endpoint).to_return(body: bad_transactions_json.to_json, status: 200)
     visit '/test-saml'

--- a/spec/models/display/rp/transaction_taxon_correlator_spec.rb
+++ b/spec/models/display/rp/transaction_taxon_correlator_spec.rb
@@ -1,0 +1,201 @@
+require 'spec_helper'
+require 'rails_helper'
+require 'models/display/rp/transaction_taxon_correlator'
+
+module Display
+  module Rp
+    describe TransactionTaxonCorrelator do
+      let(:translator) { double(:translator) }
+
+      let(:simple_id_1) { 'test-rp-1' }
+      let(:simple_id_2) { 'test-rp-2' }
+      let(:simple_id_a) { 'test-rp-a' }
+      let(:simple_id_b) { 'test-rp-b' }
+
+      let(:transaction_1_name) { 'Test RP 1' }
+      let(:transaction_2_name) { 'Test RP 2' }
+      let(:transaction_a_name) { 'Test RP a' }
+      let(:transaction_b_name) { 'Test RP B' }
+
+      let(:homepage) { 'https://example-homepage/' }
+
+      let(:loa_list) { ['LEVEL_2'] }
+
+      let(:taxon_benefits) { 'Benefits' }
+      let(:taxon_working_jobs_and_pensions) { 'Working, jobs and pensions' }
+      let(:taxon_other_services) { 'Other services' }
+
+      before(:each) do
+        allow(translator).to receive(:translate).with('rps.test-rp-1.name').and_return(transaction_1_name)
+        allow(translator).to receive(:translate).with('rps.test-rp-2.name').and_return(transaction_2_name)
+        allow(translator).to receive(:translate).with('rps.test-rp-a.name').and_return(transaction_a_name)
+        allow(translator).to receive(:translate).with('rps.test-rp-b.name').and_return(transaction_b_name)
+
+        allow(translator).to receive(:translate).with('errors.transaction_list.other_services').and_return(taxon_other_services)
+
+        @correlator = TransactionTaxonCorrelator.new(translator)
+      end
+
+      it 'should return an empty list when there are no transactions' do
+        actual_result = @correlator.correlate({})
+        expect(actual_result).to eq []
+      end
+
+      it 'should group transactions by taxon' do
+        transaction_data = [
+            { 'simpleId' => simple_id_1, 'serviceHomepage' => homepage, 'loaList' => loa_list },
+            { 'simpleId' => simple_id_2, 'serviceHomepage' => homepage, 'loaList' => loa_list },
+            { 'simpleId' => simple_id_a, 'serviceHomepage' => homepage, 'loaList' => loa_list },
+            { 'simpleId' => simple_id_b, 'serviceHomepage' => homepage, 'loaList' => loa_list },
+        ]
+        allow(translator).to receive(:translate).with('rps.test-rp-1.taxon_name').and_return(taxon_benefits)
+        allow(translator).to receive(:translate).with('rps.test-rp-2.taxon_name').and_return(taxon_working_jobs_and_pensions)
+        allow(translator).to receive(:translate).with('rps.test-rp-a.taxon_name').and_return(taxon_benefits)
+        allow(translator).to receive(:translate).with('rps.test-rp-b.taxon_name').and_return(taxon_working_jobs_and_pensions)
+
+        actual_result = @correlator.correlate(transaction_data)
+
+        expected_result = [
+            TransactionTaxonCorrelator::Taxon.new(
+              taxon_benefits,
+              [
+                  TransactionTaxonCorrelator::Transaction.new(transaction_1_name, taxon_benefits, homepage, loa_list),
+                  TransactionTaxonCorrelator::Transaction.new(transaction_a_name, taxon_benefits, homepage, loa_list)
+              ]
+            ),
+            TransactionTaxonCorrelator::Taxon.new(
+              taxon_working_jobs_and_pensions,
+              [
+                  TransactionTaxonCorrelator::Transaction.new(transaction_2_name, taxon_working_jobs_and_pensions, homepage, loa_list),
+                  TransactionTaxonCorrelator::Transaction.new(transaction_b_name, taxon_working_jobs_and_pensions, homepage, loa_list)
+              ]
+            )
+        ]
+        expect(actual_result).to eq expected_result
+      end
+
+      it 'should group transactions without a taxon as Other services' do
+        allow(translator).to receive(:translate)
+                                 .with('rps.test-rp-1.taxon_name')
+                                 .and_raise(Display::FederationTranslator::TranslationError.new)
+        transaction_data = [
+            { 'simpleId' => simple_id_1, 'serviceHomepage' => homepage, 'loaList' => loa_list }
+        ]
+        actual_result = @correlator.correlate(transaction_data)
+
+        expected_result = [
+            TransactionTaxonCorrelator::Taxon.new(
+              taxon_other_services,
+              [
+                  TransactionTaxonCorrelator::Transaction.new(transaction_1_name, taxon_other_services, homepage, loa_list),
+              ]
+            )
+        ]
+        expect(actual_result).to eq expected_result
+      end
+
+      it 'should create an other services taxon for transactions without a homepage if it does not already exist' do
+        allow(translator).to receive(:translate).with('rps.test-rp-1.taxon_name').and_return(taxon_benefits)
+        transaction_data = [
+            { 'simpleId' => simple_id_1, 'loaList' => loa_list }
+        ]
+        actual_result = @correlator.correlate(transaction_data)
+
+        expected_result = [
+            TransactionTaxonCorrelator::Taxon.new(
+              taxon_other_services,
+              [
+                  TransactionTaxonCorrelator::Transaction.new(transaction_1_name, taxon_other_services, nil, loa_list),
+              ]
+            )
+        ]
+        expect(actual_result).to eq expected_result
+      end
+
+      it 'should add transactions without a homepage to the other services taxon if the taxon already exists' do
+        allow(translator).to receive(:translate).with('rps.test-rp-1.taxon_name').and_return(taxon_other_services)
+        allow(translator).to receive(:translate).with('rps.test-rp-2.taxon_name').and_return(taxon_benefits)
+        transaction_data = [
+            { 'simpleId' => simple_id_1, 'serviceHomepage' => homepage, 'loaList' => loa_list },
+            { 'simpleId' => simple_id_2, 'loaList' => loa_list }
+        ]
+        actual_result = @correlator.correlate(transaction_data)
+
+        expected_result = [
+            TransactionTaxonCorrelator::Taxon.new(
+              taxon_other_services,
+              [
+                  TransactionTaxonCorrelator::Transaction.new(transaction_1_name, taxon_other_services, homepage, loa_list),
+                  TransactionTaxonCorrelator::Transaction.new(transaction_2_name, taxon_other_services, nil, loa_list),
+              ]
+            )
+        ]
+        expect(actual_result).to eq expected_result
+      end
+
+      it 'should sort the taxons alphabetically, with Other services last.' do
+        allow(translator).to receive(:translate).with('rps.test-rp-1.taxon_name').and_return(taxon_other_services)
+        allow(translator).to receive(:translate).with('rps.test-rp-2.taxon_name').and_return(taxon_working_jobs_and_pensions)
+        allow(translator).to receive(:translate).with('rps.test-rp-a.taxon_name').and_return(taxon_benefits)
+        transaction_data = [
+            { 'simpleId' => simple_id_2, 'serviceHomepage' => homepage, 'loaList' => loa_list },
+            { 'simpleId' => simple_id_a, 'serviceHomepage' => homepage, 'loaList' => loa_list },
+            { 'simpleId' => simple_id_1, 'serviceHomepage' => homepage, 'loaList' => loa_list },
+        ]
+
+        actual_result = @correlator.correlate(transaction_data)
+
+        expected_result = [
+            TransactionTaxonCorrelator::Taxon.new(
+              taxon_benefits,
+              [
+                  TransactionTaxonCorrelator::Transaction.new(transaction_a_name, taxon_benefits, homepage, loa_list),
+              ]
+            ),
+            TransactionTaxonCorrelator::Taxon.new(
+              taxon_working_jobs_and_pensions,
+              [
+                  TransactionTaxonCorrelator::Transaction.new(transaction_2_name, taxon_working_jobs_and_pensions, homepage, loa_list),
+              ]
+            ),
+            TransactionTaxonCorrelator::Taxon.new(
+              taxon_other_services,
+              [
+                  TransactionTaxonCorrelator::Transaction.new(transaction_1_name, taxon_other_services, homepage, loa_list),
+              ]
+            ),
+        ]
+        expect(actual_result).to eq expected_result
+      end
+
+      it 'should sort the transactions within a taxon alphabetically' do
+        allow(translator).to receive(:translate).with('rps.test-rp-1.taxon_name').and_return(taxon_benefits)
+        allow(translator).to receive(:translate).with('rps.test-rp-2.taxon_name').and_return(taxon_benefits)
+        allow(translator).to receive(:translate).with('rps.test-rp-a.taxon_name').and_return(taxon_benefits)
+        allow(translator).to receive(:translate).with('rps.test-rp-b.taxon_name').and_return(taxon_benefits)
+        transaction_data = [
+            { 'simpleId' => simple_id_2, 'serviceHomepage' => homepage, 'loaList' => loa_list },
+            { 'simpleId' => simple_id_b, 'serviceHomepage' => homepage, 'loaList' => loa_list },
+            { 'simpleId' => simple_id_a, 'serviceHomepage' => homepage, 'loaList' => loa_list },
+            { 'simpleId' => simple_id_1, 'serviceHomepage' => homepage, 'loaList' => loa_list }
+        ]
+
+        actual_result = @correlator.correlate(transaction_data)
+
+        expected_results = [
+            TransactionTaxonCorrelator::Taxon.new(
+              taxon_benefits,
+              [
+                  TransactionTaxonCorrelator::Transaction.new(transaction_1_name, taxon_benefits, homepage, loa_list),
+                  TransactionTaxonCorrelator::Transaction.new(transaction_2_name, taxon_benefits, homepage, loa_list),
+                  TransactionTaxonCorrelator::Transaction.new(transaction_a_name, taxon_benefits, homepage, loa_list),
+                  TransactionTaxonCorrelator::Transaction.new(transaction_b_name, taxon_benefits, homepage, loa_list)
+              ]
+            )
+        ]
+
+        expect(actual_result).to eq expected_results
+      end
+    end
+  end
+end

--- a/stub/locales/rps/loa1-test-rp.yml
+++ b/stub/locales/rps/loa1-test-rp.yml
@@ -7,3 +7,4 @@ en:
       other_ways_text: If you can’t verify your identity using GOV.UK Verify, there are other ways to <a href='http://www.example.com'>register for an LOA1 identity profile</a>
       other_ways_description: other ways to register for an LOA1 identity profile
       tailored_text: <p>This is tailored text for LOA1 TEST RP</p>
+      taxon_name: Benefits

--- a/stub/locales/rps/test-rp-repudiation.yml
+++ b/stub/locales/rps/test-rp-repudiation.yml
@@ -7,3 +7,4 @@ en:
       other_ways_text: If you can’t verify your identity using GOV.UK Verify, there are other ways to <a href='http://www.example.com'>register for an identity profile (repudiation step)</a>
       other_ways_description: other ways to register for an identity profile (repudiation step)
       tailored_text: <p>This is tailored text for test-rp-repudiation</p>
+      taxon_name: Benefits

--- a/stub/locales/rps/test-rp.yml
+++ b/stub/locales/rps/test-rp.yml
@@ -14,3 +14,4 @@ en:
         <p>Include any other relevant details if you have them.</p>
       other_ways_description: register for an identity profile
       tailored_text: <p>This is tailored text for test-rp</p>
+      taxon_name: Benefits


### PR DESCRIPTION
Previously the timeout page just showed a list of RPs. This list was
getting too long, so we have changed it so that it is grouped by taxon.
(ie group together all RPs related to Benefits etc)
To do this, a new correllator has been added which groups the transactions
by taxon, and a 'taxon_name' parameter has been added to the rp config.
The transaction list view has also been updated.

Authors: @michaelwalker @jakubmiarka