### PR TITLE
EID-637: Refactor Authn Response Controller for readability

### DIFF
--- a/app/controllers/authn_response_controller.rb
+++ b/app/controllers/authn_response_controller.rb
@@ -52,7 +52,6 @@ private
   end
 
   def handle_country_response(status, response)
-    set_journey_status(session[:selected_country], status)
     redirect_to country_redirects(status, response)
   end
 

--- a/app/controllers/authn_response_controller.rb
+++ b/app/controllers/authn_response_controller.rb
@@ -1,22 +1,30 @@
+# frozen_string_literal: true
+
 require 'partials/user_cookies_partial_controller'
 
 class AuthnResponseController < SamlController
   protect_from_forgery except: %i[idp_response country_response]
 
-  SIGNING_IN_STATE = 'SIGN_IN_WITH_IDP'.freeze
-  REGISTERING_STATE = 'REGISTER_WITH_IDP'.freeze
-  SUCCESS = 'SUCCESS'.freeze
-  CANCEL = 'CANCEL'.freeze
-  FAILED = 'FAILED'.freeze
-  FAILED_UPLIFT = 'FAILED_UPLIFT'.freeze
-  PENDING = 'PENDING'.freeze
-  OTHER = 'OTHER'.freeze
+  SIGNING_IN_STATE = 'SIGN_IN_WITH_IDP'
+  REGISTERING_STATE = 'REGISTER_WITH_IDP'
+  SUCCESS = 'SUCCESS'
+  CANCEL = 'CANCEL'
+  FAILED = 'FAILED'
+  FAILED_UPLIFT = 'FAILED_UPLIFT'
+  PENDING = 'PENDING'
+  OTHER = 'OTHER'
+
+  ACCEPTED_IDP_RESPONSES = [SUCCESS, CANCEL, FAILED_UPLIFT, PENDING].freeze
+  ACCEPTED_COUNTRY_RESPONSES = [SUCCESS, CANCEL, FAILED_UPLIFT].freeze
 
   def idp_response
     raise_error_if_session_mismatch(params['RelayState'], session[:verify_session_id])
 
     response = SAML_PROXY_API.idp_authn_response(session[:verify_session_id], params['SAMLResponse'])
-    idp_response_handlers[response.idp_result].call(response)
+    status = response.idp_result
+
+    return handle_idp_response(status, response) if ACCEPTED_IDP_RESPONSES.include?(status)
+    handle_idp_response(FAILED, response)
   end
 
   def country_response
@@ -24,7 +32,10 @@ class AuthnResponseController < SamlController
     raise_error_if_session_mismatch(params['RelayState'], session[:verify_session_id])
 
     response = SAML_PROXY_API.forward_country_authn_response(params['RelayState'], params['SAMLResponse'])
-    country_response_handlers[response.country_result].call(response)
+    status = response.country_result
+
+    return handle_country_response(status, response) if ACCEPTED_COUNTRY_RESPONSES.include?(status)
+    handle_country_response(FAILED, response)
   end
 
 private
@@ -34,83 +45,57 @@ private
     raise Errors::WarningLevelError, error_message if relay_state != session_id
   end
 
-  def idp_response_handlers
-    handlers = {
-      SUCCESS => ->(response) { idp_response_handler_for(SUCCESS, response) },
-      CANCEL => ->(response) { idp_response_handler_for(CANCEL, response) },
-      FAILED_UPLIFT => ->(response) { idp_response_handler_for(FAILED_UPLIFT, response) },
-      PENDING => ->(response) { idp_response_handler_for(PENDING, response) }
-    }
-    handlers.default = ->(response) { idp_response_handler_for(OTHER, response, FAILED) }
-    handlers
+  def handle_idp_response(status, response)
+    analytics_reporters(status, response)
+    set_journey_status(session[:selected_idp], status)
+    redirect_to idp_redirects(status, response)
   end
 
-  def idp_response_handler_for(status, response, report_status = status)
-    analytics_reporters[status].call(response)
-    selection_reporters(:selected_idp, report_status).call
-    redirecters[status].call(response)
+  def handle_country_response(status, response)
+    set_journey_status(session[:selected_country], status)
+    redirect_to country_redirects(status, response)
   end
 
-  def country_response_handlers
-    handlers = {
-      SUCCESS => ->(response) { country_response_handler_for(SUCCESS, response) },
-      CANCEL => ->(response) { country_response_handler_for(FAILED, response) },
-      FAILED_UPLIFT => ->(response) { country_response_handler_for(FAILED_UPLIFT, response) }
-    }
-    handlers.default = redirecters[OTHER]
-    handlers
+  def analytics_reporters(status, response)
+    report_to_analytics(analytics_message(status, response))
+    report_user_outcome_to_piwik(status)
   end
 
-  def country_response_handler_for(status, response)
-    selection_reporters(:selected_country, status).call
-    redirecters[status].call(response)
+  def set_journey_status(session_entity, status)
+    selected_entity = session_entity.try(:fetch, 'entity_id', nil)
+    set_journey_hint_by_status(selected_entity, status)
   end
 
-  def analytics_reporters
-    user_state = ->(response) { response.is_registration ? REGISTERING_STATE : SIGNING_IN_STATE }
-
+  def analytics_message(status, response)
     {
-      SUCCESS => lambda do |response|
-        report_to_analytics("Success - #{user_state.call(response)} at LOA #{response.loa_achieved}")
-        report_user_outcome_to_piwik(SUCCESS)
-      end,
-      CANCEL => lambda do |response|
-        report_to_analytics("Cancel - #{user_state.call(response)}")
-        report_user_outcome_to_piwik(CANCEL)
-      end,
-      FAILED_UPLIFT => lambda do |response|
-        report_to_analytics("Failed Uplift - #{user_state.call(response)}")
-        report_user_outcome_to_piwik(FAILED_UPLIFT)
-      end,
-      PENDING => lambda do |response|
-        report_to_analytics("Paused - #{user_state.call(response)}")
-        report_user_outcome_to_piwik(PENDING)
-      end,
-      OTHER => lambda do |response|
-        report_to_analytics("Failure - #{user_state.call(response)}")
-        report_user_outcome_to_piwik(OTHER)
-      end
-    }
+      SUCCESS => "Success - #{user_state(response)} at LOA #{response.loa_achieved}",
+      CANCEL => "Cancel - #{user_state(response)}",
+      FAILED_UPLIFT => "Failed Uplift - #{user_state(response)}",
+      PENDING => "Paused - #{user_state(response)}",
+      FAILED => "Failure - #{user_state(response)}"
+    }.fetch(status)
   end
 
-  def selection_reporters(selected_entity_type, status)
-    selected_entity = session[selected_entity_type].try(:fetch, 'entity_id', nil)
-    return unless [SUCCESS, CANCEL, FAILED_UPLIFT, PENDING, FAILED].include? status
-    ->() { set_journey_hint_by_status(selected_entity, status) }
+  def user_state(response)
+    response.is_registration ? REGISTERING_STATE : SIGNING_IN_STATE
   end
 
-  def redirecters
-    redirect_based_on_journey_type = ->(redirect_paths, response) {
-      redirect_to response.is_registration ? redirect_paths[:registration] : redirect_paths[:sign_in]
-    }
-
+  def idp_redirects(status, response)
     {
-      SUCCESS => redirect_based_on_journey_type.curry.(registration: confirmation_path, sign_in: response_processing_path),
-      CANCEL => redirect_based_on_journey_type.curry.(registration: cancelled_registration_path, sign_in: start_path),
-      FAILED => redirect_based_on_journey_type.curry.(registration: failed_registration_path, sign_in: start_path),
-      PENDING => redirect_based_on_journey_type.curry.(registration: paused_registration_path, sign_in: paused_registration_path),
-      FAILED_UPLIFT => ->(_) { redirect_to failed_uplift_path },
-      OTHER => redirect_based_on_journey_type.curry.(registration: failed_registration_path, sign_in: failed_sign_in_path)
-    }
+      SUCCESS => response.is_registration ? confirmation_path : response_processing_path,
+      CANCEL => response.is_registration ? cancelled_registration_path : start_path,
+      FAILED_UPLIFT => failed_uplift_path,
+      PENDING => paused_registration_path,
+      FAILED => response.is_registration ? failed_registration_path : failed_sign_in_path
+    }.fetch(status)
+  end
+
+  def country_redirects(status, response)
+    {
+      SUCCESS => response.is_registration ? confirmation_path : response_processing_path,
+      CANCEL => response.is_registration ? failed_registration_path : start_path,
+      FAILED_UPLIFT => failed_uplift_path,
+      FAILED => response.is_registration ? failed_registration_path : failed_sign_in_path
+    }.fetch(status)
   end
 end

--- a/spec/controllers/authn_response_controller_spec.rb
+++ b/spec/controllers/authn_response_controller_spec.rb
@@ -13,7 +13,7 @@ describe AuthnResponseController do
       include_examples 'idp_authn_response', 'registration', 'CANCEL', 'Cancel - REGISTER_WITH_IDP', :cancelled_registration_path
       include_examples 'idp_authn_response', 'registration', 'FAILED_UPLIFT', 'Failed Uplift - REGISTER_WITH_IDP', :failed_uplift_path
       include_examples 'idp_authn_response', 'registration', 'PENDING', 'Paused - REGISTER_WITH_IDP', :paused_registration_path
-      include_examples 'idp_authn_response', 'registration', 'OTHER', 'Failure - REGISTER_WITH_IDP', :failed_registration_path
+      include_examples 'idp_authn_response', 'registration', 'FAILED', 'Failure - REGISTER_WITH_IDP', :failed_registration_path
     end
 
     context 'sign_in' do
@@ -21,7 +21,7 @@ describe AuthnResponseController do
       include_examples 'idp_authn_response', 'sign_in', 'CANCEL', 'Cancel - SIGN_IN_WITH_IDP', :start_path
       include_examples 'idp_authn_response', 'sign_in', 'FAILED_UPLIFT', 'Failed Uplift - SIGN_IN_WITH_IDP', :failed_uplift_path
       include_examples 'idp_authn_response', 'sign_in', 'PENDING', 'Paused - SIGN_IN_WITH_IDP', :paused_registration_path
-      include_examples 'idp_authn_response', 'sign_in', 'OTHER', 'Failure - SIGN_IN_WITH_IDP', :failed_sign_in_path
+      include_examples 'idp_authn_response', 'sign_in', 'FAILED', 'Failure - SIGN_IN_WITH_IDP', :failed_sign_in_path
     end
 
     it 'when relay state does not equal session id in the idp response' do
@@ -39,14 +39,14 @@ describe AuthnResponseController do
       include_examples 'country_authn_response', 'registration', 'SUCCESS', :confirmation_path
       include_examples 'country_authn_response', 'registration', 'CANCEL', :failed_registration_path
       include_examples 'country_authn_response', 'registration', 'FAILED_UPLIFT', :failed_uplift_path
-      include_examples 'country_authn_response', 'registration', 'OTHER', :failed_registration_path
+      include_examples 'country_authn_response', 'registration', 'FAILED', :failed_registration_path
     end
 
     context 'sign_in' do
       include_examples 'country_authn_response', 'sign_in', 'SUCCESS', :response_processing_path
       include_examples 'country_authn_response', 'sign_in', 'CANCEL', :start_path
       include_examples 'country_authn_response', 'sign_in', 'FAILED_UPLIFT', :failed_uplift_path
-      include_examples 'country_authn_response', 'sign_in', 'OTHER', :failed_sign_in_path
+      include_examples 'country_authn_response', 'sign_in', 'FAILED', :failed_sign_in_path
     end
 
     it 'when relay state does not equal session id in the country response' do
@@ -84,9 +84,10 @@ describe AuthnResponseController do
 
     context 'receiving CANCEL status' do
       let(:status) { 'CANCEL' }
-      let(:cookie_with_failed_status) { { FAILED: 'http://idcorp.com' }.to_json }
-      it { should eq cookie_with_failed_status }
+      let(:cookie_with_cancelled_status) { { CANCEL: 'http://idcorp.com' }.to_json }
+      it { should eq cookie_with_cancelled_status }
     end
+
     context 'receiving FAILED_UPLIFT status' do
       let(:status) { 'FAILED_UPLIFT' }
       let(:cookie_with_failed_uplift_status) { { FAILED_UPLIFT: 'http://idcorp.com' }.to_json }


### PR DESCRIPTION
Previously there were a lot of lambdas being passed around and called so
tracing through the code was a bit difficult. Since these lambdas are
all called immediately after fetching anyways, they've been moved into
named methods. Hopefully this looks more readable and easier to trace
through a journey.

Bigger changes with this commit include:
	* Removing OTHER status - This means changes to current behaviour of:
		* when receiving unknown status, send FAILED to piwik
rather than OTHER. The special 'OTHER' case always maps to FAILED
scenarios anyways, except piwik. Changing this will make the code much
easier to generalise.
	* CANCEL country journey sets tracking cookie to CANCEL rather
than FAILED. nothing really uses the tracking cookie for country yet.
Previous value of FAILED probably doesn't reflect actual status.
	* separating redirects for IDP and Country journeys. Even though
it looks similar, they are subtly different, and the previous way of
forcing them to use the same map caused more complexity. Having a
seperate map for IDP and Country will allow us in the next step to
direct Country signin failures to another page without affecting the IDP
flow.

Solo: @minhngocd