### PR TITLE
bau: Update rubyzip to 1.2.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -268,7 +268,7 @@ GEM
     ruby-xz (0.2.3)
       ffi (~> 1.9)
       io-like (~> 0.3)
-    rubyzip (1.2.0)
+    rubyzip (1.2.1)
     safe_yaml (1.0.4)
     sass (3.4.25)
     sass-rails (5.0.6)
@@ -393,4 +393,4 @@ RUBY VERSION
    ruby 2.3.5p376
 
 BUNDLED WITH
-   1.15.4
+   1.16.0


### PR DESCRIPTION
rubyzip 1.2.0 has a directory traversal vulnerability - CVE-2017-5946.
It doesn't look like this would be a problem in verify-frontend, since
we do not allow uploading zips.

As far as I can tell rubyzip is only a dependency as a transitive of
selenium.

Authors: @richardtowers