### PR TITLE
HUB-150: Add custom variables to piwik img tracker

### DIFF
--- a/app/controllers/partials/analytics_partial_controller.rb
+++ b/app/controllers/partials/analytics_partial_controller.rb
@@ -8,15 +8,29 @@ module AnalyticsPartialController
   end
 
   def set_piwik_custom_variables
-    @piwik_custom_variables = [
-      Analytics::CustomVariable.build_for_js_client(:rp, current_transaction.analytics_description),
-      Analytics::CustomVariable.build_for_js_client(:loa_requested, session[:requested_loa])
-    ]
+    custom_variables_for_js
+    custom_variables_for_img_tracker
   end
 
   def delete_new_visit_flag
     http_redirect = 302
     http_see_other = 303
     session.delete(:new_visit) unless [http_redirect, http_see_other].include?(self.status)
+  end
+
+private
+
+  def custom_variables_for_js
+    @piwik_custom_variables = [
+      Analytics::CustomVariable.build_for_js_client(:rp, current_transaction.analytics_description),
+      Analytics::CustomVariable.build_for_js_client(:loa_requested, session[:requested_loa])
+    ]
+  end
+
+  def custom_variables_for_img_tracker
+    current_transaction_custom_variable = Analytics::CustomVariable.build(:rp, current_transaction.analytics_description)
+    loa_requested_custom_variable = Analytics::CustomVariable.build(:loa_requested, session[:requested_loa])
+    @piwik_custom_variables_img_tracker =
+      current_transaction_custom_variable.merge(loa_requested_custom_variable)
   end
 end

--- a/app/views/shared/_piwik.html.erb
+++ b/app/views/shared/_piwik.html.erb
@@ -11,6 +11,10 @@
         <span class="hidden" id="piwik-custom-variables"><%= @piwik_custom_variables.to_json %></span>
     <% end %>
     <noscript>
-      <%= image_tag("#{public_piwik.url}?#{piwik_noscript_query_string}", style: 'border: 0', width: 0, height: 0, alt: '', id: 'piwik-noscript-tracker') %>
+        <% if defined?(@piwik_custom_variables_img_tracker) %>
+            <%= image_tag("#{public_piwik.url}?#{piwik_noscript_query_string}&_cvar=#{@piwik_custom_variables_img_tracker.to_json}", style: 'border: 0', width: 0, height: 0, alt: '', id: 'piwik-noscript-tracker') %>
+        <% else %>
+            <%= image_tag("#{public_piwik.url}?#{piwik_noscript_query_string}", style: 'border: 0', width: 0, height: 0, alt: '', id: 'piwik-noscript-tracker') %>
+        <% end %>
     </noscript>
 <% end %>


### PR DESCRIPTION
For non-JS visitors we report only page title using the image tracker,
but missing out the key custom variables such as RP and LOA. We already
append the custom variables with any JS reporting.
This is to add it to the non-JS one too.