### PR TITLE
BAU: fix ab test variants

### DIFF
--- a/app/controllers/sign_in_variant_create_account_controller.rb
+++ b/app/controllers/sign_in_variant_create_account_controller.rb
@@ -36,7 +36,7 @@ class SignInVariantCreateAccountController < ApplicationController
 private
 
   def sign_in(entity_id, display_name)
-    SESSION_PROXY.select_idp(session[:verify_session_id], entity_id)
+    POLICY_PROXY.select_idp(session[:verify_session_id], entity_id)
     set_journey_hint(entity_id)
     FEDERATION_REPORTER.report_sign_in_idp_selection(request, display_name)
   end

--- a/app/controllers/sign_in_variant_get_setup_controller.rb
+++ b/app/controllers/sign_in_variant_get_setup_controller.rb
@@ -36,7 +36,7 @@ class SignInVariantGetSetupController < ApplicationController
 private
 
   def sign_in(entity_id, display_name)
-    SESSION_PROXY.select_idp(session[:verify_session_id], entity_id)
+    POLICY_PROXY.select_idp(session[:verify_session_id], entity_id)
     set_journey_hint(entity_id)
     FEDERATION_REPORTER.report_sign_in_idp_selection(request, display_name)
   end


### PR DESCRIPTION
AB test variant sign in controllers were trying to call a method that no longer exists
The frontend was changed to call policy directly for selecting the idp but the variants were not updated.

Solo: @hugh-emerson