### PR TITLE
BAU: Use raw instead of html_safe.

### DIFF
--- a/app/views/clever_questions/start/start.html.erb
+++ b/app/views/clever_questions/start/start.html.erb
@@ -10,7 +10,7 @@
   <%= render 'shared/form-errors', errors: flash[:errors] %>
 
   <p><%= t 'hub.about.verify_is_a_service' %></p>
-  <%= @tailored_text.html_safe %>
+  <%= raw @tailored_text %>
 
   <%= content_tag :div, class: form_question_class do %>
     <fieldset>


### PR DESCRIPTION
Use raw instead as it is nil safe.

Rails implements raw as `stringish.to_s.html_safe`, (ie its just a wrapper)
around html_safe. The advantage though is that calling `raw` on `nil` will
return an empty string (since nil.to_s returns an empty string) whereas
calling `nil.html_safe` will throw a `NoSuchMethod` exception.

@tailored_text ought to never be nil, but we have seen a very small numbers
of errors in the logs about this. The page still makes sense without the
text though, so making this defensive change for now.

Note that we should perhaps always use raw instead of html_safe, but I've
not changed any other uses for now.

Solo: @michaelwalker