### PR TITLE
TT-1410: update text on uplift and registration failure pages

### DIFF
--- a/app/views/failed_registration/_continue_rp.html.erb
+++ b/app/views/failed_registration/_continue_rp.html.erb
@@ -11,10 +11,9 @@
 
 <h2 class="heading-medium"><%= t 'hub.failed_registration.problems_verifying_your_identity' %></h2>
 
-<%= t 'hub.failed_registration.reasons_html' %>
+<%= t 'hub.failed_registration.reasons_html', idp_name: idp.display_name %>
 
 <p><%= t 'hub.failed_registration.what_to_do_next_intro' %></p>
-
 
 <details class="next-actions">
   <summary><span class="summary"><%= t 'hub.failed_registration.contact_details_intro', idp_name: idp.display_name %></span></summary>

--- a/app/views/failed_registration/_non_continue_rp.html.erb
+++ b/app/views/failed_registration/_non_continue_rp.html.erb
@@ -1,12 +1,10 @@
 <h1 class="heading-large"><%= t 'hub.failed_registration.heading', idp_name: idp.display_name %></h1>
 
-<%= t 'hub.failed_registration.reasons_html' %>
+<%= t 'hub.failed_registration.reasons_html', idp_name: idp.display_name %>
 
 <h2 class="heading-medium">
   <%= t 'hub.failed_registration.what_to_do_next' %>
 </h2>
-
-<p><%= t 'hub.failed_registration.what_to_do_next_intro' %></p>
 
 <details class="next-actions">
   <summary><span class="summary"><%= t 'hub.failed_registration.other_ways_summary', other_ways_description: transaction.other_ways_description.html_safe %></span></summary>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -373,8 +373,9 @@ cy:
       reasons_html: |
         <p>Mae ychydig o resymau pam allai hyn ddigwydd, yn cynnwys:</p>
         <ul class="list list-bullet">
+          <li>your answer to a question doesn't match online records</li>
           <li>rydych yn ddiweddar wedi cael newid yn eich amgylchiadau, ac nid ydynt wedi cael eu diweddaru ar-lein</li>
-          <li>nid oes gan y cwmni ardystiedig fynediad i ddigon o wybodaeth amdanoch</li>
+          <li>%{idp_name} doesn't have access to enough information about you</li>
         </ul>
       what_to_do_next_intro: "Gallwch roi cynnig ar y canlynol:"
       what_to_do_next: Beth i’w wneud nesaf
@@ -400,10 +401,10 @@ cy:
       reasons_html: |
         <p>Mae ychydig o resymau pam allai hyn ddigwydd, yn cynnwys:</p>
         <ul class="list list-bullet">
-          <li>nid yw eich ateb i gwestiwn yn cyfateb i’n cofnodion</li>
+          <li>your answer to a question doesn't match online records</li>
           <li>rydych yn ddiweddar wedi cael newid yn eich amgylchiadau, ac nid ydynt wedi cael eu diweddaru ar-lein</li>
-          <li>nid oes gan y cwmni ardystiedig fynediad i ddigon o wybodaeth amdanoch</li>
-         </ul>
+          <li>%{idp_name} doesn't have access to enough information about you</li>
+        </ul>
       start_again: Dod o hyd i gwmni arall i’ch gwirio
       still_use_heading: "You can still access these government services with your %{idp_name} identity account"
       try_another_text: Mae cwmniau eraill yn defnyddio dulliau gwahanol i %{idp_name} ac felly gyda gwell siawns o ddilysu eich hunaniaeth.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -368,8 +368,9 @@ en:
       reasons_html: |
         <p>There are a few reasons why this might happen, including:</p>
         <ul class="list list-bullet">
-          <li>you’ve recently had a change in your circumstances, and they aren’t updated online</li>
-          <li>the certified company doesn’t have access to enough information about you</li>
+          <li>your answer to a question doesn't match online records</li>
+          <li>you've recently had a change in your circumstances, and they aren't up to date online</li>
+          <li>%{idp_name} doesn't have access to enough information about you</li>
         </ul>
       what_to_do_next_intro: "You can try the following:"
       what_to_do_next: "What to do next"
@@ -390,22 +391,22 @@ en:
         <p>You can be verified by another company at any time. You won’t lose any data on GOV.UK services you’ve used.</p>
       start_again: "Start again"
     failed_uplift:
-          title: Failed to uplift
-          heading: "%{display_name} was not able to validate the evidence you provided"
-          reasons_html: |
-            <p>There are a few reasons why this might happen, including:</p>
-            <ul class="list list-bullet">
-              <li>your answer to a question doesn't match records</li>
-              <li>you've recently had a change in your circumstances, and they are not up to date online</li>
-              <li>the certified company doesn't have access to enough information about you</li>
-             </ul>
-          start_again: Find another company to verify you
-          still_use_heading: "You can still access these government services with your %{idp_name} identity account"
-          try_another_text: "Other companies use different methods from %{idp_name} and may therefore stand a better chance of verifying your identity."
-          try_another_summary: "Try verifying with another certified company"
-          what_next_heading: "What to do next"
-          other_ways_summary: "View other ways to %{other_ways_description}"
-          contact_summary: "Contact %{idp_name}"
+      title: Failed to uplift
+      heading: "%{display_name} was not able to validate the evidence you provided"
+      reasons_html: |
+        <p>There are a few reasons why this might happen, including:</p>
+        <ul class="list list-bullet">
+          <li>your answer to a question doesn't match online records</li>
+          <li>you've recently had a change in your circumstances, and they aren't up to date online</li>
+          <li>%{idp_name} doesn't have access to enough information about you</li>
+        </ul>
+      start_again: Find another company to verify you
+      still_use_heading: "You can still access these government services with your %{idp_name} identity account"
+      try_another_text: "Other companies use different methods from %{idp_name} and may therefore stand a better chance of verifying your identity."
+      try_another_summary: "Try verifying with another certified company"
+      what_next_heading: "What to do next"
+      other_ways_summary: "View other ways to %{other_ways_description}"
+      contact_summary: "Contact %{idp_name}"
     response_processing:
       title: Please wait
       heading: "%{rp_name} is processing your details"


### PR DESCRIPTION
Tweak the wording in the list of reasons for failure.
Make those lists on the two pages match.
Delete 'you can try the following' on the registration non-continue failure page

Solo: @hugh-emerson