### PR TITLE
HUB-59: Production bug in the interstitial logic

### DIFF
--- a/app/controllers/choose_a_certified_company_loa2_controller.rb
+++ b/app/controllers/choose_a_certified_company_loa2_controller.rb
@@ -5,6 +5,7 @@ class ChooseACertifiedCompanyLoa2Controller < ApplicationController
   include ViewableIdpPartialController
 
   def index
+    session[:selected_answers].delete(:interstitial)
     suggestions = IDP_RECOMMENDATION_ENGINE.get_suggested_idps(current_identity_providers_for_loa, selected_evidence, current_transaction_simple_id)
     @recommended_idps = IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate_collection(suggestions[:recommended])
     @non_recommended_idps = IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate_collection(suggestions[:unlikely])
@@ -14,7 +15,6 @@ class ChooseACertifiedCompanyLoa2Controller < ApplicationController
   end
 
   def select_idp
-    selected_answer_store.store_selected_answers('interstitial', {})
     select_viewable_idp_for_loa(params.fetch('entity_id')) do |decorated_idp|
       session[:selected_idp_was_recommended] = IDP_RECOMMENDATION_ENGINE.recommended?(decorated_idp.identity_provider, current_identity_providers_for_loa, selected_evidence, current_transaction_simple_id)
       redirect_to warning_or_question_page(decorated_idp)

--- a/spec/controllers/choose_a_certified_company_loa2_controller_spec.rb
+++ b/spec/controllers/choose_a_certified_company_loa2_controller_spec.rb
@@ -39,19 +39,27 @@ describe ChooseACertifiedCompanyLoa2Controller do
       expect(subject).to render_template(:choose_a_certified_company_LOA2)
       expect(stub_piwik_request).to have_been_made.once
     end
+
+    it 'removes interstitial answer when IDP picker page is rendered' do
+      set_session_and_cookies_with_loa('LEVEL_2')
+      stub_api_idp_list_for_loa([stub_idp_loa1, stub_idp_one_doc])
+      session[:selected_answers] = {
+        documents: { driving_licence: true, mobile_phone: true },
+        device_type: { device_type_other: true },
+        interstitial: { interstitial_yes: true }
+      }
+      stub_piwik_report_number_of_recommended_idps(1, 'LEVEL_2', 'analytics description for test-rp')
+
+      get :index, params: { locale: 'en' }
+
+      expect(session[:selected_answers]['interstitial']).to be_nil
+    end
   end
 
   context '#select_idp' do
     before :each do
       set_session_and_cookies_with_loa('LEVEL_2')
       stub_api_idp_list_for_loa([stub_idp_loa1, stub_idp_one_doc])
-    end
-
-    it 'resets interstitial answer to no value when IDP is selected' do
-      session[:selected_answers] = { 'interstitial' => { 'interstitial_yes' => true } }
-      post :select_idp, params: { locale: 'en', entity_id: 'http://idcorp.com' }
-
-      expect(session[:selected_answers]['interstitial']).to be_empty
     end
 
     it 'sets selected IDP in user session' do


### PR DESCRIPTION
The interstitial question is adding an 'interstitial' property to the evidence string/selected_answers, so when the user comes back after answering the interstitial question no IDPs will match as there are no segments for the 'interstitial evidence'.

Solo: @jakubmiarka