### PR TITLE
TT-1783: Visibility of Verify journey pages to search engines

### DIFF
--- a/public/google7abe5aa505b89660.html
+++ b/public/google7abe5aa505b89660.html
@@ -1,0 +1,1 @@
+google-site-verification: google7abe5aa505b89660.html


### PR DESCRIPTION
In order to hide the /start page from Google Search results, we need to remove it manually from the Google Search Console. This commit adds a file to enable the Search Console for the Verify domain (www.signin.service.gov.uk). The Search Console will be tied to the special account created in the GDS G-Suite domain to manage it (details in the Jira ticket).