### PR TITLE
TT-1209

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,5 +1,6 @@
 IDA_FRONTEND_HOST=http://api.com:50190
 CONFIG_API_HOST=http://api.com:50240
+SAML_PROXY_HOST=http://api.com:50220
 METRICS_ENABLED=false
 
 PUBLIC_PIWIK_HOST=http://localhost:4242/piwik.php

--- a/app/controllers/authn_response_controller.rb
+++ b/app/controllers/authn_response_controller.rb
@@ -24,7 +24,7 @@ class AuthnResponseController < SamlController
     end
     raise_error_if_session_mismatch(params['RelayState'], session[:verify_session_id])
 
-    response = SESSION_PROXY.country_authn_response(session[:verify_session_id], params['SAMLResponse'], params['RelayState'])
+    response = SAML_PROXY_API.forward_country_authn_response(params['RelayState'], params['SAMLResponse'])
     country_response_handlers[response.country_result].call(response)
   end
 

--- a/app/models/api/client.rb
+++ b/app/models/api/client.rb
@@ -12,21 +12,21 @@ module Api
       response = log_request(path, 'get') do
         client.get(path, options)
       end
-      @response_handler.handle_response(response.status, 200, response.to_s)
+      @response_handler.handle_response(response.status, response.to_s)
     end
 
-    def post(path, body, options = {}, expected_status = 201)
+    def post(path, body, options = {})
       response = log_request(path, 'post') do
         client.post(path, body, options)
       end
-      @response_handler.handle_response(response.status, expected_status, response.to_s)
+      @response_handler.handle_response(response.status, response.to_s)
     end
 
     def put(path, body, options = {})
       response = log_request(path, 'put') do
         client.put(path, body, options)
       end
-      @response_handler.handle_response(response.status, 200, response.to_s)
+      @response_handler.handle_response(response.status, response.to_s)
     end
 
   private

--- a/app/models/api/response_handler.rb
+++ b/app/models/api/response_handler.rb
@@ -1,10 +1,10 @@
 module Api
   class ResponseHandler
-    def handle_response(received_status, expected_status, body)
-      if received_status == expected_status
-        parse_json(body, received_status)
+    def handle_response(response_status, response_body)
+      if response_status.success?
+        parse_json(response_body, response_status.code)
       else
-        handle_error(body, received_status)
+        handle_error(response_body, response_status.code)
       end
     end
 

--- a/app/models/country_authn_response.rb
+++ b/app/models/country_authn_response.rb
@@ -5,7 +5,7 @@ class CountryAuthnResponse < Api::Response
   validates_inclusion_of :is_registration, in: [true, false]
 
   def initialize(hash)
-    @country_result = hash['countryResult']
+    @country_result = hash['result']
     @is_registration = hash['isRegistration']
     @loa_achieved = hash['loaAchieved']
   end

--- a/app/models/saml_proxy_api.rb
+++ b/app/models/saml_proxy_api.rb
@@ -14,7 +14,7 @@ class SamlProxyApi
     body = {
         PARAM_SAML_REQUEST => saml_response,
         PARAM_RELAY_STATE => relay_state,
-        PARAM_ORIGINATING_IP => originating_ip
+        PARAM_IP_SEEN_BY_FRONTEND => originating_ip
     }
     response = @api_client.post(COUNTRY_AUTHN_RESPONSE_ENDPOINT, body)
     CountryAuthnResponse.validated_response(response)

--- a/app/models/saml_proxy_api.rb
+++ b/app/models/saml_proxy_api.rb
@@ -1,0 +1,22 @@
+class SamlProxyApi
+  include SamlProxyEndpoints
+
+  def initialize(api_client, originating_ip_store)
+    @api_client = api_client
+    @originating_ip_store = originating_ip_store
+  end
+
+  def originating_ip
+    @originating_ip_store.get
+  end
+
+  def forward_country_authn_response(relay_state, saml_response)
+    body = {
+        PARAM_SAML_REQUEST => saml_response,
+        PARAM_RELAY_STATE => relay_state,
+        PARAM_ORIGINATING_IP => originating_ip
+    }
+    response = @api_client.post(COUNTRY_AUTHN_RESPONSE_ENDPOINT, body)
+    CountryAuthnResponse.validated_response(response)
+  end
+end

--- a/app/models/saml_proxy_endpoints.rb
+++ b/app/models/saml_proxy_endpoints.rb
@@ -3,5 +3,5 @@ module SamlProxyEndpoints
 
   PARAM_SAML_REQUEST = 'samlRequest'.freeze
   PARAM_RELAY_STATE = 'relayState'.freeze
-  PARAM_ORIGINATING_IP = 'originatingIp'.freeze
+  PARAM_IP_SEEN_BY_FRONTEND = 'principalIpAsSeenByFrontend'.freeze
 end

--- a/app/models/saml_proxy_endpoints.rb
+++ b/app/models/saml_proxy_endpoints.rb
@@ -1,0 +1,7 @@
+module SamlProxyEndpoints
+  COUNTRY_AUTHN_RESPONSE_ENDPOINT = '/SAML2/SSO/API/RECEIVER/EidasResponse/POST'.freeze
+
+  PARAM_SAML_REQUEST = 'samlRequest'.freeze
+  PARAM_RELAY_STATE = 'relayState'.freeze
+  PARAM_ORIGINATING_IP = 'originatingIp'.freeze
+end

--- a/app/models/session_endpoints.rb
+++ b/app/models/session_endpoints.rb
@@ -44,10 +44,6 @@ module SessionEndpoints
     session_endpoint(session_id, COUNTRY_AUTHN_REQUEST_SUFFIX)
   end
 
-  def country_authn_response_endpoint(session_id)
-    session_endpoint(session_id, COUNTRY_AUTHN_RESPONSE_SUFFIX)
-  end
-
   def idp_authn_request_endpoint(session_id)
     session_endpoint(session_id, IDP_AUTHN_REQUEST_SUFFIX)
   end

--- a/app/models/session_proxy.rb
+++ b/app/models/session_proxy.rb
@@ -38,7 +38,7 @@ class SessionProxy
   def select_a_country(session_id, country)
     # Call into Policy to change state
     # POST /api/countries (NL)
-    @api_client.post(select_a_country_endpoint(session_id, country), '', {}, 200)
+    @api_client.post(select_a_country_endpoint(session_id, country), '', {})
   end
 
   def select_idp(session_id, entity_id, registration = false)
@@ -77,16 +77,6 @@ class SessionProxy
     IdpAuthnResponse.validated_response(response)
   end
 
-  def country_authn_response(session_id, saml_response, relay_state)
-    body = {
-        PARAM_RELAY_STATE => relay_state,
-        PARAM_SAML_RESPONSE => saml_response,
-        PARAM_ORIGINATING_IP => originating_ip
-    }
-    response = @api_client.put(country_authn_response_endpoint(session_id), body)
-    CountryAuthnResponse.validated_response(response)
-  end
-
   def matching_outcome(session_id)
     response = @api_client.get(matching_outcome_endpoint(session_id))
     MatchingOutcomeResponse.validated_response(response).outcome
@@ -112,10 +102,10 @@ class SessionProxy
       PARAM_CYCLE_THREE_VALUE => value,
       PARAM_ORIGINATING_IP => originating_ip
     }
-    @api_client.post(cycle_three_endpoint(session_id), body, {}, 200)
+    @api_client.post(cycle_three_endpoint(session_id), body, {})
   end
 
   def cycle_three_cancel(session_id)
-    @api_client.post(cycle_three_cancel_endpoint(session_id), nil, {}, 200)
+    @api_client.post(cycle_three_cancel_endpoint(session_id), nil, {})
   end
 end

--- a/config/initializers/20_api_proxies.rb
+++ b/config/initializers/20_api_proxies.rb
@@ -5,4 +5,6 @@ Rails.application.config.after_initialize do
   SESSION_PROXY = SessionProxy.new(ida_frontend_client, OriginatingIpStore)
   config_api_client = Api::Client.new(CONFIG.config_api_host, Api::ResponseHandler.new)
   CONFIG_PROXY = ConfigProxy.new(config_api_client)
+  saml_proxy_client = Api::Client.new(CONFIG.saml_proxy_host, Api::ResponseHandler.new)
+  SAML_PROXY_API = SamlProxyApi.new(saml_proxy_client, OriginatingIpStore)
 end

--- a/spec/api_test_helper.rb
+++ b/spec/api_test_helper.rb
@@ -161,11 +161,11 @@ module ApiTestHelper
         .to_return(body: response.to_json, status: 200)
   end
 
-  def stub_api_country_authn_response(relay_state, response = { 'idpResult' => 'SUCCESS', 'isRegistration' => false })
+  def stub_api_country_authn_response(relay_state, response = { 'result' => 'SUCCESS', 'isRegistration' => false })
     authn_response_body = {
         PARAM_SAML_REQUEST => 'my-saml-response',
         PARAM_RELAY_STATE => relay_state,
-        PARAM_ORIGINATING_IP => '<PRINCIPAL IP ADDRESS COULD NOT BE DETERMINED>'
+        PARAM_IP_SEEN_BY_FRONTEND => '<PRINCIPAL IP ADDRESS COULD NOT BE DETERMINED>'
     }
 
     stub_request(:post, saml_proxy_api_uri(COUNTRY_AUTHN_RESPONSE_ENDPOINT))

--- a/spec/api_test_helper.rb
+++ b/spec/api_test_helper.rb
@@ -1,9 +1,14 @@
 module ApiTestHelper
   include SessionEndpoints
   include ConfigEndpoints
+  include SamlProxyEndpoints
 
   def ida_frontend_api_uri(path)
     URI.join(CONFIG.ida_frontend_host, path)
+  end
+
+  def saml_proxy_api_uri(path)
+    URI.join(CONFIG.saml_proxy_host, path)
   end
 
   def config_api_uri(path)
@@ -158,12 +163,12 @@ module ApiTestHelper
 
   def stub_api_country_authn_response(relay_state, response = { 'idpResult' => 'SUCCESS', 'isRegistration' => false })
     authn_response_body = {
-        PARAM_SAML_RESPONSE => 'my-saml-response',
+        PARAM_SAML_REQUEST => 'my-saml-response',
         PARAM_RELAY_STATE => relay_state,
         PARAM_ORIGINATING_IP => '<PRINCIPAL IP ADDRESS COULD NOT BE DETERMINED>'
     }
 
-    stub_request(:put, ida_frontend_api_uri(country_authn_response_endpoint(default_session_id)))
+    stub_request(:post, saml_proxy_api_uri(COUNTRY_AUTHN_RESPONSE_ENDPOINT))
         .with(body: authn_response_body)
         .to_return(body: response.to_json, status: 200)
   end

--- a/spec/features/user_sends_authn_response_spec.rb
+++ b/spec/features/user_sends_authn_response_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe 'User returns from an IDP with an AuthnResponse' do
   it 'will redirect the user to /response-processing on successful sign in at the Country' do
     stub_session
     stub_matching_outcome
-    api_request = stub_api_country_authn_response(session_id, 'countryResult' => 'SUCCESS', 'isRegistration' => false, 'loaAchieved' => 'LEVEL_2')
+    api_request = stub_api_country_authn_response(session_id, 'result' => 'SUCCESS', 'isRegistration' => false, 'loaAchieved' => 'LEVEL_2')
 
     visit("/test-saml?session-id=#{session_id}")
     click_button 'saml-eidas-response-post'

--- a/spec/models/api/client_spec.rb
+++ b/spec/models/api/client_spec.rb
@@ -17,7 +17,7 @@ module Api
     context '#get' do
       it 'sets cookies if provided them' do
         stub_request(:get, "#{host}#{path}").with(headers: { cookie: /COOKIE_NAME=some-val/ }).and_return(status: 200, body: '{}')
-        expect(response_handler).to receive(:handle_response).with(HTTP::Response::Status[200], 200, '{}').and_return(response_body)
+        expect(response_handler).to receive(:handle_response).with(HTTP::Response::Status[200], '{}').and_return(response_body)
         response = api_client.get(path, cookies: { 'COOKIE_NAME' => 'some-val' })
         expect(a_request(:get, "#{host}#{path}").with(headers: { cookie: /COOKIE_NAME=some-val/ })).to have_been_made.once
         expect(response).to eql response_body
@@ -25,7 +25,7 @@ module Api
 
       it 'set params if provided them' do
         stub_request(:get, "#{host}#{path}").with(query: { 'param1' => 'value1' }).and_return(status: 200, body: '{}')
-        expect(response_handler).to receive(:handle_response).with(HTTP::Response::Status[200], 200, '{}').and_return(response_body)
+        expect(response_handler).to receive(:handle_response).with(HTTP::Response::Status[200], '{}').and_return(response_body)
         response = api_client.get(path, params: { 'param1' => 'value1' })
         expect(a_request(:get, "#{host}#{path}").with(query: { 'param1' => 'value1' })).to have_been_made.once
         expect(response).to eql response_body
@@ -33,7 +33,7 @@ module Api
 
       it 'returns a JSON result when successful' do
         stub_request(:get, "#{host}#{path}").and_return(status: 200, body: '{}')
-        expect(response_handler).to receive(:handle_response).with(HTTP::Response::Status[200], 200, '{}').and_return(response_body)
+        expect(response_handler).to receive(:handle_response).with(HTTP::Response::Status[200], '{}').and_return(response_body)
         response = api_client.get(path)
         expect(a_request(:get, "#{host}#{path}")).to have_been_made.once
         expect(response).to eql response_body
@@ -45,8 +45,8 @@ module Api
 
       context 'successful post' do
         it 'takes a hash and posts it as JSON and returns json result' do
-          receive_request.and_return(status: 201, body: '{}')
-          expect(response_handler).to receive(:handle_response).with(HTTP::Response::Status[201], 201, '{}').and_return(response_body)
+          receive_request.and_return(status: 200, body: '{}')
+          expect(response_handler).to receive(:handle_response).with(HTTP::Response::Status[200], '{}').and_return(response_body)
           response = api_client.post(path, request_body)
           expect(a_request(:post, "#{host}#{path}").with(body: request_body)).to have_been_made.once
           expect(response).to eq response_body
@@ -54,8 +54,8 @@ module Api
       end
 
       it 'uses the correct user agent when acting as a client' do
-        receive_request.and_return(status: 201, body: '{}')
-        expect(response_handler).to receive(:handle_response).with(HTTP::Response::Status[201], 201, '{}').and_return(response_body).exactly(4).times
+        receive_request.and_return(status: 200, body: '{}')
+        expect(response_handler).to receive(:handle_response).with(HTTP::Response::Status[200], '{}').and_return(response_body).exactly(4).times
         api_client.post(path, request_body)
         api_client.post(path, request_body)
         api_client.post(path, request_body)
@@ -71,7 +71,7 @@ module Api
       context 'successful put' do
         it 'takes a hash and puts it as JSON and returns json result' do
           receive_request.and_return(status: 200, body: '{}')
-          expect(response_handler).to receive(:handle_response).with(HTTP::Response::Status[200], 200, '{}').and_return(response_body)
+          expect(response_handler).to receive(:handle_response).with(HTTP::Response::Status[200], '{}').and_return(response_body)
           response = api_client.put(path, request_body)
           expect(a_request(:put, "#{host}#{path}").with(body: request_body)).to have_been_made.once
           expect(response).to eq response_body
@@ -93,7 +93,7 @@ module Api
 
         it 'logs API gets' do
           stub_request(:get, "#{host}#{path}").and_return(status: 200, body: '{}')
-          expect(response_handler).to receive(:handle_response).with(HTTP::Response::Status[200], 200, '{}').and_return(response_body)
+          expect(response_handler).to receive(:handle_response).with(HTTP::Response::Status[200], '{}').and_return(response_body)
 
           payload = notification_payload_for { api_client.get(path) }
 
@@ -102,7 +102,7 @@ module Api
 
         it 'logs API puts' do
           stub_request(:put, "#{host}#{path}").with(body: request_body).and_return(status: 200, body: '{}')
-          expect(response_handler).to receive(:handle_response).with(HTTP::Response::Status[200], 200, '{}').and_return(response_body)
+          expect(response_handler).to receive(:handle_response).with(HTTP::Response::Status[200], '{}').and_return(response_body)
 
           payload = notification_payload_for { api_client.put(path, request_body) }
 
@@ -110,8 +110,8 @@ module Api
         end
 
         it 'logs API posts' do
-          stub_request(:post, "#{host}#{path}").with(body: request_body).and_return(status: 201, body: '{}')
-          expect(response_handler).to receive(:handle_response).with(HTTP::Response::Status[201], 201, '{}').and_return(response_body)
+          stub_request(:post, "#{host}#{path}").with(body: request_body).and_return(status: 200, body: '{}')
+          expect(response_handler).to receive(:handle_response).with(HTTP::Response::Status[200], '{}').and_return(response_body)
 
           payload = notification_payload_for { api_client.post(path, request_body) }
 

--- a/spec/models/api/response_handler_spec.rb
+++ b/spec/models/api/response_handler_spec.rb
@@ -5,6 +5,7 @@ require 'api/session_error'
 require 'api/session_timeout_error'
 require 'api/upstream_error'
 require 'api/error'
+require 'http/response'
 
 module Api
   describe ResponseHandler do
@@ -12,17 +13,17 @@ module Api
     context 'on a successful response' do
       it 'should return a parsed response body on a successful response' do
         expected_result = { 'id' => '12' }
-        result = response_handler.handle_response(200, 200, expected_result.to_json)
+        result = response_handler.handle_response(HTTP::Response::Status[200], expected_result.to_json)
         expect(result).to eq(expected_result)
       end
 
       it 'should return nil when response is OK but JSON is empty' do
-        expect(response_handler.handle_response(200, 200, '')).to be_nil
+        expect(response_handler.handle_response(HTTP::Response::Status[200], '')).to be_nil
       end
 
       it 'errors on receiving malformed JSON' do
         expect {
-          response_handler.handle_response(200, 200, 'aaa')
+          response_handler.handle_response(HTTP::Response::Status[200], 'aaa')
         }.to raise_error Error, 'Received 200, but unable to parse JSON'
       end
     end
@@ -32,57 +33,57 @@ module Api
         json = { 'errors' => ["something must be something", "other thing must be this thing"] }.to_json
         error_message = 'something must be something, other thing must be this thing'
         expect {
-          response_handler.handle_response(422, 200, json)
+          response_handler.handle_response(HTTP::Response::Status[422], json)
         }.to raise_error Error, "Received 422 with error message: [#{error_message}], type: 'NONE' and id: 'NONE'"
       end
       it 'errors when receiving 500 and empty JSON' do
         expect {
-          response_handler.handle_response(500, 200, '')
+          response_handler.handle_response(HTTP::Response::Status[500], '')
         }.to raise_error Error, 'Received 500 with error message: [], type: \'NONE\' and id: \'NONE\''
       end
 
       it 'raises an error when API response is not ok with message' do
         expect {
-          response_handler.handle_response(500, 200, '{"errors": ["Failure"], "type": "BAD THING"}')
+          response_handler.handle_response(HTTP::Response::Status[500], '{"errors": ["Failure"], "type": "BAD THING"}')
         }.to raise_error UpstreamError, 'Received 500 with error message: [Failure], type: \'BAD THING\' and id: \'NONE\''
       end
 
       it 'raises an error when API response is not ok with id' do
         expect {
-          response_handler.handle_response(500, 200, '{"id": "1234"}')
+          response_handler.handle_response(HTTP::Response::Status[500], '{"id": "1234"}')
         }.to raise_error Error, 'Received 500 with error message: [], type: \'NONE\' and id: \'1234\''
       end
 
       it 'raises an error when API response is not ok with malformed JSON' do
         expect {
-          response_handler.handle_response(500, 200, 'aaa')
+          response_handler.handle_response(HTTP::Response::Status[500], 'aaa')
         }.to raise_error Error, 'Received 500, but unable to parse JSON'
       end
 
       it 'raises an error when API response is not ok with JSON, but message missing' do
         expect {
-          response_handler.handle_response(500, 200, '{}')
+          response_handler.handle_response(HTTP::Response::Status[500], '{}')
         }.to raise_error Error, 'Received 500 with error message: [], type: \'NONE\' and id: \'NONE\''
       end
 
       it 'raises a session error when type is set to SESSION_ERROR' do
         error_body = { id: '0', type: 'SESSION_ERROR' }
         expect {
-          response_handler.handle_response(400, 200, error_body.to_json)
+          response_handler.handle_response(HTTP::Response::Status[400], error_body.to_json)
         }.to raise_error SessionError, 'Received 400 with error message: [], type: \'SESSION_ERROR\' and id: \'0\''
       end
 
       it 'raises a session timeout error when type is set to SESSION_TIMEOUT' do
         error_body = { id: '0', type: 'SESSION_TIMEOUT' }
         expect {
-          response_handler.handle_response(400, 200, error_body.to_json)
+          response_handler.handle_response(HTTP::Response::Status[400], error_body.to_json)
         }.to raise_error SessionTimeoutError, 'Received 400 with error message: [], type: \'SESSION_TIMEOUT\' and id: \'0\''
       end
 
       it 'raises an upstream error when type is set, but not SESSION_TIMEOUT or SESSION_ERROR' do
         error_body = { id: '0', type: 'SERVER_ERROR' }
         expect {
-          response_handler.handle_response(400, 200, error_body.to_json)
+          response_handler.handle_response(HTTP::Response::Status[400], error_body.to_json)
         }.to raise_error UpstreamError, 'Received 400 with error message: [], type: \'SERVER_ERROR\' and id: \'0\''
       end
     end

--- a/spec/models/session_proxy_spec.rb
+++ b/spec/models/session_proxy_spec.rb
@@ -320,8 +320,7 @@ describe SessionProxy do
       expect(api_client).to receive(:post)
         .with(endpoint(SessionProxy::CYCLE_THREE_SUFFIX),
               { 'value' => 'some value', 'originatingIp' => '127.0.0.1' },
-              {},
-              200
+              {}
              )
 
       session_proxy.submit_cycle_three_value(session_id, 'some value')
@@ -333,8 +332,7 @@ describe SessionProxy do
       expect(api_client).to receive(:post)
         .with(endpoint(SessionProxy::CYCLE_THREE_CANCEL_SUFFIX),
               nil,
-              {},
-              200
+              {}
              )
 
       session_proxy.cycle_three_cancel(session_id)

--- a/spec/support/authn_response_examples.rb
+++ b/spec/support/authn_response_examples.rb
@@ -15,15 +15,15 @@ shared_examples 'idp_authn_response' do |journey_hint, idp_result, piwik_action,
 end
 
 shared_examples 'country_authn_response' do |journey_hint, country_result, redirect_path|
-  let(:session_proxy) { double(:session_proxy) }
+  let(:saml_proxy_api) { double(:saml_proxy_api) }
 
   before(:each) do
-    stub_const('SESSION_PROXY', session_proxy)
+    stub_const('SAML_PROXY_API', saml_proxy_api)
     set_session_and_cookies_with_loa('LEVEL_1')
   end
 
   it "should redirect to #{redirect_path} on #{country_result}" do
-    allow(session_proxy).to receive(:country_authn_response).and_return(CountryAuthnResponse.new('countryResult' => country_result, 'isRegistration' => (journey_hint == 'registration'), 'loaAchieved' => 'LEVEL_1'))
+    allow(saml_proxy_api).to receive(:forward_country_authn_response).and_return(CountryAuthnResponse.new('result' => country_result, 'isRegistration' => (journey_hint == 'registration'), 'loaAchieved' => 'LEVEL_1'))
     post :country_response, params: { 'RelayState' => 'my-session-id-cookie', 'SAMLResponse' => 'a-saml-response', locale: 'en' }
     expect(subject).to redirect_to(send(redirect_path))
   end

--- a/stub/api/stub_api.rb
+++ b/stub/api/stub_api.rb
@@ -41,6 +41,14 @@ class StubApi < Sinatra::Base
     }'
   end
 
+  post '/SAML2/SSO/API/RECEIVER/EidasResponse/POST' do
+    '{
+      "result":"blah",
+      "isRegistration":false,
+      "loaAchieved":"LEVEL_2"
+    }'
+  end
+
   put '/api/session/:session_id/idp-authn-response' do
     '{
       "idpResult":"blah",

--- a/stub/api/stub_api_spec.rb
+++ b/stub/api/stub_api_spec.rb
@@ -16,6 +16,7 @@ require 'idp_list_response'
 require 'select_idp_response'
 require 'outbound_saml_message'
 require 'idp_authn_response'
+require 'country_authn_response'
 
 describe StubApi do
   include Rack::Test::Methods
@@ -60,6 +61,15 @@ describe StubApi do
       get '/api/session/session_id/idp-authn-request'
       expect(last_response).to be_ok
       response = OutboundSamlMessage.new(last_response_json)
+      expect(response).to be_valid
+    end
+  end
+
+  context '#post /SAML2/SSO/API/RECEIVER/EidasResponse/POST' do
+    it 'should respond with valid hash' do
+      post '/SAML2/SSO/API/RECEIVER/EidasResponse/POST'
+      expect(last_response).to be_ok
+      response = CountryAuthnResponse.new(last_response_json)
       expect(response).to be_valid
     end
   end


### PR DESCRIPTION
Add saml_proxy_api for sending HTTP requests to saml proxy
Add saml_proxy_endpoints
api_client.handle_response no longer requires expected_status
Add the saml proxy endpoint to stub api
Recommitted after it was reverted, with a fixed parameter name in saml_proxy_endpoints. Made sure to run eidas acceptance tests locally this time.

Authors: @hugh-emerson, @michaelwalker