### PR TITLE
HUB-225: Add a feature flag for single IDP journey

### DIFF
--- a/.env
+++ b/.env
@@ -33,3 +33,6 @@ ZENDESK_TOKEN=123
 SAML_PROXY_HOST=http://localhost:50220
 
 VERIFY_PRODUCT_PAGE=https://govuk-verify.cloudapps.digital/
+
+SINGLE_IDP_FEATURE=false
+

--- a/config/initializers/00_configuration.rb
+++ b/config/initializers/00_configuration.rb
@@ -41,4 +41,6 @@ CONFIG = Configuration.load! do
   option_string 'rules_directory_variant', 'RULES_DIRECTORY_VARIANT'
   option_string 'segment_definitions_variant', 'SEGMENT_DEFINITIONS_VARIANT'
   option_bool 'feedback_disabled', 'FEEDBACK_DISABLED', default: false
+  # Feature flags
+  option_bool 'single_idp_feature', 'SINGLE_IDP_FEATURE', default: false
 end

--- a/config/initializers/30_federation.rb
+++ b/config/initializers/30_federation.rb
@@ -68,4 +68,5 @@ Rails.application.config.after_initialize do
   # Feature flags
   IDP_FEATURE_FLAGS_CHECKER = IdpConfiguration::IdpFeatureFlagsLoader.new(YamlLoader.new)
                                  .load(CONFIG.rules_directory, %i[send_hints send_language_hint show_interstitial_question show_interstitial_question_loa1])
+  SINGLE_IDP_FEATURE = CONFIG.single_idp_feature
 end


### PR DESCRIPTION
We want to add a feature flag which will prevent any of the single IDP journey from being reachable or executable in production. This will allow us to test it independently of other features/tests.

Co-authored-by: Callum Knights <callum.knights@digital.cabinet-office.gov.uk>
Co-authored-by: Chris Clayson <chris.clayson@digital.cabinet-office.gov.uk>