### PR TITLE
Hub-106 IDP reminder: create cookie that breaks down types of IDP sel…

### DIFF
--- a/app/controllers/partials/user_cookies_partial_controller.rb
+++ b/app/controllers/partials/user_cookies_partial_controller.rb
@@ -20,7 +20,28 @@ module UserCookiesPartialController
   end
 
   def set_journey_hint(idp_entity_id)
-    cookies.encrypted[CookieNames::VERIFY_FRONT_JOURNEY_HINT] = { value: { entity_id: idp_entity_id }.to_json,
+    journey_hint_value_hash = journey_hint_value || Hash.new
+    journey_hint_value_hash["entity_id"] = idp_entity_id
+    journey_hint_value_hash["ATTEMPTED"] = idp_entity_id
+
+    cookies.encrypted[CookieNames::VERIFY_FRONT_JOURNEY_HINT] = { value: journey_hint_value_hash.to_json,
+                                                                 expires: 18.months.from_now }
+  end
+
+  def set_journey_hint_by_status(idp_entity_id, status)
+    return if idp_entity_id.nil?
+    journey_hint_by_status_value = journey_hint_value || Hash.new
+    journey_hint_by_status_value[status] = idp_entity_id
+
+    cookies.encrypted[CookieNames::VERIFY_FRONT_JOURNEY_HINT] = { value: journey_hint_by_status_value.to_json,
                                                                   expires: 18.months.from_now }
+  end
+
+private
+
+  def journey_hint_value
+    MultiJson.load(cookies.encrypted[CookieNames::VERIFY_FRONT_JOURNEY_HINT] ||= '')
+  rescue MultiJson::ParseError
+    nil
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -398,7 +398,7 @@ en:
         problem: "Sorry, %{rp_name} is having technical problems."
         start_again_link: start again
         start_again_message_html: "Please %{start_again_link} in a few minutes by signing in with your certified company."
-        other_ways: "If you continue having problems, there are others ways to %{other_ways_description}."
+        other_ways: "If you continue having problems, there are other ways to %{other_ways_description}."
     forgot_company:
       title: Advice for forgotten company
     redirect_to_service:

--- a/spec/controllers/authn_response_spec.rb
+++ b/spec/controllers/authn_response_spec.rb
@@ -57,4 +57,93 @@ describe AuthnResponseController do
       expect(subject).to render_template(:something_went_wrong)
     end
   end
+
+  context 'idp_cookie_tracking' do
+    let(:saml_proxy_api) { double(:saml_proxy_api) }
+
+    before(:each) do
+      stub_const('SAML_PROXY_API', saml_proxy_api)
+      set_session_and_cookies_with_loa('LEVEL_1')
+    end
+
+    def stub_saml_proxy_and_analytics(status, analytics_status)
+      allow(saml_proxy_api).to receive(:idp_authn_response).and_return(IdpAuthnResponse.new('result' => status, 'isRegistration' => 'registration', 'loaAchieved' => 'LEVEL_1'))
+      allow(subject).to receive(:report_to_analytics).with(analytics_status)
+    end
+
+    it 'should not set a cookie status if selected_idp is not in the session' do
+      stub_saml_proxy_and_analytics('SUCCESS', 'Success - REGISTER_WITH_IDP at LOA LEVEL_1')
+      post :idp_response, params: { 'RelayState' => 'my-session-id-cookie', 'SAMLResponse' => 'a-saml-response', locale: 'en' }
+      expect(cookies.encrypted[CookieNames::VERIFY_FRONT_JOURNEY_HINT]).to be_nil
+    end
+
+    it 'should add a new success status with idp entity id as a value to the journey hint cookie when response is SUCCESS' do
+      expected_cookie = "{\"SUCCESS\":\"http://idcorp.com\"}"
+
+      session[:selected_idp] = { 'entity_id' => 'http://idcorp.com', 'simple_id' => 'stub-idp-one', 'levels_of_assurance' => %w(LEVEL_1 LEVEL_2) }
+
+      stub_saml_proxy_and_analytics('SUCCESS', 'Success - REGISTER_WITH_IDP at LOA LEVEL_1')
+      post :idp_response, params: { 'RelayState' => 'my-session-id-cookie', 'SAMLResponse' => 'a-saml-response', locale: 'en' }
+      expect(cookies.encrypted[CookieNames::VERIFY_FRONT_JOURNEY_HINT]).to eq(expected_cookie)
+    end
+
+    it 'should not delete/overwrite the entity_id of the existing journey hint cookie when adding a new status' do
+      expected_cookie = "{" +
+        "\"entity_id\":\"http://idcorp.com\"," +
+        "\"simple_id\":\"stub-idp-one\"," +
+        "\"levels_of_assurance\":[\"LEVEL_1\",\"LEVEL_2\"]," +
+        "\"SUCCESS\":\"http://idcorp.com\"" +
+        "}"
+
+      session[:selected_idp] = { 'entity_id' => 'http://idcorp.com', 'simple_id' => 'stub-idp-one', 'levels_of_assurance' => %w(LEVEL_1 LEVEL_2) }
+      cookies.encrypted[CookieNames::VERIFY_FRONT_JOURNEY_HINT] = { 'entity_id' => 'http://idcorp.com', 'simple_id' => 'stub-idp-one', 'levels_of_assurance' => %w(LEVEL_1 LEVEL_2) }.to_json
+
+      stub_saml_proxy_and_analytics('SUCCESS', 'Success - REGISTER_WITH_IDP at LOA LEVEL_1')
+      post :idp_response, params: { 'RelayState' => 'my-session-id-cookie', 'SAMLResponse' => 'a-saml-response', locale: 'en' }
+      expect(cookies.encrypted[CookieNames::VERIFY_FRONT_JOURNEY_HINT]).to eq(expected_cookie)
+    end
+
+    it 'should update the existing status with a new entity id' do
+      expected_cookie = "{" +
+        "\"entity_id\":\"http://idcorp.com\"," +
+        "\"simple_id\":\"stub-idp-one\"," +
+        "\"levels_of_assurance\":[\"LEVEL_1\",\"LEVEL_2\"]," +
+        "\"SUCCESS\":\"http://idcorp.com\"" +
+        "}"
+
+      session[:selected_idp] = { 'entity_id' => 'http://idcorp.com', 'simple_id' => 'stub-idp-one', 'levels_of_assurance' => %w(LEVEL_1 LEVEL_2) }
+      cookies.encrypted[CookieNames::VERIFY_FRONT_JOURNEY_HINT] = { 'entity_id' => 'http://idcorp.com', 'simple_id' => 'stub-idp-one', 'levels_of_assurance' => %w(LEVEL_1 LEVEL_2), 'SUCCESS' => 'http://old-idcorp.com' }.to_json
+
+      stub_saml_proxy_and_analytics('SUCCESS', 'Success - REGISTER_WITH_IDP at LOA LEVEL_1')
+      post :idp_response, params: { 'RelayState' => 'my-session-id-cookie', 'SAMLResponse' => 'a-saml-response', locale: 'en' }
+      expect(cookies.encrypted[CookieNames::VERIFY_FRONT_JOURNEY_HINT]).to eq(expected_cookie)
+    end
+
+    it 'should add a new status with a new entity id to the existing statuses' do
+      expected_cookie = "{" +
+        "\"entity_id\":\"http://idcorp.com\"," +
+        "\"simple_id\":\"stub-idp-one\"," +
+        "\"levels_of_assurance\":[\"LEVEL_1\",\"LEVEL_2\"]," +
+        "\"SUCCESS\":\"http://success-idcorp.com\"," +
+        "\"PENDING\":\"http://idcorp.com\"" +
+        "}"
+
+      session[:selected_idp] = { 'entity_id' => 'http://idcorp.com', 'simple_id' => 'stub-idp-one', 'levels_of_assurance' => %w(LEVEL_1 LEVEL_2) }
+      cookies.encrypted[CookieNames::VERIFY_FRONT_JOURNEY_HINT] = { 'entity_id' => 'http://idcorp.com', 'simple_id' => 'stub-idp-one', 'levels_of_assurance' => %w(LEVEL_1 LEVEL_2), 'SUCCESS' => 'http://success-idcorp.com' }.to_json
+
+      stub_saml_proxy_and_analytics('PENDING', 'Paused - REGISTER_WITH_IDP')
+      post :idp_response, params: { 'RelayState' => 'my-session-id-cookie', 'SAMLResponse' => 'a-saml-response', locale: 'en' }
+      expect(cookies.encrypted[CookieNames::VERIFY_FRONT_JOURNEY_HINT]).to eq(expected_cookie)
+    end
+
+    it 'should add a new failure status with idp entity id as a value to the journey hint cookie when the response is OTHER' do
+      expected_cookie = "{\"FAILED\":\"http://idcorp.com\"}"
+
+      session[:selected_idp] = { 'entity_id' => 'http://idcorp.com', 'simple_id' => 'stub-idp-one', 'levels_of_assurance' => %w(LEVEL_1 LEVEL_2) }
+
+      stub_saml_proxy_and_analytics('FAILED', 'Failure - REGISTER_WITH_IDP')
+      post :idp_response, params: { 'RelayState' => 'my-session-id-cookie', 'SAMLResponse' => 'a-saml-response', locale: 'en' }
+      expect(cookies.encrypted[CookieNames::VERIFY_FRONT_JOURNEY_HINT]).to eq(expected_cookie)
+    end
+  end
 end


### PR DESCRIPTION
…ection

Updates existing journey_hint cookie to capture more details so that we can record what the user
does in the IDP and the outcome they come back with. This will enable us to more accurately recommend the most appropriate IDPs to users.
Co-authored-by: Jakub Miarka <jakub.miarka@digital.cabinet-office.gov.uk>