### PR TITLE
BAU: Shorten AB test cookie lifetime

### DIFF
--- a/app/models/ab_test/ab_test.rb
+++ b/app/models/ab_test/ab_test.rb
@@ -25,7 +25,7 @@ module AbTest
   end
 
   def self.set_ab_test_cookie(value, cookies)
-    cookies[CookieNames::AB_TEST] = { value: value.to_json, expires: 2.weeks.from_now }
+    cookies[CookieNames::AB_TEST] = { value: value.to_json, expires: 1.week.from_now }
   end
 
   def self.experiment_selections

--- a/app/views/static/cookies.cy.html.erb
+++ b/app/views/static/cookies.cy.html.erb
@@ -57,7 +57,7 @@ end %>
     <tr>
       <td><var>ab_test</var></td>
       <td>Mae hyn yn gadael i ni wybod bod eich ymweliad yn rhan o brawf i'n helpu i wella GOV.UK Verify</td>
-      <td>2 wythnos</td>
+      <td>1 wythnos</td>
     </tr>
   </tbody>
 </table>

--- a/app/views/static/cookies.en.html.erb
+++ b/app/views/static/cookies.en.html.erb
@@ -63,7 +63,7 @@ end %>
     <tr>
       <td><var>ab_test</var></td>
       <td>This lets us know your visit is part of a test to help us improve GOV.UK Verify</td>
-      <td>2 weeks</td>
+      <td>1 week</td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
This is a proposal to shorten the AB test cookie lifetime from 2 weeks to 1 week.
We hardly ever run tests for more than 10 days. Having it set at 2 weeks
makes it difficult to dial down or deactivate tests as returning users
will still have the (variant) cookie.

Comments/concerns?