### PR TITLE
TT-1606: Select phone page added for the clever questions AB test

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -19,13 +19,23 @@ window.GOVUK.shimLinksWithButtonRole.init();
 
 window.GOVUK.validation.init();
 window.GOVUK.selectDocuments.init();
-window.GOVUK.selectPhone.init();
+//window.GOVUK.selectPhone.init();
 window.GOVUK.willItWorkForMe.init();
 window.GOVUK.feedback.init();
 window.GOVUK.furtherInformation.init();
 window.GOVUK.interstitialQuestion.init();
 window.GOVUK.otherDocuments.init();
 window.GOVUK.piwikEventsTracking.init();
+
+abTest({
+  experiment: 'clever_questions',
+  control: {
+    route: window.GOVUK.selectPhone
+  },
+  alternatives: [
+    {name: 'variant', route: window.GOVUK.selectPhoneCleverQuestions}
+  ]
+})
 
 /*
  Example of how to add JavaScript A/B code

--- a/app/assets/javascripts/clever_questions/select_phone.js
+++ b/app/assets/javascripts/clever_questions/select_phone.js
@@ -1,0 +1,26 @@
+(function(global) {
+  "use strict";
+  var GOVUK = global.GOVUK || {};
+  var $ = global.jQuery;
+  var selectPhone = {
+    init: function (){
+      selectPhone.$form = $('#validate-phone');
+      var errorMessage = selectPhone.$form.data('msg');
+      if (selectPhone.$form.length === 1) {
+        selectPhone.validator = selectPhone.$form.validate($.extend({}, GOVUK.validation.radiosValidation, {
+          rules: {
+            'select_phone_form[mobile_phone]': 'required'
+          },
+          messages: {
+            'select_phone_form[mobile_phone]': errorMessage
+          }
+        }));
+        selectPhone.$form.find('input[name="select_phone_form[mobile_phone]"]').on('click',selectPhone.toggleSecondaryQuestion);
+      }
+    }
+  };
+
+  GOVUK.selectPhoneCleverQuestions = selectPhone;
+
+  global.GOVUK = GOVUK;
+})(window);

--- a/app/controllers/clever_questions/select_phone_controller.rb
+++ b/app/controllers/clever_questions/select_phone_controller.rb
@@ -1,0 +1,23 @@
+class CleverQuestions::SelectPhoneController < ApplicationController
+  def index
+    @form = CleverQuestions::SelectPhoneForm.new({})
+  end
+
+  def select_phone
+    @form = CleverQuestions::SelectPhoneForm.new(params['select_phone_form'] || {})
+    if @form.valid?
+      report_to_analytics('Phone Next')
+      selected_answer_store.store_selected_answers('phone', @form.selected_answers)
+      idps_available = IDP_ELIGIBILITY_CHECKER.any?(selected_evidence, current_identity_providers)
+      redirect_to idps_available ? choose_a_certified_company_path : no_mobile_phone_path
+    else
+      flash.now[:errors] = @form.errors.full_messages.join(', ')
+      render :index
+    end
+  end
+
+  def no_mobile_phone
+    @other_ways_description = current_transaction.other_ways_description
+    @other_ways_text = current_transaction.other_ways_text
+  end
+end

--- a/app/models/clever_questions/select_phone_form.rb
+++ b/app/models/clever_questions/select_phone_form.rb
@@ -1,0 +1,37 @@
+class CleverQuestions::SelectPhoneForm
+  include ActiveModel::Model
+
+  attr_reader :mobile_phone
+  validate :answer_not_specified
+
+  def initialize(params)
+    @mobile_phone = params[:mobile_phone]
+  end
+
+  def selected_answers
+    answers = {}
+    IdpEligibility::Evidence::PHONE_ONLY_ATTRIBUTES.each do |attr|
+      result = public_send(attr)
+      if %w(true false).include?(result)
+        answers[attr] = result == 'true'
+      end
+    end
+    answers
+  end
+
+private
+
+  def add_no_selection_error
+    errors.add(:base, I18n.t('hub.select_phone.errors.no_selection'))
+  end
+
+  def has_no_mobile_phone?
+    mobile_phone == 'false'
+  end
+
+  def answer_not_specified
+    if mobile_phone.nil?
+      add_no_selection_error
+    end
+  end
+end

--- a/app/models/idp_eligibility/evidence.rb
+++ b/app/models/idp_eligibility/evidence.rb
@@ -1,6 +1,7 @@
 module IdpEligibility
   module Evidence
     PHONE_ATTRIBUTES = %i[mobile_phone smart_phone landline].freeze
+    PHONE_ONLY_ATTRIBUTES = %i[mobile_phone].freeze
     DOCUMENT_ATTRIBUTES = %i[passport driving_licence ni_driving_licence non_uk_id_document].freeze
     PHOTO_DOCUMENT_ATTRIBUTES = %i[passport driving_licence ni_driving_licence].freeze
     ADDRESS_DOCUMENT_ATTRIBUTES = %i[uk_bank_account_details debit_card credit_card].freeze

--- a/app/views/clever_questions/select_phone/index.html.erb
+++ b/app/views/clever_questions/select_phone/index.html.erb
@@ -1,0 +1,50 @@
+<% select_phone_page = 'clever_questions.hub.select_phone'%>
+<%= page_title "#{select_phone_page}.title" %>
+<% content_for :feedback_source, 'SELECT_PHONE_PAGE' %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <h1 class="heading-large"><%= t "#{select_phone_page}.title" %></h1>
+    <p><%= t "#{select_phone_page}.explanation" %></p>
+    <div class="panel panel-border-narrow">
+      <%= t "#{select_phone_page}.highlight" %>
+    </div>
+
+    <%= form_for @form, :as => 'select_phone_form', url: select_phone_path, html: { id: 'validate-phone', class: 'select-phone-form', novalidate: 'novalidate', 'data-msg': t('hub.select_phone.errors.no_selection')} do |f| %>
+
+        <%= render 'shared/form-errors', errors: flash[:errors] %>
+
+        <h2 class="heading-medium"><%= t "#{select_phone_page}.question.mobile_phone" %></h2>
+
+        <%= content_tag :div, class: form_question_class do %>
+            <fieldset class="inline">
+              <legend class="visually-hidden">
+                <span class="form-label"><%= t "#{select_phone_page}.question.mobile_phone" %></span>
+              </legend>
+              <%= f.custom_radio_button :mobile_phone, true, t('hub.select_phone.question.mobile_phone_option_yes') %>
+              <%= f.custom_radio_button :mobile_phone, false, t('option.no') %>
+            </fieldset>
+        <% end %>
+
+        <div id="validation-error-message-js"></div>
+
+        <div class="actions">
+          <%= f.submit t('navigation.continue'), class: 'button', id: 'next-button' %>
+        </div>
+    <% end %>
+
+    <details>
+      <summary>
+        <span class="summary"><%= t "clever_questions.hub.about_choosing_an_identity_provider.summary" %></span>
+      </summary>
+      <div class="panel panel-border-narrow">
+        <%= t "clever_questions.hub.about_choosing_an_identity_provider.details_html" %>
+        <ul class="list-bullet list">
+          <% transactions_list.name_homepage.each do |transaction| -%>
+              <li><%= transaction.name %></li>
+          <% end %>
+        </ul>
+      </div>
+    </details>
+  </div>
+</div>

--- a/app/views/clever_questions/select_phone/no_mobile_phone.html.erb
+++ b/app/views/clever_questions/select_phone/no_mobile_phone.html.erb
@@ -1,0 +1,11 @@
+<%= page_title 'hub.other_ways_title' %>
+<% content_for :feedback_source, 'NO_MOBILE_PHONE' %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <h1 class="heading-large"><%= t 'hub.no_mobile_phone.heading' %></h1>
+    <%= t 'hub.no_mobile_phone.content_html', other_ways_description: @other_ways_description %>
+
+    <%= render partial: 'shared/other_ways', locals: {other_ways_text: @other_ways_text, other_ways_description: @other_ways_description} %>
+  </div>
+</div>

--- a/config/clever_questions_ab_test_routes.rb
+++ b/config/clever_questions_ab_test_routes.rb
@@ -12,8 +12,6 @@ localized do
   get 'unlikely_to_verify', to: 'select_documents#unlikely_to_verify', as: :unlikely_to_verify
   get 'other_identity_documents', to: 'other_identity_documents#index', as: :other_identity_documents
   post 'other_identity_documents', to: 'other_identity_documents#select_other_documents', as: :other_identity_documents_submit
-  get 'select_phone', to: 'select_phone#index', as: :select_phone
-  post 'select_phone', to: 'select_phone#select_phone', as: :select_phone_submit
   get 'no_mobile_phone', to: 'select_phone#no_mobile_phone', as: :no_mobile_phone
   get 'will_it_work_for_me', to: 'will_it_work_for_me#index', as: :will_it_work_for_me
   get 'why_might_this_not_work_for_me', to: 'will_it_work_for_me#why_might_this_not_work_for_me', as: :why_might_this_not_work_for_me
@@ -45,6 +43,8 @@ localized do
     post 'start', to: 'clever_questions/start#request_post', as: :start
     get 'begin_registration', to: 'clever_questions/start#register', as: :begin_registration
     post 'will_it_work_for_me', to: 'clever_questions/will_it_work_for_me#will_it_work_for_me', as: :will_it_work_for_me_submit
+    get 'select_phone', to: 'clever_questions/select_phone#index', as: :select_phone
+    post 'select_phone', to: 'clever_questions/select_phone#select_phone', as: :select_phone_submit
     get 'choose_a_certified_company', to: 'choose_a_certified_company_loa2#index', as: :choose_a_certified_company
     post 'choose_a_certified_company', to: 'choose_a_certified_company_loa2#select_idp', as: :choose_a_certified_company_submit
     get 'choose_a_certified_company_about', to: 'choose_a_certified_company_loa2#about', as: :choose_a_certified_company_about

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -554,3 +554,10 @@ cy:
           content_bottom_html: |
             <p>These 7 companies applied to be part of Verify, and have been certified to verify identities as they’ve met government security and privacy standards, so you can trust them with your personal information. They won’t share or sell your data for any other purposes without your consent.</p>
             <p>There's no charge for this service.</p>
+        select_phone:
+          title: Receiving security codes
+          heading: Receiving security codes
+          explanation: For an extra layer of security, identity providers send you security codes to your mobile phone when you’re signing in to your identity account to access government services.
+          highlight: Identity providers won't call you on your mobile. They won’t share or sell your phone number for any reason without your consent.
+          question:
+            mobile_phone: Can you receive text messages now?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -549,3 +549,10 @@ en:
           content_bottom_html: |
             <p>These 7 companies applied to be part of Verify, and have been certified to verify identities as they’ve met government security and privacy standards, so you can trust them with your personal information. They won’t share or sell your data for any other purposes without your consent.</p>
             <p>There's no charge for this service.</p>
+        select_phone:
+          title: Receiving security codes
+          heading: Receiving security codes
+          explanation: For an extra layer of security, identity providers send you security codes to your mobile phone when you’re signing in to your identity account to access government services.
+          highlight: Identity providers won't call you on your mobile. They won’t share or sell your phone number for any reason without your consent.
+          question:
+            mobile_phone: Can you receive text messages now?

--- a/spec/controllers/clever_questions/select_phone_controller_spec.rb
+++ b/spec/controllers/clever_questions/select_phone_controller_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+require 'controller_helper'
+require 'spec_helper'
+require 'api_test_helper'
+require 'piwik_test_helper'
+require 'models/display/viewable_identity_provider'
+
+describe CleverQuestions::SelectPhoneController do
+  valid_phone_evidence = { mobile_phone: 'true' }.freeze
+
+  before(:each) do
+    set_session_and_cookies_with_loa('LEVEL_2')
+    session[:selected_answers] = { 'documents' => { driving_licence: true, passport: true } }
+    stub_piwik_request('action_name' => 'Phone Next')
+  end
+
+  context 'when form is valid' do
+    subject { post :select_phone, params: { locale: 'en', select_phone_form: valid_phone_evidence } }
+
+    it 'redirects to choose certified company page when eligible IDPs exist' do
+      stub_api_idp_list([{ 'simpleId' => 'stub-idp-one',
+                           'entityId' => 'http://idcorp.com',
+                           'levelsOfAssurance' => %w(LEVEL_2) }])
+
+      expect(subject).to redirect_to('/choose-a-certified-company')
+    end
+
+    it 'redirects to no mobile phone page when no eligible IDPs' do
+      stub_api_idp_list([{ 'simpleId' => 'stub-idp-four',
+                           'entityId' => 'http://idcorp.com',
+                           'levelsOfAssurance' => %w(LEVEL_2) }])
+
+      expect(subject).to redirect_to('/no-mobile-phone')
+    end
+
+    it 'captures form values in session cookie' do
+      stub_api_idp_list
+      expect(subject).to redirect_to('/choose-a-certified-company')
+      expect(session[:selected_answers]['phone']).to eq(mobile_phone: true)
+    end
+  end
+
+  context 'when form is invalid' do
+    subject { post :select_phone, params: { locale: 'en' } }
+
+    it 'renders itself' do
+      expect(subject).to render_template(:index)
+    end
+
+    it 'does not capture form values in session cookie' do
+      expect(session[:selected_answers]['phone']).to eq(nil)
+    end
+
+    it 'does not report to Piwik' do
+      expect(ANALYTICS_REPORTER).not_to receive(:report_action)
+    end
+  end
+end

--- a/spec/features/clever_questions/user_visits_select_phone_page_spec.rb
+++ b/spec/features/clever_questions/user_visits_select_phone_page_spec.rb
@@ -1,0 +1,132 @@
+require 'feature_helper'
+require 'api_test_helper'
+require 'uri'
+
+RSpec.describe 'When the user visits the select phone page' do
+  let(:selected_answers) { { documents: { passport: true, driving_licence: true } } }
+  let(:given_a_session_with_document_evidence) {
+    page.set_rack_session(
+      selected_idp: { entity_id: 'http://idcorp.com', simple_id: 'stub-idp-one' },
+      selected_idp_was_recommended: true,
+      selected_answers: selected_answers,
+    )
+  }
+
+  before(:each) do
+    set_session_and_ab_session_cookies!('clever_questions' => 'clever_questions_variant')
+    stub_transactions_list
+    stub_api_idp_list
+  end
+
+  context 'with javascript disabled' do
+    it 'redirects to the idp picker page when user has a phone' do
+      stub_api_no_docs_idps
+      visit '/select-phone'
+
+      choose 'select_phone_form_mobile_phone_true', allow_label_click: true
+      click_button 'Continue'
+
+      expect(page).to have_current_path(choose_a_certified_company_path, only_path: true)
+      expect(page.get_rack_session['selected_answers']).to eql('phone' => { 'mobile_phone' => true })
+    end
+
+    it 'allows you to overwrite the values of your selected evidence' do
+      page.set_rack_session(transaction_simple_id: 'test-rp')
+      given_a_session_with_document_evidence
+
+      visit '/select-phone'
+
+      choose 'select_phone_form_mobile_phone_true', allow_label_click: true
+      click_button 'Continue'
+
+      visit '/select-phone'
+      choose 'select_phone_form_mobile_phone_false', allow_label_click: true
+      click_button 'Continue'
+
+      expect(page).to have_current_path(no_mobile_phone_path)
+      expect(page.get_rack_session['selected_answers']).to eql(
+        'phone' => { 'mobile_phone' => false },
+        'documents' => { 'passport' => true, 'driving_licence' => true }
+      )
+    end
+
+    it 'shows an error message when no selections are made' do
+      visit '/select-phone'
+      click_button 'Continue'
+
+      expect(page).to have_css '.validation-message', text: 'Please answer all the questions'
+      expect(page).to have_css '.form-group-error'
+    end
+  end
+
+  context 'with javascript enabled', js: true do
+    it 'redirects to the idp picker page when user has a phone' do
+      given_a_session_with_document_evidence
+
+      visit '/select-phone'
+
+      choose 'select_phone_form_mobile_phone_true', allow_label_click: true
+      click_button 'Continue'
+
+      expect(page).to have_current_path(choose_a_certified_company_path)
+      expect(page.get_rack_session['selected_answers']).to eql(
+        'phone' => { 'mobile_phone' => true },
+        'documents' => { 'passport' => true, 'driving_licence' => true }
+      )
+    end
+
+    it 'should display a validation message when user does not answer mobile phone question' do
+      visit '/select-phone'
+
+      click_button 'Continue'
+
+      expect(page).to have_current_path(select_phone_path)
+      expect(page).to have_css '#validation-error-message-js', text: 'Please answer all the questions'
+    end
+
+    it 'redirects to the no mobile phone page when no idps can verify' do
+      visit '/select-phone'
+
+      choose 'select_phone_form_mobile_phone_false', allow_label_click: true
+      click_button 'Continue'
+
+      expect(page).to have_current_path(no_mobile_phone_path)
+      expect(page.get_rack_session['selected_answers']).to eql('phone' => { 'mobile_phone' => false })
+    end
+  end
+
+  it 'includes the appropriate feedback source' do
+    visit '/select-phone'
+
+    expect_feedback_source_to_be(page, 'SELECT_PHONE_PAGE', '/select-phone')
+  end
+
+  it 'displays the page in Welsh' do
+    visit 'dewis-ffon'
+    expect(page).to have_content 'Oes'
+    expect(page).to have_css 'html[lang=cy]'
+  end
+
+  it 'reports to Piwik when form is valid' do
+    stub_request(:get, INTERNAL_PIWIK.url).with(query: hash_including({}))
+    piwik_request = { 'action_name' => 'Phone Next' }
+
+    page.set_rack_session(transaction_simple_id: 'test-rp')
+    visit '/select-phone'
+
+    choose 'select_phone_form_mobile_phone_true', allow_label_click: true
+    click_button 'Continue'
+
+    expect(a_request(:get, INTERNAL_PIWIK.url).with(query: hash_including(piwik_request))).to have_been_made.once
+  end
+
+  it 'does not report to Piwik when form is invalid' do
+    stub_request(:get, INTERNAL_PIWIK.url).with(query: hash_including({}))
+    piwik_request = { 'action_name' => 'Phone Next' }
+    visit '/select-phone'
+
+    click_button 'Continue'
+
+    expect(a_request(:get, INTERNAL_PIWIK.url).with(query: hash_including(piwik_request))).to_not have_been_made
+  end
+end

--- a/spec/javascripts/clever_questions/select_phone_spec.js
+++ b/spec/javascripts/clever_questions/select_phone_spec.js
@@ -1,0 +1,69 @@
+describe("Select Phone form", function () {
+
+  function check($radioButton) {
+    $radioButton.prop('checked', true).triggerHandler('click');
+  }
+
+  var formWithNoErrors = '' +
+    '<form novalidate="novalidate" id="validate-phone" data-msg="Please answer the question">' +
+      '<div class="form-group">' +
+        '<input id="select_phone_form_mobile_phone_true" name="select_phone_form[mobile_phone]" value="true" type="radio">' +
+        '<input id="select_phone_form_mobile_phone_false" name="select_phone_form[mobile_phone]" value="false" type="radio">' +
+      '</div>' +
+      '<div id="validation-error-message-js"></div>' +
+      '<div class="form-group">' +
+        '<input class="button" id="next-button" value="Continue" type="submit">' +
+      '</div>' +
+    '</form>';
+
+  var selectPhoneForm;
+  var $dom;
+  $('html').addClass('js-enabled');
+
+  beforeEach(function () {
+    $dom = $('<div>' + formWithNoErrors + '</div>');
+    $(document.body).append($dom);
+    GOVUK.validation.init();
+    GOVUK.selectPhoneCleverQuestions.init();
+    selectPhoneForm = GOVUK.selectPhoneCleverQuestions.$form;
+  });
+
+  afterEach(function () {
+    $dom.remove();
+  });
+
+  it("should have no errors on initialising the form.", function () {
+    expect(selectPhoneForm.find('.form-group-error').length).toBe(0);
+  });
+
+  describe("should have errors on submit when", function () {
+    function expectPleaseAnswerTheQuestion() {
+      expect(selectPhoneForm.children('.form-group:first').is('.form-group-error')).toBe(true);
+      expect(selectPhoneForm.find('#validation-error-message-js').text()).toBe('Please answer the question');
+    }
+
+    it("no answer given", function () {
+      selectPhoneForm.triggerHandler('submit');
+      expectPleaseAnswerTheQuestion();
+    });
+  });
+
+  describe("should have no errors on submit when", function () {
+    function expectNoErrors() {
+      expect(selectPhoneForm.children('.form-group:first').is('.form-group-error')).toBe(false);
+      expect(selectPhoneForm.find('#validation-error-message-js').text()).toBe('');
+    }
+
+    it("mobile answered yes ", function () {
+      check(selectPhoneForm.find('#select_phone_form_mobile_phone_true'));
+      selectPhoneForm.triggerHandler('submit');
+      expectNoErrors();
+    });
+
+    it("mobile answered no", function () {
+      check(selectPhoneForm.find('#select_phone_form_mobile_phone_false'));
+      selectPhoneForm.triggerHandler('submit');
+      expectNoErrors();
+    });
+  });
+});


### PR DESCRIPTION
Added a version of the select-phone page, to ask for mobile phone only, including a model and locales changes.

Author: @jakubmiarka