### PR TITLE
TT-1737: Change checkboxes to radio buttons for driving licence question

### DIFF
--- a/app/assets/javascripts/clever_questions/select_documents.js
+++ b/app/assets/javascripts/clever_questions/select_documents.js
@@ -13,8 +13,8 @@
             $.validator.addMethod('drivingLicenceDetailsValidation', function(value, element) {
                 return $('#select_documents_form_any_driving_licence_false').is(':checked') ||
                     ($('#select_documents_form_any_driving_licence_true').is(':checked')
-                    && ($('#select_documents_form_driving_licence').is(':checked')
-                    || $('#select_documents_form_ni_driving_licence').is(':checked')))
+                    && ($('#select_documents_form_driving_licence_great_britain').is(':checked')
+                    || $('#select_documents_form_driving_licence_northern_ireland').is(':checked')))
             }, $.validator.format(selectDocuments.$form.data('msg')));
 
             selectDocuments.validator = selectDocuments.$form.validate($.extend({}, GOVUK.validation.radiosValidation, {
@@ -22,20 +22,18 @@
                     'select_documents_form[any_driving_licence]': 'required',
                     'select_documents_form[passport]': 'required',
                     'select_documents_form[driving_licence]': 'drivingLicenceDetailsValidation',
-                    'select_documents_form[ni_driving_licence]': 'drivingLicenceDetailsValidation',
                     'select_documents_form[passport_expiry][day]': 'required',
                     'select_documents_form[passport_expiry][month]': 'required',
                     'select_documents_form[passport_expiry][year]': 'required'
                 },
                 groups: {
-                    primary: 'select_documents_form[any_driving_licence] select_documents_form[passport] select_documents_form[driving_licence] select_documents_form[ni_driving_licence]',
+                    primary: 'select_documents_form[any_driving_licence] select_documents_form[passport] select_documents_form[driving_licence]',
                     passport: 'select_documents_form[passport_expiry][day] select_documents_form[passport_expiry][month] select_documents_form[passport_expiry][year]'
                 },
                 messages: {
                     'select_documents_form[any_driving_licence]': errorMessage,
                     'select_documents_form[passport]': errorMessage,
                     'select_documents_form[driving_licence]': errorMessage,
-                    'select_documents_form[ni_driving_licence]': errorMessage,
                     'select_documents_form[passport_expiry][day]': errorMessageForPassportDate,
                     'select_documents_form[passport_expiry][month]': errorMessageForPassportDate,
                     'select_documents_form[passport_expiry][year]': errorMessageForPassportDate

--- a/app/assets/javascripts/select_documents.js
+++ b/app/assets/javascripts/select_documents.js
@@ -10,24 +10,24 @@
             var errorMessage = selectDocuments.$form.data('msg');
             $.validator.addMethod('drivingLicenceDetailsValidation', function(value, element) {
                 return $('#select_documents_form_any_driving_licence_false').is(':checked') ||
-                    ($('#select_documents_form_any_driving_licence_true').is(':checked') && ($('#select_documents_form_driving_licence').is(':checked') || $('#select_documents_form_ni_driving_licence').is(':checked')))
+                ($('#select_documents_form_any_driving_licence_true').is(':checked') 
+                && ($('#select_documents_form_driving_licence_great_britain').is(':checked') 
+                || $('#select_documents_form_driving_licence_northern_ireland').is(':checked')))
             }, $.validator.format(selectDocuments.$form.data('msg')));
 
             selectDocuments.validator = selectDocuments.$form.validate($.extend({}, GOVUK.validation.radiosValidation, {
                 rules: {
                     'select_documents_form[any_driving_licence]': 'required',
                     'select_documents_form[passport]': 'required',
-                    'select_documents_form[driving_licence]': 'drivingLicenceDetailsValidation',
-                    'select_documents_form[ni_driving_licence]': 'drivingLicenceDetailsValidation',
+                    'select_documents_form[driving_licence]': 'drivingLicenceDetailsValidation'
                 },
                 groups: {
-                    primary: 'select_documents_form[any_driving_licence] select_documents_form[passport] select_documents_form[driving_licence] select_documents_form[ni_driving_licence]'
+                    primary: 'select_documents_form[any_driving_licence] select_documents_form[passport] select_documents_form[driving_licence]'
                 },
                 messages: {
                     'select_documents_form[any_driving_licence]': errorMessage,
                     'select_documents_form[passport]': errorMessage,
-                    'select_documents_form[driving_licence]': errorMessage,
-                    'select_documents_form[ni_driving_licence]': errorMessage
+                    'select_documents_form[driving_licence]': errorMessage
                 }
             }));
 

--- a/app/models/clever_questions/select_documents_form.rb
+++ b/app/models/clever_questions/select_documents_form.rb
@@ -7,7 +7,6 @@ class CleverQuestions::SelectDocumentsForm
   validate :expiry_date_present_when_passport_expired
 
   def initialize(select_documents_form)
-    @ni_driving_licence = select_documents_form[:ni_driving_licence]
     @driving_licence = select_documents_form[:driving_licence]
     @passport = select_documents_form[:passport]
     @any_driving_licence = select_documents_form[:any_driving_licence]
@@ -27,6 +26,10 @@ class CleverQuestions::SelectDocumentsForm
       answers[:passport] = has_passport_expired_less_than_six_months
     end
 
+    if any_driving_licence == 'true'
+      answers[:driving_licence] = (driving_licence == 'great_britain')
+      answers[:ni_driving_licence] = (driving_licence == 'northern_ireland')
+    end
     if any_driving_licence == 'false'
       answers[:driving_licence] = false
       answers[:ni_driving_licence] = false
@@ -58,7 +61,7 @@ private
   end
 
   def no_driving_licence_details?
-    !(driving_licence == 'true' || ni_driving_licence == 'true')
+    !(driving_licence == 'great_britain' || ni_driving_licence == 'northern_ireland')
   end
 
   def expiry_date_present_when_passport_expired
@@ -73,24 +76,12 @@ private
     !expiry_day.between?(1, 31) || !expiry_month.between?(1, 12) || !expiry_year.between?(1, Date.today.year)
   end
 
-  def all_no_answers?
-    document_attributes.all? { |doc| doc == 'false' }
-  end
-
-  def any_yes_answers?
-    document_attributes.any? { |doc| doc == 'true' }
-  end
-
   def add_documents_error
     errors.add(:base, I18n.t('hub.select_documents.errors.no_selection'))
   end
 
   def add_date_error
     errors.add(:base, I18n.t('clever_questions.hub.select_documents.errors.invalid_date'))
-  end
-
-  def document_attributes
-    [passport, driving_licence, ni_driving_licence, any_driving_licence]
   end
 
   def expiry_day

--- a/app/models/clever_questions/select_documents_form.rb
+++ b/app/models/clever_questions/select_documents_form.rb
@@ -61,7 +61,7 @@ private
   end
 
   def no_driving_licence_details?
-    !(driving_licence == 'great_britain' || ni_driving_licence == 'northern_ireland')
+    !(driving_licence == 'great_britain' || driving_licence == 'northern_ireland')
   end
 
   def expiry_date_present_when_passport_expired

--- a/app/models/select_documents_form.rb
+++ b/app/models/select_documents_form.rb
@@ -6,7 +6,6 @@ class SelectDocumentsForm
   validate :driving_licence_details_present
 
   def initialize(hash)
-    @ni_driving_licence = hash[:ni_driving_licence]
     @driving_licence = hash[:driving_licence]
     @passport = hash[:passport]
     @any_driving_licence = hash[:any_driving_licence]
@@ -19,6 +18,10 @@ class SelectDocumentsForm
       if %w(true false).include?(result)
         answers[attr] = (result == 'true')
       end
+    end
+    if any_driving_licence == 'true'
+      answers[:driving_licence] = (driving_licence == 'great_britain')
+      answers[:ni_driving_licence] = (driving_licence == 'northern_ireland')
     end
     if any_driving_licence == 'false'
       answers[:driving_licence] = false
@@ -46,22 +49,10 @@ private
   end
 
   def no_driving_licence_details?
-    !(driving_licence == 'true' || ni_driving_licence == 'true')
-  end
-
-  def all_no_answers?
-    document_attributes.all? { |doc| doc == 'false' }
-  end
-
-  def any_yes_answers?
-    document_attributes.any? { |doc| doc == 'true' }
+    !(driving_licence == 'great_britain' || ni_driving_licence == 'northern_ireland')
   end
 
   def add_documents_error
     errors.add(:base, I18n.t('hub.select_documents.errors.no_selection'))
-  end
-
-  def document_attributes
-    [passport, driving_licence, ni_driving_licence, any_driving_licence]
   end
 end

--- a/app/models/select_documents_form.rb
+++ b/app/models/select_documents_form.rb
@@ -49,7 +49,7 @@ private
   end
 
   def no_driving_licence_details?
-    !(driving_licence == 'great_britain' || ni_driving_licence == 'northern_ireland')
+    !(driving_licence == 'great_britain' || driving_licence == 'northern_ireland')
   end
 
   def add_documents_error

--- a/app/views/clever_questions/select_documents/index.html.erb
+++ b/app/views/clever_questions/select_documents/index.html.erb
@@ -30,8 +30,8 @@
 
                 <fieldset>
                   <legend><span class="form-label"><%= t "#{select_documents}.where_driving_licence_issued" %></span></legend>
-                    <%= f.custom_check_box :driving_licence, {class: 'form-group form-field'}, "true", "false", t("#{select_documents}.driving_licence_details.great_britain")  %>
-                    <%= f.custom_check_box :ni_driving_licence, {class: 'form-group form-field'}, "true", "false", t("#{select_documents}.driving_licence_details.northern_ireland")  %>
+                    <%= f.custom_radio_button :driving_licence, 'great_britain', t("#{select_documents}.driving_licence_details.great_britain")  %>
+                    <%= f.custom_radio_button :driving_licence, 'northern_ireland', t("#{select_documents}.driving_licence_details.northern_ireland")  %>
                 </fieldset>
 
             <% end %>

--- a/app/views/select_documents/index.html.erb
+++ b/app/views/select_documents/index.html.erb
@@ -29,8 +29,8 @@
 
                 <fieldset>
                   <legend><span class="form-label"><%= t 'hub.select_documents.where_driving_licence_issued' %></span></legend>
-                    <%= f.custom_check_box :driving_licence, {class: 'form-group form-field'}, "true", "false", t('hub.select_documents.driving_licence_details.great_britain')  %>
-                    <%= f.custom_check_box :ni_driving_licence, {class: 'form-group form-field'}, "true", "false", t('hub.select_documents.driving_licence_details.northern_ireland')  %>
+                    <%= f.custom_radio_button :driving_licence, 'great_britain', t('hub.select_documents.driving_licence_details.great_britain')  %>
+                    <%= f.custom_radio_button :driving_licence, 'northern_ireland', t('hub.select_documents.driving_licence_details.northern_ireland')  %>
                 </fieldset>
 
             <% end %>

--- a/spec/controllers/clever_questions/select_documents_controller_spec.rb
+++ b/spec/controllers/clever_questions/select_documents_controller_spec.rb
@@ -34,15 +34,14 @@ describe CleverQuestions::SelectDocumentsController do
     it 'captures form values in session cookie' do
       documents_evidence = { passport: 'true',
                              any_driving_licence: 'true',
-                             driving_licence: 'true',
-                             ni_driving_licence: 'true' }.freeze
+                             driving_licence: 'great_britain' }.freeze
       stub_piwik_request('action_name' => 'trackEvent')
       post :select_documents, params: { locale: 'en', select_documents_form: documents_evidence }
 
       subject
       expect(session[:selected_answers]['documents']).to eq(passport: true,
                                                             driving_licence: true,
-                                                            ni_driving_licence: true)
+                                                            ni_driving_licence: false)
     end
   end
 

--- a/spec/controllers/select_documents_controller_spec.rb
+++ b/spec/controllers/select_documents_controller_spec.rb
@@ -32,14 +32,13 @@ describe SelectDocumentsController do
     it 'captures form values in session cookie' do
       documents_evidence = { passport: 'true',
                              any_driving_licence: 'true',
-                             driving_licence: 'true',
-                             ni_driving_licence: 'true' }.freeze
+                             driving_licence: 'great_britain' }.freeze
       post :select_documents, params: { locale: 'en', select_documents_form: documents_evidence }
 
       subject
       expect(session[:selected_answers]['documents']).to eq(passport: true,
                                                             driving_licence: true,
-                                                            ni_driving_licence: true)
+                                                            ni_driving_licence: false)
     end
   end
 

--- a/spec/features/clever_questions/user_visits_select_documents_page_spec.rb
+++ b/spec/features/clever_questions/user_visits_select_documents_page_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature 'When user visits document selection page' do
 
   it 'should go to select proof of address page when user has a valid GB licence and UK passport' do
     choose 'select_documents_form_any_driving_licence_true'
-    check 'select_documents_form_driving_licence'
+    choose 'select_documents_form_driving_licence_great_britain'
     choose 'select_documents_form_passport_true'
     click_button 'Continue'
     expect(page).to have_current_path(select_proof_of_address_path)
@@ -35,7 +35,7 @@ RSpec.feature 'When user visits document selection page' do
 
   it 'should go to select proof of address page when user has a GB licence and an expired UK passport under six months' do
     choose 'select_documents_form_any_driving_licence_true'
-    check 'select_documents_form_driving_licence'
+    choose 'select_documents_form_driving_licence_great_britain'
     choose 'select_documents_form_passport_yes_expired'
 
     fill_in 'select_documents_form_passport_expiry_day', with: Date.today.day
@@ -52,7 +52,7 @@ RSpec.feature 'When user visits document selection page' do
 
   it 'should go to select proof of address page when user has a GB licence and an expired UK passport over six months' do
     choose 'select_documents_form_any_driving_licence_true'
-    check 'select_documents_form_driving_licence'
+    choose 'select_documents_form_driving_licence_great_britain'
     choose 'select_documents_form_passport_yes_expired'
 
     fill_in 'select_documents_form_passport_expiry_day', with: Date.today.day

--- a/spec/features/user_visits_select_documents_page_spec.rb
+++ b/spec/features/user_visits_select_documents_page_spec.rb
@@ -22,7 +22,7 @@ RSpec.feature 'When user visits document selection page' do
 
   it 'should go to select phone page when user has a valid GB licence or UK passport' do
     choose 'select_documents_form_any_driving_licence_true'
-    check 'select_documents_form_driving_licence'
+    choose 'select_documents_form_driving_licence_great_britain'
     choose 'select_documents_form_passport_true'
     click_button 'Continue'
     expect(page).to have_current_path(select_phone_path)

--- a/spec/javascripts/clever_questions/select_documents_form_spec.js
+++ b/spec/javascripts/clever_questions/select_documents_form_spec.js
@@ -100,7 +100,7 @@ describe("Select Documents Form", function () {
             answerQuestion('passport', false);
         };
         this.selectPassportExpired = function () {
-          answerQuestion('passport', 'yes_expired');
+            answerQuestion('passport', 'yes_expired');
         };
         this.selectYesPassport = function () {
             answerQuestion('passport', true);

--- a/spec/javascripts/clever_questions/select_documents_form_spec.js
+++ b/spec/javascripts/clever_questions/select_documents_form_spec.js
@@ -10,22 +10,18 @@ describe("Select Documents Form", function () {
         '</div>' +
         '<form id="validate-select-documents" class="select-documents-form" novalidate="novalidate" data-msg="Please select the documents you have" action="/select-documents" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="2Vb46CN8Bljm/f6lHNxqu3PGWMVAsVdjIe6uJrnzoxbUic0vi8jU/Ea8UrmOWBtwan860qN2uvdFNW8DoFNVuQ==" />' +
         '<div class="form-group">' +
-        '<h2 class="heading-medium">Do you have a valid UK selectcard driving licence, full or provisional?</h2>' +
+        '<h2 class="heading-medium">Do you have a valid UK photocard driving licence, full or provisional?</h2>' +
         '<div class="form-group form-field">' +
         '<fieldset>' +
         '<label class="block-label selection-button-radio" for="select_documents_form_any_driving_licence_true"><input type="radio" value="true" name="select_documents_form[any_driving_licence]" id="select_documents_form_any_driving_licence_true" /> Yes</label>' +
         '<label class="block-label selection-button-radio" for="select_documents_form_any_driving_licence_false"><input type="radio" value="false" name="select_documents_form[any_driving_licence]" id="select_documents_form_any_driving_licence_false" /> No</label>' +
         '</fieldset>' +
         '</div>' +
-        '<div id="driving_licence_details" class="form-group panel panel-border-narrow js-hidden">' +
+        '<div id="driving_licence_details" class="form-group panel panel-border-narrow">' +
         '<fieldset>' +
         '<legend><span class="form-label">Where was your driving licence issued?</span></legend>' +
-        '<label class="block-label selection-button-checkbox" for="select_documents_form_driving_licence">' +
-        '<input name="select_documents_form[driving_licence]" type="hidden" value="0" /><input type="checkbox" value="1" name="select_documents_form[driving_licence]" id="select_documents_form_driving_licence" />Great Britain' +
-        '</label>' +
-        '<label class="block-label selection-button-checkbox" for="select_documents_form_ni_driving_licence">' +
-        '<input name="select_documents_form[ni_driving_licence]" type="hidden" value="0" /><input type="checkbox" value="1" name="select_documents_form[ni_driving_licence]" id="select_documents_form_ni_driving_licence" />Northern Ireland' +
-        '</label>' +
+        '<div class="multiple-choice"><input value="great_britain" name="select_documents_form[driving_licence]" id="select_documents_form_driving_licence_great_britain" type="radio"> <label for="select_documents_form_driving_licence_great_britain">Great Britain</label></div>' +
+        '<div class="multiple-choice"><input value="northern_ireland" name="select_documents_form[driving_licence]" id="select_documents_form_driving_licence_northern_ireland" type="radio"> <label for="select_documents_form_driving_licence_northern_ireland">Northern Ireland</label></div>' +
         '</fieldset>' +
         '</div>' +
         '<h2 class="heading-medium">Do you have a UK passport?</h2>' +
@@ -116,7 +112,7 @@ describe("Select Documents Form", function () {
             answerQuestion('any_driving_licence', false);
         };
         this.selectGBDrivingLicence = function () {
-            selectDocumentsForm.find('input[name="select_documents_form[driving_licence]"]').prop('checked', true).trigger('click')
+            answerQuestion('driving_licence', 'great_britain');
         };
         this.enterValidPassportExpiryDate = function (day, month, year) {
           selectDocumentsForm.find('#select_documents_form_passport_expiry_day').val(day).trigger('blur');

--- a/spec/javascripts/select_documents_form_spec.js
+++ b/spec/javascripts/select_documents_form_spec.js
@@ -10,22 +10,18 @@ describe("Select Documents Form", function () {
         '</div>' +
         '<form id="validate-select-documents" class="select-documents-form" novalidate="novalidate" data-msg="Please select the documents you have" action="/select-documents" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="2Vb46CN8Bljm/f6lHNxqu3PGWMVAsVdjIe6uJrnzoxbUic0vi8jU/Ea8UrmOWBtwan860qN2uvdFNW8DoFNVuQ==" />' +
         '<div class="form-group">' +
-        '<h2 class="heading-medium">Do you have a valid UK selectcard driving licence, full or provisional?</h2>' +
+        '<h2 class="heading-medium">Do you have a valid UK photocard driving licence, full or provisional?</h2>' +
         '<div class="form-group form-field">' +
         '<fieldset>' +
         '<label class="block-label selection-button-radio" for="select_documents_form_any_driving_licence_true"><input type="radio" value="true" name="select_documents_form[any_driving_licence]" id="select_documents_form_any_driving_licence_true" /> Yes</label>' +
         '<label class="block-label selection-button-radio" for="select_documents_form_any_driving_licence_false"><input type="radio" value="false" name="select_documents_form[any_driving_licence]" id="select_documents_form_any_driving_licence_false" /> No</label>' +
         '</fieldset>' +
         '</div>' +
-        '<div id="driving_licence_details" class="form-group panel panel-border-narrow js-hidden">' +
+        '<div id="driving_licence_details" class="form-group panel panel-border-narrow">' +
         '<fieldset>' +
         '<legend><span class="form-label">Where was your driving licence issued?</span></legend>' +
-        '<label class="block-label selection-button-checkbox" for="select_documents_form_driving_licence">' +
-        '<input name="select_documents_form[driving_licence]" type="hidden" value="0" /><input type="checkbox" value="1" name="select_documents_form[driving_licence]" id="select_documents_form_driving_licence" />Great Britain' +
-        '</label>' +
-        '<label class="block-label selection-button-checkbox" for="select_documents_form_ni_driving_licence">' +
-        '<input name="select_documents_form[ni_driving_licence]" type="hidden" value="0" /><input type="checkbox" value="1" name="select_documents_form[ni_driving_licence]" id="select_documents_form_ni_driving_licence" />Northern Ireland' +
-        '</label>' +
+        '<div class="multiple-choice"><input value="great_britain" name="select_documents_form[driving_licence]" id="select_documents_form_driving_licence_great_britain" type="radio"> <label for="select_documents_form_driving_licence_great_britain">Great Britain</label></div>' +
+        '<div class="multiple-choice"><input value="northern_ireland" name="select_documents_form[driving_licence]" id="select_documents_form_driving_licence_northern_ireland" type="radio"> <label for="select_documents_form_driving_licence_northern_ireland">Northern Ireland</label></div>' +
         '</fieldset>' +
         '</div>' +
         '<h2 class="heading-medium">Do you have a UK passport?</h2>' +
@@ -85,7 +81,7 @@ describe("Select Documents Form", function () {
             answerQuestion('any_driving_licence', false);
         };
         this.selectGBDrivingLicence = function () {
-            selectDocumentsForm.find('input[name="select_documents_form[driving_licence]"]').prop('checked', true).trigger('click')
+            answerQuestion('driving_licence', 'great_britain');
         };
     });
 

--- a/spec/models/clever_questions/select_documents_form_spec.rb
+++ b/spec/models/clever_questions/select_documents_form_spec.rb
@@ -22,7 +22,7 @@ describe CleverQuestions::SelectDocumentsForm do
       it 'should be invalid if user only inputs driving licence details' do
         form = CleverQuestions::SelectDocumentsForm.new(
           any_driving_licence: 'true',
-          driving_licence: 'true'
+          driving_licence: 'great_britain'
         )
         expect(form).to_not be_valid
         expect(form.errors.full_messages).to eql ['Please select the documents you have']
@@ -198,8 +198,7 @@ describe CleverQuestions::SelectDocumentsForm do
       it 'should be valid if answers are given to every question if passpport not expired' do
         form = CleverQuestions::SelectDocumentsForm.new(
           any_driving_licence: 'false',
-          ni_driving_licence: 'true',
-          driving_licence: 'true',
+          driving_licence: 'great_britain',
           passport: 'true',
         )
         expect(form).to be_valid
@@ -208,8 +207,7 @@ describe CleverQuestions::SelectDocumentsForm do
       it 'should set passport expiry details to empty if not supplied' do
         form = CleverQuestions::SelectDocumentsForm.new(
           any_driving_licence: 'false',
-          ni_driving_licence: 'true',
-          driving_licence: 'true',
+          driving_licence: 'great_britain',
           passport: 'true',
         )
         expect(form.passport_expiry).to eql(day: '', month: '', year: '')
@@ -218,8 +216,7 @@ describe CleverQuestions::SelectDocumentsForm do
       it 'should be valid if answers are given to every question if passport expired' do
         form = CleverQuestions::SelectDocumentsForm.new(
           any_driving_licence: 'false',
-          ni_driving_licence: 'true',
-          driving_licence: 'true',
+          driving_licence: 'great_britain',
           passport: 'yes_expired',
           passport_expiry: {
             day: Date.today.day.to_s,
@@ -252,10 +249,10 @@ describe CleverQuestions::SelectDocumentsForm do
     it 'should return a hash of driving licence true if GB driving licence selected' do
       form = CleverQuestions::SelectDocumentsForm.new(
         any_driving_licence: 'true',
-        driving_licence: 'true'
+        driving_licence: 'great_britain'
       )
       evidence = form.selected_answers
-      expect(evidence).to eql(driving_licence: true)
+      expect(evidence).to eql(driving_licence: true, ni_driving_licence: false)
     end
 
     it 'should not return selected answers when there it is not an eligible IDP evidence ' do
@@ -350,7 +347,7 @@ describe CleverQuestions::SelectDocumentsForm do
     it 'should not require further information when user has a northern ireland driving licence' do
       form = CleverQuestions::SelectDocumentsForm.new(
         any_driving_licence: 'true',
-        ni_driving_licence: 'true',
+        driving_licence: 'northern_ireland',
         passport: 'false'
       )
       expect(form).to_not be_further_id_information_required
@@ -359,7 +356,7 @@ describe CleverQuestions::SelectDocumentsForm do
     it 'should not require further information when user has a GB driving licence' do
       form = CleverQuestions::SelectDocumentsForm.new(
         any_driving_licence: 'true',
-        driving_licence: 'true',
+        driving_licence: 'great_britain',
         passport: 'false'
       )
       expect(form).to_not be_further_id_information_required
@@ -379,8 +376,7 @@ private
   def select_documents_form_with_passport_expiry(passport_expiry)
     CleverQuestions::SelectDocumentsForm.new(
       any_driving_licence: 'false',
-      ni_driving_licence: 'true',
-      driving_licence: 'true',
+      driving_licence: 'great_britain',
       passport: 'yes_expired',
       passport_expiry: passport_expiry
     )

--- a/spec/models/clever_questions/select_documents_form_spec.rb
+++ b/spec/models/clever_questions/select_documents_form_spec.rb
@@ -40,8 +40,6 @@ describe CleverQuestions::SelectDocumentsForm do
         it 'should be invalid if passport expiry date not present when passport has expired' do
           form = CleverQuestions::SelectDocumentsForm.new(
             any_driving_licence: 'false',
-            ni_driving_licence: 'true',
-            driving_licence: 'true',
             passport: 'yes_expired'
           )
 
@@ -198,7 +196,6 @@ describe CleverQuestions::SelectDocumentsForm do
       it 'should be valid if answers are given to every question if passpport not expired' do
         form = CleverQuestions::SelectDocumentsForm.new(
           any_driving_licence: 'false',
-          driving_licence: 'great_britain',
           passport: 'true',
         )
         expect(form).to be_valid
@@ -207,7 +204,6 @@ describe CleverQuestions::SelectDocumentsForm do
       it 'should set passport expiry details to empty if not supplied' do
         form = CleverQuestions::SelectDocumentsForm.new(
           any_driving_licence: 'false',
-          driving_licence: 'great_britain',
           passport: 'true',
         )
         expect(form.passport_expiry).to eql(day: '', month: '', year: '')
@@ -216,7 +212,6 @@ describe CleverQuestions::SelectDocumentsForm do
       it 'should be valid if answers are given to every question if passport expired' do
         form = CleverQuestions::SelectDocumentsForm.new(
           any_driving_licence: 'false',
-          driving_licence: 'great_britain',
           passport: 'yes_expired',
           passport_expiry: {
             day: Date.today.day.to_s,
@@ -376,7 +371,6 @@ private
   def select_documents_form_with_passport_expiry(passport_expiry)
     CleverQuestions::SelectDocumentsForm.new(
       any_driving_licence: 'false',
-      driving_licence: 'great_britain',
       passport: 'yes_expired',
       passport_expiry: passport_expiry
     )

--- a/spec/models/select_documents_form_spec.rb
+++ b/spec/models/select_documents_form_spec.rb
@@ -22,7 +22,7 @@ describe SelectDocumentsForm do
       it 'should be invalid if user only inputs driving licence details' do
         form = SelectDocumentsForm.new(
           any_driving_licence: 'true',
-          driving_licence: 'true'
+          driving_licence: 'great_britain'
         )
         expect(form).to_not be_valid
         expect(form.errors.full_messages).to eql ['Please select the documents you have']
@@ -41,8 +41,7 @@ describe SelectDocumentsForm do
       it 'should be valid if answers are given to every question' do
         form = SelectDocumentsForm.new(
           any_driving_licence: 'false',
-          ni_driving_licence: 'true',
-          driving_licence: 'true',
+          driving_licence: 'great_britain',
           passport: 'true',
         )
         expect(form).to be_valid
@@ -70,10 +69,10 @@ describe SelectDocumentsForm do
     it 'should return a hash of driving licence true if GB driving licence selected' do
       form = SelectDocumentsForm.new(
         any_driving_licence: 'true',
-        driving_licence: 'true'
+        driving_licence: 'great_britain'
       )
       evidence = form.selected_answers
-      expect(evidence).to eql(driving_licence: true)
+      expect(evidence).to eql(driving_licence: true, ni_driving_licence: false)
     end
 
     it 'should not return selected answers when there it is not an eligible IDP evidence ' do
@@ -98,7 +97,7 @@ describe SelectDocumentsForm do
     it 'should not require further information when user has a northern ireland driving licence' do
       form = SelectDocumentsForm.new(
         any_driving_licence: 'true',
-        ni_driving_licence: 'true',
+        driving_licence: 'northern_ireland',
         passport: 'false'
       )
       expect(form).to_not be_further_id_information_required
@@ -107,7 +106,7 @@ describe SelectDocumentsForm do
     it 'should not require further information when user has a GB driving licence' do
       form = SelectDocumentsForm.new(
         any_driving_licence: 'true',
-        driving_licence: 'true',
+        driving_licence: 'great_britain',
         passport: 'false'
       )
       expect(form).to_not be_further_id_information_required

--- a/spec/models/select_documents_form_spec.rb
+++ b/spec/models/select_documents_form_spec.rb
@@ -41,7 +41,6 @@ describe SelectDocumentsForm do
       it 'should be valid if answers are given to every question' do
         form = SelectDocumentsForm.new(
           any_driving_licence: 'false',
-          driving_licence: 'great_britain',
           passport: 'true',
         )
         expect(form).to be_valid


### PR DESCRIPTION
It's legally impossible to hold two driving licenses issued by two different EU countries. However, currently we allow users to select both.
This is to change the check boxes to radio buttons which consequently will also simplify our profiles.

Authors: @jakubmiarka