### PR TITLE
HUB-109: Fix for incorrect reporting of AB test

### DIFF
--- a/config/main_routes.rb
+++ b/config/main_routes.rb
@@ -112,7 +112,6 @@ constraints short_hub_variant_piwik do
 end
 
 constraints short_hub_control do
-  get 'about', to: 'about_loa2#index', as: :about
   get 'about_certified_companies', to: 'about_loa2#certified_companies', as: :about_certified_companies
   get 'about_identity_accounts', to: 'about_loa2#identity_accounts', as: :about_identity_accounts
   get 'about_choosing_a_company', to: 'about_loa2#choosing_a_company', as: :about_choosing_a_company
@@ -143,8 +142,6 @@ constraints short_hub_control do
 end
 
 constraints short_hub_variant do
-  get 'about', to: 'about_loa2_variant#index', as: :about
-
   get 'select_documents', to: 'select_documents_variant#index', as: :select_documents
   post 'select_documents', to: 'select_documents_variant#select_documents', as: :select_documents_submit
 

--- a/config/main_routes.rb
+++ b/config/main_routes.rb
@@ -38,7 +38,7 @@ end
 constraints IsLoa2 do
   get 'start', to: 'start#index', as: :start
   post 'start', to: 'start#request_post', as: :start
-  # get 'begin_registration', to: 'start#register', as: :begin_registration
+  get 'begin_registration', to: 'start#register', as: :begin_registration
   # get 'about', to: 'about_loa2#index', as: :about
   # get 'about_certified_companies', to: 'about_loa2#certified_companies', as: :about_certified_companies
   # get 'about_identity_accounts', to: 'about_loa2#identity_accounts', as: :about_identity_accounts
@@ -104,11 +104,11 @@ get 'paused_registration', to: 'paused_registration#index', as: :paused_registra
 
 # HUB-109 Short HUB A/B test
 constraints short_hub_control_piwik do
-  get 'begin_registration', to: 'start#register', as: :begin_registration
+  get 'about', to: 'about_loa2#index', as: :about
 end
 
 constraints short_hub_variant_piwik do
-  get 'begin_registration', to: 'start#register', as: :begin_registration
+  get 'about', to: 'about_loa2_variant#index', as: :about
 end
 
 constraints short_hub_control do


### PR DESCRIPTION
We have applied the piwik reporting on the begin-registration virtual page,
but not all journeys hit that. Therefore moving the reporting to the about
page.

Solo: @jakubmiarka