### PR TITLE
TT-1326: Update tests to reference variables rather than strings

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -109,7 +109,7 @@ cy:
     verify_services:    # TODO: Get cy translation
       title: Verify services
       heading: GOV.UK Verify
-      message: "GOV.UK Verify is new, and government services are joining all the time. The current services using Verify are:"
+      message: "Mae GOV.UK Verify yn newydd ac mae gwasanaethau’r llywodraeth yn ymuno drwy’r amser. Y gwasanaethau presennol sy’n defnyddio Verify yw:"
     transaction_list:
       title: Dod o hyd i’r gwasanaeth rydych yn ei ddefnyddio i ddechrau eto
       hint: Dilynnwch y cyfarwyddiadau rydych wedi’u derbyn.

--- a/spec/feature_helper.rb
+++ b/spec/feature_helper.rb
@@ -22,6 +22,7 @@ RSpec.configure do |config|
   config.before(:each, js: true) do
     page.driver.browser.manage.window.resize_to(1280, 1024)
   end
+  config.include AbstractController::Translation
 end
 
 Capybara.configure do |config|

--- a/spec/features/idp_selections_reported_to_piwik_spec.rb
+++ b/spec/features/idp_selections_reported_to_piwik_spec.rb
@@ -42,8 +42,8 @@ RSpec.describe 'When the user selects an IDP' do
     piwik_registration_virtual_page = idcorp_registration_piwik_request
 
     visit '/choose-a-certified-company'
-    click_button 'Choose IDCorp'
-    click_button 'Continue to the IDCorp website'
+    click_button t('hub.choose_a_certified_company.choose_idp', display_name: t('idps.stub-idp-one.name'))
+    click_button t('hub.redirect_to_idp_warning.continue_website', display_name: t('idps.stub-idp-one.name'))
 
     expect(piwik_registration_virtual_page).to have_been_made.once
   end
@@ -58,14 +58,14 @@ RSpec.describe 'When the user selects an IDP' do
       segments: ['non-protected-segment-3'],
     )
     visit '/choose-a-certified-company'
-    click_button 'Choose IDCorp'
-    click_button 'Continue to the IDCorp website'
+    click_button t('hub.choose_a_certified_company.choose_idp', display_name: t('idps.stub-idp-one.name'))
+    click_button t('hub.redirect_to_idp_warning.continue_website', display_name: t('idps.stub-idp-one.name'))
 
     expect(idcorp_piwik_request).to have_been_made.once
 
     visit '/choose-a-certified-company'
     click_button 'Choose Bob’s Identity Service'
-    click_button 'Continue to the Bob’s Identity Service website'
+    click_button t('hub.redirect_to_idp_warning.continue_website', display_name: t('idps.stub-idp-two.name'))
 
     expect(idcorp_and_bobs_piwik_request).to have_been_made.once
   end
@@ -81,8 +81,8 @@ RSpec.describe 'When the user selects an IDP' do
     )
     page.set_rack_session(selected_idp_names: idps)
     visit '/choose-a-certified-company'
-    click_button 'Choose IDCorp'
-    click_button 'Continue to the IDCorp website'
+    click_button t('hub.choose_a_certified_company.choose_idp', display_name: t('idps.stub-idp-one.name'))
+    click_button t('hub.redirect_to_idp_warning.continue_website', display_name: t('idps.stub-idp-one.name'))
 
     expect(idcorp_piwik_request).to have_been_made.once
   end

--- a/spec/features/idp_selections_reported_to_piwik_spec.rb
+++ b/spec/features/idp_selections_reported_to_piwik_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe 'When the user selects an IDP' do
     expect(idcorp_piwik_request).to have_been_made.once
 
     visit '/choose-a-certified-company'
-    click_button 'Choose Bob’s Identity Service'
+    click_button t('hub.choose_a_certified_company.choose_idp', display_name: t('idps.stub-idp-two.name'))
     click_button t('hub.redirect_to_idp_warning.continue_website', display_name: t('idps.stub-idp-two.name'))
 
     expect(idcorp_and_bobs_piwik_request).to have_been_made.once

--- a/spec/features/requests_fingerprint_asset_spec.rb
+++ b/spec/features/requests_fingerprint_asset_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'When the user visits the start page' do
 
       visit '/start'
 
-      expect(page).to have_content 'Sign in with GOV.UK Verify'
+      expect(page).to have_content t('hub.start.heading')
       expect(query_params_hash).to_not be_nil
       expect(query_params_hash['hash']).to match(/^[0-9]+\-[a-z0-9]+$/)
     end

--- a/spec/features/user_encounters_a_404_spec.rb
+++ b/spec/features/user_encounters_a_404_spec.rb
@@ -5,6 +5,6 @@ describe 'User encounters an unknown page' do
   it 'will render the 404 page' do
     visit '/404'
     expect(current_path).to eql '/404'
-    expect(page).to have_content 'This page can’t be found'
+    expect(page).to have_content t('errors.page_not_found.heading')
   end
 end

--- a/spec/features/user_encounters_error_page_spec.rb
+++ b/spec/features/user_encounters_error_page_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'user encounters error page' do
     stub_session_creation_error
     visit '/test-saml'
     click_button "saml-post"
-    expect(page).to have_content "Sorry, something went wrong"
+    expect(page).to have_content t('errors.something_went_wrong.heading')
     expect(page).to have_css "#piwik-custom-url", text: "errors/generic-error"
     expect(page).to have_link "register for an identity profile", href: "http://localhost:50130/test-rp"
   end
@@ -26,8 +26,8 @@ RSpec.describe 'user encounters error page' do
     stub_request(:get, api_transactions_endpoint).to_return(body: bad_transactions_json.to_json, status: 200)
     visit '/test-saml'
     click_button "saml-post"
-    expect(page).to have_content "Sorry, something went wrong"
-    expect(page).to_not have_content "Find the service you were using to start again"
+    expect(page).to have_content t('errors.something_went_wrong.heading')
+    expect(page).to_not have_content t('hub.transaction_list.title')
     expect(page).to have_css "#piwik-custom-url", text: "errors/generic-error"
     expect(page.status_code).to eq(500)
   end
@@ -37,7 +37,7 @@ RSpec.describe 'user encounters error page' do
     stub_transactions_list
     visit '/test-saml'
     click_button "saml-post"
-    expect(page).to have_content "Sorry, something went wrong"
+    expect(page).to have_content t('errors.something_went_wrong.heading')
     expect(page).to have_css "#piwik-custom-url", text: "errors/generic-error"
     expect(page.status_code).to eq(500)
   end
@@ -48,7 +48,7 @@ RSpec.describe 'user encounters error page' do
     stub_transactions_list
     visit '/test-saml'
     click_button "saml-post"
-    expect(page).to have_content "Sorry, something went wrong"
+    expect(page).to have_content t('errors.something_went_wrong.heading')
     expect(page).to have_css "#piwik-custom-url", text: "errors/generic-error"
     expect(page.status_code).to eq(500)
   end
@@ -60,7 +60,7 @@ RSpec.describe 'user encounters error page' do
     stub_transactions_list
     visit '/test-saml'
     click_button "saml-post"
-    expect(page).to have_content "Sorry, something went wrong"
+    expect(page).to have_content t('errors.something_went_wrong.heading')
     expect(page.status_code).to eq(500)
   end
 
@@ -72,7 +72,7 @@ RSpec.describe 'user encounters error page' do
     stub_transactions_list
     visit '/test-saml'
     click_button "saml-post"
-    expect(page).to have_content "Sorry, something went wrong"
+    expect(page).to have_content t('errors.something_went_wrong.heading')
     expect(page.status_code).to eq(500)
   end
 
@@ -88,8 +88,8 @@ RSpec.describe 'user encounters error page' do
       stub_request(:post, api_saml_endpoint).to_return(body: error_body.to_json, status: 400)
       visit('/test-saml')
       click_button 'saml-post'
-      expect(page).to have_content "You need to start again"
-      expect(page).to have_content "For security reasons"
+      expect(page).to have_content t('errors.session_error.heading')
+      expect(page).to have_content t('errors.session_error.security')
       expect(page).to have_css "#piwik-custom-url", text: "errors/session-error"
       expect(page.status_code).to eq(400)
     end
@@ -99,8 +99,8 @@ RSpec.describe 'user encounters error page' do
       stub_request(:post, api_saml_endpoint).to_return(body: error_body.to_json, status: 400)
       visit('/test-saml')
       click_button 'saml-post'
-      expect(page).to have_content "Your session has timed out"
-      expect(page).to have_content "Please go back to your service"
+      expect(page).to have_content t('errors.session_timeout.title')
+      expect(page).to have_content t('errors.session_timeout.return_to_service')
       expect(page).to have_css "#piwik-custom-url", text: "errors/timeout-error"
       expect(page).to have_css "a[href*=EXPIRED_ERROR_PAGE]"
       expect(page.status_code).to eq(403)
@@ -110,7 +110,7 @@ RSpec.describe 'user encounters error page' do
       stub_request(:post, api_select_idp_endpoint).and_return(status: 403)
       visit sign_in_cy_path
       click_button 'Welsh IDCorp'
-      expect(page).to have_content I18n.translate('errors.something_went_wrong.heading', locale: :cy)
+      expect(page).to have_content t('errors.something_went_wrong.heading', locale: :cy)
       expect(page.status_code).to eq(500)
     end
 
@@ -118,7 +118,7 @@ RSpec.describe 'user encounters error page' do
       stub_request(:post, api_select_idp_endpoint).and_return(status: 403)
       visit sign_in_path
       click_button 'IDCorp'
-      expect(page).to have_content "Sorry, something went wrong"
+      expect(page).to have_content t('errors.something_went_wrong.heading')
       expect(page).to have_link "register for an identity profile", href: "http://localhost:50130/test-rp"
       expect(page).to have_css "#piwik-custom-url", text: "errors/generic-error"
       expect(page.status_code).to eq(500)

--- a/spec/features/user_selects_an_unavailable_idp_for_signin_spec.rb
+++ b/spec/features/user_selects_an_unavailable_idp_for_signin_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'when user visits sign-in page with an unavailable IDP configured
     "/certified-company-unavailable/#{simple_id}"
   end
 
-  button_text = I18n.t('hub.signin.select_idp', display_name: 'Unavailable IDP')
+  let(:button_text) { t('hub.signin.select_idp', display_name: 'Unavailable IDP') }
 
   context 'the API says the IDP is actually available' do
     before(:each) do
@@ -38,7 +38,7 @@ RSpec.describe 'when user visits sign-in page with an unavailable IDP configured
 
     it 'will respond with a 404 if the user visits the certified company unavailable page for that IDP' do
       visit certified_company_unavailable_path('stub-idp-unavailable')
-      expect(page).to have_content('This page can’t be found')
+      expect(page).to have_content t('errors.page_not_found.heading')
     end
   end
 
@@ -52,8 +52,8 @@ RSpec.describe 'when user visits sign-in page with an unavailable IDP configured
 
     it 'will display the correct information on the unavailable IDP page' do
       click_link(button_text)
-      expect(page).to have_title(I18n.t('hub.certified_company_unavailable.title'))
-      expect(page).to have_link(I18n.t('hub.certified_company_unavailable.verify_another_company_link'), href: about_certified_companies_path)
+      expect(page).to have_title t('hub.certified_company_unavailable.title')
+      expect(page).to have_link t('hub.certified_company_unavailable.verify_another_company_link'), href: about_certified_companies_path
 
       expect(page).to have_content 'Other ways to register for an identity profile'
       expect(page).to have_content 'If you can’t verify your identity using GOV.UK Verify, you can register for an identity profile'
@@ -62,7 +62,7 @@ RSpec.describe 'when user visits sign-in page with an unavailable IDP configured
 
     it 'the certified company unavailable page will respond with a 404 if an IDP is not set to unavailable' do
       visit certified_company_unavailable_path('stub-idp-one')
-      expect(page).to have_content('This page can’t be found')
+      expect(page).to have_content t('errors.page_not_found.heading')
     end
   end
 end

--- a/spec/features/user_sends_authn_request_spec.rb
+++ b/spec/features/user_sends_authn_request_spec.rb
@@ -11,7 +11,7 @@ describe 'user sends authn requests' do
       visit('/test-saml')
       click_button 'saml-post'
 
-      expect(page).to have_title 'Start - GOV.UK Verify - GOV.UK'
+      expect(page).to have_title t('hub.start.title')
 
       expect(page.get_rack_session['transaction_simple_id']).to eql 'test-rp'
       expect(page.get_rack_session['verify_session_id']).to eql default_session_id
@@ -33,7 +33,7 @@ describe 'user sends authn requests' do
       stub_session_creation('transactionSupportsEidas' => true)
       visit('/test-saml')
       click_button 'saml-post-journey-hint'
-      expect(page).to have_title 'Confirm your identity - GOV.UK Verify - GOV.UK'
+      expect(page).to have_title t('hub.confirm_your_identity.title')
       expect(page.get_rack_session['transaction_supports_eidas']).to eql true
     end
 
@@ -45,7 +45,7 @@ describe 'user sends authn requests' do
       visit('/test-saml')
       click_button 'saml-post-eidas'
 
-      expect(page).to have_title 'Choose a country - GOV.UK Verify - GOV.UK'
+      expect(page).to have_title t('hub.choose_country.title')
       expect(page.get_rack_session['transaction_supports_eidas']).to eql true
     end
 
@@ -56,7 +56,7 @@ describe 'user sends authn requests' do
       visit('/test-saml')
       click_button 'saml-post-eidas'
 
-      expect(page).to have_content 'Sorry, something went wrong'
+      expect(page).to have_content t('errors.something_went_wrong.heading')
       expect(page.get_rack_session['transaction_supports_eidas']).to eql false
     end
 
@@ -113,7 +113,7 @@ describe 'user sends authn requests' do
       stub_transactions_list
       visit('/test-saml')
       click_button 'saml-post'
-      expect(page).to have_content 'Sorry, something went wrong'
+      expect(page).to have_content t('errors.something_went_wrong.heading')
     end
   end
 end

--- a/spec/features/user_sends_authn_response_spec.rb
+++ b/spec/features/user_sends_authn_response_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'User returns from an IDP with an AuthnResponse' do
     visit('/test-saml?session-id=junk')
     click_button 'saml-response-post'
 
-    expect(page).to have_content 'something went wrong'
+    expect(page).to have_content t('errors.something_went_wrong.heading')
   end
 
   it 'will redirect the user to /confirmation when successfully registered' do

--- a/spec/features/user_submits_feedback_page_spec.rb
+++ b/spec/features/user_submits_feedback_page_spec.rb
@@ -2,8 +2,10 @@ require 'feature_helper'
 require 'api_test_helper'
 
 RSpec.feature 'When the user submits the feedback page' do
+  let(:what_text_field) { 'Using verify' }
+  let(:details_text_field) { 'Some details' }
   let(:session_not_valid_link) {
-    I18n.t('hub.feedback_sent.session_not_valid', link: I18n.t('hub.feedback_sent.session_not_valid_link'))
+    t('hub.feedback_sent.session_not_valid', link: t('hub.feedback_sent.session_not_valid_link'))
   }
   context 'user session invalid' do
     before(:each) do
@@ -13,32 +15,32 @@ RSpec.feature 'When the user submits the feedback page' do
     it 'when user provides email should say message has been received and show invalid session link' do
       visit feedback_path
 
-      fill_in 'feedback_form_what', with: 'Using verify'
-      fill_in 'feedback_form_details', with: 'Some details'
+      fill_in 'feedback_form_what', with: what_text_field
+      fill_in 'feedback_form_details', with: details_text_field
       choose 'feedback_form_reply_true'
       fill_in 'feedback_form_name', with: 'Bob Smith'
       fill_in 'feedback_form_email', with: 'bob@smith.com'
 
-      click_button I18n.t('hub.feedback.send_message')
-      expect(page).to have_title(I18n.t('hub.feedback_sent.title'))
+      click_button t('hub.feedback.send_message')
+      expect(page).to have_title t('hub.feedback_sent.title')
       expect(page).to have_current_path(feedback_sent_path, only_path: true)
-      expect(page).to have_content(I18n.t('hub.feedback_sent.message_email'))
-      expect(page).to have_content(session_not_valid_link)
-      expect(page).to have_content I18n.t('hub.transaction_list.title')
+      expect(page).to have_content t('hub.feedback_sent.message_email')
+      expect(page).to have_content session_not_valid_link
+      expect(page).to have_content t('hub.transaction_list.title')
     end
 
     it 'when user does not provide email should not say message has been sent and show invalid session link' do
       visit feedback_path
 
-      fill_in 'feedback_form_what', with: 'Using verify'
-      fill_in 'feedback_form_details', with: 'Some details'
+      fill_in 'feedback_form_what', with: what_text_field
+      fill_in 'feedback_form_details', with: details_text_field
       choose 'feedback_form_reply_false'
 
-      click_button I18n.t('hub.feedback.send_message')
+      click_button t('hub.feedback.send_message')
       expect(page).to have_current_path(feedback_sent_path, only_path: true)
-      expect(page).to_not have_content(I18n.t('hub.feedback_sent.message_email'))
-      expect(page).to have_content(session_not_valid_link)
-      expect(page).to have_content I18n.t('hub.transaction_list.title')
+      expect(page).to_not have_content t('hub.feedback_sent.message_email')
+      expect(page).to have_content session_not_valid_link
+      expect(page).to have_content t('hub.transaction_list.title')
     end
 
     it 'when session has timed out should show invalid session link' do
@@ -50,36 +52,36 @@ RSpec.feature 'When the user submits the feedback page' do
 
       visit feedback_path
 
-      fill_in 'feedback_form_what', with: 'Using verify'
-      fill_in 'feedback_form_details', with: 'Some details'
+      fill_in 'feedback_form_what', with: what_text_field
+      fill_in 'feedback_form_details', with: details_text_field
       choose 'feedback_form_reply_false'
 
-      click_button I18n.t('hub.feedback.send_message')
-      expect(page).to have_content(session_not_valid_link)
-      expect(page).to have_content I18n.t('hub.transaction_list.title')
+      click_button t('hub.feedback.send_message')
+      expect(page).to have_content session_not_valid_link
+      expect(page).to have_content t('hub.transaction_list.title')
     end
   end
 
   it 'should be able to direct user back to the Verify product page if email could not be sent on first attempt' do
     visit '/feedback?feedback-source=PRODUCT_PAGE'
 
-    fill_in 'feedback_form_what', with: 'Verify my identity'
-    fill_in 'feedback_form_details', with: 'Some details'
+    fill_in 'feedback_form_what', with: what_text_field
+    fill_in 'feedback_form_details', with: details_text_field
     choose 'feedback_form_reply_false', allow_label_click: true
 
     allow_any_instance_of(FeedbackService).to receive(:submit!).and_return(false)
 
-    click_button I18n.t('hub.feedback.send_message')
+    click_button t('hub.feedback.send_message')
 
     expect(page).to have_current_path(feedback_path)
-    expect(page).to have_content 'Verify my identity'
-    expect(page).to have_content 'Some details'
+    expect(page).to have_content what_text_field
+    expect(page).to have_content details_text_field
 
     allow_any_instance_of(FeedbackService).to receive(:submit!).and_return(true)
 
-    click_button I18n.t('hub.feedback.send_message')
-    expect(page).to have_title(I18n.t('hub.feedback_sent.title'))
-    expect(page).to have_link 'Return to the GOV.UK Verify product page', href: 'https://govuk-verify.cloudapps.digital/'
+    click_button t('hub.feedback.send_message')
+    expect(page).to have_title t('hub.feedback_sent.title')
+    expect(page).to have_link t('hub.feedback_sent.product_page'), href: 'https://govuk-verify.cloudapps.digital/'
   end
 
   context 'user session valid' do
@@ -90,72 +92,72 @@ RSpec.feature 'When the user submits the feedback page' do
 
     it 'should show user link back to start page' do
       visit start_path
-      click_link I18n.t('feedback_link.feedback_form')
+      click_link t('feedback_link.feedback_form')
 
-      fill_in 'feedback_form_what', with: 'Using verify'
-      fill_in 'feedback_form_details', with: 'Some details'
+      fill_in 'feedback_form_what', with: what_text_field
+      fill_in 'feedback_form_details', with: details_text_field
       choose 'feedback_form_reply_false'
 
-      click_button I18n.t('hub.feedback.send_message')
+      click_button t('hub.feedback.send_message')
       expect(page).to have_current_path(feedback_sent_path, only_path: true)
-      expect(page).to_not have_content(session_not_valid_link)
-      expect(page).to have_link I18n.t('hub.feedback_sent.session_valid_link'), href: start_path
+      expect(page).to_not have_content session_not_valid_link
+      expect(page).to have_link t('hub.feedback_sent.session_valid_link'), href: start_path
     end
 
     it 'should show user link back to page the user came from' do
       visit select_documents_path
-      click_link I18n.t('feedback_link.feedback_form')
+      click_link t('feedback_link.feedback_form')
 
-      fill_in 'feedback_form_what', with: 'Using verify'
-      fill_in 'feedback_form_details', with: 'Some details'
+      fill_in 'feedback_form_what', with: what_text_field
+      fill_in 'feedback_form_details', with: details_text_field
       choose 'feedback_form_reply_false'
 
-      click_button I18n.t('hub.feedback.send_message')
+      click_button t('hub.feedback.send_message')
       expect(page).to have_current_path(feedback_sent_path, only_path: true)
-      expect(page).to_not have_content(session_not_valid_link)
-      expect(page).to have_link I18n.t('hub.feedback_sent.session_valid_link'), href: select_documents_path
+      expect(page).to_not have_content session_not_valid_link
+      expect(page).to have_link t('hub.feedback_sent.session_valid_link'), href: select_documents_path
     end
 
     it 'should show user link back to start page if the user came from an error page' do
       visit about_path
       visit '/404'
-      click_link I18n.t('feedback_link.feedback_form')
+      click_link t('feedback_link.feedback_form')
 
-      fill_in 'feedback_form_what', with: 'Using verify'
-      fill_in 'feedback_form_details', with: 'Some details'
+      fill_in 'feedback_form_what', with: what_text_field
+      fill_in 'feedback_form_details', with: details_text_field
       choose 'feedback_form_reply_false'
 
-      click_button I18n.t('hub.feedback.send_message')
+      click_button t('hub.feedback.send_message')
       expect(page).to have_current_path(feedback_sent_path, only_path: true)
-      expect(page).to_not have_content(session_not_valid_link)
-      expect(page).to have_link I18n.t('hub.feedback_sent.session_valid_link'), href: start_path
+      expect(page).to_not have_content session_not_valid_link
+      expect(page).to have_link t('hub.feedback_sent.session_valid_link'), href: start_path
     end
 
     it 'should show user link back to start page if the user directly visits the feedback page' do
       visit feedback_path
 
-      fill_in 'feedback_form_what', with: 'Using verify'
-      fill_in 'feedback_form_details', with: 'Some details'
+      fill_in 'feedback_form_what', with: what_text_field
+      fill_in 'feedback_form_details', with: details_text_field
       choose 'feedback_form_reply_false'
 
-      click_button I18n.t('hub.feedback.send_message')
+      click_button t('hub.feedback.send_message')
       expect(page).to have_current_path(feedback_sent_path, only_path: true)
-      expect(page).to_not have_content(session_not_valid_link)
-      expect(page).to have_link I18n.t('hub.feedback_sent.session_valid_link'), href: start_path
+      expect(page).to_not have_content session_not_valid_link
+      expect(page).to have_link t('hub.feedback_sent.session_valid_link'), href: start_path
     end
 
     it 'should show feedback sent in Welsh and have the appropriate link back to Verify' do
       visit select_documents_cy_path
-      click_link I18n.t('feedback_link.feedback_form', locale: :cy)
+      click_link t('feedback_link.feedback_form', locale: :cy)
 
-      fill_in 'feedback_form_what', with: 'Using verify'
-      fill_in 'feedback_form_details', with: 'Some details'
+      fill_in 'feedback_form_what', with: what_text_field
+      fill_in 'feedback_form_details', with: details_text_field
       choose 'feedback_form_reply_false'
-      click_button I18n.t('hub.feedback.send_message', locale: :cy)
+      click_button t('hub.feedback.send_message', locale: :cy)
 
-      expect(page).to have_title I18n.t('hub.feedback_sent.title', locale: :cy)
+      expect(page).to have_title t('hub.feedback_sent.title', locale: :cy)
       expect(page).to have_css 'html[lang=cy]'
-      expect(page).to have_link I18n.t('hub.feedback_sent.session_valid_link', locale: :cy), href: select_documents_cy_path
+      expect(page).to have_link t('hub.feedback_sent.session_valid_link', locale: :cy), href: select_documents_cy_path
     end
 
     it 'should be able to direct user back to the relevant page if user switches to Welsh on the feedback page' do
@@ -165,12 +167,12 @@ RSpec.feature 'When the user submits the feedback page' do
 
       expect(page).to have_current_path('/adborth')
 
-      fill_in 'feedback_form_what', with: 'Verify my identity'
-      fill_in 'feedback_form_details', with: 'Some details'
+      fill_in 'feedback_form_what', with: what_text_field
+      fill_in 'feedback_form_details', with: details_text_field
       choose 'feedback_form_reply_false', allow_label_click: true
 
-      click_button I18n.t('hub.feedback.send_message', locale: :cy)
-      expect(page).to have_link I18n.t('hub.feedback_sent.session_valid_link', locale: :cy), href: '/dechrau'
+      click_button t('hub.feedback.send_message', locale: :cy)
+      expect(page).to have_link t('hub.feedback_sent.session_valid_link', locale: :cy), href: '/dechrau'
     end
   end
 end

--- a/spec/features/user_submits_start_page_form_spec.rb
+++ b/spec/features/user_submits_start_page_form_spec.rb
@@ -22,13 +22,13 @@ RSpec.describe 'when user submits start page form' do
     choose('start_form_selection_false')
     click_button('next-button')
     expect(current_path).to eq('/sign-in')
-    expect(page).to have_content 'Who do you have an identity account with?'
+    expect(page).to have_content t('hub.signin.heading')
     expect(page).to have_content 'IDCorp'
     expect(page).to have_css('.company-logo input[src="/stub-logos/stub-idp-one.png"]')
-    expect(page).to have_link 'Back', href: '/start'
+    expect(page).to have_link t('hub.signin.back'), href: '/start'
     expect_feedback_source_to_be(page, 'SIGN_IN_PAGE', '/sign-in')
-    expect(page).to have_link 'start now', href: '/begin-registration'
-    expect(page).to have_link "I can’t remember which company verified me", href: '/forgot-company'
+    expect(page).to have_link t('hub.signin.about_link'), href: '/begin-registration'
+    expect(page).to have_link t('hub.signin.forgot_company'), href: '/forgot-company'
   end
 
   it 'will report user choice to analytics when user chooses to sign in' do
@@ -51,6 +51,6 @@ RSpec.describe 'when user submits start page form' do
     stub_api_idp_list_for_loa
     visit '/start'
     click_button('next-button')
-    expect(page).to have_content "Please select an option"
+    expect(page).to have_content t('hub.start.error_message')
   end
 end

--- a/spec/features/user_visits_about_certified_companies_page_spec.rb
+++ b/spec/features/user_visits_about_certified_companies_page_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe 'When the user visits the about certified companies page' do
       visit '/am-gwmniau-ardystiedig'
 
       expect(page).to have_content t('hub.about_certified_companies.summary', locale: :cy)
-      expect(page.body).to include t('hub.about_certified_companies.details_html', locale: :cy)
+      expect(page.body).to include t('hub.about_certified_companies.loa1_details_html', locale: :cy)
     end
 
     it 'displays IdPs that are enabled' do
@@ -79,7 +79,7 @@ RSpec.describe 'When the user visits the about certified companies page' do
       visit '/about-certified-companies'
 
       expect(page).to have_content t('hub.about_certified_companies.summary')
-      expect(page.body).to include t('hub.about_certified_companies.details_html')
+      expect(page.body).to include t('hub.about_certified_companies.loa1_details_html')
     end
 
     it 'will go to about identity accounts page when next is clicked' do

--- a/spec/features/user_visits_about_certified_companies_page_spec.rb
+++ b/spec/features/user_visits_about_certified_companies_page_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe 'When the user visits the about certified companies page' do
   it 'displays content in Welsh' do
     visit '/am-gwmniau-ardystiedig'
 
-    expect(page).to have_content 'Sut y gall cwmnïau wirio hunaniaeth'
-    expect(page).to have_content 'Gall y cwmnïau hyn ddefnyddio eu data eu hunain'
+    expect(page).to have_content t('hub.about_certified_companies.summary', locale: :cy)
+    expect(page.body).to include t('hub.about_certified_companies.details_html', locale: :cy)
   end
 
   it 'displays IdPs that are enabled' do
@@ -34,8 +34,8 @@ RSpec.describe 'When the user visits the about certified companies page' do
   it 'will show "How companies can verify identities" section' do
     visit '/about-certified-companies'
 
-    expect(page).to have_content 'How companies can verify identities'
-    expect(page).to have_content 'These companies can use their own data'
+    expect(page).to have_content t('hub.about_certified_companies.summary')
+    expect(page.body).to include t('hub.about_certified_companies.details_html')
   end
 
   it 'will go to about identity accounts page when next is clicked' do

--- a/spec/features/user_visits_about_identity_accounts_page_spec.rb
+++ b/spec/features/user_visits_about_identity_accounts_page_spec.rb
@@ -18,14 +18,14 @@ RSpec.describe 'When the user visits the about identity accounts page' do
   it 'displays content in Welsh' do
     visit '/am-gyfrifon-hunaniaeth'
 
-    expect(page).to have_content 'Darganfyddwch fwy am gwcis'
+    expect(page).to have_content t('cookie_message.link', locale: :cy)
   end
 
   it 'will show "Where you can use your identity account" section listing public transactions' do
     visit '/about-identity-accounts'
 
-    expect(page).to have_content 'Where you can use your identity account'
-    expect(page).to have_content 'GOV.UK Verify is new, and government services are joining all the time. The current services  using Verify are:'
+    expect(page).to have_content t('hub.about_identity_accounts.summary')
+    expect(page).to have_content t('hub.about_identity_accounts.details')
     expect(page).to have_content 'register for an identity profile'
     expect(page).to have_content 'Register for an identity profile (forceauthn & no cycle3)'
   end

--- a/spec/features/user_visits_cancelled_registration_page_spec.rb
+++ b/spec/features/user_visits_cancelled_registration_page_spec.rb
@@ -16,11 +16,11 @@ RSpec.describe 'When user visits cancelled registration page' do
 
     visit('/cancelled-registration')
 
-    expect(page).to have_title I18n.t('hub.cancelled_registration.title')
+    expect(page).to have_title t('hub.cancelled_registration.title')
     expect(page).to have_link('Find out the other ways to register for an identity profile', href: other_ways_to_access_service_path)
-    expect(page).to have_link(I18n.t('hub.cancelled_registration.options.verify_with_another_company'), href: choose_a_certified_company_path)
-    expect(page).to have_link(I18n.t('hub.cancelled_registration.options.verify_using_other_documents'), href: select_documents_path)
-    expect(page).to have_link(I18n.t('hub.cancelled_registration.options.contact_verify'), href: "#{feedback_path}?feedback-source=CANCELLED_REGISTRATION")
+    expect(page).to have_link t('hub.cancelled_registration.options.verify_with_another_company'), href: choose_a_certified_company_path
+    expect(page).to have_link t('hub.cancelled_registration.options.verify_using_other_documents'), href: select_documents_path
+    expect(page).to have_link t('hub.cancelled_registration.options.contact_verify'), href: "#{feedback_path}?feedback-source=CANCELLED_REGISTRATION"
   end
 
   it 'the page is rendered with the correct links for LOA1 journey' do
@@ -28,11 +28,11 @@ RSpec.describe 'When user visits cancelled registration page' do
 
     visit('/cancelled-registration')
 
-    expect(page).to have_title I18n.t('hub.cancelled_registration.title')
+    expect(page).to have_title t('hub.cancelled_registration.title')
     expect(page).to have_link('Find out the other ways to register for an identity profile', href: other_ways_to_access_service_path)
-    expect(page).to have_link(I18n.t('hub.cancelled_registration.options.verify_with_another_company'), href: choose_a_certified_company_path)
-    expect(page).to have_link(I18n.t('hub.cancelled_registration.options.contact_verify'), href: "#{feedback_path}?feedback-source=CANCELLED_REGISTRATION")
+    expect(page).to have_link t('hub.cancelled_registration.options.verify_with_another_company'), href: choose_a_certified_company_path
+    expect(page).to have_link t('hub.cancelled_registration.options.contact_verify'), href: "#{feedback_path}?feedback-source=CANCELLED_REGISTRATION"
 
-    expect(page).to_not have_link(I18n.t('hub.cancelled_registration.options.verify_using_other_documents'), href: select_documents_path)
+    expect(page).to_not have_link t('hub.cancelled_registration.options.verify_using_other_documents'), href: select_documents_path
   end
 end

--- a/spec/features/user_visits_choose_a_certified_company_page_spec.rb
+++ b/spec/features/user_visits_choose_a_certified_company_page_spec.rb
@@ -1,6 +1,5 @@
 require 'feature_helper'
 require 'api_test_helper'
-require 'i18n'
 
 describe 'When the user visits the choose a certified company page' do
   before(:each) do
@@ -31,7 +30,7 @@ describe 'When the user visits the choose a certified company page' do
       visit '/choose-a-certified-company'
 
       expect(page).to have_current_path(choose_a_certified_company_path)
-      expect(page).to have_content('Based on your answers, 3 companies can verify you now:')
+      expect(page).to have_content t('hub.choose_a_certified_company.idp_count_html', company_count: '3 companies')
       within('#matching-idps') do
         expect(page).to have_button('Choose IDCorp')
       end
@@ -67,7 +66,7 @@ describe 'When the user visits the choose a certified company page' do
     it 'displays the page in Welsh' do
       visit '/dewis-cwmni-ardystiedig'
 
-      expect(page).to have_title 'Dewiswch gwmni ardystiedig - GOV.UK Verify - GOV.UK'
+      expect(page).to have_title t('hub.choose_a_certified_company.title', locale: :cy)
       expect(page).to have_css 'html[lang=cy]'
     end
   end
@@ -108,7 +107,7 @@ describe 'When the user visits the choose a certified company page' do
 
     expect(page).to have_current_path(choose_a_certified_company_path)
     expect(page).to_not have_css('#non-matching-idps')
-    expect(page).to have_content('Based on your answers, no companies can verify you now:')
+    expect(page).to have_content t('hub.choose_a_certified_company.idp_count_html', company_count: 'no companies')
   end
 
   it 'recommends some IDPs with a recommended profile, hides non-recommended profiles, and omits non-matching profiles' do
@@ -124,7 +123,7 @@ describe 'When the user visits the choose a certified company page' do
 
     visit '/choose-a-certified-company'
 
-    expect(page).to have_content('Based on your answers, 2 companies can verify you now:')
+    expect(page).to have_content t('hub.choose_a_certified_company.idp_count_html', company_count: '2 companies')
     within('#matching-idps') do
       expect(page).to have_button('Choose No Docs IDP')
       expect(page).to have_button('Choose IDCorp')

--- a/spec/features/user_visits_choose_a_country_page_spec.rb
+++ b/spec/features/user_visits_choose_a_country_page_spec.rb
@@ -1,6 +1,5 @@
 require 'feature_helper'
 require 'api_test_helper'
-require 'i18n'
 
 RSpec.describe 'When the user visits the choose a country page' do
   let(:originating_ip) { '<PRINCIPAL IP ADDRESS COULD NOT BE DETERMINED>' }
@@ -28,25 +27,25 @@ RSpec.describe 'When the user visits the choose a country page' do
   end
 
   def then_im_at_the_interstitial_page(locale = 'en')
-    expect(page).to have_current_path("/#{I18n.t('routes.redirect_to_country', locale: locale)}")
-    expect(page).to have_title('Redirect to country')
-    expect(page).to have_content('Continue to next step')
-    expect(page).to have_content('Because Javascript is not enabled on your browser, you must press the continue button')
+    expect(page).to have_current_path("/#{t('routes.redirect_to_country', locale: locale)}")
+    expect(page).to have_title t('hub.redirect_to_country.title')
+    expect(page).to have_content t('hub.redirect_to_country.heading')
+    expect(page).to have_content t('hub.redirect_to_country.description')
     expect(page).to have_css("input[id=SAMLRequest]", visible: false)
     expect(find("input[id=SAMLRequest]", visible: false).value).to_not be_empty
 
-    expect(page).to have_button('Continue')
+    expect(page).to have_button t('navigation.continue')
   end
 
   def when_i_choose_to_continue
-    click_button('Continue')
+    click_button t('navigation.continue')
   end
 
   it 'should show something went wrong when visiting choose a country page directly with session not supporting eidas' do
     given_a_session_not_supporting_eidas
 
     visit '/choose-a-country'
-    expect(page).to have_content 'Sorry, something went wrong'
+    expect(page).to have_content t('errors.something_went_wrong.heading')
   end
 
   it 'should have a heading' do

--- a/spec/features/user_visits_confirm_your_identity_page_spec.rb
+++ b/spec/features/user_visits_confirm_your_identity_page_spec.rb
@@ -31,13 +31,13 @@ RSpec.describe 'When the user visits the confirm-your-identity page' do
 
     it 'displays the page in Welsh' do
       visit '/cadarnhau-eich-hunaniaeth'
-      expect(page).to have_title 'Cadarnhau eich hunaniaeth - GOV.UK Verify - GOV.UK'
+      expect(page).to have_title t('hub.confirm_your_identity.title', locale: :cy)
       expect(page).to have_css 'html[lang=cy]'
     end
 
     it 'displays the page in English' do
       visit '/confirm-your-identity'
-      expect(page).to have_title 'Confirm your identity - GOV.UK Verify - GOV.UK'
+      expect(page).to have_title t('hub.confirm_your_identity.title')
       expect(page).to have_css 'html[lang=en]'
     end
 
@@ -48,13 +48,13 @@ RSpec.describe 'When the user visits the confirm-your-identity page' do
 
     it 'includes rp display name in text' do
       visit '/confirm-your-identity'
-      expect(page).to have_text 'In order to register for an identity profile'
+      expect(page).to have_text t('hub.confirm_your_identity.need_to_signin_again', transaction_name: 'register for an identity profile')
     end
 
     it 'should include a link to sign-in in case listed idp is incorrect' do
       stub_api_idp_list_for_sign_in
       visit '/confirm-your-identity'
-      expect(page).to have_link 'sign in with a different certified company', href: '/sign-in'
+      expect(page).to have_link t('hub.confirm_your_identity.sign_in_link_message'), href: '/sign-in'
     end
 
     it 'should display only the idp that the user last verified with' do
@@ -69,7 +69,7 @@ RSpec.describe 'When the user visits the confirm-your-identity page' do
         visit '/confirm-your-identity'
         click_button 'Sign in with IDCorp'
         expect(page).to have_current_path('/redirect-to-idp/sign-in')
-        click_button 'Continue'
+        click_button t('navigation.continue')
         expect(page).to have_current_path(idp_location)
       end
     end
@@ -95,13 +95,13 @@ RSpec.describe 'When the user visits the confirm-your-identity page' do
         new_idp_location = '/another-idp-endpoint'
         stub_api_and_analytics(new_idp_location)
         click_button 'Select Bob’s Identity Service'
-        click_button 'Continue'
+        click_button t('navigation.continue')
         expect(page).to have_current_path(new_idp_location)
 
         # The new IDP is displayed for non-repudiation
         visit '/confirm-your-identity'
         click_button 'Sign in with Bob’s Identity Service'
-        click_button 'Continue'
+        click_button t('navigation.continue')
         expect(page).to have_current_path(new_idp_location)
       end
     end
@@ -112,7 +112,7 @@ RSpec.describe 'When the user visits the confirm-your-identity page' do
       set_session_and_session_cookies!
       stub_api_idp_list_for_sign_in
       visit '/confirm-your-identity'
-      expect(page).to have_title 'Sign in with a certified company - GOV.UK Verify - GOV.UK'
+      expect(page).to have_title t('hub.signin.title')
       expect(page).to have_current_path(sign_in_path)
     end
 
@@ -120,7 +120,7 @@ RSpec.describe 'When the user visits the confirm-your-identity page' do
       set_session_and_session_cookies!
       stub_api_idp_list_for_sign_in
       visit '/confirm-your-identity'
-      expect(page).to have_title 'Sign in with a certified company - GOV.UK Verify - GOV.UK'
+      expect(page).to have_title t('hub.signin.title')
       expect(page).to have_current_path(sign_in_path)
     end
 
@@ -128,7 +128,7 @@ RSpec.describe 'When the user visits the confirm-your-identity page' do
       set_up_session('bad-entity-id')
       stub_api_idp_list_for_sign_in
       visit '/confirm-your-identity'
-      expect(page).to have_title 'Sign in with a certified company - GOV.UK Verify - GOV.UK'
+      expect(page).to have_title t('hub.signin.title')
       expect(page).to have_current_path(sign_in_path)
       expect(cookie_value(CookieNames::VERIFY_FRONT_JOURNEY_HINT)).to eql("") # rails deletes cookies by setting the value to an empty string
     end
@@ -146,7 +146,7 @@ RSpec.describe 'When the user visits the confirm-your-identity page' do
 
       visit '/test-saml'
       click_button 'saml-post-journey-hint'
-      expect(page).to have_title 'Cadarnhau eich hunaniaeth - GOV.UK Verify - GOV.UK'
+      expect(page).to have_title t('hub.confirm_your_identity.title', locale: :cy)
       expect(page).to have_current_path('/cadarnhau-eich-hunaniaeth')
       expect(page).to have_css 'html[lang=cy]'
     end
@@ -169,7 +169,7 @@ RSpec.describe 'When the user visits the confirm-your-identity page' do
       visit '/test-saml'
       click_button 'saml-post-journey-hint'
 
-      expect(page).to have_title 'Cadarnhau eich hunaniaeth - GOV.UK Verify - GOV.UK'
+      expect(page).to have_title t('hub.confirm_your_identity.title', locale: :cy)
       expect(page).to have_current_path('/cadarnhau-eich-hunaniaeth')
       expect(page).to have_css 'html[lang=cy]'
     end

--- a/spec/features/user_visits_confirmation_page_spec.rb
+++ b/spec/features/user_visits_confirmation_page_spec.rb
@@ -14,16 +14,16 @@ RSpec.describe 'When user visits the confirmation page' do
 
   it 'includes the appropriate feedback source, title and content' do
     visit '/confirmation'
-    expect(page).not_to have_link I18n.t('feedback_link.feedback_form')
-    expect(page).to have_link I18n.t('hub.feedback.title'), href: '/feedback?feedback-source=CONFIRMATION_PAGE'
-    expect(page).to have_title("#{I18n.t('hub.confirmation.title')} - GOV.UK Verify - GOV.UK")
-    expect(page).to have_text(I18n.t('hub.confirmation.message', display_name: 'IDCorp'))
-    expect(page).to have_text(I18n.t('hub.confirmation.continue_to_rp', transaction_name: 'register for an identity profile'))
+    expect(page).not_to have_link t('feedback_link.feedback_form')
+    expect(page).to have_link t('hub.feedback.title'), href: '/feedback?feedback-source=CONFIRMATION_PAGE'
+    expect(page).to have_title t('hub.confirmation.title')
+    expect(page).to have_text t('hub.confirmation.message', display_name: 'IDCorp')
+    expect(page).to have_text t('hub.confirmation.continue_to_rp', transaction_name: 'register for an identity profile')
   end
 
   it 'displays the IDP name' do
     visit '/confirmation'
-    expect(page).to have_text(I18n.t('hub.confirmation.heading', display_name: 'IDCorp'))
+    expect(page).to have_text t('hub.confirmation.heading', display_name: 'IDCorp')
   end
 
   it 'displays the page in Welsh' do
@@ -39,7 +39,7 @@ RSpec.describe 'When user visits the confirmation page' do
   it 'sends user to response-processing page when they click the link' do
     stub_matching_outcome
     visit '/confirmation'
-    click_link I18n.t('navigation.continue')
+    click_link t('navigation.continue')
     expect(page).to have_current_path(response_processing_path)
   end
 
@@ -47,13 +47,13 @@ RSpec.describe 'When user visits the confirmation page' do
     stub_transactions_list
     set_loa_in_session('LEVEL_1')
     visit '/confirmation'
-    expect(page).to have_text(I18n.t('hub.confirmation.extra_security'))
+    expect(page).to have_text t('hub.confirmation.extra_security')
   end
 
   it 'does not display government services requiring extra security when LOA is level two' do
     stub_transactions_list
     set_loa_in_session('LEVEL_2')
     visit '/confirmation'
-    expect(page).not_to have_text(I18n.t('hub.confirmation.extra_security'))
+    expect(page).not_to have_text t('hub.confirmation.extra_security')
   end
 end

--- a/spec/features/user_visits_failed_registration_page_spec.rb
+++ b/spec/features/user_visits_failed_registration_page_spec.rb
@@ -23,9 +23,9 @@ RSpec.describe 'When the user visits the failed registration page and' do
       visit '/failed-registration'
 
       expect_page_to_have_main_content
-      expect(page).to have_content I18n.t('hub.failed_registration.continue_text', rp_name: 'Test RP')
-      expect(page).to have_link(I18n.t('navigation.continue'), href: redirect_to_service_error_path)
-      expect(page).to have_link(I18n.t('hub.failed_registration.try_another_company'), href: select_documents_path)
+      expect(page).to have_content t('hub.failed_registration.continue_text', rp_name: 'Test RP')
+      expect(page).to have_link t('navigation.continue'), href: redirect_to_service_error_path
+      expect(page).to have_link t('hub.failed_registration.try_another_company'), href: select_documents_path
     end
 
     it 'includes expected content for LOA1 journey' do
@@ -33,9 +33,9 @@ RSpec.describe 'When the user visits the failed registration page and' do
       visit '/failed-registration'
 
       expect_page_to_have_main_content
-      expect(page).to have_content I18n.t('hub.failed_registration.continue_text', rp_name: 'Test RP')
-      expect(page).to have_link(I18n.t('navigation.continue'), href: redirect_to_service_error_path)
-      expect(page).to have_link(I18n.t('hub.failed_registration.try_another_company'), href: choose_a_certified_company_path)
+      expect(page).to have_content t('hub.failed_registration.continue_text', rp_name: 'Test RP')
+      expect(page).to have_link t('navigation.continue'), href: redirect_to_service_error_path
+      expect(page).to have_link t('hub.failed_registration.try_another_company'), href: choose_a_certified_company_path
     end
   end
 
@@ -49,9 +49,9 @@ RSpec.describe 'When the user visits the failed registration page and' do
       visit '/failed-registration'
 
       expect_page_to_have_main_content
-      expect(page).to have_content I18n.t('hub.failed_registration.other_ways_summary',
+      expect(page).to have_content t('hub.failed_registration.other_ways_summary',
                                           other_ways_description: 'register for an identity profile')
-      expect(page).to have_link(I18n.t('hub.failed_registration.start_again'), href: select_documents_path)
+      expect(page).to have_link t('hub.failed_registration.start_again'), href: select_documents_path
     end
 
     it 'includes expected content when LOA1 journey' do
@@ -59,16 +59,16 @@ RSpec.describe 'When the user visits the failed registration page and' do
       visit '/failed-registration'
 
       expect_page_to_have_main_content
-      expect(page).to have_content I18n.t('hub.failed_registration.other_ways_summary',
+      expect(page).to have_content t('hub.failed_registration.other_ways_summary',
                                           other_ways_description: 'register for an identity profile')
-      expect(page).to have_link(I18n.t('hub.failed_registration.start_again'), href: choose_a_certified_company_path)
+      expect(page).to have_link t('hub.failed_registration.start_again'), href: choose_a_certified_company_path
     end
   end
 
   def expect_page_to_have_main_content
     expect_feedback_source_to_be(page, 'FAILED_REGISTRATION_PAGE', '/failed-registration')
-    expect(page).to have_title("#{I18n.t('hub.failed_registration.title')} - GOV.UK Verify - GOV.UK")
-    expect(page).to have_content I18n.t('hub.failed_registration.heading', idp_name: 'IDCorp')
-    expect(page).to have_content I18n.t('hub.failed_registration.contact_details_intro', idp_name: 'IDCorp')
+    expect(page).to have_title t('hub.failed_registration.title')
+    expect(page).to have_content t('hub.failed_registration.heading', idp_name: 'IDCorp')
+    expect(page).to have_content t('hub.failed_registration.contact_details_intro', idp_name: 'IDCorp')
   end
 end

--- a/spec/features/user_visits_failed_sign_in_page_spec.rb
+++ b/spec/features/user_visits_failed_sign_in_page_spec.rb
@@ -14,10 +14,10 @@ RSpec.describe 'When the user visits the failed sign in page' do
     visit '/failed-sign-in'
 
     expect_feedback_source_to_be(page, 'FAILED_SIGN_IN_PAGE', '/failed-sign-in')
-    expect(page).to have_title("#{I18n.t('hub.failed_sign_in.title')} - GOV.UK Verify - GOV.UK")
-    expect(page).to have_content I18n.t('hub.failed_sign_in.heading', display_name: 'IDCorp')
-    expect(page).to have_content 'You may have selected the wrong company. Check your emails and text messages for confirmation of who verified you.'
-    expect(page).to have_link(I18n.t('hub.failed_sign_in.start_again'), href: start_path)
+    expect(page).to have_title t('hub.failed_sign_in.title')
+    expect(page).to have_content t('hub.failed_sign_in.heading', display_name: 'IDCorp')
+    expect(page.body).to include t('hub.failed_sign_in.reasons_html')
+    expect(page).to have_link t('hub.failed_sign_in.start_again'), href: start_path
   end
 
   it 'displays the content in Welsh' do

--- a/spec/features/user_visits_feedback_page_spec.rb
+++ b/spec/features/user_visits_feedback_page_spec.rb
@@ -1,75 +1,77 @@
 require 'feature_helper'
 
 RSpec.feature 'When the user visits the feedback page' do
+  let(:what_text_field) { 'Using verify' }
+  let(:details_text_field) { 'Some details' }
   let(:long_text_limit) { FeedbackForm::LONG_TEXT_LIMIT }
 
   it 'should link back to the product page when user came from the product page' do
     visit '/feedback?feedback-source=PRODUCT_PAGE'
 
-    fill_in 'feedback_form_what', with: 'Verify my identity'
-    fill_in 'feedback_form_details', with: 'Some details'
+    fill_in 'feedback_form_what', with: what_text_field
+    fill_in 'feedback_form_details', with: details_text_field
     choose 'feedback_form_reply_false', allow_label_click: true
 
-    click_button I18n.t('hub.feedback.send_message')
+    click_button t('hub.feedback.send_message')
 
-    expect(page).to have_title(I18n.t('hub.feedback_sent.title'))
+    expect(page).to have_title t('hub.feedback_sent.title')
 
-    expect(page).to have_link 'Return to the GOV.UK Verify product page', href: 'https://govuk-verify.cloudapps.digital/'
+    expect(page).to have_link t('hub.feedback_sent.product_page'), href: 'https://govuk-verify.cloudapps.digital/'
   end
 
   it 'should display and something went wrong if the feedback source is not valid' do
     visit '/feedback?feedback-source=something_not_valid'
 
-    expect(page).to have_content('This page can’t be found')
+    expect(page).to have_content t('errors.page_not_found.heading')
   end
 
   it 'should show errors for all input fields when missing input', js: true do
     visit feedback_path
-    expect(page).to have_title(I18n.t('hub.feedback.title'))
+    expect(page).to have_title t('hub.feedback.title')
 
-    click_button I18n.t('hub.feedback.send_message')
+    click_button t('hub.feedback.send_message')
 
     expect(page).to have_css('.form-group.form-group-error', count: 3)
-    expect(page).to have_css('.error-message', text: I18n.t('hub.feedback.errors.reply'))
-    expect(page).to have_css('.error-message', text: I18n.t('hub.feedback.errors.details'), count: 2)
+    expect(page).to have_css('.error-message', text: t('hub.feedback.errors.reply'))
+    expect(page).to have_css('.error-message', text: t('hub.feedback.errors.details'), count: 2)
 
     choose 'feedback_form_reply_true', allow_label_click: true
-    click_button I18n.t('hub.feedback.send_message')
+    click_button t('hub.feedback.send_message')
 
-    expect(page).to_not have_css('.error-message', text: I18n.t('hub.feedback.errors.reply'))
+    expect(page).to_not have_css('.error-message', text: t('hub.feedback.errors.reply'))
     expect(page).to have_css('.form-group.form-group-error', count: 4)
-    expect(page).to have_css('.error-message', text: I18n.t('hub.feedback.errors.name'))
-    expect(page).to have_css('.error-message', text: I18n.t('hub.feedback.errors.email'))
+    expect(page).to have_css('.error-message', text: t('hub.feedback.errors.name'))
+    expect(page).to have_css('.error-message', text: t('hub.feedback.errors.email'))
   end
 
   it 'should show errors for email address when not valid', js: true do
     visit feedback_path
-    expect(page).to have_title(I18n.t('hub.feedback.title'))
+    expect(page).to have_title t('hub.feedback.title')
 
     choose 'feedback_form_reply_true', allow_label_click: true
     fill_in 'feedback_form_email', with: 'foo@bar'
-    click_button I18n.t('hub.feedback.send_message')
+    click_button t('hub.feedback.send_message')
 
-    expect(page).to have_css('.error-message', text: I18n.t('hub.feedback.errors.email'))
+    expect(page).to have_css('.error-message', text: t('hub.feedback.errors.email'))
 
     fill_in 'feedback_form_email', with: 'foo@bar.com'
-    click_button I18n.t('hub.feedback.send_message')
+    click_button t('hub.feedback.send_message')
 
-    expect(page).to_not have_css('.error-message', text: I18n.t('hub.feedback.errors.email'))
+    expect(page).to_not have_css('.error-message', text: t('hub.feedback.errors.email'))
   end
 
   it 'should show errors for all input fields when missing input and user wants a reply' do
     visit feedback_path
-    expect(page).to have_title(I18n.t('hub.feedback.title'))
+    expect(page).to have_title t('hub.feedback.title')
 
     choose 'feedback_form_reply_true', allow_label_click: true
-    click_button I18n.t('hub.feedback.send_message')
+    click_button t('hub.feedback.send_message')
 
     expect(page).to have_css('.form-group.form-group-error', count: 4)
-    expect(page).to have_css('.validation-message', text: I18n.t('hub.feedback.errors.no_selection'))
-    expect(page).to have_css('.error-message', text: I18n.t('hub.feedback.errors.name'))
-    expect(page).to have_css('.error-message', text: I18n.t('hub.feedback.errors.email'))
-    expect(page).to have_css('.error-message', text: I18n.t('hub.feedback.errors.details'), count: 2)
+    expect(page).to have_css('.validation-message', text: t('hub.feedback.errors.no_selection'))
+    expect(page).to have_css('.error-message', text: t('hub.feedback.errors.name'))
+    expect(page).to have_css('.error-message', text: t('hub.feedback.errors.email'))
+    expect(page).to have_css('.error-message', text: t('hub.feedback.errors.details'), count: 2)
   end
 
   it 'should show errors when input fields values too long' do
@@ -79,74 +81,71 @@ RSpec.feature 'When the user visits the feedback page' do
     fill_in 'feedback_form_details', with: 'A' * (long_text_limit + 1)
     choose 'feedback_form_reply_false', allow_label_click: true
 
-    click_button I18n.t('hub.feedback.send_message')
+    click_button t('hub.feedback.send_message')
 
     expect(page).to have_css('.form-group.form-group-error', count: 2)
-    expect(page).to have_css('.error-message', text: I18n.t('hub.feedback.errors.too_long', max_length: long_text_limit), count: 2)
+    expect(page).to have_css('.error-message', text: t('hub.feedback.errors.too_long', max_length: long_text_limit), count: 2)
   end
 
   it 'should not show errors for name and email when missing input and user does not want a reply' do
     visit feedback_path
-    expect(page).to have_title(I18n.t('hub.feedback.title'))
+    expect(page).to have_title t('hub.feedback.title')
 
     choose 'feedback_form_reply_false', allow_label_click: true
-    click_button I18n.t('hub.feedback.send_message')
+    click_button t('hub.feedback.send_message')
 
     expect(page).to have_css('.form-group.form-group-error', count: 2)
-    expect(page).to have_css('.validation-message', text: I18n.t('hub.feedback.errors.no_selection'))
-    expect(page).to_not have_css('.error-message', text: I18n.t('hub.feedback.errors.name'))
-    expect(page).to_not have_css('.error-message', text: I18n.t('hub.feedback.errors.email'))
+    expect(page).to have_css('.validation-message', text: t('hub.feedback.errors.no_selection'))
+    expect(page).to_not have_css('.error-message', text: t('hub.feedback.errors.name'))
+    expect(page).to_not have_css('.error-message', text: t('hub.feedback.errors.email'))
   end
 
   it 'should not show errors for reply when it is not selected' do
     visit feedback_path
-    expect(page).to have_title(I18n.t('hub.feedback.title'))
+    expect(page).to have_title t('hub.feedback.title')
 
-    click_button I18n.t('hub.feedback.send_message')
+    click_button t('hub.feedback.send_message')
 
     expect(page).to have_css('.form-group.form-group-error', count: 3)
-    expect(page).to have_css('.error-message', text: I18n.t('hub.feedback.errors.reply'))
-    expect(page).to have_css('.validation-message', text: I18n.t('hub.feedback.errors.no_selection'))
+    expect(page).to have_css('.error-message', text: t('hub.feedback.errors.reply'))
+    expect(page).to have_css('.validation-message', text: t('hub.feedback.errors.no_selection'))
   end
 
   it 'should report on the what box character limit', js: true do
     visit feedback_path
 
-    what = 'verify my identity'
-    character_count_message_suffix = I18n.t('hub.feedback.character_count_message', limit_message: I18n.t('hub.feedback.character_limit_message'))
-    expect(page).to have_content(I18n.t('hub.feedback.character_limit_message'))
-    expect(page).to_not have_content(character_count_message_suffix)
-    fill_in 'feedback_form_what', with: what
+    character_count_message_suffix = t('hub.feedback.character_count_message', limit_message: t('hub.feedback.character_limit_message'))
+    expect(page).to have_content t('hub.feedback.character_limit_message')
+    expect(page).to_not have_content character_count_message_suffix
+    fill_in 'feedback_form_what', with: what_text_field
     page.execute_script('$("#feedback_form_what").triggerHandler("txtinput")')
-    expect(page).to have_content("#{long_text_limit - what.size}#{character_count_message_suffix}")
+    expect(page).to have_content("#{long_text_limit - what_text_field.size}#{character_count_message_suffix}")
   end
 
   it 'should report on the details box character limit', js: true do
     visit feedback_path
 
-    details = 'here are some details'
-
-    character_count_message_suffix = I18n.t('hub.feedback.character_count_message', limit_message: I18n.t('hub.feedback.character_limit_message'))
-    expect(page).to have_content(I18n.t('hub.feedback.character_limit_message'))
-    expect(page).to_not have_content(character_count_message_suffix)
-    fill_in 'feedback_form_details', with: details
+    character_count_message_suffix = t('hub.feedback.character_count_message', limit_message: t('hub.feedback.character_limit_message'))
+    expect(page).to have_content t('hub.feedback.character_limit_message')
+    expect(page).to_not have_content character_count_message_suffix
+    fill_in 'feedback_form_details', with: details_text_field
     page.execute_script('$("#feedback_form_details").triggerHandler("txtinput")')
-    expect(page).to have_content("#{long_text_limit - details.size}#{character_count_message_suffix}")
+    expect(page).to have_content("#{long_text_limit - details_text_field.size}#{character_count_message_suffix}")
   end
 
   it 'should not go to feedback sent page when a error with zendesk occurs' do
     visit feedback_path
 
     fill_in 'feedback_form_what', with: 'break_zendesk'
-    fill_in 'feedback_form_details', with: 'Some details'
+    fill_in 'feedback_form_details', with: details_text_field
     choose 'feedback_form_reply_false', allow_label_click: true
     fill_in 'feedback_form_name', with: 'Bob Smith'
     fill_in 'feedback_form_email', with: 'bob@smith.com'
 
-    click_button I18n.t('hub.feedback.send_message')
+    click_button t('hub.feedback.send_message')
     expect(page).to have_current_path(feedback_path)
-    expect(page).to have_content(I18n.t('hub.feedback.errors.heading'))
-    expect(page).to have_content(I18n.t('hub.feedback.errors.send_failure'))
+    expect(page).to have_content t('hub.feedback.errors.heading')
+    expect(page).to have_content t('hub.feedback.errors.send_failure')
   end
 
   it 'should contain js_disabled value on page' do
@@ -160,13 +159,13 @@ RSpec.feature 'When the user visits the feedback page' do
     page.driver.browser.header('User-Agent', user_agent)
     set_session_and_session_cookies!
     visit start_path
-    click_on I18n.t('feedback_link.feedback_form')
+    click_on t('feedback_link.feedback_form')
 
-    fill_in 'feedback_form_what', with: 'Verify my identity'
-    fill_in 'feedback_form_details', with: 'Some details'
+    fill_in 'feedback_form_what', with: what_text_field
+    fill_in 'feedback_form_details', with: details_text_field
     choose 'feedback_form_reply_false', allow_label_click: true
 
-    click_button I18n.t('hub.feedback.send_message')
+    click_button t('hub.feedback.send_message')
 
     expect(DUMMY_ZENDESK_CLIENT.tickets.last.comment).to include 'From page: http://www.example.com/start'
     expect(DUMMY_ZENDESK_CLIENT.tickets.last.comment).to include "User agent: #{user_agent}"
@@ -176,24 +175,24 @@ RSpec.feature 'When the user visits the feedback page' do
   it 'should keep the referer if form submission fails validation' do
     set_session_and_session_cookies!
     visit start_path
-    click_on I18n.t('feedback_link.feedback_form')
+    click_on t('feedback_link.feedback_form')
 
-    fill_in 'feedback_form_what', with: 'Verify my identity'
-    fill_in 'feedback_form_details', with: 'Some details'
+    fill_in 'feedback_form_what', with: what_text_field
+    fill_in 'feedback_form_details', with: details_text_field
     choose 'feedback_form_reply_true', allow_label_click: true
 
-    click_button I18n.t('hub.feedback.send_message')
+    click_button t('hub.feedback.send_message')
 
     choose 'feedback_form_reply_false', allow_label_click: true
 
-    click_button I18n.t('hub.feedback.send_message')
+    click_button t('hub.feedback.send_message')
 
     expect(DUMMY_ZENDESK_CLIENT.tickets.last.comment).to include 'From page: http://www.example.com/start'
   end
 
   it 'should also be in welsh' do
     visit feedback_cy_path
-    expect(page).to have_title I18n.t('hub.feedback.title', locale: :cy)
+    expect(page).to have_title t('hub.feedback.title', locale: :cy)
     expect(page).to have_css 'html[lang=cy]'
   end
 end

--- a/spec/features/user_visits_forgot_company_page_spec.rb
+++ b/spec/features/user_visits_forgot_company_page_spec.rb
@@ -12,13 +12,13 @@ RSpec.describe 'When the user visits the forgot company page' do
 
     expect_feedback_source_to_be(page, 'FORGOT_COMPANY_PAGE', '/forgot-company')
     expect(page).to have_content 'We can’t tell you which company verified you'
-    expect(page).to have_link(I18n.t('navigation.back'))
+    expect(page).to have_link t('navigation.back')
   end
 
   it 'takes us back to the sign-in page when the Back link is clicked' do
     stub_api_idp_list_for_sign_in
     visit '/forgot-company'
-    click_link I18n.t('navigation.back')
+    click_link t('navigation.back')
 
     expect(page).to have_current_path('/sign-in')
   end

--- a/spec/features/user_visits_further_information_page_spec.rb
+++ b/spec/features/user_visits_further_information_page_spec.rb
@@ -6,14 +6,14 @@ RSpec.describe 'user visits further information page' do
   before(:each) do
     set_session_and_session_cookies!
   end
-  attribute_field_name = I18n.t('cycle3.NationalInsuranceNumber.field_name')
-  attribute_name = I18n.t('cycle3.NationalInsuranceNumber.name')
+  let(:attribute_field_name) { t('cycle3.NationalInsuranceNumber.field_name') }
+  let(:attribute_name) { t('cycle3.NationalInsuranceNumber.name') }
 
 
   it 'should also be in welsh' do
     stub_cycle_three_attribute_request('NationalInsuranceNumber')
     visit further_information_cy_path
-    expect(page).to have_title I18n.t('hub.further_information.title', cycle_three_name: attribute_field_name, locale: :cy)
+    expect(page).to have_title t('hub.further_information.title', cycle_three_name: attribute_field_name, locale: :cy)
     expect(page).to have_css 'html[lang=cy]'
   end
 
@@ -22,14 +22,14 @@ RSpec.describe 'user visits further information page' do
 
     visit further_information_path
 
-    rp_name = I18n.t('rps.test-rp.name').capitalize
+    rp_name = t('rps.test-rp.name').capitalize
 
-    expect(page).to have_title I18n.t('hub.further_information.title', cycle_three_name: attribute_field_name)
+    expect(page).to have_title t('hub.further_information.title', cycle_three_name: attribute_field_name)
     expect(page).to have_css '.form-label-bold', text: attribute_field_name
-    expect(page).to have_css 'span.form-hint', text: I18n.t('hub.further_information.example_text', example: I18n.t('cycle3.NationalInsuranceNumber.example'))
-    expect(page).to have_content I18n.t('hub.further_information.help_with_your', cycle_three_name: attribute_name)
+    expect(page).to have_css 'span.form-hint', text: t('hub.further_information.example_text', example: t('cycle3.NationalInsuranceNumber.example'))
+    expect(page).to have_content t('hub.further_information.help_with_your', cycle_three_name: attribute_name)
     expect(page).to have_content 'Your National Insurance number can be found on'
-    expect(page).to have_content I18n.t('hub.further_information.cancel', transaction_name: rp_name)
+    expect(page).to have_content t('hub.further_information.cancel', transaction_name: rp_name)
     expect_feedback_source_to_be(page, 'CYCLE_3_PAGE', further_information_path)
   end
 
@@ -43,7 +43,7 @@ RSpec.describe 'user visits further information page' do
     visit further_information_path
 
     fill_in 'cycle_three_attribute_cycle_three_data', with: 'MORGA657054SM9IJ 20'
-    click_button I18n.t('navigation.continue')
+    click_button t('navigation.continue')
 
     expect(page.current_path).to eql(response_processing_path)
     expect(stub_request).to have_been_made
@@ -58,8 +58,8 @@ RSpec.describe 'user visits further information page' do
 
     visit further_information_path
 
-    rp_name = I18n.t('rps.test-rp.name').capitalize
-    click_button I18n.t('hub.further_information.cancel', transaction_name: rp_name)
+    rp_name = t('rps.test-rp.name').capitalize
+    click_button t('hub.further_information.cancel', transaction_name: rp_name)
 
     expect(page.current_path).to eql(redirect_to_service_start_again_path)
     expect(piwik_request).to have_been_made
@@ -73,8 +73,8 @@ RSpec.describe 'user visits further information page' do
     stub_matching_outcome
 
     visit further_information_path
-    click_button I18n.t('hub.further_information.null_attribute',
-                        cycle_three_name: I18n.t('cycle3.NullableAttribute.name'))
+    click_button t('hub.further_information.null_attribute',
+                        cycle_three_name: t('cycle3.NullableAttribute.name'))
 
     expect(page.current_path).to eql(response_processing_path)
     expect(stub_request).to have_been_made
@@ -92,9 +92,9 @@ RSpec.describe 'user visits further information page' do
 
     visit further_information_path
 
-    click_button I18n.t('hub.further_information.null_attribute',
-                        cycle_three_name: I18n.t('cycle3.NullableAttribute.name'))
-    expect(page).to have_content('Sorry, something went wrong')
+    click_button t('hub.further_information.null_attribute',
+                        cycle_three_name: t('cycle3.NullableAttribute.name'))
+    expect(page).to have_content t('errors.something_went_wrong.heading')
     expect(matching_attribute_request).to have_been_made.twice
   end
 
@@ -108,12 +108,12 @@ RSpec.describe 'user visits further information page' do
 
       invalid_input = 'not valid'
       fill_in 'cycle_three_attribute_cycle_three_data', with: invalid_input
-      click_button I18n.t('navigation.continue')
+      click_button t('navigation.continue')
 
       expect(page.current_path).to eql(further_information_path)
       expect(page).to have_css(
         '.error-message',
-        text: I18n.t('hub.further_information.attribute_validation_message', cycle_three_name: attribute_name)
+        text: t('hub.further_information.attribute_validation_message', cycle_three_name: attribute_name)
       )
       expect(page.find('#cycle_three_attribute_cycle_three_data').value).to eql invalid_input
     end
@@ -130,10 +130,10 @@ RSpec.describe 'user visits further information page' do
       invalid_input = 'not valid'
       fill_in 'cycle_three_attribute_cycle_three_data', with: invalid_input
 
-      click_button I18n.t('navigation.continue')
+      click_button t('navigation.continue')
 
       expect(page).to have_current_path(further_information_path)
-      expect(page).to have_css '.error-message', text: I18n.t('hub.further_information.attribute_validation_message', cycle_three_name: attribute_name)
+      expect(page).to have_css '.error-message', text: t('hub.further_information.attribute_validation_message', cycle_three_name: attribute_name)
       expect(page.find('#cycle_three_attribute_cycle_three_data').value).to eql invalid_input
     end
   end

--- a/spec/features/user_visits_other_identity_documents_page_spec.rb
+++ b/spec/features/user_visits_other_identity_documents_page_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature 'When users visits other documents page' do
   it 'redirects user to proof of address page if selects yes' do
     visit '/other-identity-documents'
     choose 'other_identity_documents_form_non_uk_id_document_true', allow_label_click: true
-    click_button 'Continue'
+    click_button t('navigation.continue')
 
     expect(page).to have_current_path(select_phone_path, only_path: true)
   end
@@ -17,7 +17,7 @@ RSpec.feature 'When users visits other documents page' do
   it 'redirects user to proof of address page if selects no' do
     visit '/other-identity-documents'
     choose 'other_identity_documents_form_non_uk_id_document_false', allow_label_click: true
-    click_button 'Continue'
+    click_button t('navigation.continue')
 
     expect(page).to have_current_path(select_phone_path, only_path: true)
   end

--- a/spec/features/user_visits_other_ways_to_access_page_spec.rb
+++ b/spec/features/user_visits_other_ways_to_access_page_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe 'When the user visits the other ways to access page' do
   it 'includes expected content' do
     visit '/other-ways-to-access-service'
 
-    expect(page).to have_title 'Other ways to access the service - GOV.UK Verify - GOV.UK'
-    expect(page).to have_content 'Other ways to register for an identity profile'
-    expect(page).to have_content 'If you can’t verify your identity using GOV.UK Verify, you can register for an identity profile'
+    expect(page).to have_title t('hub.other_ways_title')
+    expect(page).to have_content t('hub.other_ways_heading', other_ways_description: t('rps.test-rp.name'))
+    expect(page.body).to include t('rps.test-rp.other_ways_text')
     expect(page).to have_link 'here', href: 'http://www.example.com'
     expect_feedback_source_to_be(page, 'OTHER_WAYS_PAGE', '/other-ways-to-access-service')
   end
@@ -19,8 +19,9 @@ RSpec.describe 'When the user visits the other ways to access page' do
   it 'includes expected content in welsh' do
     visit "/ffyrdd-eraill-i-gael-mynediad-i'r-gwasanaeth"
 
-    expect(page).to have_title 'Ffyrdd eraill i gael mynediad i’r gwasanaeth - GOV.UK Verify - GOV.UK'
-    expect(page).to have_content 'Ffyrdd eraill i register for an identity profile'
-    expect(page).to have_content 'If you can’t verify your identity using GOV.UK Verify, you can register for an identity profile'
+    expect(page).to have_title t('hub.other_ways_title', locale: :cy)
+    expect(page).to have_content t('hub.other_ways_heading', locale: :cy, other_ways_description: t('rps.test-rp.name'))
+
+    expect(page.body).to include t('rps.test-rp.other_ways_text')
   end
 end

--- a/spec/features/user_visits_privacy_notice_page_spec.rb
+++ b/spec/features/user_visits_privacy_notice_page_spec.rb
@@ -3,7 +3,7 @@ require 'feature_helper'
 RSpec.describe 'When the user visits the privacy notice page' do
   it 'displays the page in English' do
     visit '/privacy-notice'
-    expect(page).to have_title 'Privacy notice - GOV.UK Verify - GOV.UK'
+    expect(page).to have_title t('hub.privacy_notice.title')
     expect(page).to have_link 'Summary', href: '#summary'
     expect(page).to have_content 'GOV.UK Verify is provided by the Government Digital Service (GDS). We use your personal data to help you to transact securely with government services.'
     expect(page).to have_link 'Privacy policies of certified companies and government departments', href: '#privacy-policies-of-certified-companies-and-government-departments'
@@ -12,7 +12,7 @@ RSpec.describe 'When the user visits the privacy notice page' do
 
   it 'displays the page in Welsh' do
     visit '/hysbysiad-preifatrwydd'
-    expect(page).to have_title("Hysbysiad preifatrwydd - GOV.UK Verify - GOV.UK")
+    expect(page).to have_title t('hub.privacy_notice.title', locale: :cy)
   end
 
   it 'includes the appropriate feedback source' do

--- a/spec/features/user_visits_redirect_to_country_spec.rb
+++ b/spec/features/user_visits_redirect_to_country_spec.rb
@@ -1,6 +1,5 @@
 require 'feature_helper'
 require 'api_test_helper'
-require 'i18n'
 
 RSpec.describe 'When the user visits the redirect to country page' do
   before(:each) do
@@ -28,7 +27,7 @@ RSpec.describe 'When the user visits the redirect to country page' do
 
     visit '/redirect-to-country'
 
-    expect(page).to have_content 'Sorry, something went wrong'
+    expect(page).to have_content t('errors.something_went_wrong.heading')
   end
 
   it 'should show something went wrong when visiting redirect to country directly without choosing a country' do
@@ -38,6 +37,6 @@ RSpec.describe 'When the user visits the redirect to country page' do
 
     visit '/redirect-to-country'
 
-    expect(page).to have_content 'Sorry, something went wrong'
+    expect(page).to have_content t('errors.something_went_wrong.heading')
   end
 end

--- a/spec/features/user_visits_redirect_to_idp_page_spec.rb
+++ b/spec/features/user_visits_redirect_to_idp_page_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe 'When the user visits the redirect to IDP page' do
   it 'should contain welsh language hint' do
     given_a_session_with_a_hints_enabled_idp
     stub_session_idp_authn_request(originating_ip, location, true)
-    visit "/#{I18n.t('routes.redirect_to_idp_register', locale: 'cy')}"
+    visit "/#{t('routes.redirect_to_idp_register', locale: 'cy')}"
     expect(page).to have_css('input[name="language"][value="cy"]', visible: false)
   end
 
@@ -66,6 +66,6 @@ RSpec.describe 'When the user visits the redirect to IDP page' do
     given_a_session_with_a_hints_enabled_idp
     stub_session_idp_authn_request(originating_ip, location, false)
     visit redirect_to_idp_register_path
-    expect(page).to_not have_title('hub.redirect_to_idp.title')
+    expect(page).to have_title t('hub.redirect_to_idp.title')
   end
 end

--- a/spec/features/user_visits_redirect_to_idp_question_page_spec.rb
+++ b/spec/features/user_visits_redirect_to_idp_question_page_spec.rb
@@ -1,7 +1,6 @@
 require 'feature_helper'
 require 'api_test_helper'
 require 'piwik_test_helper'
-require 'i18n'
 
 RSpec.describe 'When the user visits the redirect to IDP question page' do
   let(:selected_answers) {
@@ -27,23 +26,23 @@ RSpec.describe 'When the user visits the redirect to IDP question page' do
   end
 
   it 'displays interstitial question' do
-    expect(page).to have_content('I have a question for you in English')
+    expect(page.body).to include t('idps.stub-idp-one-doc-question.interstitial_question')
   end
 
   it 'displays document warning text on LOA2' do
-    expect(page).to have_content('You need your identity documents with you')
+    expect(page).to have_content t('hub.redirect_to_idp_question.identity_documents')
   end
 
   it 'does not display document warning text on LOA1' do
     set_loa_in_session('LEVEL_1')
     visit '/redirect-to-idp-question'
-    expect(page).to_not have_content('You need your identity documents with you')
+    expect(page).to_not have_content t('hub.redirect_to_idp_question.identity_documents')
   end
 
   it 'displays interstitial question in Welsh' do
     visit '/ailgyfeirio-i-gwestiwn-idp'
 
-    expect(page).to have_content('I have a question for you in Welsh')
+    expect(page.body).to include t('idps.stub-idp-one-doc-question.interstitial_question', locale: :cy)
     expect(page).to have_css 'html[lang=cy]'
   end
 
@@ -54,7 +53,7 @@ RSpec.describe 'When the user visits the redirect to IDP question page' do
 
     expected_answers = selected_answers.update('interstitial' => { 'interstitial_yes' => true })
 
-    click_button 'Continue'
+    click_button t('navigation.continue')
 
     expect(page).to have_current_path(redirect_to_idp_warning_path)
     expect(page.get_rack_session['selected_answers']).to eql(expected_answers)
@@ -62,28 +61,28 @@ RSpec.describe 'When the user visits the redirect to IDP question page' do
 
   it 'goes to "idp-wont-work-for-you" page if the user answers no to the interstitial question and javascript is enabled', js: true do
     choose 'interstitial_question_form_interstitial_question_result_false', allow_label_click: true
-    click_button 'Continue'
-    expect(page).to have_title('OneDocIdp cannot verify your identity')
+    click_button t('navigation.continue')
+    expect(page).to have_title t('hub.idp_wont_work_for_you_one_doc.title', idp_name: t('idps.stub-idp-one-doc-question.name'))
   end
 
   it 'displays an error message when user does not answer the question when javascript is turned off' do
-    click_button 'Continue'
+    click_button t('navigation.continue')
 
     expect(page).to have_current_path(redirect_to_idp_question_submit_path)
-    expect(page).to have_content('Please answer the question')
+    expect(page).to have_content t('hub.redirect_to_idp_question.validation_message')
   end
 
   context 'when the form is invalid', js: true do
     it 'should display validation message if no selection is made' do
-      click_button 'Continue'
-      expect(page).to have_content('Please answer the question')
+      click_button t('navigation.continue')
+      expect(page).to have_content t('hub.redirect_to_idp_question.validation_message')
     end
 
     it 'should remove validation message once selection is made' do
-      click_button 'Continue'
-      expect(page).to have_content('Please answer the question')
+      click_button t('navigation.continue')
+      expect(page).to have_content t('hub.redirect_to_idp_question.validation_message')
       choose 'interstitial_question_form_interstitial_question_result_false', allow_label_click: true
-      expect(page).to_not have_content('Please answer the question')
+      expect(page).to_not have_content t('hub.redirect_to_idp_question.validation_message')
     end
   end
 end

--- a/spec/features/user_visits_redirect_to_idp_warning_page_spec.rb
+++ b/spec/features/user_visits_redirect_to_idp_warning_page_spec.rb
@@ -175,7 +175,7 @@ RSpec.describe 'When the user visits the redirect to IDP warning page' do
       stub_session_idp_authn_request(originating_ip, location, true)
       expect_any_instance_of(RedirectToIdpWarningController).to receive(:continue_ajax).and_call_original
 
-      click_button t('hub.redirect_to_idp_warning.continue_website', display_name: 'Bob’s Identity Service')
+      click_button t('hub.redirect_to_idp_warning.continue_website', display_name: t('idps.stub-idp-two.name'))
       expect(page).to have_current_path(location)
       expect(page).to have_content("hints are ''")
       expect(page).to have_content("language hint was ''")

--- a/spec/features/user_visits_redirect_to_idp_warning_page_spec.rb
+++ b/spec/features/user_visits_redirect_to_idp_warning_page_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe 'When the user visits the redirect to IDP warning page' do
     given_a_session_with_document_answers
     visit '/redirect-to-idp-warning'
 
-    expect(page).to have_title "You'll now be redirected - GOV.UK Verify - GOV.UK"
+    expect(page).to have_title t('hub.redirect_to_idp_warning.title')
     expect_feedback_source_to_be(page, 'REDIRECT_TO_IDP_WARNING_PAGE', '/redirect-to-idp-warning')
   end
 
@@ -74,7 +74,7 @@ RSpec.describe 'When the user visits the redirect to IDP warning page' do
     given_a_session_with_document_answers
     visit '/ailgyfeirio-i-rybudd-idp'
 
-    expect(page).to have_title "Byddwch nawr yn cael eich ailgyfeirio - GOV.UK Verify - GOV.UK"
+    expect(page).to have_title t('hub.redirect_to_idp_warning.title', locale: :cy)
     expect(page).to have_css 'html[lang=cy]'
   end
 
@@ -82,7 +82,7 @@ RSpec.describe 'When the user visits the redirect to IDP warning page' do
     stub_transactions_list
     visit '/redirect-to-idp-warning'
 
-    expect(page).to have_content 'something went wrong'
+    expect(page).to have_content t('errors.something_went_wrong.heading')
   end
 
   it 'will render the error page given a session with an IDP that has no display data' do
@@ -91,7 +91,7 @@ RSpec.describe 'When the user visits the redirect to IDP warning page' do
 
     visit '/redirect-to-idp-warning'
 
-    expect(page).to have_content('Sorry, something went wrong')
+    expect(page).to have_content t('errors.something_went_wrong.heading')
   end
 
   it 'goes to "redirect-to-idp" page on submit' do
@@ -109,7 +109,7 @@ RSpec.describe 'When the user visits the redirect to IDP warning page' do
       segments: ['test-segment'],
     )
 
-    click_button 'Continue to the IDCorp website'
+    click_button t('hub.redirect_to_idp_warning.continue_website', display_name: t('idps.stub-idp-one.name'))
 
     expect(page).to have_current_path(redirect_to_idp_register_path)
     expect(select_idp_stub_request).to have_been_made.once
@@ -127,7 +127,7 @@ RSpec.describe 'When the user visits the redirect to IDP warning page' do
 
     piwik_registration_virtual_page = stub_piwik_idp_registration('IDCorp', selected_answers: selected_answers, segments: ['test-segment'])
 
-    click_button 'Continue to the IDCorp website'
+    click_button t('hub.redirect_to_idp_warning.continue_website', display_name: t('idps.stub-idp-one.name'))
 
     expect(page).to have_current_path(redirect_to_idp_register_path)
     expect(select_idp_stub_request).to have_been_made.once
@@ -139,8 +139,8 @@ RSpec.describe 'When the user visits the redirect to IDP warning page' do
     given_a_session_with_document_answers
     visit '/redirect-to-idp-warning'
 
-    expect(page).to have_content 'Continue to the IDCorp website'
-    expect(page).to have_content "You'll now verify your identity on the IDCorp website"
+    expect(page.body).to have_content t('hub.redirect_to_idp_warning.continue_website', display_name: 'IDCorp')
+    expect(page.body).to include t('hub.redirect_to_idp_warning.identity_account_use_html', display_name: 'IDCorp')
   end
 
   context 'with JS enabled', js: true do
@@ -154,7 +154,7 @@ RSpec.describe 'When the user visits the redirect to IDP warning page' do
       stub_session_idp_authn_request(originating_ip, location, true)
       expect_any_instance_of(RedirectToIdpWarningController).to receive(:continue_ajax).and_call_original
 
-      click_button 'Continue to the IDCorp website'
+      click_button t('hub.redirect_to_idp_warning.continue_website', display_name: t('idps.stub-idp-one.name'))
       expect(page).to have_current_path(location)
       expect(page).to have_content("SAML Request is 'a-saml-request'")
       expect(page).to have_content("relay state is 'a-relay-state'")
@@ -175,7 +175,7 @@ RSpec.describe 'When the user visits the redirect to IDP warning page' do
       stub_session_idp_authn_request(originating_ip, location, true)
       expect_any_instance_of(RedirectToIdpWarningController).to receive(:continue_ajax).and_call_original
 
-      click_button 'Continue to the Bob’s Identity Service website'
+      click_button t('hub.redirect_to_idp_warning.continue_website', display_name: 'Bob’s Identity Service')
       expect(page).to have_current_path(location)
       expect(page).to have_content("hints are ''")
       expect(page).to have_content("language hint was ''")

--- a/spec/features/user_visits_redirect_to_service_page_spec.rb
+++ b/spec/features/user_visits_redirect_to_service_page_spec.rb
@@ -26,15 +26,15 @@ RSpec.describe 'When the user visits the redirect to service page' do
     end
 
     it 'supports the welsh language for error' do
-      visit "/#{I18n.t('routes.redirect_to_service_error', locale: 'cy')}"
+      visit "/#{t('routes.redirect_to_service_error', locale: 'cy')}"
       expect(page).to have_css 'html[lang=cy]'
     end
 
     it 'should redirect to service when path is error' do
       visit redirect_to_service_error_path
-      verify_redirect_to_service(I18n.t('hub.redirect_to_service.start_again.title'))
+      verify_redirect_to_service t('hub.redirect_to_service.start_again.title')
 
-      click_button I18n.t('navigation.continue')
+      click_button t('navigation.continue')
       expect(page).to have_current_path('/test-rp')
     end
   end
@@ -59,28 +59,28 @@ RSpec.describe 'When the user visits the redirect to service page' do
     end
 
     it 'supports the welsh language for signing in' do
-      visit "/#{I18n.t('routes.redirect_to_service_signing_in', locale: 'cy')}"
+      visit "/#{t('routes.redirect_to_service_signing_in', locale: 'cy')}"
       expect(page).to have_css 'html[lang=cy]'
     end
 
     it 'supports the welsh language for start again' do
-      visit "/#{I18n.t('routes.redirect_to_service_start_again', locale: 'cy')}"
+      visit "/#{t('routes.redirect_to_service_start_again', locale: 'cy')}"
       expect(page).to have_css 'html[lang=cy]'
     end
 
     it 'should redirect to service when path is signing-in' do
       visit redirect_to_service_signing_in_path
-      verify_redirect_to_service(I18n.t('hub.redirect_to_service.signing_in.title'))
+      verify_redirect_to_service t('hub.redirect_to_service.signing_in.title')
 
-      click_button I18n.t('navigation.continue')
+      click_button t('navigation.continue')
       expect(page).to have_current_path('/test-rp')
     end
 
     it 'should redirect to service when path is start-again' do
       visit redirect_to_service_start_again_path
-      verify_redirect_to_service(I18n.t('hub.redirect_to_service.start_again.title'))
+      verify_redirect_to_service t('hub.redirect_to_service.start_again.title')
 
-      click_button I18n.t('navigation.continue')
+      click_button t('navigation.continue')
       expect(page).to have_current_path('/test-rp')
     end
 

--- a/spec/features/user_visits_response_processing_page_spec.rb
+++ b/spec/features/user_visits_response_processing_page_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'When the user visits the response processing page' do
   it 'should show the user the rp name and a spinner' do
     stub_matching_outcome
     visit '/response-processing'
-    expect(page).to have_content I18n.t('hub.response_processing.heading', rp_name: 'Test RP')
+    expect(page).to have_content t('hub.response_processing.heading', rp_name: 'Test RP')
     expect(page).to have_css('img.loading')
     expect(page).to have_css 'meta[http-equiv=refresh]', visible: false
   end

--- a/spec/features/user_visits_select_documents_page_spec.rb
+++ b/spec/features/user_visits_select_documents_page_spec.rb
@@ -24,7 +24,7 @@ RSpec.feature 'When user visits document selection page' do
     choose 'select_documents_form_any_driving_licence_true'
     choose 'select_documents_form_driving_licence_great_britain'
     choose 'select_documents_form_passport_true'
-    click_button 'Continue'
+    click_button t('navigation.continue')
     expect(page).to have_current_path(select_phone_path)
     expect(page.get_rack_session['selected_answers']).to eql(
       'device_type' => { 'device_type_other' => true },
@@ -45,7 +45,7 @@ RSpec.feature 'When user visits document selection page' do
     it 'should go to other documents page if user does not have UK driving licence or UK passport' do
       choose 'select_documents_form_any_driving_licence_false'
       choose 'select_documents_form_passport_false'
-      click_button 'Continue'
+      click_button t('navigation.continue')
       expect(page).to have_current_path(other_identity_documents_path)
       expect(page.get_rack_session['selected_answers']).to eql(
         'device_type' => { 'device_type_other' => true },

--- a/spec/features/user_visits_select_phone_page_spec.rb
+++ b/spec/features/user_visits_select_phone_page_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'When the user visits the select phone page' do
 
       choose 'select_phone_form_mobile_phone_true', allow_label_click: true
       choose 'select_phone_form_smart_phone_true', allow_label_click: true
-      click_button 'Continue'
+      click_button t('navigation.continue')
 
       expect(page).to have_current_path(choose_a_certified_company_path, only_path: true)
       expect(page.get_rack_session['selected_answers']).to eql(
@@ -44,7 +44,7 @@ RSpec.describe 'When the user visits the select phone page' do
 
       choose 'select_phone_form_mobile_phone_true', allow_label_click: true
       choose 'select_phone_form_smart_phone_do_not_know', allow_label_click: true
-      click_button 'Continue'
+      click_button t('navigation.continue')
 
       expect(page).to have_current_path(choose_a_certified_company_path, only_path: true)
       expect(page.get_rack_session['selected_answers']).to eql(
@@ -61,11 +61,11 @@ RSpec.describe 'When the user visits the select phone page' do
 
       choose 'select_phone_form_mobile_phone_true', allow_label_click: true
       choose 'select_phone_form_smart_phone_true', allow_label_click: true
-      click_button 'Continue'
+      click_button t('navigation.continue')
 
       visit '/select-phone'
       choose 'select_phone_form_mobile_phone_false', allow_label_click: true
-      click_button 'Continue'
+      click_button t('navigation.continue')
 
       expect(page.get_rack_session['selected_answers']).to eql(
         'device_type' => { 'device_type_other' => true },
@@ -76,7 +76,7 @@ RSpec.describe 'When the user visits the select phone page' do
 
     it 'shows an error message when no selections are made' do
       visit '/select-phone'
-      click_button 'Continue'
+      click_button t('navigation.continue')
 
       expect(page).to have_css '.validation-message', text: 'Please answer all the questions'
       expect(page).to have_css '.form-group-error'
@@ -91,7 +91,7 @@ RSpec.describe 'When the user visits the select phone page' do
 
       choose 'select_phone_form_mobile_phone_true', allow_label_click: true
       choose 'select_phone_form_smart_phone_true', allow_label_click: true
-      click_button 'Continue'
+      click_button t('navigation.continue')
 
       expect(page).to have_current_path(choose_a_certified_company_path)
       expect(page.get_rack_session['selected_answers']).to eql(
@@ -104,7 +104,7 @@ RSpec.describe 'When the user visits the select phone page' do
     it 'should display a validation message when user does not answer mobile phone question' do
       visit '/select-phone'
 
-      click_button 'Continue'
+      click_button t('navigation.continue')
 
       expect(page).to have_current_path(select_phone_path)
       expect(page).to have_css '#validation-error-message-js', text: 'Please answer all the questions'
@@ -114,7 +114,7 @@ RSpec.describe 'When the user visits the select phone page' do
       visit '/select-phone'
 
       choose 'select_phone_form_mobile_phone_false', allow_label_click: true
-      click_button 'Continue'
+      click_button t('navigation.continue')
 
       expect(page).to have_current_path(no_mobile_phone_path)
       expect(page.get_rack_session['selected_answers']).to eql(
@@ -132,7 +132,7 @@ RSpec.describe 'When the user visits the select phone page' do
 
   it 'displays the page in Welsh' do
     visit 'dewis-ffon'
-    expect(page).to have_title 'Oes gennych ffôn symudol neu lechen?'
+    expect(page).to have_title t('hub.select_phone.title', locale: :cy)
     expect(page).to have_css 'html[lang=cy]'
   end
 
@@ -145,7 +145,7 @@ RSpec.describe 'When the user visits the select phone page' do
 
     choose 'select_phone_form_mobile_phone_true', allow_label_click: true
     choose 'select_phone_form_smart_phone_true', allow_label_click: true
-    click_button 'Continue'
+    click_button t('navigation.continue')
 
     expect(a_request(:get, INTERNAL_PIWIK.url).with(query: hash_including(piwik_request))).to have_been_made.once
   end
@@ -155,7 +155,7 @@ RSpec.describe 'When the user visits the select phone page' do
     piwik_request = { 'action_name' => 'Phone Next' }
     visit '/select-phone'
 
-    click_button 'Continue'
+    click_button t('navigation.continue')
 
     expect(a_request(:get, INTERNAL_PIWIK.url).with(query: hash_including(piwik_request))).to_not have_been_made
   end

--- a/spec/features/user_visits_sign_in_page_spec.rb
+++ b/spec/features/user_visits_sign_in_page_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'user selects an IDP on the sign in page' do
   def given_im_on_the_sign_in_page(locale = 'en')
     set_session_and_session_cookies!
     stub_api_idp_list_for_sign_in
-    visit "/#{I18n.t('routes.sign_in', locale: locale)}"
+    visit "/#{t('routes.sign_in', locale: locale)}"
   end
 
   def when_i_select_an_idp
@@ -48,11 +48,11 @@ RSpec.describe 'user selects an IDP on the sign in page' do
   end
 
   def then_im_at_the_interstitial_page(locale = 'en')
-    expect(page).to have_current_path("/#{I18n.t('routes.redirect_to_idp_sign_in', locale: locale)}")
+    expect(page).to have_current_path("/#{t('routes.redirect_to_idp_sign_in', locale: locale)}")
   end
 
   def when_i_choose_to_continue
-    click_button('Continue')
+    click_button t('navigation.continue')
   end
 
   def expect_to_have_updated_the_piwik_journey_type_variable
@@ -94,7 +94,7 @@ RSpec.describe 'user selects an IDP on the sign in page' do
       given_the_piwik_request_has_been_stubbed
       given_im_on_the_sign_in_page
       when_i_click_start_now
-      expect(page).to have_title('About - GOV.UK Verify - GOV.UK')
+      expect(page).to have_title t('hub.about.title')
       expect_to_have_updated_the_piwik_journey_type_variable
     end
   end

--- a/spec/features/user_visits_start_page_spec.rb
+++ b/spec/features/user_visits_start_page_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'When the user visits the start page' do
   it 'will display the start page in English' do
     set_session_and_session_cookies!
     visit '/start'
-    expect(page).to have_content 'Sign in with GOV.UK Verify'
+    expect(page).to have_content t('hub.start.heading')
     expect(page).to have_css 'html[lang=en]'
     expect_feedback_source_to_be(page, 'START_PAGE', '/start')
   end
@@ -14,7 +14,7 @@ RSpec.describe 'When the user visits the start page' do
   it 'will display the start page in Welsh' do
     set_session_and_session_cookies!
     visit '/dechrau'
-    expect(page).to have_content 'Mewngofnodi gyda GOV.UK Verify'
+    expect(page).to have_content t('hub.start.heading', locale: :cy)
     expect(page).to have_css 'html[lang=cy]'
   end
 
@@ -33,7 +33,7 @@ RSpec.describe 'When the user visits the start page' do
       allow(Rails.logger).to receive(:info)
       expect(Rails.logger).to receive(:info).with("No session cookies can be found").at_least(:once)
       visit "/start"
-      expect(page).to have_content "If you can’t access GOV.UK Verify from a service, enable your cookies."
+      expect(page).to have_content t('errors.no_cookies.enable_cookies')
       expect(page).to have_http_status :forbidden
       expect(page).to have_link 'feedback', href: '/feedback?feedback-source=COOKIE_NOT_FOUND_PAGE'
       expect(page).to have_link "register for an identity profile", href: "http://localhost:50130/test-rp"
@@ -46,7 +46,7 @@ RSpec.describe 'When the user visits the start page' do
       expect(Rails.logger).to receive(:info).with('start_time not in session').at_least(:once)
       set_cookies!(cookie_hash)
       visit '/start'
-      expect(page).to have_content 'Sorry, something went wrong'
+      expect(page).to have_content t('errors.something_went_wrong.heading')
       expect(page).to have_http_status :internal_server_error
       expect(page).to have_link 'feedback', href: '/feedback?feedback-source=ERROR_PAGE'
     end
@@ -57,7 +57,7 @@ RSpec.describe 'When the user visits the start page' do
       expect(Rails.logger).to receive(:info).with("The following cookies are missing: [#{CookieNames::SESSION_COOKIE_NAME}]").at_least(:once)
       set_cookies!(cookie_hash.except(CookieNames::SESSION_COOKIE_NAME))
       visit '/start'
-      expect(page).to have_content "Sorry, something went wrong"
+      expect(page).to have_content t('errors.something_went_wrong.heading')
       expect(page).to have_http_status :internal_server_error
       expect(page).to have_link 'feedback', href: '/feedback?feedback-source=ERROR_PAGE'
     end
@@ -68,7 +68,7 @@ RSpec.describe 'When the user visits the start page' do
       expect(Rails.logger).to receive(:info).with("The following cookies are missing: [#{CookieNames::SESSION_ID_COOKIE_NAME}]").at_least(:once)
       set_cookies!(cookie_hash.except(CookieNames::SESSION_ID_COOKIE_NAME))
       visit '/start'
-      expect(page).to have_content "Sorry, something went wrong"
+      expect(page).to have_content t('errors.something_went_wrong.heading')
       expect(page).to have_http_status :internal_server_error
       expect(page).to have_link 'feedback', href: '/feedback?feedback-source=ERROR_PAGE'
     end
@@ -77,7 +77,7 @@ RSpec.describe 'When the user visits the start page' do
       set_session_cookies!
       set_session!(transaction_simple_id: 'test-rp', start_time: start_time_in_millis)
       visit '/start'
-      expect(page).to have_content 'Sorry, something went wrong'
+      expect(page).to have_content t('errors.something_went_wrong.heading')
       expect(page).to have_http_status :internal_server_error
       expect(page).to have_link 'feedback', href: '/feedback?feedback-source=ERROR_PAGE'
     end
@@ -86,7 +86,7 @@ RSpec.describe 'When the user visits the start page' do
       set_session_cookies!
       set_session!(transaction_simple_id: 'test-rp', start_time: start_time_in_millis, verify_session_id: 'a mismatched value')
       visit '/start'
-      expect(page).to have_content 'Sorry, something went wrong'
+      expect(page).to have_content t('errors.something_went_wrong.heading')
       expect(page).to have_http_status :bad_request
       expect(page).to have_link 'feedback', href: '/feedback?feedback-source=ERROR_PAGE'
     end
@@ -99,7 +99,7 @@ RSpec.describe 'When the user visits the start page' do
       expired_start_time = 2.hours.ago.to_i * 1000
       page.set_rack_session(start_time: expired_start_time)
       visit '/start'
-      expect(page).to have_content 'Find the service you were using to start again'
+      expect(page).to have_content t('hub.transaction_list.title')
       expect(page).to have_link 'register for an identity profile', href: 'http://localhost:50130/test-rp'
       expect(page).to have_http_status :bad_request
       expect(page).to have_link 'feedback', href: '/feedback?feedback-source=EXPIRED_ERROR_PAGE'

--- a/spec/features/user_visits_the_choose_a_certified_company_about_idp_page_spec.rb
+++ b/spec/features/user_visits_the_choose_a_certified_company_about_idp_page_spec.rb
@@ -26,8 +26,8 @@ RSpec.feature 'user visits the choose a certified company about idp page', type:
     stub_api_idp_list_for_loa([{ 'simpleId' => 'stub-idp-one', 'entityId' => entity_id, 'levelsOfAssurance' => %w(LEVEL_1 LEVEL_2) }])
     given_a_session_with_selected_answers
     visit choose_a_certified_company_about_path('stub-idp-one')
-    expect(page).to have_content("ID Corp is the premier identity proofing service around.")
-    click_button "Choose IDCorp"
+    expect(page).to have_content('ID Corp is the premier identity proofing service around.')
+    click_button t('hub.choose_a_certified_company.choose_idp', display_name: t('idps.stub-idp-one.name'))
     expect(page).to have_current_path(redirect_to_idp_warning_path)
     expect(page.get_rack_session_key('selected_idp')).to include('entity_id' => entity_id, 'simple_id' => 'stub-idp-one', 'levels_of_assurance' => %w(LEVEL_1 LEVEL_2))
     expect(page.get_rack_session_key('selected_idp_was_recommended')).to eql true
@@ -35,12 +35,12 @@ RSpec.feature 'user visits the choose a certified company about idp page', type:
 
   scenario 'for a non-existent idp' do
     visit choose_a_certified_company_about_path('foobar')
-    expect(page).to have_content(I18n.translate("errors.page_not_found.title"))
+    expect(page).to have_content t('errors.page_not_found.title')
   end
 
   scenario 'for an idp that is not viewable' do
     visit choose_a_certified_company_about_path('foobar')
-    expect(page).to have_content(I18n.translate("errors.page_not_found.title"))
+    expect(page).to have_content t('errors.page_not_found.title')
   end
 
   scenario 'user clicks back link' do
@@ -48,7 +48,7 @@ RSpec.feature 'user visits the choose a certified company about idp page', type:
     stub_api_idp_list_for_loa([{ 'simpleId' => 'stub-idp-one', 'entityId' => entity_id, 'levelsOfAssurance' => %w(LEVEL_1 LEVEL_2) }])
     given_a_session_with_selected_answers
     visit choose_a_certified_company_about_path('stub-idp-one')
-    click_link 'Back'
+    click_link t('navigation.back')
     expect(page).to have_current_path(choose_a_certified_company_path)
   end
 end

--- a/spec/features/user_visits_verify_services_picker_page_spec.rb
+++ b/spec/features/user_visits_verify_services_picker_page_spec.rb
@@ -5,13 +5,13 @@ RSpec.describe 'When the user visits the Verify services picker page' do
   it 'should display the page in English ' do
     stub_transactions_list
     visit '/verify-services'
-    expect(page).to have_content('GOV.UK Verify is new, and government services are joining all the time. The current services using Verify are:')
+    expect(page).to have_content t('hub.verify_services.message')
   end
 
   it 'should display the page in Welsh' do
     stub_transactions_list
     visit '/verify-services-cy'
-    expect(page).to have_content('GOV.UK Verify is new, and government services are joining all the time. The current services using Verify are:')
+    expect(page).to have_content t('hub.verify_services.message', locale: :cy)
   end
 
   it 'should include the appropriate feedback source' do

--- a/spec/features/user_visits_why_companies_page_spec.rb
+++ b/spec/features/user_visits_why_companies_page_spec.rb
@@ -14,13 +14,13 @@ RSpec.describe 'When the user visits the why companies page' do
 
   it 'displays the page in Welsh' do
     visit '/pam-cwmniau'
-    expect(page).to have_title 'Pam fod dewis o gwmnïau - GOV.UK Verify - GOV.UK'
+    expect(page).to have_title t('hub.why_companies.title', locale: :cy)
     expect(page).to have_css 'html[lang=cy]'
   end
 
   it 'includes links to choose-a-certified-company page' do
     visit '/why-companies'
-    expect(page).to have_title('Why there’s a choice of companies - GOV.UK Verify - GOV.UK')
+    expect(page).to have_title t('hub.why_companies.title')
     expect(page).to have_link 'Back', href: '/choose-a-certified-company'
     expect(page).to have_link 'Choose a company', href: '/choose-a-certified-company'
   end

--- a/spec/features/user_visits_will_it_work_for_me_page_spec.rb
+++ b/spec/features/user_visits_will_it_work_for_me_page_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'When the user visits the will it work for me page' do
     it 'when js is off' do
       visit '/will-it-work-for-me'
 
-      click_button 'Continue'
+      click_button t('navigation.continue')
 
       expect(page).to have_current_path(will_it_work_for_me_path)
       expect(page).to have_content 'Please answer all the questions'
@@ -24,10 +24,10 @@ RSpec.describe 'When the user visits the will it work for me page' do
     it 'when js is on', js: true do
       visit '/will-it-work-for-me'
       choose 'will_it_work_for_me_form_above_age_threshold_false', allow_label_click: true
-      expect(page).to_not have_content(I18n.t('hub.will_it_work_for_me.question.not_resident_reason.title'))
+      expect(page).to_not have_content t('hub.will_it_work_for_me.question.not_resident_reason.title')
       choose 'will_it_work_for_me_form_resident_last_12_months_false', allow_label_click: true
-      expect(page).to have_content(I18n.t('hub.will_it_work_for_me.question.not_resident_reason.title'))
-      click_button 'Continue'
+      expect(page).to have_content t('hub.will_it_work_for_me.question.not_resident_reason.title')
+      click_button t('navigation.continue')
 
       expect(page).to have_current_path(will_it_work_for_me_path)
       expect(page).to have_css '#validation-error-message-js', text: 'Please answer all the questions'

--- a/spec/features/users_browser_sends_client_side_analytics_spec.rb
+++ b/spec/features/users_browser_sends_client_side_analytics_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe 'When the user visits a page' do
       )
       set_session_and_session_cookies!
       visit '/start'
-      expect(page).to have_content 'Sign in with GOV.UK Verify'
+      expect(page).to have_content t('hub.start.heading')
     end
 
     it 'and in Welsh sends the page title in English to analytics' do
@@ -55,7 +55,7 @@ RSpec.describe 'When the user visits a page' do
         )
       )
       visit '/start'
-      expect(page).to have_content "If you can’t access GOV.UK Verify from a service, enable your cookies."
+      expect(page).to have_content t('errors.no_cookies.enable_cookies')
     end
 
     it 'sends an event to Piwik only when the user changes selection, on the start page' do
@@ -91,7 +91,7 @@ RSpec.describe 'When the user visits a page' do
     it 'sends a page view to analytics' do
       set_session_and_session_cookies!
       visit '/start'
-      expect(page).to have_content 'Sign in with GOV.UK Verify'
+      expect(page).to have_content t('hub.start.heading')
       noscript_image = page.find(:id, 'piwik-noscript-tracker')
       expect(noscript_image).to_not be_nil
       image_src = noscript_image['src']
@@ -115,7 +115,7 @@ RSpec.describe 'When the user visits a page' do
     it 'sends a page view with a custom url for error pages' do
       stub_transactions_list
       visit '/start'
-      expect(page).to have_content "If you can’t access GOV.UK Verify from a service, enable your cookies."
+      expect(page).to have_content t('errors.no_cookies.enable_cookies')
       noscript_image = page.find(:id, 'piwik-noscript-tracker')
       expect(noscript_image).to_not be_nil
       image_src = noscript_image['src']


### PR DESCRIPTION
@rachelthecodesmith would you mind reviwing this since you raised the Kaizen?

Also, we should probably agree how much of the "strings" we want to replace, I've done the most of them, but left things like routes, but noticed some of the tests are already using the yaml references for routes such as:
`visit "/#{t('routes.redirect_to_service_error', locale: 'cy')}"`
but majority is just 'hardcoded'
`visit /start`
Using the references everywhere makes it much less readable in my opinion. And maybe a bit less TDD-friendly?