### PR TITLE
BAU: Fix bug in piwik reporting

### DIFF
--- a/app/controllers/sign_in_controller.rb
+++ b/app/controllers/sign_in_controller.rb
@@ -33,7 +33,6 @@ class SignInController < ApplicationController
     select_viewable_idp_for_sign_in(params.fetch('entityId')) do |decorated_idp|
       sign_in(decorated_idp.entity_id, decorated_idp.display_name)
       ajax_idp_redirection_sign_in_request(decorated_idp.entity_id)
-      session[:user_followed_journey_hint] = user_followed_journey_hint(decorated_idp.entity_id, 'SUCCESS')
     end
   end
 


### PR DESCRIPTION
Fix to remove bug in piwik reporting. The session variable user_followed_journey_hint was being set regardless of if journey hint was present on sign in journeys. This was happening after the initial virtual page was sent to piwik and was therefore only detectable on the outcome journey report.

solo: @rachelthecodesmith