### PR TITLE
HUB-116: Refactor to reduce session variables

### DIFF
--- a/app/controllers/partials/analytics_partial_controller.rb
+++ b/app/controllers/partials/analytics_partial_controller.rb
@@ -43,7 +43,7 @@ private
       transaction_simple_id: session[:transaction_simple_id],
       attempt_number: session[:attempt_number],
       journey_type: session[:journey_type],
-      hint_followed: session[:hint_details],
+      hint_followed: session[:user_followed_journey_hint],
       response_status: response_status
     )
   end

--- a/app/controllers/redirect_to_idp_warning_controller.rb
+++ b/app/controllers/redirect_to_idp_warning_controller.rb
@@ -30,7 +30,7 @@ class RedirectToIdpWarningController < ApplicationController
     idp = decorated_idp
     if idp.viewable?
       select_registration(idp)
-      ajax_idp_redirection_registration_request(recommended)
+      ajax_idp_redirection_registration_request(recommended, idp.entity_id)
     else
       render status: :bad_request
     end
@@ -40,6 +40,7 @@ private
 
   def select_registration(idp)
     POLICY_PROXY.select_idp(session['verify_session_id'], idp.entity_id, session['requested_loa'], true)
+    set_journey_hint_followed(idp.entity_id)
     set_journey_hint(idp.entity_id)
     register_idp_selections(idp.display_name)
   end

--- a/app/controllers/sign_in_controller.rb
+++ b/app/controllers/sign_in_controller.rb
@@ -1,11 +1,9 @@
 require 'partials/idp_selection_partial_controller'
 require 'partials/viewable_idp_partial_controller'
-require 'partials/journey_hinting_partial_controller'
 
 class SignInController < ApplicationController
   include IdpSelectionPartialController
   include ViewableIdpPartialController
-  include JourneyHintingPartialController
 
   def index
     entity_id = entity_id_of_journey_hint_for('SUCCESS')
@@ -25,9 +23,7 @@ class SignInController < ApplicationController
 
   def select_idp
     select_viewable_idp_for_sign_in(params.fetch('entity_id')) do |decorated_idp|
-      unless entity_id_of_journey_hint_for('SUCCESS').nil?
-        session[:user_followed_journey_hint] = user_followed_journey_hint(decorated_idp.entity_id, 'SUCCESS')
-      end
+      set_journey_hint_followed(decorated_idp.entity_id)
       sign_in(decorated_idp.entity_id, decorated_idp.display_name)
       redirect_to redirect_to_idp_sign_in_path
     end
@@ -35,10 +31,8 @@ class SignInController < ApplicationController
 
   def select_idp_ajax
     select_viewable_idp_for_sign_in(params.fetch('entityId')) do |decorated_idp|
-      hint_shown = !entity_id_of_journey_hint_for('SUCCESS').nil?
-      hint_followed = user_followed_journey_hint(decorated_idp.entity_id, 'SUCCESS')
       sign_in(decorated_idp.entity_id, decorated_idp.display_name)
-      ajax_idp_redirection_sign_in_request(hint_shown, hint_followed)
+      ajax_idp_redirection_sign_in_request(decorated_idp.entity_id)
       session[:user_followed_journey_hint] = user_followed_journey_hint(decorated_idp.entity_id, 'SUCCESS')
     end
   end

--- a/app/models/analytics/federation_reporter.rb
+++ b/app/models/analytics/federation_reporter.rb
@@ -55,8 +55,9 @@ module Analytics
     end
 
     def report_user_idp_attempt(journey_type:, attempt_number:, current_transaction:, request:, idp_name:, user_segments:, transaction_simple_id:, hint_followed:)
-      report = "ATTEMPT_#{attempt_number}| #{journey_type} | #{transaction_simple_id} | #{idp_name} | #{user_segments} |"
-      report << journey_hint_details(journey_type, hint_followed)
+      segment_list = user_segments.nil? ? 'nil' : user_segments.sort.join(', ')
+      report = "ATTEMPT_#{attempt_number} | #{journey_type} | #{transaction_simple_id} | #{idp_name} | #{segment_list} |"
+      report << journey_hint_details(hint_followed)
       report_action(
         current_transaction,
         request,
@@ -65,8 +66,9 @@ module Analytics
     end
 
     def report_user_idp_outcome(journey_type:, attempt_number:, current_transaction:, request:, idp_name:, user_segments:, transaction_simple_id:, hint_followed:, response_status:)
-      report = "OUTCOME_#{attempt_number}| #{journey_type} | #{transaction_simple_id} | #{idp_name} | #{user_segments} |"
-      report << journey_hint_details(journey_type, hint_followed)
+      segment_list = user_segments.nil? ? 'nil' : user_segments.sort.join(', ')
+      report = "OUTCOME_#{attempt_number} | #{journey_type} | #{transaction_simple_id} | #{idp_name} | #{segment_list} |"
+      report << journey_hint_details(hint_followed)
       report << " #{response_status} |"
       report_action(
         current_transaction,
@@ -157,13 +159,11 @@ module Analytics
 
   private
 
-    HINT_NA = ' nil | nil |'.freeze
-    HINT_NOT_PRESENT = ' not shown | not followed |'.freeze
-    HINT_FOLLOWED = ' shown | followed |'.freeze
-    HINT_NOT_FOLLOWED = ' shown | not followed |'.freeze
+    HINT_NOT_PRESENT = ' not present | not followed |'.freeze
+    HINT_FOLLOWED = ' present | followed |'.freeze
+    HINT_NOT_FOLLOWED = ' present | not followed |'.freeze
 
-    def journey_hint_details(journey, hint)
-      return HINT_NA if journey == 'registration'
+    def journey_hint_details(hint)
       return HINT_NOT_PRESENT if hint.nil?
       hint ? HINT_FOLLOWED : HINT_NOT_FOLLOWED
     end

--- a/spec/models/analytics/federation_reporter_spec.rb
+++ b/spec/models/analytics/federation_reporter_spec.rb
@@ -122,15 +122,13 @@ module Analytics
       idp_name = 'IDCorp'
       attempt_number = '1'
       transaction_simple_id = 'test-rp'
-      user_segments = %w(segment1)
-      hint_details = 'nil | nil |'
+      user_segments = 'segment1'
 
       it 'should report attempt correctly when idp selected if first registration' do
-        hint_followed = nil
         expect(analytics_reporter).to receive(:report_action)
           .with(
             request,
-            "ATTEMPT_#{attempt_number}| registration | #{transaction_simple_id} | #{idp_name} | #{user_segments} | #{hint_details}",
+            "ATTEMPT_#{attempt_number} | registration | #{transaction_simple_id} | #{idp_name} | #{user_segments} |#{FederationReporter::HINT_NOT_PRESENT}",
             1 => %w(RP description),
             2 => %w(LOA_REQUESTED LEVEL_2)
           )
@@ -142,16 +140,15 @@ module Analytics
           transaction_simple_id: 'test-rp',
           attempt_number: '1',
           journey_type: 'registration',
-          hint_followed: hint_followed
+          hint_followed: nil
         )
       end
 
       it 'should report attempt correctly when journey hint is set but the user selected registration' do
-        hint_followed = true
         expect(analytics_reporter).to receive(:report_action)
           .with(
             request,
-            "ATTEMPT_#{attempt_number}| registration | #{transaction_simple_id} | #{idp_name} | #{user_segments} | #{hint_details}",
+            "ATTEMPT_#{attempt_number} | registration | #{transaction_simple_id} | #{idp_name} | #{user_segments} |#{FederationReporter::HINT_NOT_FOLLOWED}",
             1 => %w(RP description),
             2 => %w(LOA_REQUESTED LEVEL_2)
           )
@@ -163,7 +160,27 @@ module Analytics
           transaction_simple_id: 'test-rp',
           attempt_number: '1',
           journey_type: 'registration',
-          hint_followed: hint_followed
+          hint_followed: false
+        )
+      end
+
+      it 'should report attempt correctly when segments are nil and the user followed the journey hint' do
+        expect(analytics_reporter).to receive(:report_action)
+          .with(
+            request,
+            "ATTEMPT_#{attempt_number} | sign-in | #{transaction_simple_id} | #{idp_name} | nil |#{FederationReporter::HINT_FOLLOWED}",
+            1 => %w(RP description),
+            2 => %w(LOA_REQUESTED LEVEL_2)
+          )
+        federation_reporter.report_user_idp_attempt(
+          current_transaction: current_transaction,
+          request: request,
+          idp_name: idp_name,
+          user_segments: nil,
+          transaction_simple_id: 'test-rp',
+          attempt_number: '1',
+          journey_type: 'sign-in',
+          hint_followed: true
         )
       end
     end
@@ -172,16 +189,15 @@ module Analytics
       idp_name = 'IDCorp'
       attempt_number = '1'
       transaction_simple_id = 'test-rp'
-      user_segments = %w(segment1)
-      hint_details = 'nil | nil |'
-      response_status = 'success'
+      user_segments = 'segment1'
+      response_status = 'SUCCESS'
 
       it 'should report outcome correctly on response from first registration' do
         hint_followed = nil
         expect(analytics_reporter).to receive(:report_action)
           .with(
             request,
-            "OUTCOME_#{attempt_number}| registration | #{transaction_simple_id} | #{idp_name} | #{user_segments} | #{hint_details} #{response_status} |",
+            "OUTCOME_#{attempt_number} | registration | #{transaction_simple_id} | #{idp_name} | #{user_segments} |#{FederationReporter::HINT_NOT_PRESENT} #{response_status} |",
             1 => %w(RP description),
             2 => %w(LOA_REQUESTED LEVEL_2)
           )
@@ -194,7 +210,7 @@ module Analytics
           attempt_number: '1',
           journey_type: 'registration',
           hint_followed: hint_followed,
-          response_status: 'success'
+          response_status: 'SUCCESS'
         )
       end
     end


### PR DESCRIPTION
Refactor to remove surplus hint_details session varable as user_followed_journey_hint stored the same value and used the same logic.

Co-Authored-by: Jakub Miarka <jakub.miarka@digital.cabinet-office.gov.uk>