### PR TITLE
TT-1440: Added dummy ab test

### DIFF
--- a/app/controllers/start_variant_b_controller.rb
+++ b/app/controllers/start_variant_b_controller.rb
@@ -1,4 +1,4 @@
-class StartController < ApplicationController
+class StartVariantBController < ApplicationController
   layout 'slides'
 
   def index

--- a/app/controllers/start_variant_c_controller.rb
+++ b/app/controllers/start_variant_c_controller.rb
@@ -1,4 +1,4 @@
-class StartController < ApplicationController
+class StartVariantCController < ApplicationController
   layout 'slides'
 
   def index

--- a/app/views/start_variant_b/start.html.erb
+++ b/app/views/start_variant_b/start.html.erb
@@ -1,0 +1,25 @@
+<%= page_title 'hub.start.title' %>
+<% content_for :body_classes, 'hub-start' %>
+<% content_for :feedback_source, 'START_PAGE' %>
+
+<h1 class="heading-large"><%= t 'hub.start.heading' %></h1>
+
+<%= form_for @form, url: start_path, html: {id: 'start-page-form', class: 'js-validate', novalidate: 'novalidate'} do |f| %>
+
+  <%= render 'shared/form-errors', errors: flash[:errors] %>
+
+  <%= content_tag :div, class: form_question_class do %>
+    <fieldset>
+      <%= f.custom_radio_button :selection, true, t('hub.start.answer_yes'), {required: true, data: { msg: t('hub.start.error_message')}, piwik_event_tracking: 'journey_user_type'} %>
+      <%= f.custom_radio_button :selection, false, t('hub.start.answer_no'), {required: true, data: { msg: t('hub.start.error_message')}, piwik_event_tracking: 'journey_user_type'} %>
+    </fieldset>
+  <% end %>
+
+  <div id="validation-error-message-js"></div>
+
+  <div class="form-group-tight">
+    <div class="actions">
+      <%= f.submit t('hub.start.continue'), class: 'button', id: 'next-button' %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/start_variant_c/start.html.erb
+++ b/app/views/start_variant_c/start.html.erb
@@ -1,0 +1,25 @@
+<%= page_title 'hub.start.title' %>
+<% content_for :body_classes, 'hub-start' %>
+<% content_for :feedback_source, 'START_PAGE' %>
+
+<h1 class="heading-large"><%= t 'hub.start.heading' %></h1>
+
+<%= form_for @form, url: start_path, html: {id: 'start-page-form', class: 'js-validate', novalidate: 'novalidate'} do |f| %>
+
+  <%= render 'shared/form-errors', errors: flash[:errors] %>
+
+  <%= content_tag :div, class: form_question_class do %>
+    <fieldset>
+      <%= f.custom_radio_button :selection, true, t('hub.start.answer_yes'), {required: true, data: { msg: t('hub.start.error_message')}, piwik_event_tracking: 'journey_user_type'} %>
+      <%= f.custom_radio_button :selection, false, t('hub.start.answer_no'), {required: true, data: { msg: t('hub.start.error_message')}, piwik_event_tracking: 'journey_user_type'} %>
+    </fieldset>
+  <% end %>
+
+  <div id="validation-error-message-js"></div>
+
+  <div class="form-group-tight">
+    <div class="actions">
+      <%= f.submit t('hub.start.continue'), class: 'button', id: 'next-button' %>
+    </div>
+  </div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,16 @@ Rails.application.routes.draw do
     instance_eval(File.read(Rails.root.join("config/#{routes_name}.rb")))
   end
 
+  AB_TEST_EXPERIMENT_NAME = 'dummy_ab_test'.freeze
+
+  ab_test_control_piwik = SelectRoute.new(AB_TEST_EXPERIMENT_NAME, 'control', true, 'LEVEL_1')
+  ab_test_variant_b_piwik = SelectRoute.new(AB_TEST_EXPERIMENT_NAME, 'variant_b', true, 'LEVEL_1')
+  ab_test_variant_c_piwik = SelectRoute.new(AB_TEST_EXPERIMENT_NAME, 'variant_c', true, 'LEVEL_1')
+
+  ab_test_control = SelectRoute.new(AB_TEST_EXPERIMENT_NAME, 'control')
+  ab_test_variant_b = SelectRoute.new(AB_TEST_EXPERIMENT_NAME, 'variant_b')
+  ab_test_variant_c = SelectRoute.new(AB_TEST_EXPERIMENT_NAME, 'variant_c')
+
   post 'SAML2/SSO' => 'authn_request#rp_request'
   post 'SAML2/SSO/Response/POST' => 'authn_response#idp_response'
   post 'SAML2/SSO/EidasResponse/POST' => 'authn_response#country_response'
@@ -33,9 +43,31 @@ Rails.application.routes.draw do
   end
 
   localized do
-    get 'start', to: 'start#index', as: :start
-    post 'start', to: 'start#request_post', as: :start
-    get 'begin_registration', to: 'start#register', as: :begin_registration
+    constraints ab_test_control_piwik do
+      get 'start', to: 'start#index', as: :start
+    end
+    constraints ab_test_variant_b_piwik do
+      get 'start', to: 'start_variant_b#index', as: :start
+    end
+    constraints ab_test_variant_c_piwik do
+      get 'start', to: 'start_variant_c#index', as: :start
+    end
+    constraints ab_test_control do
+      post 'start', to: 'start#request_post', as: :start
+      get 'begin_registration', to: 'start#register', as: :begin_registration
+    end
+    constraints ab_test_variant_b do
+      post 'start', to: 'start_variant_b#request_post', as: :start
+      get 'begin_registration', to: 'start_variant_b#register', as: :begin_registration
+    end
+    constraints ab_test_variant_c do
+      post 'start', to: 'start_variant_c#request_post', as: :start
+      get 'begin_registration', to: 'start_variant_c#register', as: :begin_registration
+    end
+
+    # get 'start', to: 'start#index', as: :start
+    # post 'start', to: 'start#request_post', as: :start
+    # get 'begin_registration', to: 'start#register', as: :begin_registration
     get 'sign_in', to: 'sign_in#index', as: :sign_in
     post 'sign_in', to: 'sign_in#select_idp', as: :sign_in_submit
     get 'about', to: 'about#index', as: :about

--- a/spec/features/user_sends_authn_request_spec.rb
+++ b/spec/features/user_sends_authn_request_spec.rb
@@ -77,7 +77,8 @@ describe 'user sends authn requests' do
         'about_companies' => 'about_companies_with_logo',
         'split_questions_v2' => 'split_questions_v2_control',
         'select_documents_v2' => 'select_documents_v2_control',
-        'idp_warning' => 'idp_warning_control'
+        'idp_warning' => 'idp_warning_control',
+        'dummy_ab_test' => 'dummy_ab_test_control'
       }.to_json
       cookie_hash = create_cookie_hash.merge!(ab_test: CGI.escape(ab_test_cookie_value))
       set_cookies!(cookie_hash)

--- a/stub/ab_test.yml
+++ b/stub/ab_test.yml
@@ -31,3 +31,11 @@ experiments:
           percent: 0
         - name: 'no_logo_privacy'
           percent: 0
+  - dummy_ab_test:
+      alternatives:
+        - name: 'control'
+          percent: 100
+        - name: 'variant_b'
+          percent: 0
+        - name: 'variant_c'
+          percent: 0


### PR DESCRIPTION
Following issues with reporting have added dummy ab test to allow for testing of cookie allocation in ab test from start page.

Pair: @michaelwalker @rachelthecodesmith