### PR TITLE
BAU: Implement trial function for AB testing

### DIFF
--- a/app/constraints/select_route.rb
+++ b/app/constraints/select_route.rb
@@ -2,11 +2,14 @@ require 'cookies/cookies'
 require 'ab_test/ab_test'
 
 class SelectRoute
-  def initialize(experiment_name, route, is_start_of_test = false, experiment_loa = nil)
+  def initialize(experiment_name, route, config = { is_start_of_test: false,
+                                                    experiment_loa: nil,
+                                                    trial_enabled: false })
     @experiment_name = experiment_name
     @experiment_route = "#{@experiment_name}_#{route}"
-    @experiment_loa = experiment_loa
-    @is_start_of_test = is_start_of_test
+    @experiment_loa = config[:experiment_loa]
+    @is_start_of_test = config[:is_start_of_test]
+    @trial_enabled = config[:trial_enabled]
   end
 
   def matches?(request)
@@ -22,8 +25,11 @@ private
 
   def cookie_matches_experiment?(request)
     request_experiment_route = extract_experiment_route_from_cookie(request.cookies[CookieNames::AB_TEST])
-
-    @experiment_route == request_experiment_route
+    if @trial_enabled && request.cookies[CookieNames::AB_TEST_TRIAL] == @experiment_name
+      true
+    else
+      @experiment_route == request_experiment_route
+    end
   end
 
   def loa_matches_experiment?(request)

--- a/app/models/cookie_names.rb
+++ b/app/models/cookie_names.rb
@@ -6,6 +6,7 @@ module CookieNames
   PIWIK_USER_ID = 'PIWIK_USER_ID'.freeze
   NO_CURRENT_SESSION_VALUE = 'no-current-session'.freeze
   AB_TEST = 'ab_test'.freeze
+  AB_TEST_TRIAL = 'ab_test_trial'.freeze
 
   def self.session_cookies
     [SESSION_ID_COOKIE_NAME, SESSION_COOKIE_NAME]

--- a/config/loa1_shortened_journey_ab_test_routes.rb
+++ b/config/loa1_shortened_journey_ab_test_routes.rb
@@ -1,7 +1,7 @@
 LOA1_SHORTENED_JOURNEY_EXPERIMENT = 'loa1_shortened_journey_v3'.freeze
 
-loa1_shortened_journey_control_piwik = SelectRoute.new(LOA1_SHORTENED_JOURNEY_EXPERIMENT, 'control', true, 'LEVEL_1')
-loa1_shortened_journey_variant_piwik = SelectRoute.new(LOA1_SHORTENED_JOURNEY_EXPERIMENT, 'variant', true, 'LEVEL_1')
+loa1_shortened_journey_control_piwik = SelectRoute.new(LOA1_SHORTENED_JOURNEY_EXPERIMENT, 'control', is_start_of_test: true, experiment_loa: 'LEVEL_1')
+loa1_shortened_journey_variant_piwik = SelectRoute.new(LOA1_SHORTENED_JOURNEY_EXPERIMENT, 'variant', is_start_of_test: true, experiment_loa: 'LEVEL_1')
 
 loa1_shortened_journey_control = SelectRoute.new(LOA1_SHORTENED_JOURNEY_EXPERIMENT, 'control')
 loa1_shortened_journey_variant = SelectRoute.new(LOA1_SHORTENED_JOURNEY_EXPERIMENT, 'variant')

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
 
   # Toggle on when clever questions AB test goes live
   # clever_questions_control = SelectRoute.new(CLEVER_QUESTIONS, 'control')
-  clever_questions_variant = SelectRoute.new(CLEVER_QUESTIONS, 'variant')
+  clever_questions_variant = SelectRoute.new(CLEVER_QUESTIONS, 'variant', trial_enabled: true)
 
   def add_routes(routes_name)
     instance_eval(File.read(Rails.root.join("config/#{routes_name}.rb")))

--- a/config/threshold_policy_ab_test_routes.rb
+++ b/config/threshold_policy_ab_test_routes.rb
@@ -1,7 +1,7 @@
 THRESHOLD_POLICY_EXPERIMENT = 'threshold_policy_experiment'.freeze
 
-threshold_policy_control_piwik = SelectRoute.new(THRESHOLD_POLICY_EXPERIMENT, 'control', true)
-threshold_policy_variant_piwik = SelectRoute.new(THRESHOLD_POLICY_EXPERIMENT, 'variant', true)
+threshold_policy_control_piwik = SelectRoute.new(THRESHOLD_POLICY_EXPERIMENT, 'control', is_start_of_test: true)
+threshold_policy_variant_piwik = SelectRoute.new(THRESHOLD_POLICY_EXPERIMENT, 'variant', is_start_of_test: true)
 
 threshold_policy_control = SelectRoute.new(THRESHOLD_POLICY_EXPERIMENT, 'control')
 threshold_policy_variant = SelectRoute.new(THRESHOLD_POLICY_EXPERIMENT, 'variant')


### PR DESCRIPTION
We'd like to test AB test variants in non-dev environments without enabling the test and issuing cookies to all visitors. This change will enable to set AB test to accept trial cookies and when the trial cookie is present and the value matches the experiment, it will enable user to see the variant without actually having the AB test cookie. This is immediately allowing the trial for the Clever Questions AB test.

Pair: @jakubmiarka @NasAshrafThoughtworks