### PR TITLE
HUB-190: Hide feedback form from integration.

### DIFF
--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -3,15 +3,10 @@ class FeedbackController < ApplicationController
   skip_before_action :set_piwik_custom_variables
 
   def index
-    @form = FeedbackForm.new({})
-    flash['feedback_referer'] = request.referer
-    feedback_source = params['feedback-source'].nil? ? flash['feedback_source'] : params['feedback-source']
-    if feedback_source.nil?
-      render
-    elsif FEEDBACK_SOURCE_MAPPER.is_feedback_source_valid(feedback_source)
-      flash['feedback_source'] = feedback_source
+    if FEEDBACK_DISABLED
+      render :disabled
     else
-      render 'errors/404', status: 400
+      render_feedback_form
     end
   end
 
@@ -38,5 +33,18 @@ private
 
   def feedback_form_params
     (params['feedback_form'] || {}).merge(user_agent: request.user_agent, referer: flash['feedback_referer'])
+  end
+
+  def render_feedback_form
+    @form = FeedbackForm.new({})
+    flash['feedback_referer'] = request.referer
+    feedback_source = params['feedback-source'].nil? ? flash['feedback_source'] : params['feedback-source']
+    if feedback_source.nil?
+      render
+    elsif FEEDBACK_SOURCE_MAPPER.is_feedback_source_valid(feedback_source)
+      flash['feedback_source'] = feedback_source
+    else
+      render 'errors/404', status: 400
+    end
   end
 end

--- a/app/views/feedback/disabled.html.erb
+++ b/app/views/feedback/disabled.html.erb
@@ -1,0 +1,17 @@
+<%= page_title 'hub.feedback_disabled.title' %>
+<% content_for :show_to_search_engine, true %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+
+    <div class="error-summary" role="alert" aria-labelledby="error-summary-heading-example-1" tabindex="-1">
+
+      <h1 class="heading-medium error-summary-heading" id="error-summary-heading-example-1">
+        <%= t 'hub.feedback_disabled.heading' %>
+      </h1>
+
+      <p> <%= t 'hub.feedback_disabled.error_content' %> </p>
+
+    </div>
+  </div>
+</div>

--- a/config/initializers/00_configuration.rb
+++ b/config/initializers/00_configuration.rb
@@ -38,4 +38,5 @@ CONFIG = Configuration.load! do
   option_string 'ab_test_file', 'AB_TEST_FILE', allow_missing: true
   option_string 'segment_definitions', 'SEGMENT_DEFINITIONS'
   option_string 'saml_proxy_host', 'SAML_PROXY_HOST'
+  option_bool 'feedback_disabled', 'FEEDBACK_DISABLED', default: false
 end

--- a/config/initializers/30_federation.rb
+++ b/config/initializers/30_federation.rb
@@ -60,6 +60,8 @@ Rails.application.config.after_initialize do
   transaction_grouper = TransactionGroups::TransactionGrouper.new(RP_CONFIG)
   IDP_RECOMMENDATION_ENGINE = RecommendationsEngine.new(idp_rules, segment_matcher, transaction_grouper)
 
+  FEEDBACK_DISABLED = CONFIG.feedback_disabled
+
   # Feature flags
   IDP_FEATURE_FLAGS_CHECKER = IdpConfiguration::IdpFeatureFlagsLoader.new(YamlLoader.new)
                                  .load(CONFIG.rules_directory, %i[send_hints send_language_hint show_interstitial_question show_interstitial_question_loa1])

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -475,6 +475,10 @@ cy:
         send_failure: Yn anffodus rydym yn methu cofnodi eich adborth ar hyn o bryd. Rhowch gynnig arall yn hwyrach ymlaen.
         reply: Dylech ddewis opsiwn
       send_message: Anfon neges
+    feedback_disabled:
+      title: Feedback Disabled
+      heading: Feedback is disabled on this environment
+      error_content: You are currently using a non-production version of Verify, where feedback has been disabled.
     feedback_sent:
       title: Adborth
       heading: Diolch am eich adborth

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -469,6 +469,10 @@ en:
         send_failure: Unfortunately, we are unable to record your feedback at the moment. Please try again later.
         reply: Please select an option
       send_message: Send message
+    feedback_disabled:
+      title: Feedback Disabled
+      heading: Feedback is disabled on this environment
+      error_content: You are currently using a non-production version of Verify, where feedback has been disabled.
     feedback_sent:
       title: Feedback
       heading: Thank you for your feedback

--- a/spec/controllers/feedback_controller_spec.rb
+++ b/spec/controllers/feedback_controller_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+require 'controller_helper'
+
+describe FeedbackController do
+  subject { get :index, params: { locale: 'en' } }
+
+  context 'when feedback flag is true' do
+    before(:each) do stub_const("FEEDBACK_DISABLED", true) end
+
+    it 'renders feedback disabled view' do
+      expect(subject).to render_template(:disabled)
+    end
+  end
+
+  context 'when feedback flag is not present' do
+    it 'renders feedback form' do
+      expect(subject).to render_template(:index)
+    end
+  end
+
+  context 'when feedback flag is false' do
+    before(:each) do stub_const("FEEDBACK_DISABLED", false) end
+    it 'renders feedback form' do
+      expect(subject).to render_template(:index)
+    end
+  end
+end

--- a/spec/features/user_visits_feedback_page_spec.rb
+++ b/spec/features/user_visits_feedback_page_spec.rb
@@ -190,6 +190,15 @@ RSpec.feature 'When the user visits the feedback page' do
     expect(DUMMY_ZENDESK_CLIENT.tickets.last.comment).to include 'From page: http://www.example.com/start'
   end
 
+  it 'should show altered feedback form when feedback disabled' do
+    set_session_and_session_cookies!
+    stub_const("FEEDBACK_DISABLED", true)
+    visit start_path
+    click_on t('feedback_link.feedback_form')
+
+    expect(page).to have_content "Feedback is disabled on this environment"
+  end
+
   it 'should also be in welsh' do
     visit feedback_cy_path
     expect(page).to have_title t('hub.feedback.title', locale: :cy)


### PR DESCRIPTION
The reason behind this is that since the IP whitelist has been removed the integration environment
has been visible to the public, including the feedback form, which on integration lacks any
zendesk config and merely throws an error when submitted. We decided to modify the frontend so that
when in integration if the feedback form is accessed a gov.uk styled error is shown to the user
stating that feedback is disabled in this environment.

To make these changes I have added a new view to the feedback folder, and made some changes to the
respective controller, that now checks the value of a new environment variable named
FEEDBACK_DISABLED, if true it renders the new view with the error message, if false renders the
feedback form as normal.

I have also added some unit tests for the additional functionality in the
controller, as well as a feature test to check the correct page is shown when feedback is disabled.