### PR TITLE
EID-637: Adding eIDAS specific error page

### DIFF
--- a/app/controllers/authn_response_controller.rb
+++ b/app/controllers/authn_response_controller.rb
@@ -80,21 +80,23 @@ private
   end
 
   def idp_redirects(status, response)
+    is_registration = response.is_registration
     {
-      SUCCESS => response.is_registration ? confirmation_path : response_processing_path,
-      CANCEL => response.is_registration ? cancelled_registration_path : start_path,
+      SUCCESS => is_registration ? confirmation_path : response_processing_path,
+      CANCEL => is_registration ? cancelled_registration_path : start_path,
       FAILED_UPLIFT => failed_uplift_path,
       PENDING => paused_registration_path,
-      FAILED => response.is_registration ? failed_registration_path : failed_sign_in_path
+      FAILED => is_registration ? failed_registration_path : failed_sign_in_path
     }.fetch(status)
   end
 
   def country_redirects(status, response)
+    is_registration = response.is_registration
     {
-      SUCCESS => response.is_registration ? confirmation_path : response_processing_path,
-      CANCEL => response.is_registration ? failed_registration_path : start_path,
+      SUCCESS => is_registration ? confirmation_path : response_processing_path,
+      CANCEL => is_registration ? failed_registration_path : start_path,
       FAILED_UPLIFT => failed_uplift_path,
-      FAILED => response.is_registration ? failed_registration_path : failed_sign_in_path
+      FAILED => is_registration ? failed_registration_path : failed_country_sign_in_path
     }.fetch(status)
   end
 end

--- a/app/controllers/failed_sign_in_controller.rb
+++ b/app/controllers/failed_sign_in_controller.rb
@@ -1,5 +1,11 @@
 class FailedSignInController < ApplicationController
-  def index
-    @idp = IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate(selected_identity_provider)
+  def idp
+    @entity = IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate(selected_identity_provider)
+  end
+
+  def country
+    @entity = COUNTRY_DISPLAY_DECORATOR.decorate(selected_country)
+    @other_ways_description = current_transaction.other_ways_description
+    @other_ways_text = current_transaction.other_ways_text
   end
 end

--- a/app/controllers/partials/user_session_partial_controller.rb
+++ b/app/controllers/partials/user_session_partial_controller.rb
@@ -25,10 +25,15 @@ module UserSessionPartialController
 
   def selected_identity_provider
     selected_idp = session[:selected_idp]
-    if selected_idp.nil?
-      raise(Errors::WarningLevelError, 'No selected IDP in session')
-    else
-      IdentityProvider.from_session(selected_idp)
-    end
+    raise(Errors::WarningLevelError, 'No selected IDP in session') if selected_idp.nil?
+
+    IdentityProvider.from_session(selected_idp)
+  end
+
+  def selected_country
+    selected_country = session[:selected_country]
+    raise(Errors::WarningLevelError, 'No selected Country in session') if selected_country.nil?
+
+    Country.from_session(selected_country)
   end
 end

--- a/app/controllers/redirect_to_country_controller.rb
+++ b/app/controllers/redirect_to_country_controller.rb
@@ -6,6 +6,7 @@ class RedirectToCountryController < ApplicationController
 
   def choose_a_country_submit
     country = decorated_country(params[:country])
+    session[:selected_country] = country.country
     if country.viewable?
       select_country(country)
       render :index
@@ -16,6 +17,7 @@ class RedirectToCountryController < ApplicationController
 
   def choose_a_country_submit_ajax
     country = decorated_country(params[:country])
+    session[:selected_country] = country.country
     if country.viewable?
       select_country(country)
       render json: @country_request

--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -16,4 +16,9 @@ class Country
       'enabled'   => hash['enabled']
     )
   end
+
+  def self.from_session(object)
+    return object if object.is_a? Country
+    new(object) if object.is_a? Hash
+  end
 end

--- a/app/models/feedback_source_mapper.rb
+++ b/app/models/feedback_source_mapper.rb
@@ -17,6 +17,7 @@ class FeedbackSourceMapper
       'EXPIRED_ERROR_PAGE' => nil,
       'FAILED_REGISTRATION_PAGE' => 'failed_registration',
       'FAILED_SIGN_IN_PAGE' => 'failed_sign_in',
+      'FAILED_COUNTRY_SIGN_IN_PAGE' => 'failed_country_sign_in',
       'CYCLE_3_PAGE' => 'further_information',
       'OTHER_WAYS_PAGE' => 'other_ways_to_access_service',
       'REDIRECT_TO_IDP_WARNING_PAGE' => 'redirect_to_idp_warning',

--- a/app/views/failed_sign_in/country.html.erb
+++ b/app/views/failed_sign_in/country.html.erb
@@ -1,0 +1,16 @@
+<%= page_title 'hub.failed_country_sign_in.title' %>
+<% content_for :feedback_source, 'FAILED_COUNTRY_SIGN_IN_PAGE' %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <h1 class="heading-large"><%= t 'hub.failed_country_sign_in.heading', country_name: @entity.display_name %></h1>
+
+    <%= t 'hub.failed_country_sign_in.other_ways', other_ways_description: @other_ways_description %>
+
+    <h2 class="heading-medium"><%= t 'hub.failed_country_sign_in.online' %></h2>
+    <%= link_to t('hub.failed_country_sign_in.online_link'), confirm_your_identity_path %>
+
+    <h2 class="heading-medium"><%= t 'hub.failed_country_sign_in.offline' %></h2>
+    <%= raw @other_ways_text %>
+  </div>
+</div>

--- a/app/views/failed_sign_in/idp.html.erb
+++ b/app/views/failed_sign_in/idp.html.erb
@@ -3,7 +3,7 @@
 
 <div class="grid-row">
   <div class="column-two-thirds">
-    <h1 class="heading-large"><%= t 'hub.failed_sign_in.heading', display_name: @idp.display_name %></h1>
+    <h1 class="heading-large"><%= t 'hub.failed_sign_in.heading', display_name: @entity.display_name %></h1>
 
     <%= t 'hub.failed_sign_in.reasons_html' %>
     <%= button_link_to t('hub.failed_sign_in.start_again'), start_path, id: 'startAgain' %>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -2,15 +2,15 @@ cy:
   routes:
     start: dechrau
     prove_identity: profi-hunaniaeth
-    begin_registration: begin-registration-cy
-    begin_sign_in: begin-sign-in-cy
+    begin_registration: dechrau-cofrestru
+    begin_sign_in: dechrau-mewngofnodi
     about: am
     sign_in: mewngofnodi
     about_certified_companies: am-gwmniau-ardystiedig
     about_identity_accounts: am-gyfrifon-hunaniaeth
     about_choosing_a_company: am-ddewis-cwmni
     select_documents: dewis-dogfennau
-    select_documents_none: select-documents-none-cy
+    select_documents_none: dewis-dogfennau-dim
     other_identity_documents: dogfennau-hunaniaeth-eraill
     select_phone: dewis-ffon
     will_it_work_for_me: a-fydd-yn-gweithio-i-mi
@@ -19,22 +19,22 @@ cy:
     why_might_this_not_work_for_me: pam-efallai-na-fydd-hyn-yn-gweithio-i-mi
     will_not_work_without_uk_address: ni-fydd-yn-gweithio-heb-gyfeiriad-yn-y-du
     choose_a_country: dewiswch-wlad
-    redirect_to_country: redirect-to-country-cy
+    redirect_to_country: ailgyfeirio-i-wlad
     choose_a_certified_company: dewis-cwmni-ardystiedig
     why_companies: pam-cwmniau
     unlikely_to_verify: anhebygol-i-ddilysu
     redirect_to_idp_warning: ailgyfeirio-i-rybudd-idp
     redirect_to_idp_question: ailgyfeirio-i-gwestiwn-idp
-    idp_wont_work_for_you_one_doc: idp-wont-work-for-you-one-doc-welsh
+    idp_wont_work_for_you_one_doc: nid-yw-idp-yn-gweithio-i-chi-un-ddogfen
     privacy_notice: hysbysiad-preifatrwydd
-    verify_services: verify-services-cy     # TODO: Get cy translation
+    verify_services: gwasanaethau-verify
     cookies: cwcis
     confirm_your_identity: cadarnhau-eich-hunaniaeth
     confirmation: cadarnhad
     failed_registration: cofrestru-wedi-methu
     failed_sign_in: mewngofnodi-wedi-methu
     failed_uplift: methwyd-yr-ymgodiad
-    failed_country_sign_in: failed-country-sign-in-cy
+    failed_country_sign_in: methu-mewngofnodi-gwlad
     other_ways_to_access_service: ffyrdd-eraill-i-gael-mynediad-i'r-gwasanaeth
     forgot_company: wedi-anghofio-cwmni
     response_processing: prosesu-ymateb
@@ -52,7 +52,7 @@ cy:
     no_idps_available: dim-idps-ar-gael
     cancelled_registration: cofrestru-wedi-ganslo
     select_proof_of_address: tystiolaeth-o'ch-cyfeiriad
-    confirming_it_is_you: confirming-it-is-you-cy
+    confirming_it_is_you: cadarnhau-mai-chi-ydyw
     paused_registration: wedi-oedi
   title:
     error: Error
@@ -90,7 +90,7 @@ cy:
       country_not_listed_link: ffyrdd eraill i %{other_ways_description}.
       select_label: "Dewis "
     redirect_to_country:
-      title: Redirect to country
+      title: Ailgyfeirio i wlad
       heading: Mynd ymlaen i’r cam nesaf
       description: Oherwydd nad yw Javascript wedi’i alluogi ar eich porwr, mae’n rhaid i chi bwyso’r botwm parhau
     prove_identity:
@@ -125,8 +125,8 @@ cy:
       back: Yn ôl
       about_link: Dechreuwch nawr
       registration_message_html: Os nad oes gennych gyfrif hunaniaeth, gallwch %{href}.
-      last_certified: The last certified company used on this device was %{company_name}.
-      any_certified_company: "You can use an identity account you set up with any certified company in the past:"
+      last_certified: "Y cwmni ardystiedig diwethaf a ddefnyddiwyd ar y ddyfais hon oedd %{company_name}"
+      any_certified_company: "Gallwch ddefnyddio cyfrif hunaniaeth rydych wedi'i sefydlu gydag unrhyw gwmni ardystiedig yn y gorffennol:"
       select_idp: Ddewis %{display_name}
       sign_in_idp: Llofnodi i mewn gyda %{display_name}
       forgot_company: Ni allaf gofio pa gwmni wnaeth fy nilysu
@@ -134,8 +134,8 @@ cy:
       title: Cwcis
     privacy_notice:
       title: Hysbysiad preifatrwydd
-    verify_services:    # TODO: Get cy translation
-      title: Verify services
+    verify_services:
+      title: Gwasanaethau Verify
       heading: GOV.UK Verify
       message: "Mae GOV.UK Verify yn newydd ac mae gwasanaethau’r llywodraeth yn ymuno drwy’r amser. Y gwasanaethau presennol sy’n defnyddio Verify yw:"
     transaction_list:
@@ -147,12 +147,12 @@ cy:
       verify_is_a_service: Mae GOV.UK Verify yn wasanaeth diogel a adeiladwyd i frwydro yn erbyn y broblem gynyddol o ddwyn hunaniaeth ar-lein.
       ab_test:
         eligibility_info_html: |
-          <p>To use Verify, you need to:</p>
+          <p>I ddefnyddio Verify rydych angen:</p>
           <ul class="list-bullet list">
-          <li>be over 18 years old</li>
-          <li>have a UK address</li>
+          <li>bod dros 18 oed</li>
+          <li>bod â chyfeiriad  yn y DU</li>
           </ul>
-        other_ways_link: "Other ways to %{other_ways_description}"
+        other_ways_link: "Ffyrdd eraill i %{other_ways_description}"
     about_certified_companies:
       title: Am gwmnïau ardystiedig
       a_certified_company_will_verify: Bydd cwmni ardystiedig yn gwirio eich hunaniaeth. Maent i gyd wedi bodloni safonau diogelwch a osodir gan y llywodraeth.
@@ -236,8 +236,8 @@ cy:
       title_other_identity_documents: Dogfennau hunaniaeth eraill
       non_uk_id_document: Oes gennych chi pasbort sydd ddim yn un o'r DU, cerdyn ID neu drwydded yrru?
       ab_test:
-        smart_phone_question: Do you have a smartphone or tablet that can download apps?
-        smart_phone_subtitle: You will need to download a free app and use your device's camera to take a photo of your identity document and a selfie.
+        smart_phone_question: Oes gennych ffôn clyfar neu lechen a all lawr lwytho apiau?
+        smart_phone_subtitle: Byddwch angen lawr lwytho ap am ddim a defnyddio camera eich dyfais i gymryd llun o'ch dogfen adnabyddiaeth a hun-lun.
     select_phone:
       title: Oes gennych ffôn symudol neu lechen?
       explanation: Gall cwmnïau ardystiedig anfon codau diogelwch i’ch ffôn symudol.
@@ -364,7 +364,7 @@ cy:
       no_docs_other_ways_message_html: "%{idp_no_docs_requirement}, mae %{other_ways_link}"
     redirect_to_idp_question:
       heading: Dilysu gyda %{display_name}
-      loa1_heading: Setting up a %{display_name} account
+      loa1_heading: Sefydlu cyfrif %{display_name}
       answer_yes: Ydw
       answer_no: Na
       warning_html: |
@@ -410,7 +410,7 @@ cy:
       contact_details_intro: Cysylltwch â %{idp_name}
     failed_country_sign_in:
       title: Methu eich mewngofnodi
-      heading: "Mae eich cynllun hunaniaeth yn %{country_name} wedi methu â chadarnhau eich hunaniaeth"
+      heading: "Mae'r cynllun hunaniaeth yn eich gwlad wedi methu â chadarnhau eich hunaniaeth."
       other_ways: "Mae yna ffyrdd eraill y gallwch %{other_ways_description}."
       online_link: Ffyrdd eraill i brofi eich hunaniaeth ar-lein
       online: Ar-lein

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -34,6 +34,7 @@ cy:
     failed_registration: cofrestru-wedi-methu
     failed_sign_in: mewngofnodi-wedi-methu
     failed_uplift: methwyd-yr-ymgodiad
+    failed_country_sign_in: failed-country-sign-in-cy
     other_ways_to_access_service: ffyrdd-eraill-i-gael-mynediad-i'r-gwasanaeth
     forgot_company: wedi-anghofio-cwmni
     response_processing: prosesu-ymateb
@@ -407,6 +408,13 @@ cy:
       try_another_text: Mae cwmniau eraill yn defnyddio dulliau gwahanol i %{idp_name} ac felly gyda gwell siawns o ddilysu eich hunaniaeth.
       try_another_summary: Ceisiwch wirio gyda chwmni ardystiedig arall
       contact_details_intro: Cysylltwch â %{idp_name}
+    failed_country_sign_in:
+      title: Methu eich mewngofnodi
+      heading: "Mae eich cynllun hunaniaeth yn %{country_name} wedi methu â chadarnhau eich hunaniaeth"
+      other_ways: "Mae yna ffyrdd eraill y gallwch %{other_ways_description}."
+      online_link: Ffyrdd eraill i brofi eich hunaniaeth ar-lein
+      online: Ar-lein
+      offline: All-lein
     failed_sign_in:
       title: Methu eich mewngofnodi
       heading: Ni all %{display_name} eich mewngofnodi

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -401,6 +401,13 @@ en:
       try_another_text: "Other companies use different methods from %{idp_name} and may therefore stand a better chance of verifying your identity."
       try_another_summary: Try verifying with another certified company
       contact_details_intro: "Contact %{idp_name}"
+    failed_country_sign_in:
+      title: Unable to sign you in
+      heading: "Your identity scheme in %{country_name} has been unable to confirm your identity"
+      other_ways: "There are other ways you can %{other_ways_description}."
+      online_link: Other ways to prove your identity online
+      online: Online
+      offline: Offline
     failed_sign_in:
       title: Unable to sign you in
       heading: "%{display_name} couldn’t sign you in"

--- a/config/main_routes.rb
+++ b/config/main_routes.rb
@@ -78,7 +78,8 @@ get 'confirm_your_identity', to: 'confirm_your_identity#index', as: :confirm_you
 get 'choose_a_country', to: 'choose_a_country#choose_a_country', as: :choose_a_country
 post 'redirect_to_country', to: 'redirect_to_country#choose_a_country_submit', as: :choose_a_country_submit
 get 'failed_uplift', to: 'failed_uplift#index', as: :failed_uplift
-get 'failed_sign_in', to: 'failed_sign_in#index', as: :failed_sign_in
+get 'failed_sign_in', to: 'failed_sign_in#idp', as: :failed_sign_in
+get 'failed_country_sign_in', to: 'failed_sign_in#country', as: :failed_country_sign_in
 get 'other_ways_to_access_service', to: 'other_ways_to_access_service#index', as: :other_ways_to_access_service
 get 'forgot_company', to: 'static#forgot_company', as: :forgot_company
 get 'response_processing', to: 'response_processing#index', as: :response_processing

--- a/spec/controllers/authn_response_controller_spec.rb
+++ b/spec/controllers/authn_response_controller_spec.rb
@@ -46,7 +46,7 @@ describe AuthnResponseController do
       include_examples 'country_authn_response', 'sign_in', 'SUCCESS', :response_processing_path
       include_examples 'country_authn_response', 'sign_in', 'CANCEL', :start_path
       include_examples 'country_authn_response', 'sign_in', 'FAILED_UPLIFT', :failed_uplift_path
-      include_examples 'country_authn_response', 'sign_in', 'FAILED', :failed_sign_in_path
+      include_examples 'country_authn_response', 'sign_in', 'FAILED', :failed_country_sign_in_path
     end
 
     it 'when relay state does not equal session id in the country response' do

--- a/spec/features/user_visits_verify_services_picker_page_spec.rb
+++ b/spec/features/user_visits_verify_services_picker_page_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'When the user visits the Verify services picker page' do
 
   it 'should display the page in Welsh' do
     stub_transactions_list
-    visit '/verify-services-cy'
+    visit '/gwasanaethau-verify'
     expect(page).to have_content t('hub.verify_services.message', locale: :cy)
   end
 


### PR DESCRIPTION
This adds an eIDAS-specific error page for users that come back from an EU proxy node with a failed status.

There are still a bunch of TODOs that are blocked, so we're going to merge this now and deal with them later.
- The grammar for the Welsh translations isn't quite correct because sometimes the country names change when prefixed with "in". Content design is working on an alternative.
- Still need a translation for the URL. Welsh language unit have been contacted.