### PR TITLE
ZD-64635: Constraint routes against bots

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,8 +34,10 @@ Rails.application.routes.draw do
     post 'csp-reporter', to: 'test_csp_reporter#report'
   end
 
-  localized do
-    add_routes :main_routes
+  constraints(format: /html/) do
+    localized do
+      add_routes :main_routes
+    end
   end
 
   put 'redirect-to-idp-warning', to: 'redirect_to_idp_warning#continue_ajax', as: :redirect_to_idp_warning_submit_ajax


### PR DESCRIPTION
There are regular Sentry alerts when bots (?) are trying to query our URLs
with an appended ".json" at the end. This is erroring out as a MissingTemplate error and
surfacing in Sentry. This change is to constraint the "view" routes by html format, so
any non-html requests are treated as 404 without trying to render start.json etc...

Error:
https://sentry-hub-prod-a-dmz.ida.digital.cabinet-office.gov.uk/sentry/front/group/212/

Suggestion:
https://makandracards.com/makandra/15831-how-to-not-die-with-actionview-missingtemplate-when-clients-request-weird-formats

solo: @jakubmiarka