### PR TITLE
TT-1623: Get list of countries from policy directly

### DIFF
--- a/app/controllers/choose_a_country_controller.rb
+++ b/app/controllers/choose_a_country_controller.rb
@@ -17,7 +17,7 @@ class ChooseACountryController < ApplicationController
       return
     end
 
-    SESSION_PROXY.select_a_country(session_id, country)
+    POLICY_PROXY.select_a_country(session_id, country)
 
     redirect_to '/redirect-to-country'
   end
@@ -25,7 +25,7 @@ class ChooseACountryController < ApplicationController
 private
 
   def setup_countries(session_id)
-    countries_map = SESSION_PROXY.get_countries(session_id)
+    countries_map = POLICY_PROXY.get_countries(session_id)
     @countries = COUNTRY_DISPLAY_DECORATOR.decorate_collection(countries_map.countries)
   end
 end

--- a/app/models/policy_endpoints.rb
+++ b/app/models/policy_endpoints.rb
@@ -10,6 +10,8 @@ module PolicyEndpoints
   CYCLE_THREE_SUFFIX = 'cycle-3-attribute'.freeze
   CYCLE_THREE_SUBMIT_SUFFIX = "#{CYCLE_THREE_SUFFIX}/submit".freeze
   CYCLE_THREE_CANCEL_SUFFIX = "#{CYCLE_THREE_SUFFIX}/cancel".freeze
+  COUNTRIES_PATH = '/policy/countries'.freeze
+  COUNTRIES_PATH_PREFIX = Pathname(COUNTRIES_PATH)
 
   def policy_endpoint(session_id, suffix)
     PATH_PREFIX.join(session_id, suffix).to_s
@@ -33,5 +35,13 @@ module PolicyEndpoints
 
   def cycle_three_cancel_endpoint(session_id)
     policy_endpoint(session_id, CYCLE_THREE_CANCEL_SUFFIX)
+  end
+
+  def countries_endpoint(session_id)
+    COUNTRIES_PATH_PREFIX.join(session_id).to_s
+  end
+
+  def select_a_country_endpoint(session_id, suffix)
+    COUNTRIES_PATH_PREFIX.join(session_id, suffix).to_s
   end
 end

--- a/app/models/policy_proxy.rb
+++ b/app/models/policy_proxy.rb
@@ -41,4 +41,13 @@ class PolicyProxy
   def cycle_three_cancel(session_id)
     @api_client.post(cycle_three_cancel_endpoint(session_id), nil, {})
   end
+
+  def get_countries(session_id)
+    response = @api_client.get(countries_endpoint(session_id))
+    CountryResponse.validated_response(response)
+  end
+
+  def select_a_country(session_id, country)
+    @api_client.post(select_a_country_endpoint(session_id, country), '', {})
+  end
 end

--- a/app/models/session_endpoints.rb
+++ b/app/models/session_endpoints.rb
@@ -9,16 +9,6 @@ module SessionEndpoints
   PARAM_RELAY_STATE = 'relayState'.freeze
   PARAM_ORIGINATING_IP = 'originatingIp'.freeze
   PARAM_ENTITY_ID = 'entityId'.freeze
-  COUNTRIES_PATH = '/api/countries'.freeze
-  COUNTRIES_PATH_PREFIX = Pathname(COUNTRIES_PATH)
-
-  def countries_endpoint(session_id)
-    COUNTRIES_PATH_PREFIX.join(session_id).to_s
-  end
-
-  def select_a_country_endpoint(session_id, suffix)
-    COUNTRIES_PATH_PREFIX.join(session_id, suffix).to_s
-  end
 
   def session_endpoint(session_id, suffix)
     PATH_PREFIX.join(session_id, suffix).to_s

--- a/app/models/session_proxy.rb
+++ b/app/models/session_proxy.rb
@@ -29,15 +29,4 @@ class SessionProxy
   def select_cookies(cookies, allowed_cookie_names)
     cookies.select { |name, _| allowed_cookie_names.include?(name) }.to_h
   end
-
-  def get_countries(session_id)
-    response = @api_client.get(countries_endpoint(session_id))
-    CountryResponse.validated_response(response)
-  end
-
-  def select_a_country(session_id, country)
-    # Call into Policy to change state
-    # POST /api/countries (NL)
-    @api_client.post(select_a_country_endpoint(session_id, country), '', {})
-  end
 end

--- a/spec/api_test_helper.rb
+++ b/spec/api_test_helper.rb
@@ -25,7 +25,7 @@ module ApiTestHelper
   end
 
   def api_countries_endpoint(session_id)
-    ida_frontend_api_uri('/api/countries/' + session_id)
+    policy_api_uri('/policy/countries/' + session_id)
   end
 
   def stub_transactions_list

--- a/spec/features/user_visits_choose_a_country_page_spec.rb
+++ b/spec/features/user_visits_choose_a_country_page_spec.rb
@@ -154,15 +154,15 @@ RSpec.describe 'When the user visits the choose a country page' do
     expect(page).to have_current_path('/a-country-page')
 
     # And API is called (and policy records the country selected by the user)
-    expect(a_request(:post, ida_frontend_api_uri(select_country_endpoint("my-session-id-cookie", "NL")))).to have_been_made.once
+    expect(a_request(:post, policy_api_uri(select_country_endpoint("my-session-id-cookie", "NL")))).to have_been_made.once
   end
 
   def select_country_endpoint(session_id, country_code)
-    '/api/countries/' + session_id + '/' + country_code
+    '/policy/countries/' + session_id + '/' + country_code
   end
 
   def stub_select_country_request
-    stub_request(:post, ida_frontend_api_uri(select_country_endpoint("my-session-id-cookie", "NL")))
+    stub_request(:post, policy_api_uri(select_country_endpoint("my-session-id-cookie", "NL")))
         .to_return(body: '')
   end
 end

--- a/spec/models/policy_proxy_spec.rb
+++ b/spec/models/policy_proxy_spec.rb
@@ -92,4 +92,33 @@ describe PolicyProxy do
       policy_proxy.cycle_three_cancel(session_id)
     end
   end
+
+  describe('#get_countries') do
+    countries_json = [
+        { 'entityId' => 'http://netherlandsEntity.nl', 'simpleId' => 'NL', 'enabled' => false },
+        { 'entityId' => 'http://spainEntity.es', 'simpleId' => 'ES', 'enabled' => true }
+    ]
+    let(:api_response) { countries_json }
+
+    it 'should retrieve countries' do
+      expect(api_client).to receive(:get).with('/policy/countries/my-session-id').and_return(api_response)
+
+      response = policy_proxy.get_countries(session_id)
+      expect(response.countries.count).to eq(2)
+      response.countries.each do |country|
+        case country.simple_id
+        when 'ES'
+          expect(country).to have_attributes(simple_id: 'ES',
+                                                    entity_id: 'http://spainEntity.es',
+                                                    enabled: true)
+        when 'NL'
+          expect(country).to have_attributes(simple_id: 'NL',
+                                                    entity_id: 'http://netherlandsEntity.nl',
+                                                    enabled: false)
+        else
+          fail('Invalid list of countries')
+        end
+      end
+    end
+  end
 end

--- a/spec/models/session_proxy_spec.rb
+++ b/spec/models/session_proxy_spec.rb
@@ -69,33 +69,4 @@ describe SessionProxy do
       }.to raise_error Api::Response::ModelError, "Session can't be blank, Transaction simple can't be blank, Levels of assurance can't be blank, Transaction entity can't be blank, Transaction supports eidas is not included in the list"
     end
   end
-
-  describe('#get_countries') do
-    countries_json = [
-      { 'entityId' => 'http://netherlandsEnitity.nl', 'simpleId' => 'NL', 'enabled' => false },
-      { 'entityId' => 'http://spainEnitity.es', 'simpleId' => 'ES', 'enabled' => true }
-    ]
-    let(:api_response) { countries_json }
-
-    it 'should retrieve countries' do
-      expect(api_client).to receive(:get).with('/api/countries/my-session-id').and_return(api_response)
-
-      response = session_proxy.get_countries(session_id)
-      expect(response.countries.count).to eq(2)
-      response.countries.each do |country|
-        case country.simple_id
-        when 'ES'
-          expect(country).to have_attributes(simple_id: 'ES',
-                                             entity_id: 'http://spainEnitity.es',
-                                             enabled: true)
-        when 'NL'
-          expect(country).to have_attributes(simple_id: 'NL',
-                                             entity_id: 'http://netherlandsEnitity.nl',
-                                             enabled: false)
-        else
-          fail('Invalid list of countries')
-        end
-      end
-    end
-  end
 end


### PR DESCRIPTION
- Frontend calls policy endpoint directly and gets list of countries instead of session proxy
- Updated tests and stubs to call policy and not the session

Authors: @mahmudh @jakubmiarka