### PR TITLE
HUB-71 feature tests and routing fix

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -167,7 +167,7 @@ cy:
         </ul>
         <p>Fodd bynnag, mae gan bob cwmni ddulliau gwahanol ar gyfer pob un o'r camau hyn.</p>
         <p>Felly byddwn nawr yn gofyn rhai cwestiynau i chi wirio pa gwmnïau all eich dilysu. Byddwn wedyn yn eich anfon at wefan y cwmni rydych yn ei ddewis.</p>
-    content_variant_html: |
+      content_variant_html: |
         <p>Mae cwmnïau ardystiedig wedi adeiladu systemau newydd, diogel i ddilysu hunaniaeth. Mae'r systemau hyn yn gweithio trwy wirio:</p>
         <ul class="list-bullet list">
         <li>bod eich dogfennau hunaniaeth yn ddilys</li>

--- a/config/main_routes.rb
+++ b/config/main_routes.rb
@@ -5,21 +5,6 @@ end
 get 'sign_in', to: 'sign_in#index', as: :sign_in
 post 'sign_in', to: 'sign_in#select_idp', as: :sign_in_submit
 
-get 'select_documents', to: 'select_documents#index', as: :select_documents
-get 'select_documents_none', to: 'select_documents#no_documents', as: :select_documents_no_documents
-post 'select_documents', to: 'select_documents#select_documents', as: :select_documents_submit
-get 'unlikely_to_verify', to: 'select_documents#unlikely_to_verify', as: :unlikely_to_verify
-get 'other_identity_documents', to: 'other_identity_documents#index', as: :other_identity_documents
-post 'other_identity_documents', to: 'other_identity_documents#select_other_documents', as: :other_identity_documents_submit
-get 'select_phone', to: 'select_phone#index', as: :select_phone
-post 'select_phone', to: 'select_phone#select_phone', as: :select_phone_submit
-get 'no_mobile_phone', to: 'select_phone#no_mobile_phone', as: :no_mobile_phone
-get 'will_it_work_for_me', to: 'will_it_work_for_me#index', as: :will_it_work_for_me
-post 'will_it_work_for_me', to: 'will_it_work_for_me#will_it_work_for_me', as: :will_it_work_for_me_submit
-get 'why_might_this_not_work_for_me', to: 'will_it_work_for_me#why_might_this_not_work_for_me', as: :why_might_this_not_work_for_me
-get 'may_not_work_if_you_live_overseas', to: 'will_it_work_for_me#may_not_work_if_you_live_overseas', as: :may_not_work_if_you_live_overseas
-get 'will_not_work_without_uk_address', to: 'will_it_work_for_me#will_not_work_without_uk_address', as: :will_not_work_without_uk_address
-
 NO_QUESTIONS = 'no_questions'.freeze
 
 no_questions_control_piwik = SelectRoute.new(NO_QUESTIONS, 'control', is_start_of_test: true, experiment_loa: 'LEVEL_2')
@@ -53,6 +38,21 @@ constraints no_questions_control_piwik do
 end
 
 constraints no_questions_control do
+  get 'select_documents', to: 'select_documents#index', as: :select_documents
+  get 'select_documents_none', to: 'select_documents#no_documents', as: :select_documents_no_documents
+  post 'select_documents', to: 'select_documents#select_documents', as: :select_documents_submit
+  get 'unlikely_to_verify', to: 'select_documents#unlikely_to_verify', as: :unlikely_to_verify
+  get 'other_identity_documents', to: 'other_identity_documents#index', as: :other_identity_documents
+  post 'other_identity_documents', to: 'other_identity_documents#select_other_documents', as: :other_identity_documents_submit
+  get 'select_phone', to: 'select_phone#index', as: :select_phone
+  post 'select_phone', to: 'select_phone#select_phone', as: :select_phone_submit
+  get 'no_mobile_phone', to: 'select_phone#no_mobile_phone', as: :no_mobile_phone
+  get 'will_it_work_for_me', to: 'will_it_work_for_me#index', as: :will_it_work_for_me
+  post 'will_it_work_for_me', to: 'will_it_work_for_me#will_it_work_for_me', as: :will_it_work_for_me_submit
+  get 'why_might_this_not_work_for_me', to: 'will_it_work_for_me#why_might_this_not_work_for_me', as: :why_might_this_not_work_for_me
+  get 'may_not_work_if_you_live_overseas', to: 'will_it_work_for_me#may_not_work_if_you_live_overseas', as: :may_not_work_if_you_live_overseas
+  get 'will_not_work_without_uk_address', to: 'will_it_work_for_me#will_not_work_without_uk_address', as: :will_not_work_without_uk_address
+
   get 'choose_a_certified_company', to: 'choose_a_certified_company_loa2#index', as: :choose_a_certified_company
   post 'choose_a_certified_company', to: 'choose_a_certified_company_loa2#select_idp', as: :choose_a_certified_company_submit
 end

--- a/spec/features/user_visits_about_choosing_a_company_page_no_questions_variant_spec.rb
+++ b/spec/features/user_visits_about_choosing_a_company_page_no_questions_variant_spec.rb
@@ -1,0 +1,34 @@
+require 'feature_helper'
+require 'cookie_names'
+require 'api_test_helper'
+
+# HUB-71 Delete with test teardown
+RSpec.describe 'When a user in the no_questions variant visits the about choosing a company page' do
+  before(:each) do
+    set_session_and_ab_session_cookies!('no_questions' => 'no_questions_variant')
+    stub_api_idp_list_for_loa
+  end
+
+  it 'will display variant content in Welsh' do
+    visit '/am-ddewis-cwmni'
+
+    expect(page).to have_content 'Dod o hyd i’r cwmni iawn i’ch dilysu chi'
+    expect(page).to have_content 'Mae cwmnïau ardystiedig wedi adeiladu systemau newydd'
+    expect(page).not_to have_content 'Felly byddwn nawr yn gofyn rhai cwestiynau i chi wirio pa gwmnïau all eich dilysu.'
+  end
+
+  it 'will display the variant content' do
+    visit '/about-choosing-a-company'
+
+    expect(page).to have_content 'Finding the right company to verify you'
+    expect(page).to have_content 'Certified companies have built new, secure systems to verify identities.'
+    expect(page).not_to have_content 'So we’ll now ask you some questions to check which companies can verify you.'
+  end
+
+  it 'will take user to choose-a-certified-company page when user clicks "Continue"' do
+    visit '/about-choosing-a-company'
+
+    click_link 'Continue'
+    expect(page).to have_current_path(choose_a_certified_company_path)
+  end
+end

--- a/spec/features/user_visits_about_choosing_a_company_page_spec.rb
+++ b/spec/features/user_visits_about_choosing_a_company_page_spec.rb
@@ -26,34 +26,4 @@ RSpec.describe 'When the user visits the about choosing a company page' do
     click_link 'Continue'
     expect(page).to have_current_path(will_it_work_for_me_path)
   end
-
-  # HUB-71 Delete with test teardown
-  context 'in the no questions test variant' do
-    before(:each) do
-      set_session_and_ab_session_cookies!('no_questions' => 'no_questions_variant')
-    end
-
-    it 'will display variant content in Welsh' do
-      visit '/am-ddewis-cwmni'
-
-      expect(page).to have_content 'Dod o hyd i’r cwmni iawn i’ch dilysu chi'
-      expect(page).to have_content 'Mae cwmnïau ardystiedig wedi adeiladu systemau newydd'
-      expect(page).not_to have_content 'Felly byddwn nawr yn gofyn rhai cwestiynau i chi wirio pa gwmnïau all eich dilysu.'
-    end
-
-    it 'will display the variant content' do
-      visit '/about-choosing-a-company'
-
-      expect(page).to have_content 'Finding the right company to verify you'
-      expect(page).to have_content 'Certified companies have built new, secure systems to verify identities.'
-      expect(page).not_to have_content 'So we’ll now ask you some questions to check which companies can verify you.'
-    end
-
-    it 'will take user to choose-a-certified-company page when user clicks "Continue"' do
-      visit '/about-choosing-a-company'
-
-      click_link 'Continue'
-      expect(page).to have_current_path(choose_a_certified_company_path)
-    end
-  end
 end

--- a/spec/features/user_visits_about_choosing_a_company_page_spec.rb
+++ b/spec/features/user_visits_about_choosing_a_company_page_spec.rb
@@ -1,5 +1,6 @@
 require 'feature_helper'
 require 'cookie_names'
+require 'api_test_helper'
 
 RSpec.describe 'When the user visits the about choosing a company page' do
   before(:each) do
@@ -24,5 +25,35 @@ RSpec.describe 'When the user visits the about choosing a company page' do
 
     click_link 'Continue'
     expect(page).to have_current_path(will_it_work_for_me_path)
+  end
+
+  # HUB-71 Delete with test teardown
+  context 'in the no questions test variant' do
+    before(:each) do
+      set_session_and_ab_session_cookies!('no_questions' => 'no_questions_variant')
+    end
+
+    it 'will display variant content in Welsh' do
+      visit '/am-ddewis-cwmni'
+
+      expect(page).to have_content 'Dod o hyd i’r cwmni iawn i’ch dilysu chi'
+      expect(page).to have_content 'Mae cwmnïau ardystiedig wedi adeiladu systemau newydd'
+      expect(page).not_to have_content 'Felly byddwn nawr yn gofyn rhai cwestiynau i chi wirio pa gwmnïau all eich dilysu.'
+    end
+
+    it 'will display the variant content' do
+      visit '/about-choosing-a-company'
+
+      expect(page).to have_content 'Finding the right company to verify you'
+      expect(page).to have_content 'Certified companies have built new, secure systems to verify identities.'
+      expect(page).not_to have_content 'So we’ll now ask you some questions to check which companies can verify you.'
+    end
+
+    it 'will take user to choose-a-certified-company page when user clicks "Continue"' do
+      visit '/about-choosing-a-company'
+
+      click_link 'Continue'
+      expect(page).to have_current_path(choose_a_certified_company_path)
+    end
   end
 end

--- a/spec/features/user_visits_choose_a_certified_company_page_spec.rb
+++ b/spec/features/user_visits_choose_a_certified_company_page_spec.rb
@@ -183,14 +183,14 @@ describe 'When the user visits the choose a certified company page' do
 
     context 'user has two docs and a mobile' do
       selected_answers = {
-          device_type: { device_type_other: true },
-          documents: { passport: true, driving_licence: true },
-          phone: { mobile_phone: true }
+        device_type: { device_type_other: true },
+        documents: { passport: true, driving_licence: true },
+        phone: { mobile_phone: true }
       }
       before :each do
         page.set_rack_session(
-            transaction_simple_id: 'test-rp',
-            selected_answers: selected_answers,
+          transaction_simple_id: 'test-rp',
+          selected_answers: selected_answers,
         )
       end
 
@@ -214,12 +214,12 @@ describe 'When the user visits the choose a certified company page' do
         additional_documents = selected_answers[:documents].clone
         additional_documents[:driving_licence] = false
         page.set_rack_session(
-            transaction_simple_id: 'test-rp',
-            selected_answers: {
-                selected_answers: additional_documents,
-                phone: selected_answers[:phone],
-                device_type: { device_type_other: true }
-            }
+          transaction_simple_id: 'test-rp',
+          selected_answers: {
+            selected_answers: additional_documents,
+            phone: selected_answers[:phone],
+            device_type: { device_type_other: true }
+          }
         )
 
         visit '/choose-a-certified-company'
@@ -249,13 +249,13 @@ describe 'When the user visits the choose a certified company page' do
       it 'only LEVEL_1 recommended IDPs are displayed' do
         stub_api_idp_list_for_loa(default_idps, 'LEVEL_1')
         page.set_rack_session(
-            transaction_simple_id: 'test-rp',
-            requested_loa: 'LEVEL_1',
-            selected_answers: {
-                device_type: { device_type_other: true },
-                documents: { passport: true, driving_licence: true },
-                phone: { mobile_phone: true }
-            },
+          transaction_simple_id: 'test-rp',
+          requested_loa: 'LEVEL_1',
+          selected_answers: {
+            device_type: { device_type_other: true },
+            documents: { passport: true, driving_licence: true },
+            phone: { mobile_phone: true }
+          },
         )
 
         visit '/choose-a-certified-company'
@@ -270,11 +270,11 @@ describe 'When the user visits the choose a certified company page' do
 
     it 'displays all IDPs even if no recommendations' do
       page.set_rack_session(
-          transaction_simple_id: 'test-rp',
-          selected_answers: {
-              device_type: { device_type_other: true },
-              documents: { passport: false }
-          },
+        transaction_simple_id: 'test-rp',
+        selected_answers: {
+            device_type: { device_type_other: true },
+            documents: { passport: false }
+        },
       )
 
       visit '/choose-a-certified-company'
@@ -286,12 +286,12 @@ describe 'When the user visits the choose a certified company page' do
     it 'shows all IDPs regardless of profiles' do
       stub_api_no_docs_idps
       page.set_rack_session(
-          transaction_simple_id: 'test-rp',
-          selected_answers: {
-              device_type: { device_type_other: true },
-              documents: { driving_licence: true },
-              phone: { mobile_phone: true }
-          },
+        transaction_simple_id: 'test-rp',
+        selected_answers: {
+            device_type: { device_type_other: true },
+            documents: { driving_licence: true },
+            phone: { mobile_phone: true }
+        },
       )
 
       visit '/choose-a-certified-company'
@@ -308,15 +308,15 @@ describe 'When the user visits the choose a certified company page' do
 
     context 'IDP profile is in a demo period' do
       selected_answers = {
-          device_type: { device_type_other: true },
-          documents: { passport: true, driving_licence: true },
-          phone: { mobile_phone: true }
+        device_type: { device_type_other: true },
+        documents: { passport: true, driving_licence: true },
+        phone: { mobile_phone: true }
       }
 
       it 'shows the IDP if the RP is not protected' do
         page.set_rack_session(
-            transaction_simple_id: 'test-rp',
-            selected_answers: selected_answers
+          transaction_simple_id: 'test-rp',
+          selected_answers: selected_answers
         )
 
         visit '/choose-a-certified-company'
@@ -328,8 +328,8 @@ describe 'When the user visits the choose a certified company page' do
 
       it 'shows the IDP if the RP is protected' do
         page.set_rack_session(
-            transaction_simple_id: 'test-rp-no-demo',
-            selected_answers: selected_answers
+          transaction_simple_id: 'test-rp-no-demo',
+          selected_answers: selected_answers
         )
 
         visit '/choose-a-certified-company'

--- a/spec/features/user_visits_choose_a_certified_company_page_spec.rb
+++ b/spec/features/user_visits_choose_a_certified_company_page_spec.rb
@@ -174,4 +174,170 @@ describe 'When the user visits the choose a certified company page' do
       end
     end
   end
+
+  # HUB-71 Delete with test teardown
+  context 'in the no_questions test variant' do
+    before(:each) do
+      set_session_and_ab_session_cookies!('no_questions' => 'no_questions_variant')
+    end
+
+    context 'user has two docs and a mobile' do
+      selected_answers = {
+          device_type: { device_type_other: true },
+          documents: { passport: true, driving_licence: true },
+          phone: { mobile_phone: true }
+      }
+      before :each do
+        page.set_rack_session(
+            transaction_simple_id: 'test-rp',
+            selected_answers: selected_answers,
+        )
+      end
+
+      it 'includes the appropriate feedback source' do
+        visit '/choose-a-certified-company'
+
+        expect_feedback_source_to_be(page, 'CHOOSE_A_CERTIFIED_COMPANY_PAGE', '/choose-a-certified-company')
+      end
+
+      it 'displays recommended IDPs' do
+        visit '/choose-a-certified-company'
+
+        expect(page).to have_current_path(choose_a_certified_company_path)
+        expect(page).not_to have_content 'Based on your answers'
+        within('#matching-idps') do
+          expect(page).to have_button('Choose IDCorp')
+        end
+      end
+
+      it 'does show an IDP if the IDP profile has a subset of the user evidence, but not an exact match' do
+        additional_documents = selected_answers[:documents].clone
+        additional_documents[:driving_licence] = false
+        page.set_rack_session(
+            transaction_simple_id: 'test-rp',
+            selected_answers: {
+                selected_answers: additional_documents,
+                phone: selected_answers[:phone],
+                device_type: { device_type_other: true }
+            }
+        )
+
+        visit '/choose-a-certified-company'
+
+        within('#matching-idps') do
+          expect(page).to have_button('Choose IDCorp')
+        end
+      end
+
+      it 'redirects to the choose a certified company about page when selecting About link' do
+        visit '/choose-a-certified-company'
+
+        click_link 'About IDCorp'
+
+        expect(page).to have_current_path(choose_a_certified_company_about_path('stub-idp-one'))
+      end
+
+      it 'displays the page in Welsh' do
+        visit '/dewis-cwmni-ardystiedig'
+
+        expect(page).to have_title t('hub.choose_a_certified_company.title', locale: :cy)
+        expect(page).to have_css 'html[lang=cy]'
+      end
+    end
+
+    context 'user is from an LOA1 service' do
+      it 'only LEVEL_1 recommended IDPs are displayed' do
+        stub_api_idp_list_for_loa(default_idps, 'LEVEL_1')
+        page.set_rack_session(
+            transaction_simple_id: 'test-rp',
+            requested_loa: 'LEVEL_1',
+            selected_answers: {
+                device_type: { device_type_other: true },
+                documents: { passport: true, driving_licence: true },
+                phone: { mobile_phone: true }
+            },
+        )
+
+        visit '/choose-a-certified-company'
+
+        expect(page).to have_current_path(choose_a_certified_company_path)
+
+        within('#matching-idps') do
+          expect(page).to have_button('Choose LOA1 Corp')
+        end
+      end
+    end
+
+    it 'displays all IDPs even if no recommendations' do
+      page.set_rack_session(
+          transaction_simple_id: 'test-rp',
+          selected_answers: {
+              device_type: { device_type_other: true },
+              documents: { passport: false }
+          },
+      )
+
+      visit '/choose-a-certified-company'
+
+      expect(page).to have_current_path(choose_a_certified_company_path)
+      expect(page).not_to have_content t('hub.choose_a_certified_company.idp_count_html', company_count: 'no companies')
+    end
+
+    it 'shows all IDPs regardless of profiles' do
+      stub_api_no_docs_idps
+      page.set_rack_session(
+          transaction_simple_id: 'test-rp',
+          selected_answers: {
+              device_type: { device_type_other: true },
+              documents: { driving_licence: true },
+              phone: { mobile_phone: true }
+          },
+      )
+
+      visit '/choose-a-certified-company'
+
+      expect(page).not_to have_content 'Based on your answers'
+
+      within('#matching-idps') do
+        expect(page).to have_button('Choose No Docs IDP')
+        expect(page).to have_button('Choose IDCorp')
+        expect(page).to have_button('Bob’s Identity Service')
+        expect(page).to have_button('Choose Carol’s Secure ID')
+      end
+    end
+
+    context 'IDP profile is in a demo period' do
+      selected_answers = {
+          device_type: { device_type_other: true },
+          documents: { passport: true, driving_licence: true },
+          phone: { mobile_phone: true }
+      }
+
+      it 'shows the IDP if the RP is not protected' do
+        page.set_rack_session(
+            transaction_simple_id: 'test-rp',
+            selected_answers: selected_answers
+        )
+
+        visit '/choose-a-certified-company'
+
+        within('#matching-idps') do
+          expect(page).to have_button('Choose Bob’s Identity Service')
+        end
+      end
+
+      it 'shows the IDP if the RP is protected' do
+        page.set_rack_session(
+            transaction_simple_id: 'test-rp-no-demo',
+            selected_answers: selected_answers
+        )
+
+        visit '/choose-a-certified-company'
+
+        within('#matching-idps') do
+          expect(page).to have_button('Choose Bob’s Identity Service')
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fix the routing so that users can't go off the rails and see the questions (e.g. by clicking a link or a bookmark, or url-hacking)

Fix a bug in the welsh yaml, which was spotted by the new tests (yay tests)

Adding feature tests for the two affected pages