### PR TITLE
TT-988: Limit the number of services that appear.

### DIFF
--- a/app/models/display/rp/transaction_taxon_correlator.rb
+++ b/app/models/display/rp/transaction_taxon_correlator.rb
@@ -4,12 +4,15 @@ module Display
       Transaction = Struct.new(:name, :taxon, :homepage, :loa_list)
       Taxon = Struct.new(:name, :transactions)
 
-      def initialize(translator)
+      def initialize(translator, rps_with_homepage_link, rps_with_name_only)
         @translator = translator
+        @rps_with_homepage_link = rps_with_homepage_link
+        @rps_with_name_only = rps_with_name_only
         @other_services_translation = @translator.translate('errors.transaction_list.other_services')
       end
 
       def correlate(data)
+        data = filter_for_allowed_transactions(data)
         transaction_list = map_to_transactions(data)
         transaction_list = sort_transactions(transaction_list)
         taxon_groups = group_by_taxon(transaction_list)
@@ -26,12 +29,17 @@ module Display
       def map_to_transactions(data)
         data.map do |item|
           name = translate_name(item)
-          homepage = item.fetch('serviceHomepage', nil)
+          homepage = @rps_with_name_only.include?(item.fetch('simpleId')) ? nil : item.fetch('serviceHomepage', nil)
           # if there's no homepage, move the transaction down to the 'Other service' taxon
           taxon = homepage.nil? ? @other_services_translation : translate_taxon(item)
           loa_list = item.fetch('loaList')
           Transaction.new(name, taxon, homepage, loa_list)
         end
+      end
+
+      def filter_for_allowed_transactions(data)
+        all_allowed_rps = @rps_with_homepage_link.concat @rps_with_name_only
+        data.keep_if { |transaction| all_allowed_rps.include? transaction.fetch('simpleId') }
       end
 
       def sort_transactions(transactions)

--- a/config/initializers/30_federation.rb
+++ b/config/initializers/30_federation.rb
@@ -27,7 +27,7 @@ Rails.application.config.after_initialize do
   rps_name_and_homepage = RP_CONFIG['transaction_type']['display_name_and_homepage'] || []
   rps_name_only = RP_CONFIG['transaction_type']['display_name_only'] || []
   DATA_CORRELATOR = Display::Rp::DisplayDataCorrelator.new(federation_translator, rps_name_and_homepage, rps_name_only)
-  TRANSACTION_TAXON_CORRELATOR = Display::Rp::TransactionTaxonCorrelator.new(federation_translator)
+  TRANSACTION_TAXON_CORRELATOR = Display::Rp::TransactionTaxonCorrelator.new(federation_translator, rps_name_and_homepage, rps_name_only)
 
   # IDP Config
   IDP_CONFIG = YAML.load_file(CONFIG.idp_config)


### PR DESCRIPTION
The previous implementation of TT-988 allowed all enabled transactions to
appear in the transaction list. However this allowed in some test data that
should not be present.
The list now filters out transactions which are not explicitly in the
allowed in the transaction types display list in federation config.

Authors: @michaelwalker @jakubmiarka