### PR TITLE
Hub-135 Spike: recognise existing GOV.UK users on interstitial page

### DIFF
--- a/app/controllers/hint_controller.rb
+++ b/app/controllers/hint_controller.rb
@@ -1,0 +1,20 @@
+require 'partials/journey_hinting_partial_controller'
+
+class HintController < ApplicationController
+  include JourneyHintingPartialController
+  skip_before_action :validate_session
+  skip_before_action :set_piwik_custom_variables
+
+  def index
+    set_headers
+
+    entity_id = entity_id_of_journey_hint_for('SUCCESS')
+
+    render json: { 'status': 'OK', 'value': !entity_id.nil? }
+  end
+
+  def set_headers
+    response.headers['Access-Control-Allow-Origin'] = 'https://www.gov.uk'
+    response.headers['Access-Control-Request-Method'] = 'GET'
+  end
+end

--- a/config/main_routes.rb
+++ b/config/main_routes.rb
@@ -94,3 +94,5 @@ post 'further_information_null_attribute', to: 'further_information#submit_null_
 get 'no_idps_available', to: 'no_idps_available#index', as: :no_idps_available
 get 'cancelled_registration', to: 'cancelled_registration#index', as: :cancelled_registration
 get 'paused_registration', to: 'paused_registration#index', as: :paused_registration
+
+get 'hint', to: 'hint#index'


### PR DESCRIPTION
Adds endpoint allowing us to test whether we can retrieve data from verify-frontend using a request from GOV.UK

Co-Authored-By: Jakub Miarka <jakub.miarka@digital.cabinet-office.gov.uk>