### PR TITLE
EID-795: updated error pages

### DIFF
--- a/app/controllers/response_processing_controller.rb
+++ b/app/controllers/response_processing_controller.rb
@@ -22,18 +22,21 @@ class ResponseProcessingController < ApplicationController
       redirect_to further_information_path
     when MatchingOutcomeResponse::SHOW_MATCHING_ERROR_PAGE
       report_to_analytics('Matching Outcome - Error')
-      @other_ways_description = current_transaction.other_ways_description
-      @other_ways_text = current_transaction.other_ways_text
-      render 'matching_error', status: 500, locals: { error_feedback_source: 'MATCHING_ERROR_PAGE' }
+      render_error_page('MATCHING_ERROR_PAGE')
     when MatchingOutcomeResponse::USER_ACCOUNT_CREATION_FAILED
       report_to_analytics('Unknown User Outcome - Account Creation Failed')
-      @other_ways_description = current_transaction.other_ways_description
-      @other_ways_text = current_transaction.other_ways_text
-      render 'matching_error', status: 500, locals: { error_feedback_source: 'ACCOUNT_CREATION_FAILED_PAGE' }
+      render_error_page('ACCOUNT_CREATION_FAILED_PAGE')
     when MatchingOutcomeResponse::WAIT
       render
     else
       something_went_wrong("Unknown matching response #{outcome.inspect}")
     end
+  end
+
+  def render_error_page(feedback_source)
+    @hide_available_languages = false
+    @other_ways_description = current_transaction.other_ways_description
+    @other_ways_text = current_transaction.other_ways_text
+    render 'matching_error', status: 500, locals: { error_feedback_source: feedback_source }
   end
 end

--- a/app/views/failed_sign_in/country.html.erb
+++ b/app/views/failed_sign_in/country.html.erb
@@ -5,12 +5,12 @@
   <div class="column-two-thirds">
     <h1 class="heading-large"><%= t 'hub.failed_country_sign_in.heading', country_name: @entity.display_name %></h1>
 
-    <%= t 'hub.failed_country_sign_in.other_ways', other_ways_description: @other_ways_description %>
+    <p><%= t 'hub.failed_country_sign_in.other_ways', other_ways_description: @other_ways_description %></p>
 
     <h2 class="heading-medium"><%= t 'hub.failed_country_sign_in.online' %></h2>
-    <%= link_to t('hub.failed_country_sign_in.online_link'), confirm_your_identity_path %>
+    <p><%= link_to t('hub.failed_country_sign_in.online_link'), redirect_to_service_error_path %></p>
 
     <h2 class="heading-medium"><%= t 'hub.failed_country_sign_in.offline' %></h2>
-    <%= raw @other_ways_text %>
+    <p><%= raw @other_ways_text %></p>
   </div>
 </div>

--- a/app/views/response_processing/matching_error.html.erb
+++ b/app/views/response_processing/matching_error.html.erb
@@ -3,13 +3,14 @@
 
 <div class="grid-row">
   <div class="column-two-thirds">
-    <h1 class="heading-large"><%= t 'errors.something_went_wrong.heading' %></h1>
-    <p>
-      <%= t('hub.response_processing.matching_error.problem', rp_name: @rp_name) %>
-    </p>
-    <p><%= t('hub.response_processing.matching_error.start_again_message_html', start_again_link: link_to(t('hub.response_processing.matching_error.start_again_link'), redirect_to_service_error_path)) %></p>
+    <h1 class="heading-large"><%= t 'hub.response_processing.matching_error.heading' %></h1>
 
     <p><%= t('hub.response_processing.matching_error.other_ways', other_ways_description: @other_ways_description) %></p>
-    <%= render partial: 'shared/other_ways', locals: {other_ways_description: @other_ways_description, other_ways_text: @other_ways_text} %>
+
+    <h2 class="heading-medium"><%= t 'hub.response_processing.matching_error.online' %></h2>
+    <p><%= link_to(t('hub.response_processing.matching_error.online_link'), redirect_to_service_error_path) %></p>
+
+    <h2 class="heading-medium"><%= t 'hub.response_processing.matching_error.offline' %></h2>
+    <div class="other-ways-to-complete-transaction"><%= raw @other_ways_text %></div>
   </div>
 </div>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -410,7 +410,7 @@ cy:
       contact_details_intro: Cysylltwch â %{idp_name}
     failed_country_sign_in:
       title: Methu eich mewngofnodi
-      heading: "Mae'r cynllun hunaniaeth yn eich gwlad wedi methu â chadarnhau eich hunaniaeth."
+      heading: "Your identity scheme in %{country_name} was unable to confirm your identity"
       other_ways: "Mae yna ffyrdd eraill y gallwch %{other_ways_description}."
       online_link: Ffyrdd eraill i brofi eich hunaniaeth ar-lein
       online: Ar-lein
@@ -444,10 +444,11 @@ cy:
       heading: Mae %{rp_name} yn prosesu eich manylion
       bear_with_us: Gallai hyn gymryd ychydig o eiliadau, diolch am eich amynedd.
       matching_error:
-        problem: Mae’n ddrwg gennym, mae %{rp_name} yn cael problemau technegol.
-        start_again_link: dechrau eto
-        start_again_message_html: Dylech %{start_again_link} mewn ychydig o funudau drwy fewngofnodi gyda’ch cwmni ardystiedig.
-        other_ways: Os byddwch yn parhau i gael problemau, mae ffyrdd eraill i %{other_ways_description}.
+        heading: Sorry, there is a problem with the service
+        other_ways: "Please try again later or see other ways you can %{other_ways_description}."
+        online_link: Ffyrdd eraill i brofi eich hunaniaeth ar-lein
+        online: Ar-lein
+        offline: All-lein
     forgot_company:
       title: Cyngor ar gyfer cwmni sydd wedi’i anghofio
     redirect_to_service:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -403,7 +403,7 @@ en:
       contact_details_intro: "Contact %{idp_name}"
     failed_country_sign_in:
       title: Unable to sign you in
-      heading: "Your identity scheme in %{country_name} has been unable to confirm your identity"
+      heading: "Your identity scheme in %{country_name} was unable to confirm your identity"
       other_ways: "There are other ways you can %{other_ways_description}."
       online_link: Other ways to prove your identity online
       online: Online
@@ -437,10 +437,11 @@ en:
       heading: "%{rp_name} is processing your details"
       bear_with_us: "This may take a few seconds, please bear with us."
       matching_error:
-        problem: "Sorry, %{rp_name} is having technical problems."
-        start_again_link: start again
-        start_again_message_html: "Please %{start_again_link} in a few minutes by signing in with your certified company."
-        other_ways: "If you continue having problems, there are other ways to %{other_ways_description}."
+        heading: "Sorry, there is a problem with the service"
+        other_ways: "Please try again later or see other ways you can %{other_ways_description}."
+        online_link: Other ways to prove your identity online
+        online: Online
+        offline: Offline
     forgot_company:
       title: Advice for forgotten company
     redirect_to_service:


### PR DESCRIPTION
- Updated text content for matching error page
- failed sign in for country now also redirects to RP service error for
consistency

Co-authored-by: Felix Millne <felix.millne@digital.cabinet-office.gov.uk>