### PR TITLE
HUB-11 IDP journey hint

### DIFF
--- a/app/controllers/partials/idp_selection_partial_controller.rb
+++ b/app/controllers/partials/idp_selection_partial_controller.rb
@@ -1,6 +1,10 @@
 module IdpSelectionPartialController
-  def ajax_idp_redirection_sign_in_request(hinted)
-    FEDERATION_REPORTER.report_sign_in_idp_selection(current_transaction, request, session[:selected_idp_name], hinted)
+  def ajax_idp_redirection_sign_in_request(hint_shown, hint_followed)
+    if hint_shown
+      FEDERATION_REPORTER.report_sign_in_idp_selection_after_journey_hint(current_transaction, request, session[:selected_idp_name], hint_followed)
+    else
+      FEDERATION_REPORTER.report_sign_in_idp_selection(current_transaction, request, session[:selected_idp_name])
+    end
 
     outbound_saml_message = SAML_PROXY_API.authn_request(session[:verify_session_id])
     idp_request = idp_request_initilization(outbound_saml_message)

--- a/app/controllers/partials/idp_selection_partial_controller.rb
+++ b/app/controllers/partials/idp_selection_partial_controller.rb
@@ -1,6 +1,6 @@
 module IdpSelectionPartialController
-  def ajax_idp_redirection_sign_in_request
-    FEDERATION_REPORTER.report_sign_in_idp_selection(current_transaction, request, session[:selected_idp_name])
+  def ajax_idp_redirection_sign_in_request(hinted)
+    FEDERATION_REPORTER.report_sign_in_idp_selection(current_transaction, request, session[:selected_idp_name], hinted)
 
     outbound_saml_message = SAML_PROXY_API.authn_request(session[:verify_session_id])
     idp_request = idp_request_initilization(outbound_saml_message)

--- a/app/controllers/partials/journey_hinting_partial_controller.rb
+++ b/app/controllers/partials/journey_hinting_partial_controller.rb
@@ -1,0 +1,12 @@
+# Shared methods for controllers which use the journey hint cookie to give users IDP suggestions
+module JourneyHintingPartialController
+  def journey_hint_value
+    MultiJson.load(cookies.encrypted[CookieNames::VERIFY_FRONT_JOURNEY_HINT] ||= '')
+  rescue MultiJson::ParseError
+    nil
+  end
+
+  def retrieve_decorated_singleton_idp_array_by_entity_id(providers, entity_id)
+    IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate_collection(providers.select { |idp| idp.entity_id == entity_id })
+  end
+end

--- a/app/controllers/partials/journey_hinting_partial_controller.rb
+++ b/app/controllers/partials/journey_hinting_partial_controller.rb
@@ -11,9 +11,9 @@ module JourneyHintingPartialController
     journey_hint.nil? ? nil : journey_hint['entity_id']
   end
 
-  def user_followed_journey_hint(entity_id)
+  def user_followed_journey_hint(entity_id_followed_by_user)
     hinted_id = entity_id_of_journey_hint
-    !hinted_id.nil? && hinted_id == entity_id
+    !hinted_id.nil? && hinted_id == entity_id_followed_by_user
   end
 
   def retrieve_decorated_singleton_idp_array_by_entity_id(providers, entity_id)

--- a/app/controllers/partials/journey_hinting_partial_controller.rb
+++ b/app/controllers/partials/journey_hinting_partial_controller.rb
@@ -11,6 +11,11 @@ module JourneyHintingPartialController
     journey_hint.nil? ? nil : journey_hint['entity_id']
   end
 
+  def user_followed_journey_hint(entity_id)
+    hinted_id = entity_id_of_journey_hint
+    !hinted_id.nil? && hinted_id == entity_id
+  end
+
   def retrieve_decorated_singleton_idp_array_by_entity_id(providers, entity_id)
     IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate_collection(providers.select { |idp| idp.entity_id == entity_id })
   end

--- a/app/controllers/partials/journey_hinting_partial_controller.rb
+++ b/app/controllers/partials/journey_hinting_partial_controller.rb
@@ -6,6 +6,11 @@ module JourneyHintingPartialController
     nil
   end
 
+  def entity_id_of_journey_hint
+    journey_hint = journey_hint_value
+    journey_hint.nil? ? nil : journey_hint['entity_id']
+  end
+
   def retrieve_decorated_singleton_idp_array_by_entity_id(providers, entity_id)
     IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate_collection(providers.select { |idp| idp.entity_id == entity_id })
   end

--- a/app/controllers/redirect_to_idp_controller.rb
+++ b/app/controllers/redirect_to_idp_controller.rb
@@ -11,7 +11,8 @@ class RedirectToIdpController < ApplicationController
 
   def sign_in
     request_form
-    FEDERATION_REPORTER.report_sign_in_idp_selection(current_transaction, request, session[:selected_idp_name])
+    hinted = session[:user_followed_journey_hint] ||= false
+    FEDERATION_REPORTER.report_sign_in_idp_selection(current_transaction, request, session[:selected_idp_name], hinted)
     render :redirect_to_idp
   end
 

--- a/app/controllers/redirect_to_idp_controller.rb
+++ b/app/controllers/redirect_to_idp_controller.rb
@@ -11,8 +11,11 @@ class RedirectToIdpController < ApplicationController
 
   def sign_in
     request_form
-    hinted = session[:user_followed_journey_hint] ||= false
-    FEDERATION_REPORTER.report_sign_in_idp_selection(current_transaction, request, session[:selected_idp_name], hinted)
+    if session[:user_followed_journey_hint].nil?
+      FEDERATION_REPORTER.report_sign_in_idp_selection(current_transaction, request, session[:selected_idp_name])
+    else
+      FEDERATION_REPORTER.report_sign_in_idp_selection_after_journey_hint(current_transaction, request, session[:selected_idp_name], session[:user_followed_journey_hint])
+    end
     render :redirect_to_idp
   end
 

--- a/app/controllers/sign_in_controller.rb
+++ b/app/controllers/sign_in_controller.rb
@@ -10,8 +10,9 @@ class SignInController < ApplicationController
   def index
     entity_id = entity_id_of_journey_hint
     @suggested_idp = entity_id.nil? ? [] : retrieve_decorated_singleton_idp_array_by_entity_id(current_identity_providers_for_sign_in, entity_id)
-
-    # TODO HUB-11 report hint shown event to piwik if hint exists
+    unless @suggested_idp.empty?
+      FEDERATION_REPORTER.report_sign_in_journey_hint_shown(current_transaction, request, @suggested_idp[0].display_name)
+    end
 
     @identity_providers = IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate_collection(current_identity_providers_for_sign_in)
 

--- a/app/controllers/sign_in_controller.rb
+++ b/app/controllers/sign_in_controller.rb
@@ -1,11 +1,20 @@
 require 'partials/idp_selection_partial_controller'
 require 'partials/viewable_idp_partial_controller'
+require 'partials/journey_hinting_partial_controller'
 
 class SignInController < ApplicationController
   include IdpSelectionPartialController
   include ViewableIdpPartialController
+  include JourneyHintingPartialController
 
   def index
+    journey_hint = journey_hint_value
+
+    unless journey_hint.nil?
+      entity_id = journey_hint['entity_id']
+      @suggested_idp = entity_id.nil? ? [] : retrieve_decorated_singleton_idp_array_by_entity_id(current_identity_providers_for_sign_in, entity_id)
+    end
+
     @identity_providers = IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate_collection(current_identity_providers_for_sign_in)
 
     @unavailable_identity_providers = IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate_collection(

--- a/app/controllers/sign_in_controller.rb
+++ b/app/controllers/sign_in_controller.rb
@@ -8,12 +8,10 @@ class SignInController < ApplicationController
   include JourneyHintingPartialController
 
   def index
-    journey_hint = journey_hint_value
+    entity_id = entity_id_of_journey_hint
+    @suggested_idp = entity_id.nil? ? [] : retrieve_decorated_singleton_idp_array_by_entity_id(current_identity_providers_for_sign_in, entity_id)
 
-    unless journey_hint.nil?
-      entity_id = journey_hint['entity_id']
-      @suggested_idp = entity_id.nil? ? [] : retrieve_decorated_singleton_idp_array_by_entity_id(current_identity_providers_for_sign_in, entity_id)
-    end
+    # TODO HUB-11 report hint shown event to piwik if hint exists
 
     @identity_providers = IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate_collection(current_identity_providers_for_sign_in)
 
@@ -33,8 +31,9 @@ class SignInController < ApplicationController
 
   def select_idp_ajax
     select_viewable_idp_for_sign_in(params.fetch('entityId')) do |decorated_idp|
+      hinted = entity_id_of_journey_hint == decorated_idp.entity_id
       sign_in(decorated_idp.entity_id, decorated_idp.display_name)
-      ajax_idp_redirection_sign_in_request
+      ajax_idp_redirection_sign_in_request(hinted)
     end
   end
 

--- a/app/controllers/sign_in_controller.rb
+++ b/app/controllers/sign_in_controller.rb
@@ -25,7 +25,9 @@ class SignInController < ApplicationController
 
   def select_idp
     select_viewable_idp_for_sign_in(params.fetch('entity_id')) do |decorated_idp|
-      session[:user_followed_journey_hint] = user_followed_journey_hint(decorated_idp.entity_id)
+      unless entity_id_of_journey_hint.nil?
+        session[:user_followed_journey_hint] = user_followed_journey_hint(decorated_idp.entity_id)
+      end
       sign_in(decorated_idp.entity_id, decorated_idp.display_name)
       redirect_to redirect_to_idp_sign_in_path
     end
@@ -33,9 +35,10 @@ class SignInController < ApplicationController
 
   def select_idp_ajax
     select_viewable_idp_for_sign_in(params.fetch('entityId')) do |decorated_idp|
-      hinted = user_followed_journey_hint(decorated_idp.entity_id)
+      hint_shown = !entity_id_of_journey_hint.nil?
+      hint_followed = user_followed_journey_hint(decorated_idp.entity_id)
       sign_in(decorated_idp.entity_id, decorated_idp.display_name)
-      ajax_idp_redirection_sign_in_request(hinted)
+      ajax_idp_redirection_sign_in_request(hint_shown, hint_followed)
     end
   end
 

--- a/app/controllers/sign_in_controller.rb
+++ b/app/controllers/sign_in_controller.rb
@@ -24,6 +24,7 @@ class SignInController < ApplicationController
 
   def select_idp
     select_viewable_idp_for_sign_in(params.fetch('entity_id')) do |decorated_idp|
+      session[:user_followed_journey_hint] = user_followed_journey_hint(decorated_idp.entity_id)
       sign_in(decorated_idp.entity_id, decorated_idp.display_name)
       redirect_to redirect_to_idp_sign_in_path
     end
@@ -31,7 +32,7 @@ class SignInController < ApplicationController
 
   def select_idp_ajax
     select_viewable_idp_for_sign_in(params.fetch('entityId')) do |decorated_idp|
-      hinted = entity_id_of_journey_hint == decorated_idp.entity_id
+      hinted = user_followed_journey_hint(decorated_idp.entity_id)
       sign_in(decorated_idp.entity_id, decorated_idp.display_name)
       ajax_idp_redirection_sign_in_request(hinted)
     end

--- a/app/models/analytics/federation_reporter.rb
+++ b/app/models/analytics/federation_reporter.rb
@@ -48,9 +48,9 @@ module Analytics
 
     def report_sign_in_journey_hint_shown(current_transaction, request, idp_display_name)
       report_action(
-          current_transaction,
-          request,
-          "Sign In Journey Hint Shown - #{idp_display_name}"
+        current_transaction,
+        request,
+        "Sign In Journey Hint Shown - #{idp_display_name}"
       )
     end
 
@@ -65,11 +65,19 @@ module Analytics
       )
     end
 
-    def report_sign_in_idp_selection(current_transaction, request, idp_display_name, hinted = false)
+    def report_sign_in_idp_selection(current_transaction, request, idp_display_name)
       report_action(
         current_transaction,
         request,
-        "Sign In - #{idp_display_name}" + (hinted ? " - Hinted" : "")
+        "Sign In - #{idp_display_name}"
+      )
+    end
+
+    def report_sign_in_idp_selection_after_journey_hint(current_transaction, request, idp_display_name, hint_followed)
+      report_action(
+        current_transaction,
+        request,
+        "Sign In - #{idp_display_name} - Hint #{hint_followed ? 'Followed' : 'Ignored'}"
       )
     end
 

--- a/app/models/analytics/federation_reporter.rb
+++ b/app/models/analytics/federation_reporter.rb
@@ -57,11 +57,11 @@ module Analytics
       )
     end
 
-    def report_sign_in_idp_selection(current_transaction, request, idp_display_name)
+    def report_sign_in_idp_selection(current_transaction, request, idp_display_name, hinted = false)
       report_action(
         current_transaction,
         request,
-        "Sign In - #{idp_display_name}"
+        "Sign In - #{idp_display_name}" + (hinted ? " - Hinted" : "")
       )
     end
 

--- a/app/models/analytics/federation_reporter.rb
+++ b/app/models/analytics/federation_reporter.rb
@@ -46,6 +46,14 @@ module Analytics
       end
     end
 
+    def report_sign_in_journey_hint_shown(current_transaction, request, idp_display_name)
+      report_action(
+          current_transaction,
+          request,
+          "Sign In Journey Hint Shown - #{idp_display_name}"
+      )
+    end
+
     def report_idp_registration(current_transaction:, request:, idp_name:, idp_name_history:, evidence:, recommended:, user_segments:)
       list_of_evidence = evidence.sort.join(', ')
       list_of_segments = user_segments.nil? ? nil : user_segments.sort.join(', ')

--- a/app/views/sign_in/index.html.erb
+++ b/app/views/sign_in/index.html.erb
@@ -10,7 +10,23 @@
   </div>
 </div>
 
-<div class="grid-row js-continue-to-idp" data-location="<%= url_for(controller: 'sign_in', action: 'select_idp_ajax', locale: I18n.locale)  %>">
+<% if defined?(@suggested_idp) && !@suggested_idp.empty? %>
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      <p><%= t 'hub.signin.last_certified', company_name: @suggested_idp[0].display_name %></p>
+    </div>
+  </div>
+  <div class="grid-row js-continue-to-idp" data-location="<%= url_for(controller: 'sign_in', action: 'select_idp_ajax', locale: I18n.locale) %>">
+    <%= render partial: 'shared/idp_list', locals: {identity_providers: @suggested_idp} %>
+  </div>
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      <p><%= t 'hub.signin.any_certified_company' %></p>
+    </div>
+  </div>
+<% end %>
+
+<div class="grid-row js-continue-to-idp" data-location="<%= url_for(controller: 'sign_in', action: 'select_idp_ajax', locale: I18n.locale) %>">
   <%= render partial: 'shared/idp_list', locals: {identity_providers: @identity_providers} %>
   <%= render partial: 'shared/unavailable_idp_list', locals: {unavailable_identity_providers: @unavailable_identity_providers, offset: @identity_providers.count} %>
   <%= render partial: 'shared/continue_to_idp_form' %>

--- a/app/views/sign_in/index.html.erb
+++ b/app/views/sign_in/index.html.erb
@@ -6,7 +6,7 @@
 <div class="grid-row">
   <div class="column-two-thirds">
     <h1 class="heading-large"><%= t 'hub.signin.heading' %></h1>
-    <p><%= t 'hub.signin.registration_message_html', href: link_to(t('hub.signin.about_link'), begin_registration_path, id: 'begin-registration-route') %></p>
+    <p class="lede"><%= t 'hub.signin.registration_message_html', href: link_to(t('hub.signin.about_link'), begin_registration_path, id: 'begin-registration-route') %></p>
   </div>
 </div>
 

--- a/app/views/sign_in/index.html.erb
+++ b/app/views/sign_in/index.html.erb
@@ -16,7 +16,7 @@
       <p><%= t 'hub.signin.last_certified', company_name: @suggested_idp[0].display_name %></p>
     </div>
   </div>
-  <div class="grid-row js-continue-to-idp" data-location="<%= url_for(controller: 'sign_in', action: 'select_idp_ajax', locale: I18n.locale) %>">
+  <div class="grid-row js-continue-to-idp journey-hint" data-location="<%= url_for(controller: 'sign_in', action: 'select_idp_ajax', locale: I18n.locale) %>">
     <%= render partial: 'shared/idp_list', locals: {identity_providers: @suggested_idp} %>
   </div>
   <div class="grid-row">

--- a/app/views/sign_in/index.html.erb
+++ b/app/views/sign_in/index.html.erb
@@ -16,7 +16,7 @@
       <p><%= t 'hub.signin.last_certified', company_name: @suggested_idp[0].display_name %></p>
     </div>
   </div>
-  <div class="grid-row js-continue-to-idp journey-hint" data-location="<%= url_for(controller: 'sign_in', action: 'select_idp_ajax', locale: I18n.locale) %>">
+  <div class="grid-row js-continue-to-idp" data-location="<%= url_for(controller: 'sign_in', action: 'select_idp_ajax', locale: I18n.locale) %>">
     <%= render partial: 'shared/idp_list', locals: {identity_providers: @suggested_idp} %>
   </div>
   <div class="grid-row">

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -99,6 +99,8 @@ cy:
       back: Yn ôl
       about_link: Dechreuwch nawr
       registration_message_html: Os nad oes gennych gyfrif hunaniaeth, gallwch %{href}.
+      last_certified: The last certified company used on this device was %{company_name}.
+      any_certified_company: "You can use an identity account you set up with any certified company in the past:"
       select_idp: Ddewis %{display_name}
       sign_in_idp: Llofnodi i mewn gyda %{display_name}
       forgot_company: Ni allaf gofio pa gwmni wnaeth fy nilysu

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -95,8 +95,10 @@ en:
       title: Sign in with a certified company
       heading: Who do you have an identity account with?
       back: Back
-      about_link: start now
+      about_link: set one up now
       registration_message_html: If you don’t have an identity account, you can %{href}.
+      last_certified: The last certified company used on this device was %{company_name}.
+      any_certified_company: "You can use an identity account you set up with any certified company in the past:"
       select_idp: Select %{display_name}
       sign_in_idp: Sign in with %{display_name}
       forgot_company: I can’t remember which company verified me

--- a/spec/controllers/redirect_to_idp_controller_spec.rb
+++ b/spec/controllers/redirect_to_idp_controller_spec.rb
@@ -90,8 +90,7 @@ describe RedirectToIdpController do
       expect(FEDERATION_REPORTER).to receive(:report_sign_in_idp_selection)
                                          .with(a_kind_of(Display::RpDisplayData),
                                                a_kind_of(ActionDispatch::Request),
-                                               bobs_identity_service_idp_name,
-                                               false)
+                                               bobs_identity_service_idp_name)
 
       subject
     end
@@ -102,11 +101,27 @@ describe RedirectToIdpController do
       end
 
       it 'reports idp selection details to piwik' do
-        expect(FEDERATION_REPORTER).to receive(:report_sign_in_idp_selection)
+        expect(FEDERATION_REPORTER).to receive(:report_sign_in_idp_selection_after_journey_hint)
                                            .with(a_kind_of(Display::RpDisplayData),
                                                  a_kind_of(ActionDispatch::Request),
                                                  bobs_identity_service_idp_name,
                                                  true)
+
+        subject
+      end
+    end
+
+    context 'and with the journey hint session param suggesting hint ignored' do
+      before :each do
+        session[:user_followed_journey_hint] = false
+      end
+
+      it 'reports idp selection details to piwik' do
+        expect(FEDERATION_REPORTER).to receive(:report_sign_in_idp_selection_after_journey_hint)
+                                           .with(a_kind_of(Display::RpDisplayData),
+                                                 a_kind_of(ActionDispatch::Request),
+                                                 bobs_identity_service_idp_name,
+                                                 false)
 
         subject
       end

--- a/spec/controllers/sign_in_controller_spec.rb
+++ b/spec/controllers/sign_in_controller_spec.rb
@@ -15,6 +15,14 @@ describe SignInController do
     it 'will render the index page' do
       get :index, params: { locale: 'en' }
       expect(subject).to render_template(:index)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'will render the index page with invalid cookie' do
+      cookies[CookieNames::VERIFY_FRONT_JOURNEY_HINT] = 'some-nonsense-idp-entity-id'
+      get :index, params: { locale: 'en' }
+      expect(subject).to render_template(:index)
+      expect(response).to have_http_status(:ok)
     end
   end
 

--- a/spec/features/user_visits_confirm_your_identity_page_spec.rb
+++ b/spec/features/user_visits_confirm_your_identity_page_spec.rb
@@ -130,7 +130,6 @@ RSpec.describe 'When the user visits the confirm-your-identity page' do
       visit '/confirm-your-identity'
       expect(page).to have_title t('hub.signin.title')
       expect(page).to have_current_path(sign_in_path)
-      expect(cookie_value(CookieNames::VERIFY_FRONT_JOURNEY_HINT)).to eql("") # rails deletes cookies by setting the value to an empty string
     end
   end
 

--- a/spec/features/user_visits_sign_in_page_spec.rb
+++ b/spec/features/user_visits_sign_in_page_spec.rb
@@ -26,7 +26,8 @@ RSpec.describe 'user selects an IDP on the sign in page' do
   end
 
   def when_i_select_an_idp
-    # click_button(idp_display_name, maximum: 2)
+    # There may be multiple identical buttons due to the journey hint
+    # so we can't use 'click_button'
     all(:button, idp_display_name)[0].click
   end
 

--- a/spec/features/user_visits_sign_in_page_spec.rb
+++ b/spec/features/user_visits_sign_in_page_spec.rb
@@ -56,6 +56,10 @@ RSpec.describe 'user selects an IDP on the sign in page' do
     expect(stub_piwik_request('action_name' => "Sign In - #{idp_display_name} - Hinted")).to have_been_made.once
   end
 
+  def then_piwik_was_sent_a_journey_hint_shown_event
+    expect(stub_piwik_request('action_name' => "Sign In Journey Hint Shown - #{idp_display_name}")).to have_been_made.once
+  end
+
   def and_the_language_hint_is_set
     expect(page).to have_content("language hint was 'en'")
   end
@@ -150,12 +154,14 @@ RSpec.describe 'user selects an IDP on the sign in page' do
         expect(page).to have_text 'You can use an identity account you set up with any certified company in the past:'
         expect(page).to have_text 'The last certified company used on this device was IDCorp.'
         expect(page).to have_button('Select IDCorp', count: 2)
+        then_piwik_was_sent_a_journey_hint_shown_event
       end
 
       it 'will redirect the user to the hinted IDP' do
         page.set_rack_session(transaction_simple_id: 'test-rp')
         given_api_requests_have_been_mocked!
         given_im_on_the_sign_in_page
+        then_piwik_was_sent_a_journey_hint_shown_event
         expect_any_instance_of(SignInController).to receive(:select_idp_ajax).and_call_original
         when_i_select_an_idp
         then_im_at_the_idp

--- a/spec/features/user_visits_sign_in_page_spec.rb
+++ b/spec/features/user_visits_sign_in_page_spec.rb
@@ -112,8 +112,6 @@ RSpec.describe 'user selects an IDP on the sign in page' do
       given_im_on_the_sign_in_page
       expect(page).not_to have_text 'The last certified company used on this device was'
       expect(page).not_to have_text 'You can use an identity account you set up with any certified company in the past:'
-
-      # TODO HUB-11 test that the box with the idp logo is NOT shown?
     end
 
     context 'with an invalid idp-hint cookie' do

--- a/spec/features/user_visits_sign_in_page_spec.rb
+++ b/spec/features/user_visits_sign_in_page_spec.rb
@@ -52,12 +52,16 @@ RSpec.describe 'user selects an IDP on the sign in page' do
     expect(stub_piwik_request('action_name' => "Sign In - #{idp_display_name}")).to have_been_made.once
   end
 
-  def and_piwik_was_sent_a_signin_hinted_event
-    expect(stub_piwik_request('action_name' => "Sign In - #{idp_display_name} - Hinted")).to have_been_made.once
+  def and_piwik_was_sent_a_signin_hint_followed_event
+    expect(stub_piwik_request('action_name' => "Sign In - #{idp_display_name} - Hint Followed")).to have_been_made.once
   end
 
-  def then_piwik_was_sent_a_journey_hint_shown_event
-    expect(stub_piwik_request('action_name' => "Sign In Journey Hint Shown - #{idp_display_name}")).to have_been_made.once
+  def and_piwik_was_sent_a_signin_hint_ignored_event
+    expect(stub_piwik_request('action_name' => "Sign In - #{idp_display_name} - Hint Ignored")).to have_been_made.once
+  end
+
+  def then_piwik_was_sent_a_journey_hint_shown_event_for(idp_name)
+    expect(stub_piwik_request('action_name' => "Sign In Journey Hint Shown - #{idp_name}")).to have_been_made.once
   end
 
   def and_the_language_hint_is_set
@@ -152,20 +156,46 @@ RSpec.describe 'user selects an IDP on the sign in page' do
         given_api_requests_have_been_mocked!
         given_im_on_the_sign_in_page
         expect(page).to have_text 'You can use an identity account you set up with any certified company in the past:'
-        expect(page).to have_text 'The last certified company used on this device was IDCorp.'
-        expect(page).to have_button('Select IDCorp', count: 2)
-        then_piwik_was_sent_a_journey_hint_shown_event
+        expect(page).to have_text "The last certified company used on this device was #{idp_display_name}."
+        expect(page).to have_button("Select #{idp_display_name}", count: 2)
+        then_piwik_was_sent_a_journey_hint_shown_event_for(idp_display_name)
       end
 
       it 'will redirect the user to the hinted IDP' do
         page.set_rack_session(transaction_simple_id: 'test-rp')
         given_api_requests_have_been_mocked!
         given_im_on_the_sign_in_page
-        then_piwik_was_sent_a_journey_hint_shown_event
+        then_piwik_was_sent_a_journey_hint_shown_event_for(idp_display_name)
         expect_any_instance_of(SignInController).to receive(:select_idp_ajax).and_call_original
         when_i_select_an_idp
         then_im_at_the_idp
-        and_piwik_was_sent_a_signin_hinted_event
+        and_piwik_was_sent_a_signin_hint_followed_event
+        and_the_language_hint_is_set
+        and_the_hints_are_not_set
+        expect(page.get_rack_session_key('selected_idp')).to include('entity_id' => idp_entity_id, 'simple_id' => 'stub-idp-one', 'levels_of_assurance' => %w(LEVEL_2))
+      end
+    end
+
+    context 'with a different valid idp-hint cookie' do
+      before :each do
+        given_the_journey_hint_cookie_is_set_with_value('other-entity-id')
+      end
+
+      hinted_idp_name = "Bob’s Identity Service"
+
+      it 'will redirect the user to a non-hinted IDP if hint ignored' do
+        page.set_rack_session(transaction_simple_id: 'test-rp')
+        given_api_requests_have_been_mocked!
+        given_im_on_the_sign_in_page
+        then_piwik_was_sent_a_journey_hint_shown_event_for(hinted_idp_name)
+        expect(page).to have_text 'You can use an identity account you set up with any certified company in the past:'
+        expect(page).to have_text "The last certified company used on this device was #{hinted_idp_name}."
+        expect(page).to have_button("Select #{hinted_idp_name}", count: 2)
+
+        expect_any_instance_of(SignInController).to receive(:select_idp_ajax).and_call_original
+        when_i_select_an_idp
+        then_im_at_the_idp
+        and_piwik_was_sent_a_signin_hint_ignored_event
         and_the_language_hint_is_set
         and_the_hints_are_not_set
         expect(page.get_rack_session_key('selected_idp')).to include('entity_id' => idp_entity_id, 'simple_id' => 'stub-idp-one', 'levels_of_assurance' => %w(LEVEL_2))


### PR DESCRIPTION
If we have a journey hint cookie, modify the sign-in page to display that IDP prominently as per the design on the ticket.

Changes to piwik events:
* New event fired whenever we show a hint "Sign In Journey Hint Shown - ${idp_name}"
* Existing sign in event has " - Hint Followed" appended if the user followed a journey hint
* Existing sign in event has " - Hint Ignored" appended if the user ignored a journey hint

In the non-JS case we need a new session param to tell the idp redirect controller to send the correct event type - that controller can't check the hint cookie itself because the cookie has already been overwritten to the new IDP choice that was just clicked