### PR TITLE
BAU: Add autoprefixer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'connection_pool'
 
 # Assets
 gem 'sass-rails', '~> 5.0'
+gem 'autoprefixer-rails'
 gem 'uglifier', '>= 1.3.0'
 gem 'jquery-rails'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,8 @@ GEM
     arr-pm (0.0.10)
       cabin (> 0)
     ast (2.3.0)
+    autoprefixer-rails (7.1.6)
+      execjs
     backports (3.6.8)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
@@ -343,6 +345,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  autoprefixer-rails
   byebug
   capybara (~> 2.10)
   connection_pool

--- a/app/assets/stylesheets/browserslist
+++ b/app/assets/stylesheets/browserslist
@@ -1,0 +1,3 @@
+> 1%
+last 2 versions
+IE > 7 # as per https://www.gov.uk/service-manual/technology/designing-for-different-browsers-and-devices#browsers-to-test-in

--- a/app/assets/stylesheets/pages/_slides.scss
+++ b/app/assets/stylesheets/pages/_slides.scss
@@ -67,8 +67,6 @@
       background: $white;
       color: $mainstream-brand;
       font-weight: bold;
-      -webkit-box-shadow: 0 2px 0 darken($mainstream-brand, 15%);
-      -moz-box-shadow: 0 2px 0 darken($mainstream-brand, 15%);
       box-shadow: 0 2px 0 darken($mainstream-brand, 15%);
     }
   }


### PR DESCRIPTION
Adding autoprefixer for CSS to automatically add vendor prefixes for CSS properties requiring prefix in browsers specified in browserlist.

Solo: @jakubmiarka