### PR TITLE
HUB-79 show interstitial idp question when 0 docs

### DIFF
--- a/app/controllers/choose_a_certified_company_loa1_controller.rb
+++ b/app/controllers/choose_a_certified_company_loa1_controller.rb
@@ -28,10 +28,6 @@ private
     end
   end
 
-  def only_one_uk_doc_selected
-    (%i[passport driving_licence] & selected_evidence).size == 1
-  end
-
   def interstitial_question_flag_enabled_for(decorated_idp)
     IDP_FEATURE_FLAGS_CHECKER.enabled?(:show_interstitial_question_loa1, decorated_idp.simple_id)
   end

--- a/app/controllers/choose_a_certified_company_loa2_controller.rb
+++ b/app/controllers/choose_a_certified_company_loa2_controller.rb
@@ -32,7 +32,7 @@ private
   end
 
   def only_one_uk_doc_selected
-    (%i[passport driving_licence] & selected_evidence).size == 1
+    (%i[passport driving_licence] & selected_evidence).size <= 1
   end
 
   def interstitial_question_flag_enabled_for(decorated_idp)

--- a/app/controllers/choose_a_certified_company_loa2_controller.rb
+++ b/app/controllers/choose_a_certified_company_loa2_controller.rb
@@ -24,14 +24,14 @@ class ChooseACertifiedCompanyLoa2Controller < ApplicationController
 private
 
   def warning_or_question_page(decorated_idp)
-    if only_one_uk_doc_selected && interstitial_question_flag_enabled_for(decorated_idp)
+    if not_more_than_one_uk_doc_selected && interstitial_question_flag_enabled_for(decorated_idp)
       redirect_to_idp_question_path
     else
       redirect_to_idp_warning_path
     end
   end
 
-  def only_one_uk_doc_selected
+  def not_more_than_one_uk_doc_selected
     (%i[passport driving_licence] & selected_evidence).size <= 1
   end
 

--- a/spec/controllers/choose_a_certified_company_loa2_controller_spec.rb
+++ b/spec/controllers/choose_a_certified_company_loa2_controller_spec.rb
@@ -93,6 +93,13 @@ describe ChooseACertifiedCompanyLoa2Controller do
       expect(subject).to redirect_to redirect_to_idp_question_path
     end
 
+    it 'redirects to IDP question page when user has zero docs and IDP flag is enabled' do
+      session[:selected_answers] = { 'documents' => { 'driving_licence' => false } }
+      post :select_idp, params: { locale: 'en', entity_id: 'http://idcorp.com' }
+
+      expect(subject).to redirect_to redirect_to_idp_question_path
+    end
+
     it 'returns 404 page if IDP is non-existent' do
       post :select_idp, params: { locale: 'en', entity_id: 'http://notanidp.com' }
 


### PR DESCRIPTION
We are adding 0 docs segments to an IDP with an interstitial question.

We want the question to show up for 0-docs users as well as for 1-doc
users.

Also removed a dead method from the loa1 version of the controller.