### PR TITLE
TT-1756: Use 'raw' in preference to 'html_safe'

### DIFF
--- a/app/views/about/about.html.erb
+++ b/app/views/about/about.html.erb
@@ -2,7 +2,7 @@
 <% content_for :feedback_source, 'ABOUT_PAGE' %>
 
 <p><%= t 'hub.about.verify_is_a_service' %></p>
-<%= @tailored_text.html_safe %>
+<%= raw @tailored_text %>
 
 <div class="actions">
   <%= button_link_to t('navigation.next'), about_certified_companies_path, id: 'next-button' %>

--- a/app/views/certified_company_unavailable/index.html.erb
+++ b/app/views/certified_company_unavailable/index.html.erb
@@ -16,7 +16,7 @@
   <div class="column-two-thirds">
     <h1 class="heading-large"><%= t 'hub.other_ways_heading', other_ways_description: @other_ways_description %></h1>
     <div class="other-ways-to-complete-transaction">
-      <%= @other_ways_text.html_safe %>
+      <%= raw @other_ways_text %>
     </div>
   </div>
 </div>

--- a/app/views/choose_a_certified_company/about.html.erb
+++ b/app/views/choose_a_certified_company/about.html.erb
@@ -7,7 +7,7 @@
       <h1 class="heading-large"><%= @idp.display_name %></h1>
       <div class="about-idp-content">
         <p class="subtitle"><%= t 'hub.choose_a_certified_company.about.information_provided_by', display_name: @idp.display_name %></p>
-        <%= @idp.about_content.html_safe %>
+        <%= raw @idp.about_content %>
       </div>
       <%= render partial: 'choose_a_certified_company/select_idp_form', locals: {recommended: @recommended, identity_provider: @idp} %>
     </div>

--- a/app/views/confirm_your_identity/index.html.erb
+++ b/app/views/confirm_your_identity/index.html.erb
@@ -11,5 +11,5 @@
 </div>
 
 <p>
-  <%= t('hub.confirm_your_identity.use_other_idp', sign_in_link: link_to(t('hub.confirm_your_identity.sign_in_link_message'), sign_in_path)).html_safe %>
+  <%= raw t('hub.confirm_your_identity.use_other_idp', sign_in_link: link_to(t('hub.confirm_your_identity.sign_in_link_message'), sign_in_path)) %>
 </p>

--- a/app/views/errors/cookie_expired.html.erb
+++ b/app/views/errors/cookie_expired.html.erb
@@ -8,6 +8,6 @@
     <h1 class="heading-large"><%= t 'errors.cookie_expired.title' %></h1>
     <h2 class="heading-medium"><%= t 'hub.transaction_list.title' %></h2>
     <%= render partial: 'shared/transaction_list' %>
-    <p><%= t('errors.cookie_expired.feedback_message', feedback_link: link_to(t('errors.cookie_expired.feedback'), feedback_path('feedback-source': feedback_source))).html_safe %></p>
+    <p><%= raw t('errors.cookie_expired.feedback_message', feedback_link: link_to(t('errors.cookie_expired.feedback'), feedback_path('feedback-source': feedback_source))) %></p>
   </div>
 </div>

--- a/app/views/errors/session_error.html.erb
+++ b/app/views/errors/session_error.html.erb
@@ -7,6 +7,6 @@
     <h1 class="heading-large"><%= t 'errors.session_error.heading' %></h1>
     <p><%= t 'errors.session_error.security' %></p>
     <p><%= link_to t('errors.session_error.start_again'), '/redirect-to-service/error' %></p>
-    <p><%= t('errors.session_error.feedback_message', feedback_link: link_to(t('errors.session_error.feedback'), feedback_path('feedback-source' => feedback_source))).html_safe %></p>
+    <p><%= raw t('errors.session_error.feedback_message', feedback_link: link_to(t('errors.session_error.feedback'), feedback_path('feedback-source' => feedback_source))) %></p>
   </div>
 </div>

--- a/app/views/errors/session_timeout.html.erb
+++ b/app/views/errors/session_timeout.html.erb
@@ -7,6 +7,6 @@
     <h1 class="heading-large"><%= t 'errors.session_timeout.title' %></h1>
     <h2 class="heading-medium"><%= t 'errors.session_timeout.return_to_service' %></h2>
     <p><%= link_to t('errors.session_timeout.start_again'), '/redirect-to-service/error', class: 'button' %></p>
-    <p><%= t('errors.session_timeout.feedback_message', feedback_link: link_to(t('errors.session_timeout.feedback'), feedback_path('feedback-source': feedback_source))).html_safe %></p>
+    <p><%= raw t('errors.session_timeout.feedback_message', feedback_link: link_to(t('errors.session_timeout.feedback'), feedback_path('feedback-source': feedback_source))) %></p>
   </div>
 </div>

--- a/app/views/failed_registration/_continue_rp.html.erb
+++ b/app/views/failed_registration/_continue_rp.html.erb
@@ -2,7 +2,7 @@
 
 <p>
   <%= t 'hub.failed_registration.continue_idp_text', idp_name: idp.display_name %>
-  <%= transaction.other_ways_text.html_safe %>
+  <%= raw transaction.other_ways_text %>
 </p>
 
 <p><%= t 'hub.failed_registration.continue_text', rp_name: transaction.rp_name %></p>
@@ -18,7 +18,7 @@
 <details class="next-actions">
   <summary><span class="summary"><%= t 'hub.failed_registration.contact_details_intro', idp_name: idp.display_name %></span></summary>
   <div class="panel panel-border-narrow">
-    <%= idp.contact_details.html_safe %>
+    <%= raw idp.contact_details %>
   </div>
 </details>
 

--- a/app/views/failed_registration/_non_continue_rp.html.erb
+++ b/app/views/failed_registration/_non_continue_rp.html.erb
@@ -7,16 +7,16 @@
 </h2>
 
 <details class="next-actions">
-  <summary><span class="summary"><%= t 'hub.failed_registration.other_ways_summary', other_ways_description: transaction.other_ways_description.html_safe %></span></summary>
+  <summary><span class="summary"><%= t 'hub.failed_registration.other_ways_summary', other_ways_description: raw(transaction.other_ways_description) %></span></summary>
   <div class="panel panel-border-narrow">
-    <%= transaction.other_ways_text.html_safe %>
+    <%= raw transaction.other_ways_text %>
   </div>
 </details>
 
 <details class="next-actions">
   <summary><span class="summary"><%= t 'hub.failed_registration.contact_details_intro', idp_name: idp.display_name %></span></summary>
   <div class="panel panel-border-narrow">
-    <%= idp.contact_details.html_safe %>
+    <%= raw idp.contact_details %>
   </div>
 </details>
 

--- a/app/views/failed_uplift/index.html.erb
+++ b/app/views/failed_uplift/index.html.erb
@@ -11,14 +11,14 @@
     <details class="next-actions">
       <summary><span class="summary"><%= t 'hub.failed_uplift.other_ways_summary', other_ways_description: @transaction.other_ways_description %></span></summary>
       <div class="panel panel-border-narrow">
-        <%= @transaction.other_ways_text.html_safe %>
+        <%= raw @transaction.other_ways_text %>
       </div>
     </details>
 
     <details class="next-actions">
       <summary><span class="summary"><%= t 'hub.failed_uplift.contact_summary', idp_name: @idp.display_name %></span></summary>
       <div class="panel panel-border-narrow">
-        <%= @idp.contact_details.html_safe %>
+        <%= raw @idp.contact_details %>
       </div>
     </details>
 

--- a/app/views/further_information/index.html.erb
+++ b/app/views/further_information/index.html.erb
@@ -32,7 +32,7 @@
             <span class="summary"><%= t 'hub.further_information.help_with_your', cycle_three_name: @cycle_three_attribute.name %></span>
           </summary>
           <div class="panel help-finding-further-information">
-            <%= @cycle_three_attribute.help_to_find.html_safe %>
+            <%= raw @cycle_three_attribute.help_to_find %>
           </div>
         </details>
         </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -46,7 +46,7 @@
     <li><%= link_to(t('hub.privacy_notice.title'), privacy_notice_path) %></li>
     <li>
     <% if feedback_source.present? %>
-        <%= link_to(t('hub.feedback.title'), feedback_path('feedback-source' => feedback_source)).html_safe %>
+        <%= raw link_to(t('hub.feedback.title'), feedback_path('feedback-source' => feedback_source)) %>
     <% else %>
         <%= link_to(t('hub.feedback.title'), feedback_path) %>
     <% end %>

--- a/app/views/no_idps_available/no_idps_available.html.erb
+++ b/app/views/no_idps_available/no_idps_available.html.erb
@@ -9,7 +9,7 @@
     <h2 class="heading-medium"><%= t 'hub.other_ways_heading', other_ways_description: @other_ways_description %></h2>
 
     <div class="other-ways-to-complete-transaction">
-      <%= @other_ways_text.html_safe %>
+      <%= raw @other_ways_text %>
     </div>
   </div>
 </div>

--- a/app/views/other_ways_to_access_service/index.html.erb
+++ b/app/views/other_ways_to_access_service/index.html.erb
@@ -5,7 +5,7 @@
   <div class="column-two-thirds">
     <h1 class="heading-large"><%= t 'hub.other_ways_heading', other_ways_description: @other_ways_description %></h1>
     <div class="other-ways-to-complete-transaction">
-      <%= @other_ways_text.html_safe %>
+      <%= raw @other_ways_text %>
     </div>
   </div>
 </div>

--- a/app/views/redirect_to_idp_question/idp_wont_work_for_you.html.erb
+++ b/app/views/redirect_to_idp_question/idp_wont_work_for_you.html.erb
@@ -4,7 +4,7 @@
 <div class="grid-row">
   <div class="column-two-thirds">
     <h1 class="heading-large"><%= t 'hub.idp_wont_work_for_you_one_doc.heading', idp_name: @idp.display_name %></h1>
-        <%= @idp.interstitial_explanation.html_safe %>
+        <%= raw @idp.interstitial_explanation %>
 
     <div>
       <p>

--- a/app/views/redirect_to_idp_question/redirect_to_idp_question_LOA1.html.erb
+++ b/app/views/redirect_to_idp_question/redirect_to_idp_question_LOA1.html.erb
@@ -4,7 +4,7 @@
 <div class="grid-row js-continue-to-idp" data-location="<%= url_for(controller: 'redirect_to_idp_warning', action: 'continue_ajax', locale: I18n.locale)  %>">
   <div class="column-two-thirds">
     <h1 class="heading-large"><%= t 'hub.redirect_to_idp_question.loa1_heading', display_name: @idp.display_name %></h1>
-    <%= @idp.interstitial_question.html_safe %>
+    <%= raw @idp.interstitial_question %>
 
     <%= form_for @form, url: redirect_to_idp_question_submit_path, html: {id: 'interstitial-question-form', class: 'js-validate', novalidate: 'novalidate'} do |f| %>
 

--- a/app/views/redirect_to_idp_question/redirect_to_idp_question_LOA2.html.erb
+++ b/app/views/redirect_to_idp_question/redirect_to_idp_question_LOA2.html.erb
@@ -4,7 +4,7 @@
 <div class="grid-row js-continue-to-idp" data-location="<%= url_for(controller: 'redirect_to_idp_warning', action: 'continue_ajax', locale: I18n.locale)  %>">
   <div class="column-two-thirds">
     <h1 class="heading-large"><%= t 'hub.redirect_to_idp_question.heading', display_name: @idp.display_name %></h1>
-    <%= @idp.interstitial_question.html_safe %>
+    <%= raw @idp.interstitial_question %>
 
     <%= form_for @form, url: redirect_to_idp_question_submit_path, html: {id: 'interstitial-question-form', class: 'js-validate', novalidate: 'novalidate'} do |f| %>
 

--- a/app/views/select_documents/unlikely_to_verify.html.erb
+++ b/app/views/select_documents/unlikely_to_verify.html.erb
@@ -5,7 +5,7 @@
   <div class="column-two-thirds">
     <h1 class="heading-large"><%= t 'hub.unlikely_to_verify.heading' %></h1>
 
-    <p><%= t('hub.unlikely_to_verify.explanation', add_more_documents_link: link_to(t('hub.unlikely_to_verify.explanation_link_text'), select_documents_path)).html_safe %></p>
+    <p><%= raw t('hub.unlikely_to_verify.explanation', add_more_documents_link: link_to(t('hub.unlikely_to_verify.explanation_link_text'), select_documents_path)) %></p>
     <%= render partial: 'shared/other_ways', locals: {other_ways_text: @other_ways_text, other_ways_description: @other_ways_description} %>
   </div>
 </div>

--- a/app/views/shared/_feedback_link.html.erb
+++ b/app/views/shared/_feedback_link.html.erb
@@ -1,3 +1,3 @@
 <div class="meta-data feedback-link">
-  <p><%= t('feedback_link.message', href: link_to(t('feedback_link.feedback_form'), feedback_path('feedback-source': feedback_source))).html_safe %></p>
+  <p><%= raw t('feedback_link.message', href: link_to(t('feedback_link.feedback_form'), feedback_path('feedback-source': feedback_source))) %></p>
 </div>

--- a/app/views/shared/_other_ways.html.erb
+++ b/app/views/shared/_other_ways.html.erb
@@ -1,4 +1,4 @@
 <h2 class="heading-medium"><%= t 'hub.other_ways_heading', other_ways_description: other_ways_description %></h2>
 <div class="other-ways-to-complete-transaction">
-  <%= other_ways_text.html_safe %>
+  <%= raw other_ways_text %>
 </div>

--- a/app/views/will_it_work_for_me/why_might_this_not_work_for_me.html.erb
+++ b/app/views/will_it_work_for_me/why_might_this_not_work_for_me.html.erb
@@ -26,7 +26,7 @@
     <p><%= link_to t('hub.why_might_this_not_work_for_me.try_to_verify'), select_documents_path, id: 'verify-identity-online' %></p>
     <h2 class="heading-medium"><%= t 'hub.other_ways_heading', other_ways_description: @other_ways_description %></h2>
     <div class="other-ways-to-complete-transaction">
-      <%= @other_ways_text.html_safe %>
+      <%= raw @other_ways_text %>
     </div>
 
 

--- a/app/views/will_it_work_for_me/will_not_work_without_uk_address.html.erb
+++ b/app/views/will_it_work_for_me/will_not_work_without_uk_address.html.erb
@@ -9,7 +9,7 @@
     <h2 class="heading-medium"><%= t 'hub.other_ways_heading', other_ways_description: @other_ways_description %></h2>
     <div class="other-ways-to-complete-transaction">
       <p>
-      <%= @other_ways_text.html_safe %>
+      <%= raw @other_ways_text %>
       </p>
     </div>
   </div>


### PR DESCRIPTION
'raw' is a rails method wrapping 'html_safe' and is defined as

def raw(stringish)
  stringish.to_s.html_safe
end

For use in views, it has 2 advantages over html_safe

1) Its nil safe.
html_safe is only defined on strings. Therefore nil.html_safe causes a
NoSuchMethod error to be thrown.
raw(nil) is fine however, as nil.to_s returns an empty string, which you
can then call html_safe on (again to return an empty string).
This means that using nil acts as a defensive measure against variables
in our template unexpectedly being nil.

2) Its a clearer name.
'html_safe' is potentially confusing, as it can sound like it is making
the string safe in some way (ie sanitising the input). In reality, its
marking the string as safe - ie telling rails that it doesn't need to
escape the string at all.
Raw is a little clearer in this respect.

Solo: @michaelwalker