### PR TITLE
EID-457: Improvements to the country picker

### DIFF
--- a/app/assets/stylesheets/pages/_choose-a-country.scss
+++ b/app/assets/stylesheets/pages/_choose-a-country.scss
@@ -67,6 +67,10 @@
         }
       }
     }
+
+    &:last-child {
+      border: none;
+    }
   }
 
   .scheme-option {
@@ -80,6 +84,12 @@
         display: inline-block;
         vertical-align: middle;
         width: 34%;
+      }
+    }
+
+    &:not(:last-child) {
+      @include media(mobile) {
+        border-bottom: 1px solid $grey-1;
       }
     }
   }
@@ -122,15 +132,5 @@
         }
       }
     }
-  }
-
-  .scheme-option:not(:last-child) {
-    @include media(mobile) {
-      border-bottom: 1px solid $grey-1;
-    }
-  }
-
-  .country-option:last-child {
-    border: none;
   }
 }

--- a/app/models/display/country_display_decorator.rb
+++ b/app/models/display/country_display_decorator.rb
@@ -7,7 +7,7 @@ module Display
 
     def decorate_collection(country_list)
       country_list.map { |country| correlate_display_data(country) }
-          .select(&:viewable?).sort_by(&:display_name)
+          .select(&:viewable?).sort_by { |country| country.display_name.downcase }
     end
 
     def decorate(country)

--- a/app/models/display/eidas_scheme_display_decorator.rb
+++ b/app/models/display/eidas_scheme_display_decorator.rb
@@ -12,7 +12,8 @@ module Display
 
     def decorate_collection(scheme_list)
       return [] if scheme_list.nil? || scheme_list.empty?
-      scheme_list.map { |scheme| correlate_display_data(scheme) }.select(&:viewable?).sort_by(&:display_name)
+      scheme_list.map { |scheme| correlate_display_data(scheme) }.select(&:viewable?)
+          .sort_by { |scheme| scheme.display_name.downcase }
     end
 
     def decorate(scheme)

--- a/app/views/choose_a_country/choose_a_country.html.erb
+++ b/app/views/choose_a_country/choose_a_country.html.erb
@@ -15,14 +15,14 @@
             <div class="scheme-option">
               <div class="scheme-info">
                 <div class="country-flag">
-                  <%= image_tag country.flag_path, alt: country.display_name + ' flag' %>
+                  <%= image_tag country.flag_path, alt: '' %>
                 </div>
                 <div class="country-name">
                   <p class="bold"><%= country.display_name %></p>
                 </div>
                 <div class="scheme-logo">
                   <div class="scheme-logo-img-container">
-                    <%= image_tag scheme.logo_path, alt: scheme.display_name + ' logo' %>
+                    <%= image_tag scheme.logo_path, alt: '' %>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
- Sort countries and schemes correctly. Previously, the sort_by wasn't taking case into account
- Reformat the SCSS to be easier to understand
- Better handle missing images: make alt text for flags and logos empty so the browser would hide them instead of displaying a broken image graphic and the unnecessary alt text. This is also better for screen readers and accessibilty as the users don't need to hear, e.g. 'Austria flag. Austria'.