### PR TITLE
BAU: Remove warnings about already initialized constants

### DIFF
--- a/spec/models/display/rp_display_repository_spec.rb
+++ b/spec/models/display/rp_display_repository_spec.rb
@@ -24,7 +24,6 @@ module Display
       @translator = instance_double("Display::FederationTranslator")
       allow(@translator).to receive(:translate).and_return("")
 
-      RP_TRANSLATION_SERVICE = instance_double("RpTranslationService")
       allow(RP_TRANSLATION_SERVICE).to receive(:transactions).and_return(['test-rp'])
       allow(RP_TRANSLATION_SERVICE).to receive(:update_rp_translations).with('test-rp').and_return(@translations)
     end

--- a/spec/services/rp_translation_service_spec.rb
+++ b/spec/services/rp_translation_service_spec.rb
@@ -7,7 +7,6 @@ require 'i18n'
 
 describe 'RpTranslationService' do
   before(:each) do
-    CONFIG_PROXY = instance_double("ConfigProxy")
     allow(CONFIG_PROXY).to receive(:transactions).and_return(MultiJson.load('[{
       "simpleId":"test-rp",
       "entityId":"http://example.com/test-rp",


### PR DESCRIPTION
The tests re-initialize the global RP_TRANSLATION_SERVICE and CONFIG_PROXY
instances resulting in warnings in the results.