### PR TITLE
ZD-64417: Migrate feedback to GOV.UK Zendesk

### DIFF
--- a/app/models/feedback_service.rb
+++ b/app/models/feedback_service.rb
@@ -40,7 +40,7 @@ With email: <%= presented_email(form) %>
   end
 
   def subject(form)
-    form.reply_required? ? 'Enquiry' : 'Feedback'
+    form.reply_required? ? '[GOV.UK Verify] Enquiry' : '[GOV.UK Verify] Feedback'
   end
 
   def presented_name(form)

--- a/spec/models/feedback_service_spec.rb
+++ b/spec/models/feedback_service_spec.rb
@@ -71,7 +71,7 @@ With email: #{email}
 
 
     expected_ticket = {
-                        subject: 'Enquiry',
+                        subject: '[GOV.UK Verify] Enquiry',
                         comment: { value: enquiry_comment_value },
                         requester: { name: name, email: email }
                       }
@@ -93,7 +93,7 @@ With email: #{email}
 
 
     expected_ticket = {
-                        subject: 'Feedback',
+                        subject: '[GOV.UK Verify] Feedback',
                         comment: { value: feedback_comment_value },
                         requester: { name: '', email: default_email }
                       }


### PR DESCRIPTION
We're migrating the feedback form from Verify Zendesk to GOV.UK Zendesk.
To enable proper routing of all the tickets in GOV.UK instance we need to
prepend the subject with [GOV.UK Verify].

solo: @jakubmiarka