### PR TITLE
Tt 1437 remove idp authn response api resource

### DIFF
--- a/app/controllers/authn_response_controller.rb
+++ b/app/controllers/authn_response_controller.rb
@@ -12,7 +12,7 @@ class AuthnResponseController < SamlController
   def idp_response
     raise_error_if_session_mismatch(params['RelayState'], session[:verify_session_id])
 
-    response = SESSION_PROXY.idp_authn_response(session[:verify_session_id], params['SAMLResponse'], params['RelayState'])
+    response = SAML_PROXY_API.idp_authn_response(session[:verify_session_id], params['SAMLResponse'], params['RelayState'])
     idp_response_handlers[response.idp_result].call(response)
   end
 

--- a/app/controllers/authn_response_controller.rb
+++ b/app/controllers/authn_response_controller.rb
@@ -12,7 +12,7 @@ class AuthnResponseController < SamlController
   def idp_response
     raise_error_if_session_mismatch(params['RelayState'], session[:verify_session_id])
 
-    response = SAML_PROXY_API.idp_authn_response(session[:verify_session_id], params['SAMLResponse'], params['RelayState'])
+    response = SAML_PROXY_API.idp_authn_response(session[:verify_session_id], params['SAMLResponse'])
     idp_response_handlers[response.idp_result].call(response)
   end
 

--- a/app/models/idp_authn_response.rb
+++ b/app/models/idp_authn_response.rb
@@ -5,7 +5,7 @@ class IdpAuthnResponse < Api::Response
   validates_inclusion_of :is_registration, in: [true, false]
 
   def initialize(hash)
-    @idp_result = hash['idpResult']
+    @idp_result = hash['result']
     @is_registration = hash['isRegistration']
     @loa_achieved = hash['loaAchieved']
   end

--- a/app/models/saml_proxy_api.rb
+++ b/app/models/saml_proxy_api.rb
@@ -34,13 +34,14 @@ class SamlProxyApi
     ResponseForRp.validated_response(response)
   end
 
-  def idp_authn_response(session_id, saml_response, relay_state)
+  def idp_authn_response(session_id, saml_response)
     body = {
-        PARAM_RELAY_STATE => relay_state,
-        PARAM_SAML_RESPONSE => saml_response,
-        PARAM_ORIGINATING_IP => originating_ip
+        PARAM_RELAY_STATE => session_id,
+        PARAM_SAML_REQUEST => saml_response,
+        PARAM_IP_SEEN_BY_FRONTEND => originating_ip
     }
-    response = @api_client.put(idp_authn_response_endpoint(session_id), body)
+    response = @api_client.post(IDP_AUTHN_RESPONSE_ENDPOINT, body)
+
     IdpAuthnResponse.validated_response(response)
   end
 end

--- a/app/models/saml_proxy_api.rb
+++ b/app/models/saml_proxy_api.rb
@@ -33,4 +33,14 @@ class SamlProxyApi
     response = @api_client.get(error_response_for_rp_endpoint(session_id), headers: x_forwarded_for)
     ResponseForRp.validated_response(response)
   end
+
+  def idp_authn_response(session_id, saml_response, relay_state)
+    body = {
+        PARAM_RELAY_STATE => relay_state,
+        PARAM_SAML_RESPONSE => saml_response,
+        PARAM_ORIGINATING_IP => originating_ip
+    }
+    response = @api_client.put(idp_authn_response_endpoint(session_id), body)
+    IdpAuthnResponse.validated_response(response)
+  end
 end

--- a/app/models/saml_proxy_endpoints.rb
+++ b/app/models/saml_proxy_endpoints.rb
@@ -1,8 +1,11 @@
 module SamlProxyEndpoints
   COUNTRY_AUTHN_RESPONSE_ENDPOINT = '/SAML2/SSO/API/RECEIVER/EidasResponse/POST'.freeze
+  IDP_AUTHN_RESPONSE_ENDPOINT = '/SAML2/SSO/API/RECEIVER/Response/POST'.freeze
 
   PARAM_SAML_REQUEST = 'samlRequest'.freeze
   PARAM_RELAY_STATE = 'relayState'.freeze
+  PARAM_SAML_RESPONSE = 'samlResponse'.freeze
+  PARAM_ORIGINATING_IP = 'originatingIp'.freeze
   PARAM_IP_SEEN_BY_FRONTEND = 'principalIpAsSeenByFrontend'.freeze
   RESPONSE_FOR_RP_PATH = '/SAML2/SSO/API/SENDER/RESPONSE'.freeze
   ERROR_RESPONSE_FOR_RP_PATH = '/SAML2/SSO/API/SENDER/ERROR_RESPONSE'.freeze
@@ -15,5 +18,10 @@ module SamlProxyEndpoints
   def error_response_for_rp_endpoint(session_id)
     session_id_query_parameter = { sessionId: session_id }.to_query
     ERROR_RESPONSE_FOR_RP_PATH + "?#{session_id_query_parameter}"
+  end
+
+  def idp_authn_response_endpoint(session_id)
+    session_id_query_parameter = { sessionId: session_id }.to_query
+    IDP_AUTHN_RESPONSE_ENDPOINT + "?#{session_id_query_parameter}"
   end
 end

--- a/app/models/saml_proxy_endpoints.rb
+++ b/app/models/saml_proxy_endpoints.rb
@@ -5,7 +5,6 @@ module SamlProxyEndpoints
   PARAM_SAML_REQUEST = 'samlRequest'.freeze
   PARAM_RELAY_STATE = 'relayState'.freeze
   PARAM_SAML_RESPONSE = 'samlResponse'.freeze
-  PARAM_ORIGINATING_IP = 'originatingIp'.freeze
   PARAM_IP_SEEN_BY_FRONTEND = 'principalIpAsSeenByFrontend'.freeze
   RESPONSE_FOR_RP_PATH = '/SAML2/SSO/API/SENDER/RESPONSE'.freeze
   ERROR_RESPONSE_FOR_RP_PATH = '/SAML2/SSO/API/SENDER/ERROR_RESPONSE'.freeze
@@ -18,10 +17,5 @@ module SamlProxyEndpoints
   def error_response_for_rp_endpoint(session_id)
     session_id_query_parameter = { sessionId: session_id }.to_query
     ERROR_RESPONSE_FOR_RP_PATH + "?#{session_id_query_parameter}"
-  end
-
-  def idp_authn_response_endpoint(session_id)
-    session_id_query_parameter = { sessionId: session_id }.to_query
-    IDP_AUTHN_RESPONSE_ENDPOINT + "?#{session_id_query_parameter}"
   end
 end

--- a/app/models/session_endpoints.rb
+++ b/app/models/session_endpoints.rb
@@ -4,7 +4,6 @@ module SessionEndpoints
   IDP_LIST_SUFFIX = 'idp-list'.freeze
   SELECT_IDP_SUFFIX = 'select-idp'.freeze
   IDP_AUTHN_REQUEST_SUFFIX = 'idp-authn-request'.freeze
-  IDP_AUTHN_RESPONSE_SUFFIX = 'idp-authn-response'.freeze
   SESSION_STATE_PATH = "#{PATH}/state".freeze
   CYCLE_THREE_SUFFIX = 'cycle-three'.freeze
   CYCLE_THREE_CANCEL_SUFFIX = "#{CYCLE_THREE_SUFFIX}/cancel".freeze
@@ -39,10 +38,6 @@ module SessionEndpoints
 
   def idp_authn_request_endpoint(session_id)
     session_endpoint(session_id, IDP_AUTHN_REQUEST_SUFFIX)
-  end
-
-  def idp_authn_response_endpoint(session_id)
-    session_endpoint(session_id, IDP_AUTHN_RESPONSE_SUFFIX)
   end
 
   def cycle_three_endpoint(session_id)

--- a/app/models/session_proxy.rb
+++ b/app/models/session_proxy.rb
@@ -57,16 +57,6 @@ class SessionProxy
     OutboundSamlMessage.validated_response(response)
   end
 
-  def idp_authn_response(session_id, saml_response, relay_state)
-    body = {
-      PARAM_RELAY_STATE => relay_state,
-      PARAM_SAML_RESPONSE => saml_response,
-      PARAM_ORIGINATING_IP => originating_ip
-    }
-    response = @api_client.put(idp_authn_response_endpoint(session_id), body)
-    IdpAuthnResponse.validated_response(response)
-  end
-
   def cycle_three_attribute_name(session_id)
     response = @api_client.get(cycle_three_endpoint(session_id))
     CycleThreeAttributeResponse.validated_response(response).name

--- a/spec/api_test_helper.rb
+++ b/spec/api_test_helper.rb
@@ -154,14 +154,14 @@ module ApiTestHelper
     stub_request(:post, ida_frontend_api_uri(cycle_three_cancel_endpoint(default_session_id))).to_return(status: 200)
   end
 
-  def stub_api_authn_response(relay_state, response = { 'idpResult' => 'SUCCESS', 'isRegistration' => false })
+  def stub_api_authn_response(relay_state, response = { 'result' => 'SUCCESS', 'isRegistration' => false })
     authn_response_body = {
-        PARAM_SAML_RESPONSE => 'my-saml-response',
+        PARAM_SAML_REQUEST => 'my-saml-response',
         PARAM_RELAY_STATE => relay_state,
-        PARAM_ORIGINATING_IP => '<PRINCIPAL IP ADDRESS COULD NOT BE DETERMINED>'
+        PARAM_IP_SEEN_BY_FRONTEND => '<PRINCIPAL IP ADDRESS COULD NOT BE DETERMINED>'
     }
 
-    stub_request(:put, saml_proxy_api_uri(idp_authn_response_endpoint(default_session_id)))
+    stub_request(:post, saml_proxy_api_uri(IDP_AUTHN_RESPONSE_ENDPOINT))
         .with(body: authn_response_body)
         .to_return(body: response.to_json, status: 200)
   end

--- a/spec/api_test_helper.rb
+++ b/spec/api_test_helper.rb
@@ -161,7 +161,7 @@ module ApiTestHelper
         PARAM_ORIGINATING_IP => '<PRINCIPAL IP ADDRESS COULD NOT BE DETERMINED>'
     }
 
-    stub_request(:put, ida_frontend_api_uri(idp_authn_response_endpoint(default_session_id)))
+    stub_request(:put, saml_proxy_api_uri(idp_authn_response_endpoint(default_session_id)))
         .with(body: authn_response_body)
         .to_return(body: response.to_json, status: 200)
   end

--- a/spec/features/user_sends_authn_response_spec.rb
+++ b/spec/features/user_sends_authn_response_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe 'User returns from an IDP with an AuthnResponse' do
   end
 
   it 'will redirect the user to /confirmation when successfully registered' do
-    api_request = stub_api_authn_response(session_id, 'idpResult' => 'SUCCESS', 'isRegistration' => true, 'loaAchieved' => 'LEVEL_2')
+    api_request = stub_api_authn_response(session_id, 'result' => 'SUCCESS', 'isRegistration' => true, 'loaAchieved' => 'LEVEL_2')
     stub_session
     stub_request(:get, INTERNAL_PIWIK.url).with(query: hash_including({}))
 
@@ -51,7 +51,7 @@ RSpec.describe 'User returns from an IDP with an AuthnResponse' do
       selected_idp: { entity_id: 'http://idcorp.com', simple_id: 'stub-idp-one' },
       transaction_simple_id: 'test-rp'
     )
-    api_request = stub_api_authn_response(session_id, 'idpResult' => 'CANCEL', 'isRegistration' => true, 'loaAchieved' => nil)
+    api_request = stub_api_authn_response(session_id, 'result' => 'CANCEL', 'isRegistration' => true, 'loaAchieved' => nil)
     visit("/test-saml?session-id=#{session_id}")
     click_button 'saml-response-post'
 
@@ -64,7 +64,7 @@ RSpec.describe 'User returns from an IDP with an AuthnResponse' do
       selected_idp: { entity_id: 'http://idcorp.com', simple_id: 'stub-idp-one' },
       transaction_simple_id: 'test-rp'
     )
-    api_request = stub_api_authn_response(session_id, 'idpResult' => 'OTHER', 'isRegistration' => true, 'loaAchieved' => nil)
+    api_request = stub_api_authn_response(session_id, 'result' => 'OTHER', 'isRegistration' => true, 'loaAchieved' => nil)
     visit("/test-saml?session-id=#{session_id}")
     click_button 'saml-response-post'
 
@@ -73,7 +73,7 @@ RSpec.describe 'User returns from an IDP with an AuthnResponse' do
   end
 
   it 'will redirect the user to /failed-sign-in when they failed sign in at the IDP' do
-    api_request = stub_api_authn_response(session_id, 'idpResult' => 'OTHER', 'isRegistration' => false, 'loaAchieved' => nil)
+    api_request = stub_api_authn_response(session_id, 'result' => 'OTHER', 'isRegistration' => false, 'loaAchieved' => nil)
     page.set_rack_session(
       selected_idp: { entity_id: 'http://idcorp.com', simple_id: 'stub-idp-one' }
     )
@@ -91,7 +91,7 @@ RSpec.describe 'User returns from an IDP with an AuthnResponse' do
   it 'will redirect the user to /response-processing on successful sign in at the IDP' do
     stub_session
     stub_matching_outcome
-    api_request = stub_api_authn_response(session_id, 'idpResult' => 'SUCCESS', 'isRegistration' => false, 'loaAchieved' => 'LEVEL_2')
+    api_request = stub_api_authn_response(session_id, 'result' => 'SUCCESS', 'isRegistration' => false, 'loaAchieved' => 'LEVEL_2')
 
     visit("/test-saml?session-id=#{session_id}")
     click_button 'saml-response-post'

--- a/spec/models/saml_proxy_api_spec.rb
+++ b/spec/models/saml_proxy_api_spec.rb
@@ -86,4 +86,58 @@ describe SamlProxyApi do
       }.to raise_error(Api::Response::ModelError, "Location can't be blank, Saml message can't be blank")
     end
   end
+
+  describe '#idp_authn_response' do
+    it 'should return a confirmation result' do
+      ip_address = '1.2.3.4'
+      expected_request = { 'samlRequest' => 'saml-response', 'relayState' => 'my-session-id', SamlProxyApi::PARAM_IP_SEEN_BY_FRONTEND => ip_address }
+      expect(originating_ip_store).to receive(:get).and_return(ip_address)
+      expect(api_client).to receive(:post)
+        .with(SamlProxyApi::IDP_AUTHN_RESPONSE_ENDPOINT, expected_request)
+        .and_return(
+          'result' => 'some-location',
+          'isRegistration' => false,
+          'loaAchieved' => 'LEVEL_2'
+        )
+
+      response = saml_proxy_api.idp_authn_response(session_id, 'saml-response')
+
+      attributes = {
+          idp_result: 'some-location',
+          is_registration: false,
+          loa_achieved: 'LEVEL_2'
+      }
+      expect(response).to have_attributes(attributes)
+    end
+
+    it 'should raise an error when fields are missing from the api response' do
+      ip_address = '1.2.3.4'
+      expected_request = { 'samlRequest' => 'saml-response', 'relayState' => 'my-session-id', SamlProxyApi::PARAM_IP_SEEN_BY_FRONTEND => ip_address }
+      expect(originating_ip_store).to receive(:get).and_return(ip_address)
+      expect(api_client).to receive(:post)
+        .with(SamlProxyApi::IDP_AUTHN_RESPONSE_ENDPOINT, expected_request)
+        .and_return({})
+
+      expect {
+        saml_proxy_api.idp_authn_response(session_id, 'saml-response')
+      }.to raise_error Api::Response::ModelError, "Idp result can't be blank, Is registration is not included in the list"
+    end
+
+    it 'should raise an error when loa_achieved is not an accepted value' do
+      ip_address = '1.2.3.4'
+      expected_request = { 'samlRequest' => 'saml-response', 'relayState' => 'my-session-id', SamlProxyApi::PARAM_IP_SEEN_BY_FRONTEND => ip_address }
+      expect(originating_ip_store).to receive(:get).and_return(ip_address)
+      expect(api_client).to receive(:post)
+        .with(SamlProxyApi::IDP_AUTHN_RESPONSE_ENDPOINT, expected_request)
+        .and_return(
+          'result' => 'some-location',
+          'isRegistration' => false,
+          'loaAchieved' => 'something',
+        )
+
+      expect {
+        saml_proxy_api.idp_authn_response(session_id, 'saml-response')
+      }.to raise_error Api::Response::ModelError, 'Loa achieved is not included in the list'
+    end
+  end
 end

--- a/spec/models/session_proxy_spec.rb
+++ b/spec/models/session_proxy_spec.rb
@@ -140,60 +140,6 @@ describe SessionProxy do
     end
   end
 
-  describe '#idp_authn_response' do
-    it 'should return a confirmation result' do
-      ip_address = '1.2.3.4'
-      expected_request = { 'samlResponse' => 'saml-response', 'relayState' => 'relay-state', SessionProxy::PARAM_ORIGINATING_IP => ip_address }
-      expect(originating_ip_store).to receive(:get).and_return(ip_address)
-      expect(api_client).to receive(:put)
-        .with(endpoint(SessionProxy::IDP_AUTHN_RESPONSE_SUFFIX), expected_request)
-        .and_return(
-          'idpResult' => 'some-location',
-          'isRegistration' => false,
-          'loaAchieved' => 'LEVEL_2'
-        )
-
-      response = session_proxy.idp_authn_response(session_id, 'saml-response', 'relay-state')
-
-      attributes = {
-        idp_result: 'some-location',
-        is_registration: false,
-        loa_achieved: 'LEVEL_2'
-      }
-      expect(response).to have_attributes(attributes)
-    end
-
-    it 'should raise an error when fields are missing from the api response' do
-      ip_address = '1.2.3.4'
-      expected_request = { 'samlResponse' => 'saml-response', 'relayState' => 'relay-state', SessionProxy::PARAM_ORIGINATING_IP => ip_address }
-      expect(originating_ip_store).to receive(:get).and_return(ip_address)
-      expect(api_client).to receive(:put)
-        .with(endpoint(SessionProxy::IDP_AUTHN_RESPONSE_SUFFIX), expected_request)
-        .and_return({})
-
-      expect {
-        session_proxy.idp_authn_response(session_id, 'saml-response', 'relay-state')
-      }.to raise_error Api::Response::ModelError, "Idp result can't be blank, Is registration is not included in the list"
-    end
-
-    it 'should raise an error when loa_achieved is not an accepted value' do
-      ip_address = '1.2.3.4'
-      expected_request = { 'samlResponse' => 'saml-response', 'relayState' => 'relay-state', SessionProxy::PARAM_ORIGINATING_IP => ip_address }
-      expect(originating_ip_store).to receive(:get).and_return(ip_address)
-      expect(api_client).to receive(:put)
-        .with(endpoint(SessionProxy::IDP_AUTHN_RESPONSE_SUFFIX), expected_request)
-        .and_return(
-          'idpResult' => 'some-location',
-          'isRegistration' => false,
-          'loaAchieved' => 'something',
-        )
-
-      expect {
-        session_proxy.idp_authn_response(session_id, 'saml-response', 'relay-state')
-      }.to raise_error Api::Response::ModelError, 'Loa achieved is not included in the list'
-    end
-  end
-
   describe '#cycle_three_attribute_name' do
     it 'should return an attribute name' do
       expect(api_client).to receive(:get)

--- a/spec/support/authn_response_examples.rb
+++ b/spec/support/authn_response_examples.rb
@@ -1,13 +1,13 @@
 shared_examples 'idp_authn_response' do |journey_hint, idp_result, piwik_action, redirect_path|
-  let(:session_proxy) { double(:session_proxy) }
+  let(:saml_proxy_api) { double(:saml_proxy_api) }
 
   before(:each) do
-    stub_const('SESSION_PROXY', session_proxy)
+    stub_const('SAML_PROXY_API', saml_proxy_api)
     set_session_and_cookies_with_loa('LEVEL_1')
   end
 
   it "should redirect to #{redirect_path} on #{idp_result}" do
-    allow(session_proxy).to receive(:idp_authn_response).and_return(IdpAuthnResponse.new('idpResult' => idp_result, 'isRegistration' => (journey_hint == 'registration'), 'loaAchieved' => 'LEVEL_1'))
+    allow(saml_proxy_api).to receive(:idp_authn_response).and_return(IdpAuthnResponse.new('idpResult' => idp_result, 'isRegistration' => (journey_hint == 'registration'), 'loaAchieved' => 'LEVEL_1'))
     allow(subject).to receive(:report_to_analytics).with(piwik_action)
     post :idp_response, params: { 'RelayState' => 'my-session-id-cookie', 'SAMLResponse' => 'a-saml-response', locale: 'en' }
     expect(subject).to redirect_to(send(redirect_path))

--- a/spec/support/authn_response_examples.rb
+++ b/spec/support/authn_response_examples.rb
@@ -7,7 +7,7 @@ shared_examples 'idp_authn_response' do |journey_hint, idp_result, piwik_action,
   end
 
   it "should redirect to #{redirect_path} on #{idp_result}" do
-    allow(saml_proxy_api).to receive(:idp_authn_response).and_return(IdpAuthnResponse.new('idpResult' => idp_result, 'isRegistration' => (journey_hint == 'registration'), 'loaAchieved' => 'LEVEL_1'))
+    allow(saml_proxy_api).to receive(:idp_authn_response).and_return(IdpAuthnResponse.new('result' => idp_result, 'isRegistration' => (journey_hint == 'registration'), 'loaAchieved' => 'LEVEL_1'))
     allow(subject).to receive(:report_to_analytics).with(piwik_action)
     post :idp_response, params: { 'RelayState' => 'my-session-id-cookie', 'SAMLResponse' => 'a-saml-response', locale: 'en' }
     expect(subject).to redirect_to(send(redirect_path))

--- a/stub/api/stub_api.rb
+++ b/stub/api/stub_api.rb
@@ -59,10 +59,11 @@ class StubApi < Sinatra::Base
     }'
   end
 
-  put '/api/session/:session_id/idp-authn-response' do
+  post '/SAML2/SSO/API/RECEIVER/Response/POST' do
     '{
-      "idpResult":"blah",
-      "isRegistration":false
+       "result":"blah",
+      "isRegistration":false,
+      "loaAchieved":"LEVEL_2"
     }'
   end
 

--- a/stub/api/stub_api_spec.rb
+++ b/stub/api/stub_api_spec.rb
@@ -74,9 +74,9 @@ describe StubApi do
     end
   end
 
-  context '#put /api/session/:session_id/idp-authn-response' do
+  context '#post /SAML2/SSO/API/RECEIVER/Response/POST' do
     it 'should respond with valid hash' do
-      put '/api/session/session_id/idp-authn-response'
+      post '/SAML2/SSO/API/RECEIVER/Response/POST'
       expect(last_response).to be_ok
       response = IdpAuthnResponse.new(last_response_json)
       expect(response).to be_valid


### PR DESCRIPTION
This allows IdpAuthnReponse's to be passed onto Saml Proxy by Verify Frontend directly without going through Frontend Api. 