### PR TITLE
HUB-113: Force new Piwik visit on each SAML request

### DIFF
--- a/app/assets/javascripts/analytics.js
+++ b/app/assets/javascripts/analytics.js
@@ -25,8 +25,10 @@
     var siteId = $('#piwik-site-id').text();
     var customUrl = $('#piwik-custom-url').text();
     var enTitle = $('meta[name="verify|title"]').attr("content");
+    var newVisit = $('#piwik-new-visit').length ? 1 : 0;
 
     var piwikAnalyticsQueue = [
+        ['appendToTrackingUrl', 'new_visit=' + newVisit],
         ['setUserId', getPiwikVisitorIdCookie()],
         ['setDocumentTitle', enTitle ],
         ['trackPageView'],

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -25,6 +25,7 @@ class ApplicationController < ActionController::Base
   before_action :store_originating_ip
   before_action :set_piwik_custom_variables
   after_action :store_locale_in_cookie, if: -> { request.method == 'GET' }
+  after_action :delete_new_visit_flag
 
   helper_method :transaction_taxon_list
   helper_method :transactions_list

--- a/app/controllers/authn_request_controller.rb
+++ b/app/controllers/authn_request_controller.rb
@@ -7,6 +7,7 @@ class AuthnRequestController < SamlController
 
   def rp_request
     create_session
+    session[:new_visit] = true
 
     AbTest.set_or_update_ab_test_cookie(current_transaction_simple_id, cookies)
 

--- a/app/controllers/partials/analytics_partial_controller.rb
+++ b/app/controllers/partials/analytics_partial_controller.rb
@@ -13,4 +13,10 @@ module AnalyticsPartialController
       Analytics::CustomVariable.build_for_js_client(:loa_requested, session[:requested_loa])
     ]
   end
+
+  def delete_new_visit_flag
+    http_redirect = 302
+    http_see_other = 303
+    session.delete(:new_visit) unless [http_redirect, http_see_other].include?(self.status)
+  end
 end

--- a/app/controllers/start_controller.rb
+++ b/app/controllers/start_controller.rb
@@ -5,8 +5,6 @@ class StartController < ApplicationController
   def index
     @form = StartForm.new({})
 
-    FEDERATION_REPORTER.report_start_page(current_transaction, request)
-
     render :start
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -34,6 +34,7 @@ module ApplicationHelper
         rec: 1,
         rand: Random.rand(2**32 - 1),
         action_name: content_for(:page_title_in_english),
+        new_visit: session[:new_visit] ? 1 : 0
     }
     hash[:url] = piwik_custom_url if piwik_custom_url?
     hash.to_query

--- a/app/views/shared/_piwik.html.erb
+++ b/app/views/shared/_piwik.html.erb
@@ -4,6 +4,9 @@
     <% if piwik_custom_url? %>
         <span class="hidden" id="piwik-custom-url"><%= piwik_custom_url %></span>
     <% end %>
+    <% if session[:new_visit] %>
+        <input class="hidden" id="piwik-new-visit" />
+    <% end %>
     <% if defined?(@piwik_custom_variables) %>
         <span class="hidden" id="piwik-custom-variables"><%= @piwik_custom_variables.to_json %></span>
     <% end %>

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -4,6 +4,20 @@
 
 export RAILS_ENV=test
 
+for focus in fdescribe fcontext fit fspecify fexample; do
+  FILES=$(git diff -G"^\s*$focus" --name-only | wc -l)
+  if [ $FILES -gt 0 ] 
+  then
+    echo ""
+    tput setaf 1; echo "You forgot to remove a $focus in the following files:"; tput sgr 0
+    git diff --name-only -G"^\s*$focus"
+    echo ""
+    STATUS=1
+    funky_fail_banner
+    exit $STATUS
+  fi
+done
+
 bundle check || bundle install
 bundle exec rake
 success=$((success || $?))

--- a/spec/features/redirects_with_see_other_spec.rb
+++ b/spec/features/redirects_with_see_other_spec.rb
@@ -6,4 +6,10 @@ describe 'pages redirect with see other', type: :request do
     post '/SAML2/SSO', params: { 'SAMLRequest' => 'my-saml-request', 'RelayState' => 'my-relay-state' }
     expect(response.status).to eql 303
   end
+
+  it 'does not delete the new_visit flag' do
+    stub_session_creation
+    post '/SAML2/SSO', params: { 'SAMLRequest' => 'my-saml-request', 'RelayState' => 'my-relay-state' }
+    expect(request.session['new_visit']).to eql true
+  end
 end

--- a/spec/features/server_sends_analytics_spec.rb
+++ b/spec/features/server_sends_analytics_spec.rb
@@ -13,14 +13,14 @@ RSpec.describe 'When a page with a virtual page view is visited' do
     Capybara.current_session.driver.header('Accept-Language', 'en-US,en;q=0.5')
     Capybara.current_session.driver.header('X-Forwarded-For', '1.1.1.1')
 
-    visit '/start'
+    visit '/begin-registration'
 
     piwik_request = {
         'rec' => '1',
         'apiv' => '1',
         'idsite' => INTERNAL_PIWIK.site_id.to_s,
         'cookie' => 'false',
-        'action_name' => 'The user has reached the start page'
+        'action_name' => 'The user started a registration journey'
     }
     piwik_headers = {
         'X-Forwarded-For' => '1.1.1.1',
@@ -29,7 +29,7 @@ RSpec.describe 'When a page with a virtual page view is visited' do
         'User-Agent' => 'my user agent',
         'Accept-Language' => 'en-US,en;q=0.5',
     }
-    stubbed_piwik_request = stub_piwik_request(piwik_request, piwik_headers)
+    stubbed_piwik_request = stub_piwik_request(piwik_request, piwik_headers, 'LEVEL_2', ["\"3\":[\"JOURNEY_TYPE\",\"REGISTRATION\"]"])
 
     expect(stubbed_piwik_request).to have_been_made.at_least_once
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -57,14 +57,14 @@ RSpec.configure do |config|
 
 # The settings below are suggested to provide a good initial experience
 # with RSpec, but feel free to customize to your heart's content.
-=begin
+
   # These two settings work together to allow you to limit a spec run
   # to individual examples or groups you care about by tagging them with
   # `:focus` metadata. When nothing is tagged with `:focus`, all examples
   # get run.
-  config.filter_run :focus
+  config.filter_run :focus unless ENV['RAILS_ENV'] == 'test'
   config.run_all_when_everything_filtered = true
-
+=begin
   # Allows RSpec to persist some state between runs in order to support
   # the `--only-failures` and `--next-failure` CLI options. We recommend
   # you configure your source control system to ignore this file.


### PR DESCRIPTION
**READY TO BE MERGED AND DEPLOYED FOR TUESDAY (22/05/2018) TEST**

To improve our analytics data we're going create new visits for visitors
each time they come from an RP.

Also updated the pre-commit hook with check on focusing RSpec tests.

Co-Authored-By: Rachel Smith <rachel.smith@digital.cabinet-office.gov.uk>