### PR TITLE
TT-1606: Add new start page for clever questions AB test

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,8 @@
 Metrics/BlockLength:
   Exclude:
     - 'config/routes.rb'
+    - 'config/main_routes.rb'
+    - 'config/clever_questions_ab_test_routes.rb'
     - '**/*.rake'
     - 'spec/**/*.rb'
     - 'config/initializers/**/*.rb'

--- a/app/controllers/clever_questions/start_controller.rb
+++ b/app/controllers/clever_questions/start_controller.rb
@@ -1,0 +1,30 @@
+require 'ab_test/ab_test'
+
+class CleverQuestions::StartController < ApplicationController
+  layout 'slides'
+
+  def index
+    FEDERATION_REPORTER.report_start_page(current_transaction, request)
+    render :start
+  end
+
+  def request_post
+    @form = StartForm.new(params['start_form'] || {})
+    if @form.valid?
+      if @form.registration?
+        register
+      else
+        FEDERATION_REPORTER.report_sign_in(current_transaction, request)
+        redirect_to sign_in_path
+      end
+    else
+      flash.now[:errors] = @form.errors.full_messages.join(', ')
+      render :start
+    end
+  end
+
+  def register
+    FEDERATION_REPORTER.report_registration(current_transaction, request)
+    redirect_to will_it_work_for_me_path
+  end
+end

--- a/app/views/clever_questions/start/start.html.erb
+++ b/app/views/clever_questions/start/start.html.erb
@@ -1,0 +1,15 @@
+<% start_page = 'clever_questions.hub.start'%>
+<%= page_title "#{start_page}.title" %>
+<% content_for :body_classes, 'hub-start' %>
+<% content_for :feedback_source, 'START_PAGE' %>
+
+<h1 class="heading-large"><%= t "#{start_page}.heading" %></h1>
+
+<p><%= t "#{start_page}.secure_service" %></p>
+<p><%= t "#{start_page}.prevent_viewing" %></p>
+
+<div class="actions">
+  <%= button_link_to t("#{start_page}.create_account"), start_path(:start_form => {:selection => true}), :method => :post %>
+  <p> or <%= link_to t("#{start_page}.sign_in"), start_path(:start_form => {:selection => false}), :method => :post %></p>
+</div>
+

--- a/config/clever_questions_ab_test_routes.rb
+++ b/config/clever_questions_ab_test_routes.rb
@@ -1,0 +1,95 @@
+def add_routes(routes_name)
+  instance_eval(File.read(Rails.root.join("config/#{routes_name}.rb")))
+end
+
+localized do
+  get 'sign_in', to: 'sign_in#index', as: :sign_in
+  post 'sign_in', to: 'sign_in#select_idp', as: :sign_in_submit
+
+  get 'select_documents', to: 'select_documents#index', as: :select_documents
+  get 'select_documents_none', to: 'select_documents#no_documents', as: :select_documents_no_documents
+  post 'select_documents', to: 'select_documents#select_documents', as: :select_documents_submit
+  get 'unlikely_to_verify', to: 'select_documents#unlikely_to_verify', as: :unlikely_to_verify
+  get 'other_identity_documents', to: 'other_identity_documents#index', as: :other_identity_documents
+  post 'other_identity_documents', to: 'other_identity_documents#select_other_documents', as: :other_identity_documents_submit
+  get 'select_phone', to: 'select_phone#index', as: :select_phone
+  post 'select_phone', to: 'select_phone#select_phone', as: :select_phone_submit
+  get 'no_mobile_phone', to: 'select_phone#no_mobile_phone', as: :no_mobile_phone
+  get 'will_it_work_for_me', to: 'will_it_work_for_me#index', as: :will_it_work_for_me
+  post 'will_it_work_for_me', to: 'will_it_work_for_me#will_it_work_for_me', as: :will_it_work_for_me_submit
+  get 'why_might_this_not_work_for_me', to: 'will_it_work_for_me#why_might_this_not_work_for_me', as: :why_might_this_not_work_for_me
+  get 'may_not_work_if_you_live_overseas', to: 'will_it_work_for_me#may_not_work_if_you_live_overseas', as: :may_not_work_if_you_live_overseas
+  get 'will_not_work_without_uk_address', to: 'will_it_work_for_me#will_not_work_without_uk_address', as: :will_not_work_without_uk_address
+
+  constraints IsLoa1 do
+    get 'start', to: 'start#index', as: :start
+    post 'start', to: 'start#request_post', as: :start
+    get 'begin_registration', to: 'start#register', as: :begin_registration
+    get 'choose_a_certified_company', to: 'choose_a_certified_company_loa1#index', as: :choose_a_certified_company
+    post 'choose_a_certified_company', to: 'choose_a_certified_company_loa1#select_idp', as: :choose_a_certified_company_submit
+    get 'choose_a_certified_company_about', to: 'choose_a_certified_company_loa1#about', as: :choose_a_certified_company_about
+    get 'why_companies', to: 'why_companies_loa1#index', as: :why_companies
+    get 'failed_registration', to: 'failed_registration_loa1#index', as: :failed_registration
+    get 'cancelled_registration', to: 'cancelled_registration_loa1#index', as: :cancelled_registration
+    get 'redirect_to_idp_question', to: 'redirect_to_idp_question_loa1#index', as: :redirect_to_idp_question
+    post 'redirect_to_idp_question', to: 'redirect_to_idp_question_loa1#continue', as: :redirect_to_idp_question_submit
+    get 'idp_wont_work_for_you_one_doc', to: 'redirect_to_idp_question_loa1#idp_wont_work_for_you', as: :idp_wont_work_for_you_one_doc
+    get 'confirmation', to: 'confirmation_loa1#index', as: :confirmation
+    get 'about', to: 'about_loa1#index', as: :about
+    get 'about_certified_companies', to: 'about_loa1#certified_companies', as: :about_certified_companies
+    get 'about_identity_accounts', to: 'about_loa1#identity_accounts', as: :about_identity_accounts
+    get 'about_choosing_a_company', to: 'about_loa1#choosing_a_company', as: :about_choosing_a_company
+  end
+
+  constraints IsLoa2 do
+    get 'start', to: 'clever_questions/start#index', as: :start
+    post 'start', to: 'clever_questions/start#request_post', as: :start
+    get 'begin_registration', to: 'clever_questions/start#register', as: :begin_registration
+    get 'choose_a_certified_company', to: 'choose_a_certified_company_loa2#index', as: :choose_a_certified_company
+    post 'choose_a_certified_company', to: 'choose_a_certified_company_loa2#select_idp', as: :choose_a_certified_company_submit
+    get 'choose_a_certified_company_about', to: 'choose_a_certified_company_loa2#about', as: :choose_a_certified_company_about
+    get 'why_companies', to: 'why_companies_loa2#index', as: :why_companies
+    get 'failed_registration', to: 'failed_registration_loa2#index', as: :failed_registration
+    get 'cancelled_registration', to: 'cancelled_registration_loa2#index', as: :cancelled_registration
+    get 'redirect_to_idp_question', to: 'redirect_to_idp_question_loa2#index', as: :redirect_to_idp_question
+    post 'redirect_to_idp_question', to: 'redirect_to_idp_question_loa2#continue', as: :redirect_to_idp_question_submit
+    get 'idp_wont_work_for_you_one_doc', to: 'redirect_to_idp_question_loa2#idp_wont_work_for_you', as: :idp_wont_work_for_you_one_doc
+    get 'confirmation', to: 'confirmation_loa2#index', as: :confirmation
+    get 'about', to: 'about_loa2#index', as: :about
+    get 'about_certified_companies', to: 'about_loa2#certified_companies', as: :about_certified_companies
+    get 'about_identity_accounts', to: 'about_loa2#identity_accounts', as: :about_identity_accounts
+    get 'about_choosing_a_company', to: 'about_loa2#choosing_a_company', as: :about_choosing_a_company
+  end
+
+  post 'redirect_to_idp_warning', to: 'redirect_to_idp_warning#continue', as: :redirect_to_idp_warning_submit
+  get 'redirect_to_idp_warning', to: 'redirect_to_idp_warning#index', as: :redirect_to_idp_warning
+
+  get 'privacy_notice', to: 'static#privacy_notice', as: :privacy_notice
+  get 'cookies', to: 'static#cookies', as: :cookies
+  get 'confirm_your_identity', to: 'confirm_your_identity#index', as: :confirm_your_identity
+  get 'choose_a_country', to: 'choose_a_country#choose_a_country', as: :choose_a_country
+  post 'choose_a_country', to: 'choose_a_country#choose_a_country_submit', as: :choose_a_country_submit
+  get 'failed_uplift', to: 'failed_uplift#index', as: :failed_uplift
+  get 'failed_sign_in', to: 'failed_sign_in#index', as: :failed_sign_in
+  get 'other_ways_to_access_service', to: 'other_ways_to_access_service#index', as: :other_ways_to_access_service
+  get 'forgot_company', to: 'static#forgot_company', as: :forgot_company
+  get 'response_processing', to: 'response_processing#index', as: :response_processing
+  get 'redirect_to_idp_register', to: 'redirect_to_idp#register', as: :redirect_to_idp_register
+  get 'redirect_to_idp_sign_in', to: 'redirect_to_idp#sign_in', as: :redirect_to_idp_sign_in
+  get 'redirect_to_service_signing_in' => 'redirect_to_service#signing_in', as: :redirect_to_service_signing_in
+  get 'redirect_to_service_start_again' => 'redirect_to_service#start_again', as: :redirect_to_service_start_again
+  get 'redirect_to_service_error' => 'redirect_to_service#error', as: :redirect_to_service_error
+  get 'redirect_to_country' => 'redirect_to_country#index', as: :redirect_to_country
+  post 'redirect_to_country', to: 'redirect_to_country#submit', as: :redirect_to_country
+  post 'a_country_page' => 'a_country_page#index', as: :a_country_page
+  get 'feedback', to: 'feedback#index', as: :feedback
+  post 'feedback', to: 'feedback#submit', as: :feedback_submit
+  get 'feedback_sent', to: 'feedback_sent#index', as: :feedback_sent
+  get 'certified_company_unavailable', to: 'certified_company_unavailable#index', as: :certified_company_unavailable
+  get 'further_information', to: 'further_information#index', as: :further_information
+  post 'further_information', to: 'further_information#submit', as: :further_information_submit
+  post 'further_information_cancel', to: 'further_information#cancel', as: :further_information_cancel
+  post 'further_information_null_attribute', to: 'further_information#submit_null_attribute', as: :further_information_null_attribute_submit
+  get 'no_idps_available', to: 'no_idps_available#index', as: :no_idps_available
+  get 'cancelled_registration', to: 'cancelled_registration#index', as: :cancelled_registration
+end

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -522,3 +522,13 @@ cy:
       reason_one: bod y ddolen rydych wedi clicio arni wedi torri
       reason_two: rydych wedi rhoi cyfeiriad gwefan anghywir
     no_selection: Dylech ateb y cwestiynau
+  clever_questions:
+      hub:
+       start:
+          title: Start
+          heading: GOV.UK Verify
+          secure_service: GOV.UK Verify is a secure service built to help fight the growing problem of online identity theft.
+          prevent_viewing: HMRC uses Verify to help prevent other people viewing your personal pension information as it stops someone from pretending to be you.
+          create_account: Create a new identity account
+          sign_in: sign in with your identity account
+          error_message: Please select an option

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -517,3 +517,13 @@ en:
       reason_one: the link you clicked is broken
       reason_two: you entered an incorrect web address
     no_selection: Please answer all the questions
+  clever_questions:
+      hub:
+       start:
+          title: Start
+          heading: GOV.UK Verify
+          secure_service: GOV.UK Verify is a secure service built to help fight the growing problem of online identity theft.
+          prevent_viewing: HMRC uses Verify to help prevent other people viewing your personal pension information as it stops someone from pretending to be you.
+          create_account: Create a new identity account
+          sign_in: sign in with your identity account
+          error_message: Please select an option

--- a/config/main_routes.rb
+++ b/config/main_routes.rb
@@ -1,0 +1,99 @@
+def add_routes(routes_name)
+  instance_eval(File.read(Rails.root.join("config/#{routes_name}.rb")))
+end
+
+localized do
+  get 'sign_in', to: 'sign_in#index', as: :sign_in
+  post 'sign_in', to: 'sign_in#select_idp', as: :sign_in_submit
+
+  get 'select_documents', to: 'select_documents#index', as: :select_documents
+  get 'select_documents_none', to: 'select_documents#no_documents', as: :select_documents_no_documents
+  post 'select_documents', to: 'select_documents#select_documents', as: :select_documents_submit
+  get 'unlikely_to_verify', to: 'select_documents#unlikely_to_verify', as: :unlikely_to_verify
+  get 'other_identity_documents', to: 'other_identity_documents#index', as: :other_identity_documents
+  post 'other_identity_documents', to: 'other_identity_documents#select_other_documents', as: :other_identity_documents_submit
+  # get 'select_phone', to: 'select_phone#index', as: :select_phone
+  # post 'select_phone', to: 'select_phone#select_phone', as: :select_phone_submit
+  get 'no_mobile_phone', to: 'select_phone#no_mobile_phone', as: :no_mobile_phone
+  get 'will_it_work_for_me', to: 'will_it_work_for_me#index', as: :will_it_work_for_me
+  post 'will_it_work_for_me', to: 'will_it_work_for_me#will_it_work_for_me', as: :will_it_work_for_me_submit
+  get 'why_might_this_not_work_for_me', to: 'will_it_work_for_me#why_might_this_not_work_for_me', as: :why_might_this_not_work_for_me
+  get 'may_not_work_if_you_live_overseas', to: 'will_it_work_for_me#may_not_work_if_you_live_overseas', as: :may_not_work_if_you_live_overseas
+  get 'will_not_work_without_uk_address', to: 'will_it_work_for_me#will_not_work_without_uk_address', as: :will_not_work_without_uk_address
+
+  constraints IsLoa1 do
+    # get 'start', to: 'start#index', as: :start
+    # post 'start', to: 'start#request_post', as: :start
+    # get 'begin_registration', to: 'start#register', as: :begin_registration
+    get 'choose_a_certified_company', to: 'choose_a_certified_company_loa1#index', as: :choose_a_certified_company
+    post 'choose_a_certified_company', to: 'choose_a_certified_company_loa1#select_idp', as: :choose_a_certified_company_submit
+    get 'choose_a_certified_company_about', to: 'choose_a_certified_company_loa1#about', as: :choose_a_certified_company_about
+    get 'why_companies', to: 'why_companies_loa1#index', as: :why_companies
+    get 'failed_registration', to: 'failed_registration_loa1#index', as: :failed_registration
+    get 'cancelled_registration', to: 'cancelled_registration_loa1#index', as: :cancelled_registration
+    get 'redirect_to_idp_question', to: 'redirect_to_idp_question_loa1#index', as: :redirect_to_idp_question
+    post 'redirect_to_idp_question', to: 'redirect_to_idp_question_loa1#continue', as: :redirect_to_idp_question_submit
+    get 'idp_wont_work_for_you_one_doc', to: 'redirect_to_idp_question_loa1#idp_wont_work_for_you', as: :idp_wont_work_for_you_one_doc
+    get 'confirmation', to: 'confirmation_loa1#index', as: :confirmation
+    get 'about', to: 'about_loa1#index', as: :about
+    get 'about_certified_companies', to: 'about_loa1#certified_companies', as: :about_certified_companies
+    get 'about_identity_accounts', to: 'about_loa1#identity_accounts', as: :about_identity_accounts
+    get 'about_choosing_a_company', to: 'about_loa1#choosing_a_company', as: :about_choosing_a_company
+
+    add_routes :loa1_shortened_journey_ab_test_routes
+  end
+
+  constraints IsLoa2 do
+    get 'start', to: 'start#index', as: :start
+    post 'start', to: 'start#request_post', as: :start
+    get 'begin_registration', to: 'start#register', as: :begin_registration
+    # get 'choose_a_certified_company', to: 'choose_a_certified_company_loa2#index', as: :choose_a_certified_company
+    # post 'choose_a_certified_company', to: 'choose_a_certified_company_loa2#select_idp', as: :choose_a_certified_company_submit
+    # get 'choose_a_certified_company_about', to: 'choose_a_certified_company_loa2#about', as: :choose_a_certified_company_about
+    get 'why_companies', to: 'why_companies_loa2#index', as: :why_companies
+    get 'failed_registration', to: 'failed_registration_loa2#index', as: :failed_registration
+    get 'cancelled_registration', to: 'cancelled_registration_loa2#index', as: :cancelled_registration
+    get 'redirect_to_idp_question', to: 'redirect_to_idp_question_loa2#index', as: :redirect_to_idp_question
+    post 'redirect_to_idp_question', to: 'redirect_to_idp_question_loa2#continue', as: :redirect_to_idp_question_submit
+    get 'idp_wont_work_for_you_one_doc', to: 'redirect_to_idp_question_loa2#idp_wont_work_for_you', as: :idp_wont_work_for_you_one_doc
+    get 'confirmation', to: 'confirmation_loa2#index', as: :confirmation
+    get 'about', to: 'about_loa2#index', as: :about
+    get 'about_certified_companies', to: 'about_loa2#certified_companies', as: :about_certified_companies
+    get 'about_identity_accounts', to: 'about_loa2#identity_accounts', as: :about_identity_accounts
+    get 'about_choosing_a_company', to: 'about_loa2#choosing_a_company', as: :about_choosing_a_company
+  end
+
+  post 'redirect_to_idp_warning', to: 'redirect_to_idp_warning#continue', as: :redirect_to_idp_warning_submit
+  get 'redirect_to_idp_warning', to: 'redirect_to_idp_warning#index', as: :redirect_to_idp_warning
+
+  get 'privacy_notice', to: 'static#privacy_notice', as: :privacy_notice
+  get 'cookies', to: 'static#cookies', as: :cookies
+  get 'confirm_your_identity', to: 'confirm_your_identity#index', as: :confirm_your_identity
+  get 'choose_a_country', to: 'choose_a_country#choose_a_country', as: :choose_a_country
+  post 'choose_a_country', to: 'choose_a_country#choose_a_country_submit', as: :choose_a_country_submit
+  get 'failed_uplift', to: 'failed_uplift#index', as: :failed_uplift
+  get 'failed_sign_in', to: 'failed_sign_in#index', as: :failed_sign_in
+  get 'other_ways_to_access_service', to: 'other_ways_to_access_service#index', as: :other_ways_to_access_service
+  get 'forgot_company', to: 'static#forgot_company', as: :forgot_company
+  get 'response_processing', to: 'response_processing#index', as: :response_processing
+  get 'redirect_to_idp_register', to: 'redirect_to_idp#register', as: :redirect_to_idp_register
+  get 'redirect_to_idp_sign_in', to: 'redirect_to_idp#sign_in', as: :redirect_to_idp_sign_in
+  get 'redirect_to_service_signing_in' => 'redirect_to_service#signing_in', as: :redirect_to_service_signing_in
+  get 'redirect_to_service_start_again' => 'redirect_to_service#start_again', as: :redirect_to_service_start_again
+  get 'redirect_to_service_error' => 'redirect_to_service#error', as: :redirect_to_service_error
+  get 'redirect_to_country' => 'redirect_to_country#index', as: :redirect_to_country
+  post 'redirect_to_country', to: 'redirect_to_country#submit', as: :redirect_to_country
+  post 'a_country_page' => 'a_country_page#index', as: :a_country_page
+  get 'feedback', to: 'feedback#index', as: :feedback
+  post 'feedback', to: 'feedback#submit', as: :feedback_submit
+  get 'feedback_sent', to: 'feedback_sent#index', as: :feedback_sent
+  get 'certified_company_unavailable', to: 'certified_company_unavailable#index', as: :certified_company_unavailable
+  get 'further_information', to: 'further_information#index', as: :further_information
+  post 'further_information', to: 'further_information#submit', as: :further_information_submit
+  post 'further_information_cancel', to: 'further_information#cancel', as: :further_information_cancel
+  post 'further_information_null_attribute', to: 'further_information#submit_null_attribute', as: :further_information_null_attribute_submit
+  get 'no_idps_available', to: 'no_idps_available#index', as: :no_idps_available
+  get 'cancelled_registration', to: 'cancelled_registration#index', as: :cancelled_registration
+
+  add_routes :threshold_policy_ab_test_routes
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,11 @@ Rails.application.routes.draw do
   # You can have the root of your site routed with "root"
   # root 'welcome#index'
 
+  CLEVER_QUESTIONS = 'clever_questions'.freeze
+
+  clever_questions_control = SelectRoute.new(CLEVER_QUESTIONS, 'control')
+  clever_questions_variant = SelectRoute.new(CLEVER_QUESTIONS, 'variant')
+
   def add_routes(routes_name)
     instance_eval(File.read(Rails.root.join("config/#{routes_name}.rb")))
   end
@@ -36,102 +41,15 @@ Rails.application.routes.draw do
     post 'csp-reporter', to: 'test_csp_reporter#report'
   end
 
-  localized do
-    get 'sign_in', to: 'sign_in#index', as: :sign_in
-    post 'sign_in', to: 'sign_in#select_idp', as: :sign_in_submit
-
-    get 'select_documents', to: 'select_documents#index', as: :select_documents
-    get 'select_documents_none', to: 'select_documents#no_documents', as: :select_documents_no_documents
-    post 'select_documents', to: 'select_documents#select_documents', as: :select_documents_submit
-    get 'unlikely_to_verify', to: 'select_documents#unlikely_to_verify', as: :unlikely_to_verify
-    get 'other_identity_documents', to: 'other_identity_documents#index', as: :other_identity_documents
-    post 'other_identity_documents', to: 'other_identity_documents#select_other_documents', as: :other_identity_documents_submit
-    # get 'select_phone', to: 'select_phone#index', as: :select_phone
-    # post 'select_phone', to: 'select_phone#select_phone', as: :select_phone_submit
-    get 'no_mobile_phone', to: 'select_phone#no_mobile_phone', as: :no_mobile_phone
-    get 'will_it_work_for_me', to: 'will_it_work_for_me#index', as: :will_it_work_for_me
-    post 'will_it_work_for_me', to: 'will_it_work_for_me#will_it_work_for_me', as: :will_it_work_for_me_submit
-    get 'why_might_this_not_work_for_me', to: 'will_it_work_for_me#why_might_this_not_work_for_me', as: :why_might_this_not_work_for_me
-    get 'may_not_work_if_you_live_overseas', to: 'will_it_work_for_me#may_not_work_if_you_live_overseas', as: :may_not_work_if_you_live_overseas
-    get 'will_not_work_without_uk_address', to: 'will_it_work_for_me#will_not_work_without_uk_address', as: :will_not_work_without_uk_address
-
-    constraints IsLoa1 do
-      # get 'start', to: 'start#index', as: :start
-      # post 'start', to: 'start#request_post', as: :start
-      # get 'begin_registration', to: 'start#register', as: :begin_registration
-      get 'choose_a_certified_company', to: 'choose_a_certified_company_loa1#index', as: :choose_a_certified_company
-      post 'choose_a_certified_company', to: 'choose_a_certified_company_loa1#select_idp', as: :choose_a_certified_company_submit
-      get 'choose_a_certified_company_about', to: 'choose_a_certified_company_loa1#about', as: :choose_a_certified_company_about
-      get 'why_companies', to: 'why_companies_loa1#index', as: :why_companies
-      get 'failed_registration', to: 'failed_registration_loa1#index', as: :failed_registration
-      get 'cancelled_registration', to: 'cancelled_registration_loa1#index', as: :cancelled_registration
-      get 'redirect_to_idp_question', to: 'redirect_to_idp_question_loa1#index', as: :redirect_to_idp_question
-      post 'redirect_to_idp_question', to: 'redirect_to_idp_question_loa1#continue', as: :redirect_to_idp_question_submit
-      get 'idp_wont_work_for_you_one_doc', to: 'redirect_to_idp_question_loa1#idp_wont_work_for_you', as: :idp_wont_work_for_you_one_doc
-      get 'confirmation', to: 'confirmation_loa1#index', as: :confirmation
-      get 'about', to: 'about_loa1#index', as: :about
-      get 'about_certified_companies', to: 'about_loa1#certified_companies', as: :about_certified_companies
-      get 'about_identity_accounts', to: 'about_loa1#identity_accounts', as: :about_identity_accounts
-      get 'about_choosing_a_company', to: 'about_loa1#choosing_a_company', as: :about_choosing_a_company
-
-      add_routes :loa1_shortened_journey_ab_test_routes
-    end
-
-    constraints IsLoa2 do
-      get 'start', to: 'start#index', as: :start
-      post 'start', to: 'start#request_post', as: :start
-      get 'begin_registration', to: 'start#register', as: :begin_registration
-      # get 'choose_a_certified_company', to: 'choose_a_certified_company_loa2#index', as: :choose_a_certified_company
-      # post 'choose_a_certified_company', to: 'choose_a_certified_company_loa2#select_idp', as: :choose_a_certified_company_submit
-      # get 'choose_a_certified_company_about', to: 'choose_a_certified_company_loa2#about', as: :choose_a_certified_company_about
-      get 'why_companies', to: 'why_companies_loa2#index', as: :why_companies
-      get 'failed_registration', to: 'failed_registration_loa2#index', as: :failed_registration
-      get 'cancelled_registration', to: 'cancelled_registration_loa2#index', as: :cancelled_registration
-      get 'redirect_to_idp_question', to: 'redirect_to_idp_question_loa2#index', as: :redirect_to_idp_question
-      post 'redirect_to_idp_question', to: 'redirect_to_idp_question_loa2#continue', as: :redirect_to_idp_question_submit
-      get 'idp_wont_work_for_you_one_doc', to: 'redirect_to_idp_question_loa2#idp_wont_work_for_you', as: :idp_wont_work_for_you_one_doc
-      get 'confirmation', to: 'confirmation_loa2#index', as: :confirmation
-      get 'about', to: 'about_loa2#index', as: :about
-      get 'about_certified_companies', to: 'about_loa2#certified_companies', as: :about_certified_companies
-      get 'about_identity_accounts', to: 'about_loa2#identity_accounts', as: :about_identity_accounts
-      get 'about_choosing_a_company', to: 'about_loa2#choosing_a_company', as: :about_choosing_a_company
-    end
-
-    post 'redirect_to_idp_warning', to: 'redirect_to_idp_warning#continue', as: :redirect_to_idp_warning_submit
-    get 'redirect_to_idp_warning', to: 'redirect_to_idp_warning#index', as: :redirect_to_idp_warning
-
-    get 'privacy_notice', to: 'static#privacy_notice', as: :privacy_notice
-    get 'cookies', to: 'static#cookies', as: :cookies
-    get 'confirm_your_identity', to: 'confirm_your_identity#index', as: :confirm_your_identity
-    get 'choose_a_country', to: 'choose_a_country#choose_a_country', as: :choose_a_country
-    post 'choose_a_country', to: 'choose_a_country#choose_a_country_submit', as: :choose_a_country_submit
-    get 'failed_uplift', to: 'failed_uplift#index', as: :failed_uplift
-    get 'failed_sign_in', to: 'failed_sign_in#index', as: :failed_sign_in
-    get 'other_ways_to_access_service', to: 'other_ways_to_access_service#index', as: :other_ways_to_access_service
-    get 'forgot_company', to: 'static#forgot_company', as: :forgot_company
-    get 'response_processing', to: 'response_processing#index', as: :response_processing
-    get 'redirect_to_idp_register', to: 'redirect_to_idp#register', as: :redirect_to_idp_register
-    get 'redirect_to_idp_sign_in', to: 'redirect_to_idp#sign_in', as: :redirect_to_idp_sign_in
-    get 'redirect_to_service_signing_in' => 'redirect_to_service#signing_in', as: :redirect_to_service_signing_in
-    get 'redirect_to_service_start_again' => 'redirect_to_service#start_again', as: :redirect_to_service_start_again
-    get 'redirect_to_service_error' => 'redirect_to_service#error', as: :redirect_to_service_error
-    get 'redirect_to_country' => 'redirect_to_country#index', as: :redirect_to_country
-    post 'redirect_to_country', to: 'redirect_to_country#submit', as: :redirect_to_country
-    post 'a_country_page' => 'a_country_page#index', as: :a_country_page
-    get 'feedback', to: 'feedback#index', as: :feedback
-    post 'feedback', to: 'feedback#submit', as: :feedback_submit
-    get 'feedback_sent', to: 'feedback_sent#index', as: :feedback_sent
-    get 'certified_company_unavailable', to: 'certified_company_unavailable#index', as: :certified_company_unavailable
-    get 'further_information', to: 'further_information#index', as: :further_information
-    post 'further_information', to: 'further_information#submit', as: :further_information_submit
-    post 'further_information_cancel', to: 'further_information#cancel', as: :further_information_cancel
-    post 'further_information_null_attribute', to: 'further_information#submit_null_attribute', as: :further_information_null_attribute_submit
-    get 'no_idps_available', to: 'no_idps_available#index', as: :no_idps_available
-    get 'cancelled_registration', to: 'cancelled_registration#index', as: :cancelled_registration
-
-    add_routes :threshold_policy_ab_test_routes
+  constraints clever_questions_control do
+    add_routes :main_routes
   end
 
+  constraints clever_questions_variant do
+    add_routes :clever_questions_ab_test_routes
+  end
+
+  put 'choose_a_certified_company', to: 'choose_a_certified_company_loa1_variant_radio#select_idp_ajax', as: :choose_a_certified_company_submit_ajax
   put 'redirect-to-idp-warning', to: 'redirect_to_idp_warning#continue_ajax', as: :redirect_to_idp_warning_submit_ajax
   put 'select-idp', to: 'sign_in#select_idp_ajax', as: :select_idp_submit_ajax
   get 'service-status', to: 'service_status#index', as: :service_status
@@ -139,50 +57,4 @@ Rails.application.routes.draw do
   get '/SAML2/metadata/sp', to: 'metadata#service_providers', as: :service_provider_metadata
   get '/SAML2/metadata/idp', to: 'metadata#identity_providers', as: :identity_provider_metadata
   get '/humans.txt', to: 'static#humanstxt'
-
-  # Example of named route that can be invoked with purchase_url(id: product.id)
-  #   get 'products/:id/purchase' => 'catalog#purchase', as: :purchase
-
-  # Example resource route (maps HTTP verbs to controller actions automatically):
-  #   resources :products
-
-  # Example resource route with options:
-  #   resources :products do
-  #     member do
-  #       get 'short'
-  #       post 'toggle'
-  #     end
-  #
-  #     collection do
-  #       get 'sold'
-  #     end
-  #   end
-
-  # Example resource route with sub-resources:
-  #   resources :products do
-  #     resources :comments, :sales
-  #     resource :seller
-  #   end
-
-  # Example resource route with more complex sub-resources:
-  #   resources :products do
-  #     resources :comments
-  #     resources :sales do
-  #       get 'recent', on: :collection
-  #     end
-  #   end
-
-  # Example resource route with concerns:
-  #   concern :toggleable do
-  #     post 'toggle'
-  #   end
-  #   resources :posts, concerns: :toggleable
-  #   resources :photos, concerns: :toggleable
-
-  # Example resource route within a namespace:
-  #   namespace :admin do
-  #     # Directs /admin/products/* to Admin::ProductsController
-  #     # (app/controllers/admin/products_controller.rb)
-  #     resources :products
-  #   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,8 @@ Rails.application.routes.draw do
 
   CLEVER_QUESTIONS = 'clever_questions'.freeze
 
-  clever_questions_control = SelectRoute.new(CLEVER_QUESTIONS, 'control')
+  # Toggle on when clever questions AB test goes live
+  # clever_questions_control = SelectRoute.new(CLEVER_QUESTIONS, 'control')
   clever_questions_variant = SelectRoute.new(CLEVER_QUESTIONS, 'variant')
 
   def add_routes(routes_name)
@@ -41,13 +42,16 @@ Rails.application.routes.draw do
     post 'csp-reporter', to: 'test_csp_reporter#report'
   end
 
-  constraints clever_questions_control do
-    add_routes :main_routes
-  end
+  # Toggle on when clever questions AB test goes live
+  # constraints clever_questions_control do
+  #   add_routes :main_routes
+  # end
 
   constraints clever_questions_variant do
     add_routes :clever_questions_ab_test_routes
   end
+
+  add_routes :main_routes
 
   put 'choose_a_certified_company', to: 'choose_a_certified_company_loa1_variant_radio#select_idp_ajax', as: :choose_a_certified_company_submit_ajax
   put 'redirect-to-idp-warning', to: 'redirect_to_idp_warning#continue_ajax', as: :redirect_to_idp_warning_submit_ajax

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,7 +53,6 @@ Rails.application.routes.draw do
 
   add_routes :main_routes
 
-  put 'choose_a_certified_company', to: 'choose_a_certified_company_loa1_variant_radio#select_idp_ajax', as: :choose_a_certified_company_submit_ajax
   put 'redirect-to-idp-warning', to: 'redirect_to_idp_warning#continue_ajax', as: :redirect_to_idp_warning_submit_ajax
   put 'select-idp', to: 'sign_in#select_idp_ajax', as: :select_idp_submit_ajax
   get 'service-status', to: 'service_status#index', as: :service_status

--- a/spec/controllers/clever_questions/start_controller_spec.rb
+++ b/spec/controllers/clever_questions/start_controller_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+require 'controller_helper'
+require 'api_test_helper'
+require 'piwik_test_helper'
+
+describe CleverQuestions::StartController do
+  before(:each) do
+    set_session_and_cookies_with_loa('LEVEL_2')
+  end
+
+  it 'renders LOA2 start page if service is level 2' do
+    stub_piwik_request = stub_piwik_request_with_rp_and_loa('action_name' => 'The user has reached the start page')
+    get :index, params: { locale: 'en' }
+    expect(stub_piwik_request).to have_been_made.once
+    expect(subject).to render_template(:start)
+  end
+
+  context 'when form is valid' do
+    it 'will redirect to sign in page when selection is false' do
+      stub_piwik_request = stub_piwik_journey_type_request(
+        'SIGN_IN',
+        'The user started a sign-in journey',
+        'LEVEL_2'
+      )
+      post :request_post, params: { locale: 'en', start_form: { selection: false } }
+      expect(subject).to redirect_to('/sign-in')
+      expect(stub_piwik_request).to have_been_made.once
+    end
+
+    it 'will redirect to will it work for me page when selection is true' do
+      stub_piwik_request = stub_piwik_journey_type_request(
+        'REGISTRATION',
+        'The user started a registration journey',
+        'LEVEL_2'
+      )
+      post :request_post, params: { locale: 'en', start_form: { selection: true } }
+      expect(subject).to redirect_to('/will-it-work-for-me')
+      expect(stub_piwik_request).to have_been_made.once
+    end
+  end
+
+  context 'when form is invalid' do
+    it 'renders itself' do
+      post :request_post, params: { locale: 'en' }
+      expect(subject).to render_template(:start)
+      expect(flash[:errors]).not_to be_empty
+    end
+  end
+end

--- a/spec/features/clever_questions/user_visits_start_page_spec.rb
+++ b/spec/features/clever_questions/user_visits_start_page_spec.rb
@@ -1,0 +1,114 @@
+require 'feature_helper'
+require 'api_test_helper'
+require 'cookie_names'
+
+RSpec.describe 'When the user visits the start page' do
+  it 'will display the start page in English' do
+    set_session_and_ab_session_cookies!('clever_questions' => 'clever_questions_variant')
+    visit '/start'
+    expect(page).to have_content 'GOV.UK Verify'
+    expect(page).to have_css 'html[lang=en]'
+    expect_feedback_source_to_be(page, 'START_PAGE', '/start')
+  end
+
+  it 'will display the start page in Welsh' do
+    set_session_and_ab_session_cookies!('clever_questions' => 'clever_questions_variant')
+    visit '/dechrau'
+    expect(page).to have_content 'GOV.UK Verify'
+    expect(page).to have_css 'html[lang=cy]'
+  end
+
+  it 'will not automatically disable the continue button on submit' do
+    set_session_and_ab_session_cookies!('clever_questions' => 'clever_questions_variant')
+    visit '/start'
+    expect(page).to_not have_css '#next-button[data-disable-with]'
+  end
+
+  context 'when there is an error' do
+    before(:each) do
+      stub_transactions_list
+    end
+
+    it 'will display the no cookies error when all cookies are missing' do
+      allow(Rails.logger).to receive(:info)
+      expect(Rails.logger).to receive(:info).with("No session cookies can be found").at_least(:once)
+      visit "/start"
+      expect(page).to have_content "If you can’t access GOV.UK Verify from a service, enable your cookies."
+      expect(page).to have_http_status :forbidden
+      expect(page).to have_link 'feedback', href: '/feedback?feedback-source=COOKIE_NOT_FOUND_PAGE'
+      expect(page).to have_link "register for an identity profile", href: "http://localhost:50130/test-rp"
+    end
+
+    it 'will display the generic error when start time is missing from session' do
+      set_session!(transaction_simple_id: 'test-rp', verify_session_id: 'my-session-id-cookie', identity_providers: [{ 'simple_id' => 'stub-idp-one' }])
+      cookie_hash = create_cookie_hash
+      allow(Rails.logger).to receive(:info)
+      expect(Rails.logger).to receive(:info).with('start_time not in session').at_least(:once)
+      set_cookies!(cookie_hash)
+      visit '/start'
+      expect(page).to have_content 'Sorry, something went wrong'
+      expect(page).to have_http_status :internal_server_error
+      expect(page).to have_link 'feedback', href: '/feedback?feedback-source=ERROR_PAGE'
+    end
+
+    it 'will display the generic error when the session cookie is missing' do
+      cookie_hash = create_cookie_hash
+      allow(Rails.logger).to receive(:info)
+      expect(Rails.logger).to receive(:info).with("The following cookies are missing: [#{CookieNames::SESSION_COOKIE_NAME}]").at_least(:once)
+      set_cookies!(cookie_hash.except(CookieNames::SESSION_COOKIE_NAME))
+      visit '/start'
+      expect(page).to have_content "Sorry, something went wrong"
+      expect(page).to have_http_status :internal_server_error
+      expect(page).to have_link 'feedback', href: '/feedback?feedback-source=ERROR_PAGE'
+    end
+
+    it 'will display the generic error when the session id cookie is missing' do
+      cookie_hash = create_cookie_hash
+      allow(Rails.logger).to receive(:info)
+      expect(Rails.logger).to receive(:info).with("The following cookies are missing: [#{CookieNames::SESSION_ID_COOKIE_NAME}]").at_least(:once)
+      set_cookies!(cookie_hash.except(CookieNames::SESSION_ID_COOKIE_NAME))
+      visit '/start'
+      expect(page).to have_content "Sorry, something went wrong"
+      expect(page).to have_http_status :internal_server_error
+      expect(page).to have_link 'feedback', href: '/feedback?feedback-source=ERROR_PAGE'
+    end
+
+    it 'will display the something went wrong page when the session id is missing' do
+      set_session_cookies!
+      set_session!(transaction_simple_id: 'test-rp', start_time: start_time_in_millis)
+      visit '/start'
+      expect(page).to have_content 'Sorry, something went wrong'
+      expect(page).to have_http_status :internal_server_error
+      expect(page).to have_link 'feedback', href: '/feedback?feedback-source=ERROR_PAGE'
+    end
+
+    it 'will display the something went wrong page when the session id does not match the cookie value' do
+      set_session_cookies!
+      set_session!(transaction_simple_id: 'test-rp', start_time: start_time_in_millis, verify_session_id: 'a mismatched value')
+      visit '/start'
+      expect(page).to have_content 'Sorry, something went wrong'
+      expect(page).to have_http_status :bad_request
+      expect(page).to have_link 'feedback', href: '/feedback?feedback-source=ERROR_PAGE'
+    end
+
+    it 'will display the timeout expiration error when the session start cookie is old' do
+      session_id_cookie = create_cookie_hash[CookieNames::SESSION_ID_COOKIE_NAME]
+      allow(Rails.logger).to receive(:info)
+      expect(Rails.logger).to receive(:info).with("session \"#{session_id_cookie}\" has expired").at_least(:once)
+      set_session_and_session_cookies!
+      expired_start_time = 2.hours.ago.to_i * 1000
+      page.set_rack_session(start_time: expired_start_time)
+      visit '/start'
+      expect(page).to have_content 'Find the service you were using to start again'
+      expect(page).to have_link 'register for an identity profile', href: 'http://localhost:50130/test-rp'
+      expect(page).to have_http_status :bad_request
+      expect(page).to have_link 'feedback', href: '/feedback?feedback-source=EXPIRED_ERROR_PAGE'
+    end
+  end
+
+  it 'will not allow robots to index' do
+    set_session_and_ab_session_cookies!('clever_questions' => 'clever_questions_variant')
+    visit '/start'
+    expect(page).to have_css('meta[name="robots"][content="noindex"]', visible: false)
+  end
+end

--- a/spec/features/user_sends_authn_request_spec.rb
+++ b/spec/features/user_sends_authn_request_spec.rb
@@ -77,6 +77,7 @@ describe 'user sends authn requests' do
         'about_companies' => 'about_companies_with_logo',
         'select_documents_v2' => 'select_documents_v2_control',
         'threshold_policy_experiment' => 'threshold_policy_experiment_control',
+        'clever_questions' => 'clever_questions_control',
         'loa1_shortened_journey_v3' => 'loa1_shortened_journey_v3_control'
       }.to_json
       cookie_hash = create_cookie_hash.merge!(ab_test: CGI.escape(ab_test_cookie_value))

--- a/stub/ab_test.yml
+++ b/stub/ab_test.yml
@@ -43,3 +43,9 @@ experiments:
           percent: 100
         - name: 'variant'
           percent: 0
+  - clever_questions:
+      alternatives:
+        - name: 'control'
+          percent: 100
+        - name: 'variant'
+          percent: 0


### PR DESCRIPTION
Clever questions AB test is more of an AB test epic as it will drastically change the normal journey. To allow continuous integration the routes files have been split into two:
* main_route : normal routes 
* clever_questions_routes: new routes for the new change

Note: the clever questions AB test is toggled off until it is complete, it'll be switched on by releasing the fed config

Author: @NasAshrafThoughtworks