### PR TITLE
TT-1462: metadata endpoints no longer return html on errors

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,12 +130,12 @@ GEM
     inflection (1.0.0)
     insist (1.0.0)
     io-like (0.3.0)
-    jasmine (2.5.0)
-      jasmine-core (~> 2.5)
+    jasmine (2.8.0)
+      jasmine-core (>= 2.8.0, < 3.0.0)
       phantomjs
       rack (>= 1.2.1)
       rake
-    jasmine-core (2.5.0)
+    jasmine-core (2.8.0)
     jasmine-jquery-rails (2.0.3)
     jquery-rails (4.1.1)
       rails-dom-testing (>= 1, < 3)

--- a/app/controllers/metadata_controller.rb
+++ b/app/controllers/metadata_controller.rb
@@ -3,6 +3,10 @@ class MetadataController < ApplicationController
   skip_before_action :set_piwik_custom_variables
   skip_after_action :store_locale_in_cookie
 
+  rescue_from StandardError do |exception|
+    render xml: exception, status: 500
+  end
+
   METADATA_CONTENT_TYPE = 'application/samlmetadata+xml'.freeze
 
   def service_providers
@@ -15,13 +19,13 @@ class MetadataController < ApplicationController
     render xml: metadata_client.sp_metadata, content_type: METADATA_CONTENT_TYPE
   end
 
-  def metadata_client
-    METADATA_CLIENT
-  end
-
 private
 
   def do_not_cache
     response.headers['Cache-Control'] = 'no-cache, no-store, no-transform'
+  end
+
+  def metadata_client
+    METADATA_CLIENT
   end
 end

--- a/spec/features/service_retrieves_metadata_spec.rb
+++ b/spec/features/service_retrieves_metadata_spec.rb
@@ -16,7 +16,6 @@ describe 'service retrieves metadata', type: :request do
     stub_transactions_list
     status = get(service_provider_metadata_path)
     expect(status).to eql 500
-    # TODO TT-1462: this error returns html. Gross.
   end
 
   it 'successfully gets idp metadata' do
@@ -33,7 +32,6 @@ describe 'service retrieves metadata', type: :request do
     stub_transactions_list
     status = get(identity_provider_metadata_path)
     expect(status).to eql 500
-    # TODO TT-1462: this error returns html. Gross.
   end
 
   def saml_proxy_uri(path)


### PR DESCRIPTION
XML endpoints shouldn't start returning HTML when they throw an error

Solo: @hugh-emerson