### PR TITLE
TT-1165: recommend RPs correctly for NI DL users

### DIFF
--- a/app/controllers/other_identity_documents_controller.rb
+++ b/app/controllers/other_identity_documents_controller.rb
@@ -7,7 +7,7 @@ class OtherIdentityDocumentsController < ApplicationController
     @form = OtherIdentityDocumentsForm.new(params['other_identity_documents_form'] || {})
     if @form.valid?
       report_to_analytics('Other Documents Next')
-      selected_answer_store.store_selected_answers('documents', @form.selected_answers)
+      selected_answer_store.store_selected_answers('other_documents', @form.selected_answers)
       redirect_to select_phone_path
     else
       flash.now[:errors] = @form.errors.full_messages.join(', ')

--- a/app/models/select_documents_form.rb
+++ b/app/models/select_documents_form.rb
@@ -28,7 +28,7 @@ class SelectDocumentsForm
   end
 
   def further_id_information_required?
-    passport == 'false' && (any_driving_licence == 'false' || (ni_driving_licence == 'true' && driving_licence != 'true'))
+    passport == 'false' && any_driving_licence == 'false'
   end
 
 private

--- a/spec/controllers/other_identity_documents_controller_spec.rb
+++ b/spec/controllers/other_identity_documents_controller_spec.rb
@@ -17,7 +17,7 @@ describe OtherIdentityDocumentsController do
     }
 
     expect(subject).to redirect_to(select_phone_path)
-    expect(session[:selected_answers]).to eql('documents' => { non_uk_id_document: true })
+    expect(session[:selected_answers]).to eql('other_documents' => { non_uk_id_document: true })
   end
 
   it 'should not advance if form is invalid' do
@@ -29,7 +29,7 @@ describe OtherIdentityDocumentsController do
     expect(subject).to render_template('index')
   end
 
-  it 'will only contain has non-uk id document and will ignore any stale form values for passport and licence' do
+  it 'will not replace form values for passport and licence' do
     session[:selected_answers] = { 'documents' => { driving_licence: true, passport: true } }
 
     post :select_other_documents, params: {
@@ -37,6 +37,6 @@ describe OtherIdentityDocumentsController do
       other_identity_documents_form: { non_uk_id_document: 'true' }
     }
 
-    expect(session[:selected_answers]).to eql('documents' => { non_uk_id_document: true })
+    expect(session[:selected_answers]).to eql('other_documents' => { non_uk_id_document: true }, 'documents' => { passport: true, driving_licence: true })
   end
 end

--- a/spec/models/select_documents_form_spec.rb
+++ b/spec/models/select_documents_form_spec.rb
@@ -95,13 +95,13 @@ describe SelectDocumentsForm do
       expect(form).to be_further_id_information_required
     end
 
-    it 'should require further information when user has a northern ireland driving licence' do
+    it 'should not require further information when user has a northern ireland driving licence' do
       form = SelectDocumentsForm.new(
         any_driving_licence: 'true',
         ni_driving_licence: 'true',
         passport: 'false'
       )
-      expect(form).to be_further_id_information_required
+      expect(form).to_not be_further_id_information_required
     end
 
     it 'should not require further information when user has a GB driving licence' do


### PR DESCRIPTION
Select other documents page was overwriting the data for the first set of documents
Give non-uk id its own key in the evidence hash to avoid replacing other evidence.
No longer show the other documents page for users who select NI driving licence

Authors: @DataMinerUK, @hugh-emerson