### PR TITLE
HUB-236: Rename taxon to serviceCategory in list of services endpoint

### DIFF
--- a/app/models/display/rp/service_list_data_correlator.rb
+++ b/app/models/display/rp/service_list_data_correlator.rb
@@ -1,7 +1,7 @@
 module Display
   module Rp
     class ServiceListDataCorrelator
-      Transaction = Struct.new(:name, :loa, :taxon, :serviceId)
+      Transaction = Struct.new(:name, :loa, :serviceCategory, :serviceId)
 
       def initialize(translator, rps_name_homepage)
         @translator = translator

--- a/spec/controllers/metadata_controller_spec.rb
+++ b/spec/controllers/metadata_controller_spec.rb
@@ -21,7 +21,7 @@ describe MetadataController do
     expect(test_rp_object.nil?).to be false
     expect(test_rp_object['name']).to eq('register for an identity profile')
     expect(test_rp_object['loa']).to eq('LEVEL_2')
-    expect(test_rp_object['taxon']).to eq('Benefits')
+    expect(test_rp_object['serviceCategory']).to eq('Benefits')
 
     another_test_rp_object =
       body.find { |rp| rp['serviceId'] == 'some-other-entity-id' }
@@ -30,6 +30,6 @@ describe MetadataController do
     expect(another_test_rp_object['name'])
       .to eq('Register for an identity profile (forceauthn & no cycle3)')
     expect(another_test_rp_object['loa']).to eq('LEVEL_2')
-    expect(another_test_rp_object['taxon']).to eq('Benefits')
+    expect(another_test_rp_object['serviceCategory']).to eq('Benefits')
   end
 end


### PR DESCRIPTION
Update ServiceListDataCorrelator to reflect attribute name change.