### PR TITLE
ZD48070: Fix typo on the error page 'others ways'

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -398,7 +398,7 @@ en:
         problem: "Sorry, %{rp_name} is having technical problems."
         start_again_link: start again
         start_again_message_html: "Please %{start_again_link} in a few minutes by signing in with your certified company."
-        other_ways: "If you continue having problems, there are others ways to %{other_ways_description}."
+        other_ways: "If you continue having problems, there are other ways to %{other_ways_description}."
     forgot_company:
       title: Advice for forgotten company
     redirect_to_service:


### PR DESCRIPTION
This has been incorrect since May 2016:
d8187da8df84dd1cc238b54bf9107abffb4ae70c

Pair: @rhowe-gds @sgreensmith