### PR TITLE
HUB-113: Pausing the new visit reporting

### DIFF
--- a/app/controllers/authn_request_controller.rb
+++ b/app/controllers/authn_request_controller.rb
@@ -7,7 +7,9 @@ class AuthnRequestController < SamlController
 
   def rp_request
     create_session
-    session[:new_visit] = true
+
+    # HUB-113: Temporarily disabling to allow the perf team to analyze the data
+    # session[:new_visit] = true
 
     AbTest.set_or_update_ab_test_cookie(current_transaction_simple_id, cookies)
 

--- a/spec/features/redirects_with_see_other_spec.rb
+++ b/spec/features/redirects_with_see_other_spec.rb
@@ -7,9 +7,10 @@ describe 'pages redirect with see other', type: :request do
     expect(response.status).to eql 303
   end
 
-  it 'does not delete the new_visit flag' do
-    stub_session_creation
-    post '/SAML2/SSO', params: { 'SAMLRequest' => 'my-saml-request', 'RelayState' => 'my-relay-state' }
-    expect(request.session['new_visit']).to eql true
-  end
+  # HUB-113: Temporarily disabling to allow the perf team to analyze the data
+  # it 'does not delete the new_visit flag' do
+  #   stub_session_creation
+  #   post '/SAML2/SSO', params: { 'SAMLRequest' => 'my-saml-request', 'RelayState' => 'my-relay-state' }
+  #   expect(request.session['new_visit']).to eql true
+  # end
 end


### PR DESCRIPTION
To allow the perf team to analyze the data and assess the impact of forcing
a new piwik visit for each SAML request, we're temporarily disabling it.
Depending on the outcome of the analysis we'll decide the next course of action.