### PR TITLE
HUB-114: Add reporting to ajax request

### DIFF
--- a/app/controllers/redirect_to_idp_controller.rb
+++ b/app/controllers/redirect_to_idp_controller.rb
@@ -3,14 +3,10 @@ require 'partials/idp_selection_partial_controller'
 class RedirectToIdpController < ApplicationController
   include IdpSelectionPartialController
 
-  # TODO: HUB-114: To be removed together with segment logic once we have assessed if the new reporting works
-  SEGMENT_TO_BE_TESTED = '2doc_nidl_pp_mobile_app'.freeze
-  SEGMENT_FOR_TEST = 'test-segment'.freeze
-
   def register
     request_form
     increase_attempt_number
-    report_user_idp_attempt_to_piwik if segment_should_be_reported?
+    report_user_idp_attempt_to_piwik
     report_idp_registration_to_piwik(recommended)
     render :redirect_to_idp
   end
@@ -26,16 +22,6 @@ class RedirectToIdpController < ApplicationController
   end
 
 private
-
-  def segment_should_be_reported?
-    return false if session[:user_segments].nil?
-    session[:user_segments].include?(SEGMENT_TO_BE_TESTED) || session[:user_segments].include?(SEGMENT_FOR_TEST)
-  end
-
-  def increase_attempt_number
-    session[:attempt_number] = 0 if session[:attempt_number].nil?
-    session[:attempt_number] = session[:attempt_number] + 1
-  end
 
   def request_form
     saml_message = SAML_PROXY_API.authn_request(session[:verify_session_id])


### PR DESCRIPTION
Add attempt reporting to ajax request and move logic for limitation by segment and increase attempt number to partial.

solo: @Rachelthecodesmith