### PR TITLE
ZD-56753: Fix for incorrect view rendering

### DIFF
--- a/app/controllers/select_documents_variant_controller.rb
+++ b/app/controllers/select_documents_variant_controller.rb
@@ -5,7 +5,7 @@ class SelectDocumentsVariantController < ApplicationController
 
   def index
     @form = SelectDocumentsForm.new({})
-    render :index
+    render 'select_documents/index'
   end
 
   def select_documents
@@ -15,7 +15,7 @@ class SelectDocumentsVariantController < ApplicationController
       redirect_to @form.further_id_information_required? ? other_identity_documents_path : choose_a_certified_company_path
     else
       flash.now[:errors] = @form.errors.full_messages.join(', ')
-      render :index
+      render 'select_documents/index'
     end
   end
 


### PR DESCRIPTION
When a user is on variant, has a JS disabled and submits invalid form,
the select_documents_variant controller tries to re-render the page with
the error message. However, we don't use that view and so it isn't present.
The fix is to render the control views (instead of adding the variant view)

Solo: @jakubmiarka