### PR TITLE
EID-638 Handle new journey hint values

### DIFF
--- a/app/views/test_saml/index.html.erb
+++ b/app/views/test_saml/index.html.erb
@@ -27,6 +27,12 @@
   <div><%= submit_tag 'saml-post-journey-hint' %></div>
 <% end -%>
 <%= form_tag('/SAML2/SSO') do -%>
+    <%= hidden_field_tag('SAMLRequest', 'my-saml-request') %>
+    <%= hidden_field_tag('RelayState', 'my-relay-state') %>
+    <%= hidden_field_tag('journey_hint', 'submission_confirmation') %>
+    <div><%= submit_tag 'saml-post-journey-hint_submission_confirmation' %></div>
+  <% end -%>
+<%= form_tag('/SAML2/SSO') do -%>
   <%= hidden_field_tag('SAMLRequest', 'my-saml-request') %>
   <%= hidden_field_tag('RelayState', 'my-relay-state') %>
   <%= hidden_field_tag('journey_hint', 'registration') %>
@@ -35,13 +41,13 @@
 <%= form_tag('/SAML2/SSO') do -%>
   <%= hidden_field_tag('SAMLRequest', 'my-saml-request') %>
   <%= hidden_field_tag('RelayState', 'my-relay-state') %>
-  <%= hidden_field_tag('journey_hint', 'sign_in') %>
+  <%= hidden_field_tag('journey_hint', 'uk_idp_sign_in') %>
   <div><%= submit_tag 'saml-post-journey-hint-sign-in' %></div>
 <% end -%>
 <%= form_tag('/SAML2/SSO') do -%>
     <%= hidden_field_tag('SAMLRequest', 'my-saml-request') %>
     <%= hidden_field_tag('RelayState', 'my-relay-state') %>
-    <%= hidden_field_tag('eidas_journey', 'true') %>
+    <%= hidden_field_tag('journey_hint', 'eidas_sign_in') %>
     <div><%= submit_tag 'saml-post-eidas' %></div>
 <% end -%>
 <%= form_tag('/SAML2/SSO/Response/POST') do -%>

--- a/spec/features/redirects_with_journey_hint_authn_request_spec.rb
+++ b/spec/features/redirects_with_journey_hint_authn_request_spec.rb
@@ -8,28 +8,22 @@ describe 'pages redirect with journey hint parameter', type: :request do
     expect(response).to redirect_to begin_registration_path
   end
 
-  it 'will redirect the user to registration path when journey hint parameter is set to registration and is case insensitive' do
+  it 'will redirect the user to sign-in path when journey hint parameter is set to uk_idp_sign_in' do
     stub_session_creation
-    post '/SAML2/SSO', params: { 'SAMLRequest' => 'my-saml-request', 'RelayState' => 'my-relay-state', 'journey_hint' => 'RegiStraTion' }
-    expect(response).to redirect_to begin_registration_path
-  end
-
-  it 'will redirect the user to sign-in path when journey hint parameter is set to sign_in' do
-    stub_session_creation
-    post '/SAML2/SSO', params: { 'SAMLRequest' => 'my-saml-request', 'RelayState' => 'my-relay-state', 'journey_hint' => 'sign_in' }
+    post '/SAML2/SSO', params: { 'SAMLRequest' => 'my-saml-request', 'RelayState' => 'my-relay-state', 'journey_hint' => 'uk_idp_sign_in' }
     expect(response).to redirect_to begin_sign_in_path
   end
 
-  it 'will redirect the user to non-repudiation path when journey hint parameter is present (not sign_in or registration)' do
+  it 'will redirect the user to non-repudiation path when journey hint parameter is set to submission_confirmation' do
     stub_session_creation
     post '/SAML2/SSO', params: { 'SAMLRequest' => 'my-saml-request', 'RelayState' => 'my-relay-state', 'journey_hint' => 'submission_confirmation' }
     expect(response).to redirect_to confirm_your_identity_path
   end
 
-  it 'will redirect the user to non-repudiation path when journey hint parameter is present (not sign_in or registration)' do
+  it 'will redirect the user to start path path when journey hint parameter is an unknown value' do
     stub_session_creation
     post '/SAML2/SSO', params: { 'SAMLRequest' => 'my-saml-request', 'RelayState' => 'my-relay-state', 'journey_hint' => 'foobar' }
-    expect(response).to redirect_to confirm_your_identity_path
+    expect(response).to redirect_to start_path
   end
 
   it 'will redirect the user to start path when journey hint parameter is not present' do

--- a/spec/features/user_sends_authn_request_spec.rb
+++ b/spec/features/user_sends_authn_request_spec.rb
@@ -27,16 +27,6 @@ describe 'user sends authn requests' do
       expect(page.get_rack_session['transaction_supports_eidas']).to eql false
     end
 
-    it 'will redirect user to /confirm-your-identity when journey hint is set (not to registration or sign_in)' do
-      stub_api_idp_list_for_loa(default_idps, 'LEVEL_1')
-      set_journey_hint_cookie('http://idcorp.com')
-      stub_session_creation('transactionSupportsEidas' => true)
-      visit('/test-saml')
-      click_button 'saml-post-journey-hint'
-      expect(page).to have_title t('hub.confirm_your_identity.title')
-      expect(page.get_rack_session['transaction_supports_eidas']).to eql true
-    end
-
     it 'will redirect the user to /choose-a-country for an eidas journey where eidas is enabled' do
       stub_session_creation('transactionSupportsEidas' => true)
       stub_transactions_list
@@ -47,17 +37,6 @@ describe 'user sends authn requests' do
 
       expect(page).to have_title t('hub.choose_a_country.title')
       expect(page.get_rack_session['transaction_supports_eidas']).to eql true
-    end
-
-    it 'will render the something went wrong page for an eidas journey where eidas is disabled' do
-      stub_session_creation('transactionSupportsEidas' => false)
-      stub_transactions_list
-
-      visit('/test-saml')
-      click_button 'saml-post-eidas'
-
-      expect(page).to have_content t('errors.something_went_wrong.heading')
-      expect(page.get_rack_session['transaction_supports_eidas']).to eql false
     end
 
     it 'will redirect the user to /about when journey hint is set to registration' do

--- a/spec/features/user_visits_confirm_your_identity_page_spec.rb
+++ b/spec/features/user_visits_confirm_your_identity_page_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe 'When the user visits the confirm-your-identity page' do
       click_button 'Ddewis Welsh IDCorp'
 
       visit '/test-saml'
-      click_button 'saml-post-journey-hint'
+      click_button 'saml-post-journey-hint_submission_confirmation'
       expect(page).to have_title t('hub.confirm_your_identity.title', locale: :cy)
       expect(page).to have_current_path('/cadarnhau-eich-hunaniaeth')
       expect(page).to have_css 'html[lang=cy]'
@@ -166,7 +166,7 @@ RSpec.describe 'When the user visits the confirm-your-identity page' do
 
       stub_session_creation
       visit '/test-saml'
-      click_button 'saml-post-journey-hint'
+      click_button 'saml-post-journey-hint_submission_confirmation'
 
       expect(page).to have_title t('hub.confirm_your_identity.title', locale: :cy)
       expect(page).to have_current_path('/cadarnhau-eich-hunaniaeth')


### PR DESCRIPTION
- We used to specify an `eidas_journey` parameter to
  frontend to skip to the country picker.
- We now have a `eidas_sign_in` value for the `journey_hint`
  parameter which we have replaced it with.
- We have also renamed `sign_in` to `uk_idp_sign_in` to
  differentiate it from the eIDAS version.
- We also now explictly support `unspecified` which is
  the same as if the journey hint is missing.
- Previously we would raise an error if the journey hint was set to
  country-sign-in and the RP had eidas disabled. We will now treat this
  as undefined and redirect to the start page.
- Some tests relied on using a non standard journey_hint to redirect to
  subject_confirmation flow. This is no longer valid. Tests and setup
  changed to reflect this.