### PR TITLE
HUB-178: Update IDP order

### DIFF
--- a/config/main_routes.rb
+++ b/config/main_routes.rb
@@ -11,6 +11,11 @@ LOA1_PERF_MANAGEMENT = "loa1_perf_management".freeze
 loa1_perf_management_control_piwik = SelectRoute.new(LOA1_PERF_MANAGEMENT, 'control', is_start_of_test: true, experiment_loa: 'LEVEL_1')
 loa1_perf_management_variant_piwik = SelectRoute.new(LOA1_PERF_MANAGEMENT, 'variant', is_start_of_test: true, experiment_loa: 'LEVEL_1')
 
+LOA1_PERF_MANAGEMENT_V2 = "loa1_perf_management_v2".freeze
+# HUB-135 LOA1 perf management A/B test
+loa1_perf_management_v2_control_piwik = SelectRoute.new(LOA1_PERF_MANAGEMENT_V2, 'control', is_start_of_test: true, experiment_loa: 'LEVEL_1')
+loa1_perf_management_v2_variant_piwik = SelectRoute.new(LOA1_PERF_MANAGEMENT_V2, 'variant', is_start_of_test: true, experiment_loa: 'LEVEL_1')
+
 SHORT_HUB_V3 = "short_hub_v3".freeze
 # HUB-160 Short hub v3 A/B test
 short_hub_v3_control_piwik = SelectRoute.new(SHORT_HUB_V3, 'control', is_start_of_test: true, experiment_loa: 'LEVEL_2')
@@ -46,6 +51,14 @@ constraints IsLoa1 do
   end
 
   constraints loa1_perf_management_variant_piwik do
+    get 'choose_a_certified_company', to: 'choose_a_certified_company_loa1_variant#index', as: :choose_a_certified_company
+  end
+
+  constraints loa1_perf_management_v2_control_piwik do
+    get 'choose_a_certified_company', to: 'choose_a_certified_company_loa1#index', as: :choose_a_certified_company
+  end
+
+  constraints loa1_perf_management_v2_variant_piwik do
     get 'choose_a_certified_company', to: 'choose_a_certified_company_loa1_variant#index', as: :choose_a_certified_company
   end
 end

--- a/spec/features/user_sends_authn_request_spec.rb
+++ b/spec/features/user_sends_authn_request_spec.rb
@@ -103,7 +103,7 @@ describe 'user sends authn requests' do
       ab_test_cookie_value = {
         'about_companies' => 'about_companies_with_logo',
         'select_documents_v2' => 'select_documents_v2_control',
-        'loa1_perf_management' => 'loa1_perf_management_control',
+        'loa1_perf_management_v2' => 'loa1_perf_management_v2_control',
         'short_hub_v3' => 'short_hub_v3_control'
       }.to_json
       cookie_hash = create_cookie_hash.merge!(ab_test: CGI.escape(ab_test_cookie_value))

--- a/stub/ab_test.yml
+++ b/stub/ab_test.yml
@@ -31,7 +31,7 @@ experiments:
           percent: 0
         - name: 'no_logo_privacy'
           percent: 0
-  - loa1_perf_management:
+  - loa1_perf_management_v2:
       alternatives:
         - name: 'control'
           percent: 100


### PR DESCRIPTION
Made the necessary changes to the frontend to update the current AB test.

Added new routes for the updated iteration of the AB test, as well as updating
to reflect the new cookie name.