### PR TITLE
HUB-113: Re-enable forcing a new piwik visit

### DIFF
--- a/app/assets/javascripts/analytics.js
+++ b/app/assets/javascripts/analytics.js
@@ -25,15 +25,13 @@
     var siteId = $('#piwik-site-id').text();
     var customUrl = $('#piwik-custom-url').text();
     var enTitle = $('meta[name="verify|title"]').attr("content");
-    var newVisit = $('#piwik-new-visit')
+    var newVisit = $('#piwik-new-visit');
 
+    var newVisitFlag = 0;
     if(newVisit.length) {
-        var newVisitFlag = 1;
+        newVisitFlag = 1;
         // to make sure the new visit flag is used only once
         newVisit.remove();
-    }
-    else {
-        var newVisitFlag = 0;
     }
 
     var piwikAnalyticsQueue = [

--- a/app/assets/javascripts/analytics.js
+++ b/app/assets/javascripts/analytics.js
@@ -25,10 +25,19 @@
     var siteId = $('#piwik-site-id').text();
     var customUrl = $('#piwik-custom-url').text();
     var enTitle = $('meta[name="verify|title"]').attr("content");
-    var newVisit = $('#piwik-new-visit').length ? 1 : 0;
+    var newVisit = $('#piwik-new-visit')
+
+    if(newVisit.length) {
+        var newVisitFlag = 1;
+        // to make sure the new visit flag is used only once
+        newVisit.remove();
+    }
+    else {
+        var newVisitFlag = 0;
+    }
 
     var piwikAnalyticsQueue = [
-        ['appendToTrackingUrl', 'new_visit=' + newVisit],
+        ['appendToTrackingUrl', 'new_visit=' + newVisitFlag],
         ['setUserId', getPiwikVisitorIdCookie()],
         ['setDocumentTitle', enTitle ],
         ['trackPageView'],

--- a/app/controllers/authn_request_controller.rb
+++ b/app/controllers/authn_request_controller.rb
@@ -8,8 +8,7 @@ class AuthnRequestController < SamlController
   def rp_request
     create_session
 
-    # HUB-113: Temporarily disabling to allow the perf team to analyze the data
-    # session[:new_visit] = true
+    session[:new_visit] = true
 
     AbTest.set_or_update_ab_test_cookie(current_transaction_simple_id, cookies)
 

--- a/spec/features/redirects_with_see_other_spec.rb
+++ b/spec/features/redirects_with_see_other_spec.rb
@@ -7,10 +7,9 @@ describe 'pages redirect with see other', type: :request do
     expect(response.status).to eql 303
   end
 
-  # HUB-113: Temporarily disabling to allow the perf team to analyze the data
-  # it 'does not delete the new_visit flag' do
-  #   stub_session_creation
-  #   post '/SAML2/SSO', params: { 'SAMLRequest' => 'my-saml-request', 'RelayState' => 'my-relay-state' }
-  #   expect(request.session['new_visit']).to eql true
-  # end
+  it 'does not delete the new_visit flag' do
+    stub_session_creation
+    post '/SAML2/SSO', params: { 'SAMLRequest' => 'my-saml-request', 'RelayState' => 'my-relay-state' }
+    expect(request.session['new_visit']).to eql true
+  end
 end


### PR DESCRIPTION
Performance analyst team analysed the data from the day we forced
the new piwik visit for each RP request and they are happy to enable it
as a default. We also identified a small issue when on start page we do
an additional JS reporting, the flag was still present, so added a fix
to remove it as soon as it gets used.

Solo: @jakubmiarka