### PR TITLE
TT-1613: Switch hub-policy to fetch valid IDPs using LoA in addition …

### DIFF
--- a/app/controllers/redirect_to_idp_warning_controller.rb
+++ b/app/controllers/redirect_to_idp_warning_controller.rb
@@ -39,7 +39,7 @@ class RedirectToIdpWarningController < ApplicationController
 private
 
   def select_registration(idp)
-    POLICY_PROXY.select_idp(session['verify_session_id'], idp.entity_id, true)
+    POLICY_PROXY.select_idp(session['verify_session_id'], idp.entity_id, session['requested_loa'], true)
     set_journey_hint(idp.entity_id)
     register_idp_selections(idp.display_name)
   end

--- a/app/controllers/sign_in_controller.rb
+++ b/app/controllers/sign_in_controller.rb
@@ -32,7 +32,7 @@ class SignInController < ApplicationController
 private
 
   def sign_in(entity_id, idp_name)
-    POLICY_PROXY.select_idp(session[:verify_session_id], entity_id)
+    POLICY_PROXY.select_idp(session[:verify_session_id], entity_id, session['requested_loa'])
     set_journey_hint(entity_id)
     session[:selected_idp_name] = idp_name
   end

--- a/app/models/policy_endpoints.rb
+++ b/app/models/policy_endpoints.rb
@@ -8,6 +8,7 @@ module PolicyEndpoints
   PARAM_CYCLE_3_INPUT = 'cycle3Input'.freeze
   PARAM_SELECTED_ENTITY_ID = 'selectedIdpEntityId'.freeze
   PARAM_REGISTRATION = 'registration'.freeze
+  PARAM_REQUESTED_LOA = 'requestedLoa'.freeze
   CYCLE_THREE_SUFFIX = 'cycle-3-attribute'.freeze
   CYCLE_THREE_SUBMIT_SUFFIX = "#{CYCLE_THREE_SUFFIX}/submit".freeze
   CYCLE_THREE_CANCEL_SUFFIX = "#{CYCLE_THREE_SUFFIX}/cancel".freeze

--- a/app/models/policy_proxy.rb
+++ b/app/models/policy_proxy.rb
@@ -15,11 +15,12 @@ class PolicyProxy
     SignInProcessDetailsResponse.validated_response(response)
   end
 
-  def select_idp(session_id, entity_id, registration = false)
+  def select_idp(session_id, entity_id, requested_loa, registration = false)
     body = {
       PARAM_SELECTED_ENTITY_ID => entity_id,
       PARAM_PRINCIPAL_IP => originating_ip,
-      PARAM_REGISTRATION => registration
+      PARAM_REGISTRATION => registration,
+      PARAM_REQUESTED_LOA => requested_loa
     }
 
     @api_client.post(select_idp_endpoint(session_id), body)

--- a/spec/features/idp_selections_reported_to_piwik_spec.rb
+++ b/spec/features/idp_selections_reported_to_piwik_spec.rb
@@ -91,6 +91,7 @@ end
 def stub_idp_select_request(idp_entity_id)
   stub_session_select_idp_request(
     encrypted_entity_id,
-    PolicyEndpoints::PARAM_SELECTED_ENTITY_ID => idp_entity_id, PolicyEndpoints::PARAM_PRINCIPAL_IP => originating_ip, PolicyEndpoints::PARAM_REGISTRATION => true
+    PolicyEndpoints::PARAM_SELECTED_ENTITY_ID => idp_entity_id, PolicyEndpoints::PARAM_PRINCIPAL_IP => originating_ip,
+    PolicyEndpoints::PARAM_REGISTRATION => true, PolicyEndpoints::PARAM_REQUESTED_LOA => 'LEVEL_2'
   )
 end

--- a/spec/features/user_visits_redirect_to_idp_warning_page_spec.rb
+++ b/spec/features/user_visits_redirect_to_idp_warning_page_spec.rb
@@ -53,7 +53,8 @@ RSpec.describe 'When the user visits the redirect to IDP warning page' do
   let(:select_idp_stub_request) {
     stub_session_select_idp_request(
       encrypted_entity_id,
-       PolicyEndpoints::PARAM_SELECTED_ENTITY_ID => idp_entity_id, PolicyEndpoints::PARAM_PRINCIPAL_IP => originating_ip, PolicyEndpoints::PARAM_REGISTRATION => true
+      PolicyEndpoints::PARAM_SELECTED_ENTITY_ID => idp_entity_id, PolicyEndpoints::PARAM_PRINCIPAL_IP => originating_ip,
+      PolicyEndpoints::PARAM_REGISTRATION => true, PolicyEndpoints::PARAM_REQUESTED_LOA => 'LEVEL_2'
     )
   }
 

--- a/spec/features/user_visits_sign_in_page_spec.rb
+++ b/spec/features/user_visits_sign_in_page_spec.rb
@@ -33,7 +33,8 @@ RSpec.describe 'user selects an IDP on the sign in page' do
     expect(page).to have_content("registration is 'false'")
     expect(cookie_value('verify-front-journey-hint')).to_not be_nil
     expect(a_request(:post, policy_api_uri(select_idp_endpoint(default_session_id)))
-             .with(body: { PolicyEndpoints::PARAM_SELECTED_ENTITY_ID => idp_entity_id, PolicyEndpoints::PARAM_PRINCIPAL_IP => originating_ip, PolicyEndpoints::PARAM_REGISTRATION => false })).to have_been_made.once
+             .with(body: { PolicyEndpoints::PARAM_SELECTED_ENTITY_ID => idp_entity_id, PolicyEndpoints::PARAM_PRINCIPAL_IP => originating_ip,
+                           PolicyEndpoints::PARAM_REGISTRATION => false, PolicyEndpoints::PARAM_REQUESTED_LOA => 'LEVEL_2' })).to have_been_made.once
     expect(a_request(:get, saml_proxy_api_uri(authn_request_endpoint(default_session_id)))
              .with(headers: { 'X_FORWARDED_FOR' => originating_ip })).to have_been_made.once
     expect(stub_piwik_request('action_name' => "Sign In - #{idp_display_name}")).to have_been_made.once

--- a/spec/models/policy_proxy_spec.rb
+++ b/spec/models/policy_proxy_spec.rb
@@ -17,20 +17,32 @@ describe PolicyProxy do
   describe('#select_idp') do
     it 'should select an IDP for the session' do
       ip_address = '1.1.1.1'
-      body = { PolicyEndpoints::PARAM_SELECTED_ENTITY_ID => 'an-entity-id', PolicyEndpoints::PARAM_PRINCIPAL_IP => ip_address, PolicyEndpoints::PARAM_REGISTRATION => false }
+      body = { PolicyEndpoints::PARAM_SELECTED_ENTITY_ID => 'an-entity-id', PolicyEndpoints::PARAM_PRINCIPAL_IP => ip_address,
+               PolicyEndpoints::PARAM_REGISTRATION => false, PolicyEndpoints::PARAM_REQUESTED_LOA => 'LEVEL_2' }
       expect(api_client).to receive(:post)
         .with(endpoint(PolicyProxy::SELECT_IDP_SUFFIX), body)
       expect(originating_ip_store).to receive(:get).and_return(ip_address)
-      policy_proxy.select_idp(session_id, 'an-entity-id')
+      policy_proxy.select_idp(session_id, 'an-entity-id', 'LEVEL_2')
+    end
+
+    it 'should select an IDP for the session with LOA1' do
+      ip_address = '1.1.1.1'
+      body = { PolicyEndpoints::PARAM_SELECTED_ENTITY_ID => 'an-entity-id', PolicyEndpoints::PARAM_PRINCIPAL_IP => ip_address,
+               PolicyEndpoints::PARAM_REGISTRATION => false, PolicyEndpoints::PARAM_REQUESTED_LOA => 'LEVEL_1' }
+      expect(api_client).to receive(:post)
+                                .with(endpoint(PolicyProxy::SELECT_IDP_SUFFIX), body)
+      expect(originating_ip_store).to receive(:get).and_return(ip_address)
+      policy_proxy.select_idp(session_id, 'an-entity-id', 'LEVEL_1')
     end
 
     it 'should select an IDP for the session when registering' do
       ip_address = '1.1.1.1'
-      body = { PolicyEndpoints::PARAM_SELECTED_ENTITY_ID => 'an-entity-id', PolicyEndpoints::PARAM_PRINCIPAL_IP => ip_address, PolicyEndpoints::PARAM_REGISTRATION => true }
+      body = { PolicyEndpoints::PARAM_SELECTED_ENTITY_ID => 'an-entity-id', PolicyEndpoints::PARAM_PRINCIPAL_IP => ip_address,
+               PolicyEndpoints::PARAM_REGISTRATION => true, PolicyEndpoints::PARAM_REQUESTED_LOA => 'LEVEL_2' }
       expect(api_client).to receive(:post)
         .with(endpoint(PolicyProxy::SELECT_IDP_SUFFIX), body)
       expect(originating_ip_store).to receive(:get).and_return(ip_address)
-      policy_proxy.select_idp(session_id, 'an-entity-id', true)
+      policy_proxy.select_idp(session_id, 'an-entity-id', 'LEVEL_2', true,)
     end
   end
 


### PR DESCRIPTION
…to Transaction

Frontend sends the transaction requested LOA to Policy when IDP is selected

Author: @CharlesIC