### PR TITLE
TT-1284: fixed 404 error from about company page to feedback from

### DIFF
--- a/app/models/feedback_source_mapper.rb
+++ b/app/models/feedback_source_mapper.rb
@@ -45,6 +45,7 @@ class FeedbackSourceMapper
   end
 
   def is_feedback_source_valid(feedback_source)
+    return true if feedback_source.starts_with?('CHOOSE_A_CERTIFIED_COMPANY_ABOUT_')
     @page_to_source_mappings.has_key?(feedback_source)
   end
 

--- a/spec/models/feedback_source_mapper_spec.rb
+++ b/spec/models/feedback_source_mapper_spec.rb
@@ -16,6 +16,10 @@ describe FeedbackSourceMapper do
     expect(@feedback_source_mapper.is_feedback_source_valid('EXPIRED_ERROR_PAGE')).to be true
   end
 
+  it 'feedback source should be valid if it is from any about company page' do
+    expect(@feedback_source_mapper.is_feedback_source_valid('CHOOSE_A_CERTIFIED_COMPANY_ABOUT_SOME_IDP_PAGE')).to be true
+  end
+
   it 'should map to anywhere if feedback source is EXPIRED_ERROR_PAGE' do
     expect(@feedback_source_mapper.page_from_source('EXPIRED_ERROR_PAGE', :en)).to be_nil
   end


### PR DESCRIPTION
Added binary return to feedback mapper to return as vaild if feedback source is from any about company page. Tests updated to cover new logic.

pair: @rachelthecodesmith @jakubmiarka