### PR TITLE
TT-1489: Fixed green shadow on buttons

### DIFF
--- a/app/assets/stylesheets/pages/_slides.scss
+++ b/app/assets/stylesheets/pages/_slides.scss
@@ -67,6 +67,9 @@
       background: $white;
       color: $mainstream-brand;
       font-weight: bold;
+      -webkit-box-shadow: 0 2px 0 darken($mainstream-brand, 15%);
+      -moz-box-shadow: 0 2px 0 darken($mainstream-brand, 15%);
+      box-shadow: 0 2px 0 darken($mainstream-brand, 15%);
     }
   }
 


### PR DESCRIPTION
Buttons on blue slides used default green shadow. Changed to dark blue (15% darker of the main blue colour) after a chat with Mike Thomas.

Solo: @jakubmiarka