### PR TITLE
BAU: disable the Rails IP spoofing check

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -35,6 +35,9 @@ module VerifyFrontend
 
     config.exceptions_app = self.routes
 
+    # Disable the ip_spoofing_check as we only store/read X_FORWARDED_FOR, not CLIENT_IP
+    config.action_dispatch.ip_spoofing_check = false
+
     # Add recommended security headers and apply a basic lenient Content Security Policy
     config.action_dispatch.default_headers = {
       'X-Frame-Options' => 'DENY',


### PR DESCRIPTION
It can cause errors but gives no benefit. From Rails release notes:
"The fact that Rails checks for IP spoofing can be a nuisance for sites that do heavy traffic with cell phones, because their proxies don't generally set things up right."
In our case, we think it’s some misconfiguration at the Welsh Assembly causing errors in the frontend.

Solo: @hugh-emerson