### PR TITLE
BAU: Fix to logic in setting journey hint

### DIFF
--- a/app/controllers/partials/journey_hinting_partial_controller.rb
+++ b/app/controllers/partials/journey_hinting_partial_controller.rb
@@ -1,7 +1,7 @@
 # Shared methods for controllers which use the journey hint cookie to give users IDP suggestions
 module JourneyHintingPartialController
   def journey_hint_value
-    MultiJson.load(cookies.encrypted[CookieNames::VERIFY_FRONT_JOURNEY_HINT] ||= '')
+    MultiJson.load(cookies.encrypted[CookieNames::VERIFY_FRONT_JOURNEY_HINT])
   rescue MultiJson::ParseError
     nil
   end

--- a/app/controllers/partials/user_cookies_partial_controller.rb
+++ b/app/controllers/partials/user_cookies_partial_controller.rb
@@ -40,7 +40,7 @@ module UserCookiesPartialController
 private
 
   def journey_hint_value
-    MultiJson.load(cookies.encrypted[CookieNames::VERIFY_FRONT_JOURNEY_HINT] ||= '')
+    MultiJson.load(cookies.encrypted[CookieNames::VERIFY_FRONT_JOURNEY_HINT])
   rescue MultiJson::ParseError
     nil
   end


### PR DESCRIPTION
Logic that checked for a journey hint cookie would set an empty string
if no hint present. This has been removed to allow checks against nil to
return intended results.

Co-Authored-by: Jakub Miarka <jakub.miarka@digital.cabinet-office.gov.uk>