### PR TITLE
Hub 114 report attempts registration

### DIFF
--- a/app/controllers/authn_response_controller.rb
+++ b/app/controllers/authn_response_controller.rb
@@ -66,8 +66,11 @@ private
     user_state = ->(response) { response.is_registration ? REGISTERING_STATE : SIGNING_IN_STATE }
 
     {
-      SUCCESS => ->(response) { report_to_analytics("Success - #{user_state.call(response)} at LOA #{response.loa_achieved}") },
-      CANCEL  => ->(response) { report_to_analytics("Cancel - #{user_state.call(response)}") },
+      SUCCESS => lambda do |response|
+        report_to_analytics("Success - #{user_state.call(response)} at LOA #{response.loa_achieved}");
+        report_user_outcome_to_piwik(SUCCESS)
+      end,
+      CANCEL => ->(response) { report_to_analytics("Cancel - #{user_state.call(response)}") },
       FAILED_UPLIFT => ->(response) { report_to_analytics("Failed Uplift - #{user_state.call(response)}") },
       PENDING => ->(response) { report_to_analytics("Paused - #{user_state.call(response)}") },
       OTHER => ->(response) { report_to_analytics("Failure - #{user_state.call(response)}") }
@@ -79,7 +82,7 @@ private
 
     {
       SUCCESS => ->() { set_journey_hint_by_status(selected_idp, SUCCESS) },
-      CANCEL  => ->() { set_journey_hint_by_status(selected_idp, CANCEL) },
+      CANCEL => ->() { set_journey_hint_by_status(selected_idp, CANCEL) },
       FAILED_UPLIFT => ->() { set_journey_hint_by_status(selected_idp, FAILED_UPLIFT) },
       PENDING => ->() { set_journey_hint_by_status(selected_idp, PENDING) },
       FAILED => ->() { set_journey_hint_by_status(selected_idp, FAILED) }

--- a/app/controllers/partials/analytics_partial_controller.rb
+++ b/app/controllers/partials/analytics_partial_controller.rb
@@ -33,4 +33,32 @@ private
     @piwik_custom_variables_img_tracker =
       current_transaction_custom_variable.merge(loa_requested_custom_variable)
   end
+
+  #TODO: HUB-114: Remove logic, reg only & segment_to_be_tested once confirmed with analytics
+  SEGMENT_TO_BE_TESTED = '2doc_nidl_pp_mobile_app'.freeze
+  SEGMENT_FOR_TEST = 'test-segment'.freeze
+
+  def report_user_outcome_to_piwik(response_status)
+    if segment_should_be_reported? && is_registration?
+      FEDERATION_REPORTER.report_user_idp_outcome(
+        current_transaction: current_transaction,
+        request: request,
+        idp_name: session[:selected_idp_name],
+        user_segments: session[:user_segments],
+        transaction_simple_id: session[:transaction_simple_id],
+        attempt_number: session[:attempt_number],
+        journey_type: session[:journey_type],
+        response_status: response_status
+      )
+    end
+  end
+
+  def segment_should_be_reported?
+    return false if session[:user_segments].nil?
+    session[:user_segments].include?(SEGMENT_TO_BE_TESTED) || session[:user_segments].include?(SEGMENT_FOR_TEST)
+  end
+
+  def is_registration?
+    session[:journey_type] == 'registration'
+  end
 end

--- a/app/controllers/partials/idp_selection_partial_controller.rb
+++ b/app/controllers/partials/idp_selection_partial_controller.rb
@@ -26,6 +26,18 @@ module IdpSelectionPartialController
     render json: idp_request.to_json(methods: :hints)
   end
 
+  def report_user_idp_attempt_to_piwik
+    FEDERATION_REPORTER.report_user_idp_attempt(
+      current_transaction: current_transaction,
+      request: request,
+      idp_name: session[:selected_idp_name],
+      user_segments: session[:user_segments],
+      transaction_simple_id: session[:transaction_simple_id],
+      attempt_number: session[:attempt_number],
+      journey_type: session[:journey_type]
+    )
+  end
+
   def report_idp_registration_to_piwik(recommended)
     FEDERATION_REPORTER.report_idp_registration(
       current_transaction: current_transaction,

--- a/app/controllers/redirect_to_idp_controller.rb
+++ b/app/controllers/redirect_to_idp_controller.rb
@@ -3,8 +3,14 @@ require 'partials/idp_selection_partial_controller'
 class RedirectToIdpController < ApplicationController
   include IdpSelectionPartialController
 
+  # TODO: HUB-114: To be removed together with segment logic once we have assessed if the new reporting works
+  SEGMENT_TO_BE_TESTED = '2doc_nidl_pp_mobile_app'.freeze
+  SEGMENT_FOR_TEST = 'test-segment'.freeze
+
   def register
     request_form
+    increase_attempt_number
+    report_user_idp_attempt_to_piwik if segment_should_be_reported?
     report_idp_registration_to_piwik(recommended)
     render :redirect_to_idp
   end
@@ -20,6 +26,16 @@ class RedirectToIdpController < ApplicationController
   end
 
 private
+
+  def segment_should_be_reported?
+    return false if session[:user_segments].nil?
+    session[:user_segments].include?(SEGMENT_TO_BE_TESTED) || session[:user_segments].include?(SEGMENT_FOR_TEST)
+  end
+
+  def increase_attempt_number
+    session[:attempt_number] = '0' if session[:attempt_number].nil?
+    session[:attempt_number] = (session[:attempt_number].to_i + 1).to_s
+  end
 
   def request_form
     saml_message = SAML_PROXY_API.authn_request(session[:verify_session_id])

--- a/app/controllers/redirect_to_idp_controller.rb
+++ b/app/controllers/redirect_to_idp_controller.rb
@@ -33,8 +33,8 @@ private
   end
 
   def increase_attempt_number
-    session[:attempt_number] = '0' if session[:attempt_number].nil?
-    session[:attempt_number] = (session[:attempt_number].to_i + 1).to_s
+    session[:attempt_number] = 0 if session[:attempt_number].nil?
+    session[:attempt_number] = session[:attempt_number] + 1
   end
 
   def request_form

--- a/app/controllers/start_controller.rb
+++ b/app/controllers/start_controller.rb
@@ -24,11 +24,13 @@ class StartController < ApplicationController
 
   def register
     FEDERATION_REPORTER.report_registration(current_transaction, request)
+    session[:journey_type] = 'registration'
     redirect_to about_path
   end
 
   def sign_in
     FEDERATION_REPORTER.report_sign_in(current_transaction, request)
+    session[:journey_type] = 'sign-in'
     redirect_to sign_in_path
   end
 end

--- a/app/models/analytics/federation_reporter.rb
+++ b/app/models/analytics/federation_reporter.rb
@@ -54,6 +54,14 @@ module Analytics
       )
     end
 
+    def report_user_idp_attempt(journey_type:, attempt_number:, current_transaction:, request:, idp_name:, user_segments:, transaction_simple_id:)
+      report_action(
+        current_transaction,
+        request,
+        "ATTEMPT_#{attempt_number}: #{journey_type} | #{transaction_simple_id} | #{idp_name} | #{user_segments}"
+      )
+    end
+
     def report_idp_registration(current_transaction:, request:, idp_name:, idp_name_history:, evidence:, recommended:, user_segments:)
       list_of_evidence = evidence.sort.join(', ')
       list_of_segments = user_segments.nil? ? nil : user_segments.sort.join(', ')

--- a/app/models/analytics/federation_reporter.rb
+++ b/app/models/analytics/federation_reporter.rb
@@ -62,6 +62,14 @@ module Analytics
       )
     end
 
+    def report_user_idp_outcome(journey_type:, attempt_number:, current_transaction:, request:, idp_name:, user_segments:, transaction_simple_id:, response_status:)
+      report_action(
+        current_transaction,
+        request,
+        "OUTCOME_#{attempt_number}: #{journey_type} | #{transaction_simple_id} | #{idp_name} | #{user_segments} | #{response_status}"
+      )
+    end
+
     def report_idp_registration(current_transaction:, request:, idp_name:, idp_name_history:, evidence:, recommended:, user_segments:)
       list_of_evidence = evidence.sort.join(', ')
       list_of_segments = user_segments.nil? ? nil : user_segments.sort.join(', ')

--- a/spec/controllers/redirect_to_idp_controller_spec.rb
+++ b/spec/controllers/redirect_to_idp_controller_spec.rb
@@ -34,13 +34,13 @@ describe RedirectToIdpController do
       session[:user_segments] = ['test-segment']
 
       expect(FEDERATION_REPORTER).to receive(:report_idp_registration)
-                                 .with(current_transaction: a_kind_of(Display::RpDisplayData),
-                                       request: a_kind_of(ActionDispatch::Request),
-                                       idp_name: bobs_identity_service_idp_name,
-                                       idp_name_history: [bobs_identity_service_idp_name],
-                                       evidence: evidence.keys,
-                                       recommended: idp_was_recommended,
-                                       user_segments: ['test-segment'])
+        .with(current_transaction: a_kind_of(Display::RpDisplayData),
+              request: a_kind_of(ActionDispatch::Request),
+              idp_name: bobs_identity_service_idp_name,
+              idp_name_history: [bobs_identity_service_idp_name],
+              evidence: evidence.keys,
+              recommended: idp_was_recommended,
+              user_segments: ['test-segment'])
 
       subject
     end

--- a/spec/models/analytics/federation_reporter_spec.rb
+++ b/spec/models/analytics/federation_reporter_spec.rb
@@ -144,6 +144,34 @@ module Analytics
       end
     end
 
+    describe '#report_user_idp_outcome' do
+      idp_name = 'IDCorp'
+      attempt_number = '1'
+      transaction_simple_id = 'test-rp'
+      user_segments = %w(segment1)
+      response_status = 'success'
+
+      it 'should report correctly if first registration' do
+        expect(analytics_reporter).to receive(:report_action)
+          .with(
+            request,
+            "OUTCOME_#{attempt_number}: registration | #{transaction_simple_id} | #{idp_name} | #{user_segments} | #{response_status}",
+            1 => %w(RP description),
+            2 => %w(LOA_REQUESTED LEVEL_2)
+                                          )
+        federation_reporter.report_user_idp_outcome(
+          current_transaction: current_transaction,
+          request: request,
+          idp_name: idp_name,
+          user_segments: %w(segment1),
+          transaction_simple_id: 'test-rp',
+          attempt_number: '1',
+          journey_type: 'registration',
+          response_status: 'success'
+        )
+      end
+    end
+
     describe '#report_ab_test' do
       before(:each) do
         RP_DISPLAY_REPOSITORY = double

--- a/spec/models/analytics/federation_reporter_spec.rb
+++ b/spec/models/analytics/federation_reporter_spec.rb
@@ -118,6 +118,32 @@ module Analytics
       end
     end
 
+    describe '#report_user_idp_attempt' do
+      idp_name = 'IDCorp'
+      attempt_number = '1'
+      transaction_simple_id = 'test-rp'
+      user_segments = %w(segment1)
+
+      it 'should report correctly if first registration' do
+        expect(analytics_reporter).to receive(:report_action)
+          .with(
+            request,
+            "ATTEMPT_#{attempt_number}: registration | #{transaction_simple_id} | #{idp_name} | #{user_segments}",
+            1 => %w(RP description),
+            2 => %w(LOA_REQUESTED LEVEL_2)
+          )
+        federation_reporter.report_user_idp_attempt(
+          current_transaction: current_transaction,
+          request: request,
+          idp_name: idp_name,
+          user_segments: %w(segment1),
+          transaction_simple_id: 'test-rp',
+          attempt_number: '1',
+          journey_type: 'registration'
+        )
+      end
+    end
+
     describe '#report_ab_test' do
       before(:each) do
         RP_DISPLAY_REPOSITORY = double

--- a/spec/support/authn_response_examples.rb
+++ b/spec/support/authn_response_examples.rb
@@ -9,6 +9,7 @@ shared_examples 'idp_authn_response' do |journey_hint, idp_result, piwik_action,
   it "should redirect to #{redirect_path} on #{idp_result}" do
     allow(saml_proxy_api).to receive(:idp_authn_response).and_return(IdpAuthnResponse.new('result' => idp_result, 'isRegistration' => (journey_hint == 'registration'), 'loaAchieved' => 'LEVEL_1'))
     allow(subject).to receive(:report_to_analytics).with(piwik_action)
+    allow(subject).to receive(:report_user_outcome_to_piwik).with(idp_result)
     post :idp_response, params: { 'RelayState' => 'my-session-id-cookie', 'SAMLResponse' => 'a-saml-response', locale: 'en' }
     expect(subject).to redirect_to(send(redirect_path))
   end


### PR DESCRIPTION
First release to test new string for analytics on one segment on successful registration journey. If this does not conflict with existing reporting and if it provides useful information we will roll this out for sign in and all registration journeys else the code will be removed.  