### PR TITLE
TT-1259: Add interstitial page for LOA1 journey

### DIFF
--- a/app/controllers/choose_a_certified_company_controller.rb
+++ b/app/controllers/choose_a_certified_company_controller.rb
@@ -39,6 +39,8 @@ private
   def warning_or_question_page(decorated_idp)
     if only_one_uk_doc_selected && interstitial_question_flag_enabled_for(decorated_idp)
       redirect_to_idp_question_path
+    elsif is_loa1? && interstitial_question_flag_enabled_for(decorated_idp)
+      redirect_to_idp_question_path
     else
       redirect_to_idp_warning_path
     end
@@ -49,6 +51,10 @@ private
   end
 
   def interstitial_question_flag_enabled_for(decorated_idp)
-    IDP_FEATURE_FLAGS_CHECKER.enabled?(:show_interstitial_question, decorated_idp.simple_id)
+    if is_loa1?
+      IDP_FEATURE_FLAGS_CHECKER.enabled?(:show_interstitial_question_loa1, decorated_idp.simple_id)
+    else
+      IDP_FEATURE_FLAGS_CHECKER.enabled?(:show_interstitial_question, decorated_idp.simple_id)
+    end
   end
 end

--- a/app/controllers/choose_a_certified_company_variant_create_account_controller.rb
+++ b/app/controllers/choose_a_certified_company_variant_create_account_controller.rb
@@ -39,6 +39,8 @@ private
   def warning_or_question_page(decorated_idp)
     if only_one_uk_doc_selected && interstitial_question_flag_enabled_for(decorated_idp)
       redirect_to_idp_question_path
+    elsif is_loa1? && interstitial_question_flag_enabled_for(decorated_idp)
+      redirect_to_idp_question_path
     else
       redirect_to_idp_warning_path
     end
@@ -49,6 +51,10 @@ private
   end
 
   def interstitial_question_flag_enabled_for(decorated_idp)
-    IDP_FEATURE_FLAGS_CHECKER.enabled?(:show_interstitial_question, decorated_idp.simple_id)
+    if is_loa1?
+      IDP_FEATURE_FLAGS_CHECKER.enabled?(:show_interstitial_question_loa1, decorated_idp.simple_id)
+    else
+      IDP_FEATURE_FLAGS_CHECKER.enabled?(:show_interstitial_question, decorated_idp.simple_id)
+    end
   end
 end

--- a/app/controllers/choose_a_certified_company_variant_get_setup_controller.rb
+++ b/app/controllers/choose_a_certified_company_variant_get_setup_controller.rb
@@ -39,6 +39,8 @@ private
   def warning_or_question_page(decorated_idp)
     if only_one_uk_doc_selected && interstitial_question_flag_enabled_for(decorated_idp)
       redirect_to_idp_question_path
+    elsif is_loa1? && interstitial_question_flag_enabled_for(decorated_idp)
+      redirect_to_idp_question_path
     else
       redirect_to_idp_warning_path
     end
@@ -49,6 +51,10 @@ private
   end
 
   def interstitial_question_flag_enabled_for(decorated_idp)
-    IDP_FEATURE_FLAGS_CHECKER.enabled?(:show_interstitial_question, decorated_idp.simple_id)
+    if is_loa1?
+      IDP_FEATURE_FLAGS_CHECKER.enabled?(:show_interstitial_question_loa1, decorated_idp.simple_id)
+    else
+      IDP_FEATURE_FLAGS_CHECKER.enabled?(:show_interstitial_question, decorated_idp.simple_id)
+    end
   end
 end

--- a/app/controllers/redirect_to_idp_question_controller.rb
+++ b/app/controllers/redirect_to_idp_question_controller.rb
@@ -2,6 +2,7 @@ class RedirectToIdpQuestionController < ApplicationController
   def index
     @idp = decorated_idp
     @form = InterstitialQuestionForm.new({})
+    @is_loa2 = is_loa2?
   end
 
   def continue

--- a/app/controllers/redirect_to_idp_question_controller.rb
+++ b/app/controllers/redirect_to_idp_question_controller.rb
@@ -2,7 +2,7 @@ class RedirectToIdpQuestionController < ApplicationController
   def index
     @idp = decorated_idp
     @form = InterstitialQuestionForm.new({})
-    @is_loa2 = is_loa2?
+    render is_loa1? ? 'redirect_to_idp_question_LOA1' : 'redirect_to_idp_question_LOA2'
   end
 
   def continue
@@ -17,7 +17,7 @@ class RedirectToIdpQuestionController < ApplicationController
     else
       @idp = decorated_idp
       flash.now[:errors] = @form.errors.full_messages.join(', ')
-      render 'index'
+      render is_loa1? ? 'redirect_to_idp_question_LOA1' : 'redirect_to_idp_question_LOA2'
     end
   end
 

--- a/app/views/redirect_to_idp_question/index.html.erb
+++ b/app/views/redirect_to_idp_question/index.html.erb
@@ -23,9 +23,11 @@
           <%= t 'hub.redirect_to_idp_question.warning_html', display_name: @idp.display_name, choose_another_company_link: link_to(t('hub.redirect_to_idp_question.choose_another_certified_company_link'), choose_a_certified_company_path)%>
         </div>
 
+        <% if @is_loa2 %>
         <div class="panel panel-border-wide">
           <%= t 'hub.redirect_to_idp_question.identity_documents' %>
         </div>
+        <% end %>
 
         <div class="form-group-tight">
             <%= button_tag t('navigation.continue'),

--- a/app/views/redirect_to_idp_question/redirect_to_idp_question_LOA1.html.erb
+++ b/app/views/redirect_to_idp_question/redirect_to_idp_question_LOA1.html.erb
@@ -1,0 +1,39 @@
+<%= page_title 'hub.redirect_to_idp_warning.title' %>
+<% content_for :feedback_source, 'REDIRECT_TO_IDP_WARNING_PAGE' %>
+
+<div class="grid-row js-continue-to-idp" data-location="<%= url_for(controller: 'redirect_to_idp_warning', action: 'continue_ajax', locale: I18n.locale)  %>">
+  <div class="column-two-thirds">
+    <h1 class="heading-large"><%= t 'hub.redirect_to_idp_question.heading', display_name: @idp.display_name %></h1>
+    <%= @idp.interstitial_question.html_safe %>
+
+    <%= form_for @form, url: redirect_to_idp_question_submit_path, html: {id: 'interstitial-question-form', class: 'js-validate', novalidate: 'novalidate'} do |f| %>
+
+        <%= render 'shared/form-errors', errors: flash[:errors] %>
+
+        <%= content_tag :div, class: form_question_class do %>
+            <fieldset>
+              <%= f.custom_radio_button :interstitial_question_result, true, t('hub.redirect_to_idp_question.answer_yes'), {required: true, data: { msg: t('hub.redirect_to_idp_question.validation_message')}} %>
+              <%= f.custom_radio_button :interstitial_question_result, false, t('hub.redirect_to_idp_question.answer_no'), {required: true, data: { msg: t('hub.redirect_to_idp_question.validation_message')}} %>
+            </fieldset>
+        <% end %>
+
+        <div id="validation-error-message-js"></div>
+
+        <div id="interstitial_question_details" class="hidden panel">
+          <%= t 'hub.redirect_to_idp_question.warning_html', display_name: @idp.display_name, choose_another_company_link: link_to(t('hub.redirect_to_idp_question.choose_another_certified_company_link'), choose_a_certified_company_path)%>
+        </div>
+
+        <div class="form-group-tight">
+            <%= button_tag t('navigation.continue'),
+                           class: 'button',
+                           id: 'continue-to-idp-button',
+                           type: 'submit'
+            %>
+        </div>
+    <% end %>
+    <div>
+      <%= t 'hub.redirect_to_idp_question.or_html', choose_another_company_link: link_to(t('hub.redirect_to_idp_question.choose_another_certified_company_link'), choose_a_certified_company_path)%>
+    </div>
+  </div>
+  <%= render partial: 'shared/continue_to_idp_form' %>
+</div>

--- a/app/views/redirect_to_idp_question/redirect_to_idp_question_LOA2.html.erb
+++ b/app/views/redirect_to_idp_question/redirect_to_idp_question_LOA2.html.erb
@@ -23,11 +23,9 @@
           <%= t 'hub.redirect_to_idp_question.warning_html', display_name: @idp.display_name, choose_another_company_link: link_to(t('hub.redirect_to_idp_question.choose_another_certified_company_link'), choose_a_certified_company_path)%>
         </div>
 
-        <% if @is_loa2 %>
         <div class="panel panel-border-wide">
           <%= t 'hub.redirect_to_idp_question.identity_documents' %>
         </div>
-        <% end %>
 
         <div class="form-group-tight">
             <%= button_tag t('navigation.continue'),

--- a/config/initializers/30_federation.rb
+++ b/config/initializers/30_federation.rb
@@ -46,5 +46,5 @@ Rails.application.config.after_initialize do
 
   # Feature flags
   IDP_FEATURE_FLAGS_CHECKER = IdpEligibility::IdpFeatureFlagsLoader.new(YamlLoader.new)
-                                 .load(CONFIG.rules_directory, [:send_hints, :send_language_hint, :show_interstitial_question])
+                                 .load(CONFIG.rules_directory, [:send_hints, :send_language_hint, :show_interstitial_question, :show_interstitial_question_loa1])
 end

--- a/spec/controllers/choose_a_certified_company_controller_spec.rb
+++ b/spec/controllers/choose_a_certified_company_controller_spec.rb
@@ -90,6 +90,13 @@ describe ChooseACertifiedCompanyController do
       expect(subject).to redirect_to redirect_to_idp_question_path
     end
 
+    it 'redirects to IDP question page for LOA1 users when IDP flag is enabled' do
+      set_session_and_cookies_with_loa('LEVEL_1')
+      post :select_idp, params: { locale: 'en', entity_id: 'http://idcorp-loa1.com' }
+
+      expect(subject).to redirect_to redirect_to_idp_question_path
+    end
+
     it 'returns 404 page if IDP is non-existent' do
       post :select_idp, params: { locale: 'en', entity_id: 'http://notanidp.com' }
 

--- a/spec/controllers/redirect_to_idp_question_controller_spec.rb
+++ b/spec/controllers/redirect_to_idp_question_controller_spec.rb
@@ -28,12 +28,32 @@ describe RedirectToIdpQuestionController do
                      :idp_wont_work_for_you_one_doc_path
   end
 
+  context 'starts on correct view for loa' do
+    it 'displays correct view for loa1' do
+      set_session_and_cookies_with_loa('LEVEL_1')
+      get :index, params: { locale: 'en' }
+      expect(subject).to render_template(:redirect_to_idp_question_LOA1)
+    end
+
+    it 'displays correct view for loa2' do
+      set_session_and_cookies_with_loa('LEVEL_2')
+      get :index, params: { locale: 'en' }
+      expect(subject).to render_template(:redirect_to_idp_question_LOA2)
+    end
+  end
+
   context 'when form is invalid' do
     subject { post :continue, params: { locale: 'en', interstitial_question_form: invalid_form_answers } }
 
-    it 'stores flash errors' do
+    it 'stores flash errors and redirects to loa1' do
       set_session_and_cookies_with_loa('LEVEL_1')
-      expect(subject).to render_template(:index)
+      expect(subject).to render_template(:redirect_to_idp_question_LOA1)
+      expect(flash[:errors]).not_to be_empty
+    end
+
+    it 'stores flash errors and redirects to loa2' do
+      set_session_and_cookies_with_loa('LEVEL_2')
+      expect(subject).to render_template(:redirect_to_idp_question_LOA2)
       expect(flash[:errors]).not_to be_empty
     end
   end

--- a/spec/features/user_visits_redirect_to_idp_question_page_spec.rb
+++ b/spec/features/user_visits_redirect_to_idp_question_page_spec.rb
@@ -29,6 +29,16 @@ RSpec.describe 'When the user visits the redirect to IDP question page' do
     expect(page).to have_content('I have a question for you in English')
   end
 
+  it 'displays document warning text on LOA2' do
+    expect(page).to have_content('You need your identity documents with you')
+  end
+
+  it 'does not display document warning text on LOA1' do
+    set_loa_in_session('LEVEL_1')
+    visit '/redirect-to-idp-question'
+    expect(page).to_not have_content('You need your identity documents with you')
+  end
+
   it 'displays interstitial question in Welsh' do
     visit '/ailgyfeirio-i-gwestiwn-idp'
 

--- a/stub/api/stub_api.rb
+++ b/stub/api/stub_api.rb
@@ -14,7 +14,12 @@ class StubApi < Sinatra::Base
         "simpleId":"stub-idp-one",
         "entityId":"http://example.com/stub-idp-one",
         "levelsOfAssurance": ["LEVEL_1", "LEVEL_2"]
-     }]'
+     },
+     {
+        "simpleId":"stub-idp-loa1",
+        "entityId":"http://stub-idp-loa1.com",
+        "levelsOfAssurance": ["LEVEL_1"]
+      }]'
   end
 
   put '/api/session/:session_id/select-idp' do

--- a/stub/idp-rules/stub-idp-loa1.yml
+++ b/stub/idp-rules/stub-idp-loa1.yml
@@ -1,0 +1,4 @@
+simpleIds: [ "stub-idp-loa1" ]
+recommended_profiles: []
+non_recommended_profiles: []
+show_interstitial_question_loa1: true

--- a/stub/locales/idps/stub-idp-loa1.yml
+++ b/stub/locales/idps/stub-idp-loa1.yml
@@ -8,6 +8,11 @@ en:
         - a UK photocard driving licence
       contact_details: |
         <strong id="stub-idp-two-contact-details">5 Somewhere Avenue</strong>
+      interstitial_question: |
+        <p>I have a question for you in English</p>
+        <h2 class="heading-medium">Are you sure you want to continue?</h2>
+      interstitial_explanation: |
+        <p>LOA1 Corp will not work for you.</p>
 cy:
   idps:
     stub-idp-loa1:
@@ -16,3 +21,8 @@ cy:
       requirements:
         - a UK passport
         - a UK photocard driving licence
+      interstitial_question: |
+        <p>I have a question for you in Welsh</p>
+        <h2 class="heading-medium">Are you sure you want to continue?</h2>
+      interstitial_explanation: |
+        <p>LOA1 Corp will not work for you.</p>


### PR DESCRIPTION
In preparations for a new LOA1 IDP we want to show additional question before redirection. This is using the current interstitial logic but excluding the LOA1 if flag is not set.

Pair: @rachelthecodesmith @jakubmiarka