### PR TITLE
TT-1399: update the sign-in/registration virtual page names

### DIFF
--- a/app/models/analytics/federation_reporter.rb
+++ b/app/models/analytics/federation_reporter.rb
@@ -1,6 +1,6 @@
 module Analytics
   class FederationReporter
-    AB_TEST_ACTION_NAME = 'AB test - %s'.freeze
+    AB_TEST_ACTION_NAME = 'The user has started an AB test'.freeze
 
     def initialize(analytics_reporter)
       @analytics_reporter = analytics_reporter
@@ -13,14 +13,14 @@ module Analytics
     def report_sign_in(current_transaction, request)
       report_action(current_transaction,
                     request,
-                    'The No option was selected on the introduction page',
+                    'The user started a sign-in journey',
                     Analytics::CustomVariable.build(:journey_type, 'SIGN_IN'))
     end
 
     def report_registration(current_transaction, request)
       report_action(current_transaction,
                     request,
-                    'The Yes option was selected on the start page',
+                    'The user started a registration journey',
                     Analytics::CustomVariable.build(:journey_type, 'REGISTRATION'))
     end
 
@@ -31,7 +31,7 @@ module Analytics
 
         report_action(current_transaction,
                       request,
-                      AB_TEST_ACTION_NAME % alternative_name,
+                      AB_TEST_ACTION_NAME,
                       ab_test_custom_var)
       end
     end

--- a/spec/controllers/start_controller_spec.rb
+++ b/spec/controllers/start_controller_spec.rb
@@ -19,7 +19,7 @@ describe StartController do
     it 'will redirect to sign in page when selection is false' do
       stub_piwik_request = stub_piwik_journey_type_request(
         'SIGN_IN',
-        'The No option was selected on the introduction page',
+        'The user started a sign-in journey',
         'LEVEL_2'
       )
       post :request_post, params: { locale: 'en', start_form: { selection: false } }
@@ -30,7 +30,7 @@ describe StartController do
     it 'will redirect to about page when selection is true' do
       stub_piwik_request = stub_piwik_journey_type_request(
         'REGISTRATION',
-        'The Yes option was selected on the start page',
+        'The user started a registration journey',
         'LEVEL_2'
       )
       post :request_post, params: { locale: 'en', start_form: { selection: true } }
@@ -50,7 +50,7 @@ describe StartController do
   it 'will redirect to about page when selection is registration' do
     stub_piwik_request = stub_piwik_journey_type_request(
       'REGISTRATION',
-      'The Yes option was selected on the start page',
+      'The user started a registration journey',
       'LEVEL_2'
     )
     get :register, params: { locale: 'en' }

--- a/spec/features/user_submits_start_page_form_spec.rb
+++ b/spec/features/user_submits_start_page_form_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe 'when user submits start page form' do
         'rec' => '1',
         'apiv' => '1',
         '_cvar' => '{"1":["RP","analytics description for test-rp"],"2":["LOA_REQUESTED","LEVEL_2"],"3":["JOURNEY_TYPE","SIGN_IN"]}',
-        'action_name' => 'The No option was selected on the introduction page'
+        'action_name' => 'The user started a sign-in journey'
     }
     expect(a_request(:get, INTERNAL_PIWIK.url).with(query: hash_including(piwik_request))).to have_been_made.once
   end

--- a/spec/features/user_visits_sign_in_page_spec.rb
+++ b/spec/features/user_visits_sign_in_page_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'user selects an IDP on the sign in page' do
   end
 
   def given_the_piwik_request_has_been_stubbed
-    @stub_piwik_journey_request = stub_piwik_journey_type_request('REGISTRATION', 'The Yes option was selected on the start page', 'LEVEL_2')
+    @stub_piwik_journey_request = stub_piwik_journey_type_request('REGISTRATION', 'The user started a registration journey', 'LEVEL_2')
   end
 
   def given_im_on_the_sign_in_page(locale = 'en')

--- a/spec/models/analytics/federation_reporter_spec.rb
+++ b/spec/models/analytics/federation_reporter_spec.rb
@@ -73,6 +73,28 @@ module Analytics
       end
     end
 
+    describe '#report_ab_test' do
+      before(:each) do
+        RP_DISPLAY_REPOSITORY = double
+        transaction = double
+        allow(transaction).to receive(:analytics_description).and_return('description')
+        allow(RP_DISPLAY_REPOSITORY).to receive(:fetch).with('test-rp').and_return(transaction)
+      end
+
+      it 'should report an ab test custom variable' do
+        alternative_name = 'alternative_name'
+        expect(analytics_reporter).to receive(:report_custom_variable)
+          .with(
+            request,
+            'The user has started an AB test',
+            1 => %w(RP description),
+            2 => %w(LOA_REQUESTED LEVEL_2),
+            6 => ['AB_TEST', alternative_name]
+          )
+        federation_reporter.report_ab_test('test-rp', request, alternative_name)
+      end
+    end
+
     describe '#report_cycle_three' do
       it 'should report cycle 3 attribute name' do
         attribute_name = 'anAttribute'
@@ -110,7 +132,7 @@ module Analytics
       expect(analytics_reporter).to receive(:report_custom_variable)
         .with(
           request,
-          'The No option was selected on the introduction page',
+          'The user started a sign-in journey',
           1 => %w(RP description),
           2 => %w(LOA_REQUESTED LEVEL_2),
           3 => %w(JOURNEY_TYPE SIGN_IN)
@@ -126,7 +148,7 @@ module Analytics
       expect(analytics_reporter).to receive(:report_custom_variable)
         .with(
           request,
-          'The Yes option was selected on the start page',
+          'The user started a registration journey',
           1 => %w(RP description),
           2 => %w(LOA_REQUESTED LEVEL_2),
           3 => %w(JOURNEY_TYPE REGISTRATION)


### PR DESCRIPTION
Make the sign in and registration virtual page names meaningful.
Make the ab test virtual page name more generic (the custom variable is still set as before)
Removing the action name altogether would result in "Page Name not defined" page views
Add a test for the federation reporter report_ab_test method

Authors: @hugh-emerson, @jakubmiarka