### PR TITLE
BAU: Fix duplicate RPs appearing in the frontend.

### DIFF
--- a/app/models/display/rp/transaction_taxon_correlator.rb
+++ b/app/models/display/rp/transaction_taxon_correlator.rb
@@ -38,7 +38,7 @@ module Display
       end
 
       def filter_for_allowed_transactions(data)
-        all_allowed_rps = @rps_with_homepage_link.concat @rps_with_name_only
+        all_allowed_rps = @rps_with_homepage_link + @rps_with_name_only
         data.keep_if { |transaction| all_allowed_rps.include? transaction.fetch('simpleId') }
       end
 

--- a/config/initializers/30_federation.rb
+++ b/config/initializers/30_federation.rb
@@ -26,8 +26,8 @@ Rails.application.config.after_initialize do
   CONTINUE_ON_FAILED_REGISTRATION_RPS = RP_CONFIG.fetch('allow_continue_on_failed_registration', [])
   rps_name_and_homepage = RP_CONFIG['transaction_type']['display_name_and_homepage'] || []
   rps_name_only = RP_CONFIG['transaction_type']['display_name_only'] || []
-  DATA_CORRELATOR = Display::Rp::DisplayDataCorrelator.new(federation_translator, rps_name_and_homepage, rps_name_only)
-  TRANSACTION_TAXON_CORRELATOR = Display::Rp::TransactionTaxonCorrelator.new(federation_translator, rps_name_and_homepage, rps_name_only)
+  DATA_CORRELATOR = Display::Rp::DisplayDataCorrelator.new(federation_translator, rps_name_and_homepage.clone, rps_name_only.clone)
+  TRANSACTION_TAXON_CORRELATOR = Display::Rp::TransactionTaxonCorrelator.new(federation_translator, rps_name_and_homepage.clone, rps_name_only.clone)
 
   # IDP Config
   IDP_CONFIG = YAML.load_file(CONFIG.idp_config)


### PR DESCRIPTION
Duplicate RPs were appearing in the front end due to accidently mutating
the list of name and homepage rps.
To fix this, we now use '+' instead of 'concat' to avoid mutating the
original object, and we clone the original list so that each correlator
has a unique version of the list.

Authors: @jakubmiarka, @hugh-emerson, @michaelwalker