### PR TITLE
Eid 638

### DIFF
--- a/app/controllers/authn_request_controller.rb
+++ b/app/controllers/authn_request_controller.rb
@@ -73,23 +73,19 @@ private
     when 'uk_idp_sign_in'
       redirect_to begin_sign_in_path
     when 'eidas_sign_in'
-      raise StandardError, 'Users session does not support eIDAS journeys' unless session[:transaction_supports_eidas]
-      redirect_to choose_a_country_path
+      if session[:transaction_supports_eidas]
+        redirect_to choose_a_country_path
+      else
+        redirect_to start_path
+      end
     when 'submission_confirmation'
       redirect_to confirm_your_identity_path
-    when 'unspecified'
+    else
       if session[:transaction_supports_eidas]
         redirect_to prove_identity_path
       else
         redirect_to start_path
       end
-    else
-      # TODO: we actually want this to be the same as the unspecified case.
-      # However, the old code allowed RPs to submit any other value they liked
-      # and get the non-repudiation flow. Hence, we cannot remove this until we've
-      # verified what everyone is sending to activate that flow.
-      logger.info "journey_hint value: #{hint}"
-      redirect_to confirm_your_identity_path
     end
   end
 end

--- a/app/controllers/authn_request_controller.rb
+++ b/app/controllers/authn_request_controller.rb
@@ -13,17 +13,9 @@ class AuthnRequestController < SamlController
 
     AbTest.set_or_update_ab_test_cookie(current_transaction_simple_id, cookies)
 
-    if params['journey_hint'].present?
-      logger.info "journey_hint value: #{params['journey_hint']}"
-      follow_journey_hint
-    elsif params['eidas_journey'].present?
-      raise StandardError, 'Users session does not support eIDAS journeys' unless session[:transaction_supports_eidas]
-      redirect_to choose_a_country_path
-    elsif session[:transaction_supports_eidas]
-      redirect_to prove_identity_path
-    else
-      redirect_to start_path
-    end
+
+    journey_hint = params['journey_hint'].present? ? params['journey_hint'] : 'unspecified'
+    follow_journey_hint journey_hint
   end
 
 private
@@ -74,17 +66,30 @@ private
     session[:transaction_homepage] = transaction_homepage
   end
 
-  def follow_journey_hint
-    if check_journey_hint('registration')
+  def follow_journey_hint(hint)
+    case hint
+    when 'registration'
       redirect_to begin_registration_path
-    elsif check_journey_hint('sign_in')
+    when 'uk_idp_sign_in'
       redirect_to begin_sign_in_path
+    when 'eidas_sign_in'
+      raise StandardError, 'Users session does not support eIDAS journeys' unless session[:transaction_supports_eidas]
+      redirect_to choose_a_country_path
+    when 'submission_confirmation'
+      redirect_to confirm_your_identity_path
+    when 'unspecified'
+      if session[:transaction_supports_eidas]
+        redirect_to prove_identity_path
+      else
+        redirect_to start_path
+      end
     else
+      # TODO: we actually want this to be the same as the unspecified case.
+      # However, the old code allowed RPs to submit any other value they liked
+      # and get the non-repudiation flow. Hence, we cannot remove this until we've
+      # verified what everyone is sending to activate that flow.
+      logger.info "journey_hint value: #{hint}"
       redirect_to confirm_your_identity_path
     end
-  end
-
-  def check_journey_hint(path)
-    params['journey_hint'].downcase == path
   end
 end

--- a/app/views/test_saml/index.html.erb
+++ b/app/views/test_saml/index.html.erb
@@ -35,13 +35,13 @@
 <%= form_tag('/SAML2/SSO') do -%>
   <%= hidden_field_tag('SAMLRequest', 'my-saml-request') %>
   <%= hidden_field_tag('RelayState', 'my-relay-state') %>
-  <%= hidden_field_tag('journey_hint', 'sign_in') %>
+  <%= hidden_field_tag('journey_hint', 'uk_idp_sign_in') %>
   <div><%= submit_tag 'saml-post-journey-hint-sign-in' %></div>
 <% end -%>
 <%= form_tag('/SAML2/SSO') do -%>
     <%= hidden_field_tag('SAMLRequest', 'my-saml-request') %>
     <%= hidden_field_tag('RelayState', 'my-relay-state') %>
-    <%= hidden_field_tag('eidas_journey', 'true') %>
+    <%= hidden_field_tag('journey_hint', 'eidas_sign_in') %>
     <div><%= submit_tag 'saml-post-eidas' %></div>
 <% end -%>
 <%= form_tag('/SAML2/SSO/Response/POST') do -%>


### PR DESCRIPTION
EID-638 Handle new journey hint values
- We used to specify an `eidas_journey` parameter to
  frontend to skip to the country picker.
- We now have a `eidas_sign_in` value for the `journey_hint`
  parameter which we have replaced it with.
- We have also renamed `sign_in` to `uk_idp_sign_in` to
  differentiate it from the eIDAS version.
- We also now explictly support `unspecified` which is
  the same as if the journey hint is missing.