### PR TITLE
EID-886: Added Welsh translations to the revised error pages

### DIFF
--- a/app/controllers/partials/user_session_partial_controller.rb
+++ b/app/controllers/partials/user_session_partial_controller.rb
@@ -36,4 +36,14 @@ module UserSessionPartialController
 
     Country.from_session(selected_country)
   end
+
+  def switch_to_verify_journey(selected_idp)
+    session.delete(:selected_country)
+    session[:selected_idp] = selected_idp
+  end
+
+  def switch_to_eidas_journey(selected_country)
+    session.delete(:selected_idp)
+    session[:selected_country] = selected_country
+  end
 end

--- a/app/controllers/partials/viewable_idp_partial_controller.rb
+++ b/app/controllers/partials/viewable_idp_partial_controller.rb
@@ -1,14 +1,14 @@
 module ViewableIdpPartialController
   def select_viewable_idp_for_sign_in(entity_id)
     for_viewable_idp(entity_id, current_identity_providers_for_sign_in) do |decorated_idp|
-      session[:selected_idp] = decorated_idp.identity_provider
+      switch_to_verify_journey(decorated_idp.identity_provider)
       yield decorated_idp
     end
   end
 
   def select_viewable_idp_for_loa(entity_id)
     for_viewable_idp(entity_id, current_identity_providers_for_loa) do |decorated_idp|
-      session[:selected_idp] = decorated_idp.identity_provider
+      switch_to_verify_journey(decorated_idp.identity_provider)
       yield decorated_idp
     end
   end

--- a/app/controllers/redirect_to_country_controller.rb
+++ b/app/controllers/redirect_to_country_controller.rb
@@ -5,10 +5,9 @@ class RedirectToCountryController < ApplicationController
   before_action :ensure_session_eidas_supported
 
   def choose_a_country_submit
-    country = decorated_country(params[:country])
-    session[:selected_country] = country.country
-    if country.viewable?
-      select_country(country)
+    decorated_country = decorated_country(params[:country])
+    if decorated_country.viewable?
+      select_country(decorated_country)
       render :index
     else
       something_went_wrong("Couldn't redirect to country with id #{params[:country]}")
@@ -16,10 +15,9 @@ class RedirectToCountryController < ApplicationController
   end
 
   def choose_a_country_submit_ajax
-    country = decorated_country(params[:country])
-    session[:selected_country] = country.country
-    if country.viewable?
-      select_country(country)
+    decorated_country = decorated_country(params[:country])
+    if decorated_country.viewable?
+      select_country(decorated_country)
       render json: @country_request
     else
       render status: :bad_request
@@ -35,11 +33,12 @@ private
 
     return Display::NotViewableCountry.new unless countries.count == 1
 
-    @decorated_country ||= COUNTRY_DISPLAY_DECORATOR.decorate(countries.first)
+    COUNTRY_DISPLAY_DECORATOR.decorate(countries.first)
   end
 
-  def select_country(country)
-    POLICY_PROXY.select_a_country(session[:verify_session_id], country.simple_id)
+  def select_country(decorated_country)
+    switch_to_eidas_journey(decorated_country.country)
+    POLICY_PROXY.select_a_country(session[:verify_session_id], decorated_country.simple_id)
 
     saml_message = SAML_PROXY_API.authn_request(session[:verify_session_id])
     @country_request = CountryRequest.new(saml_message)

--- a/app/controllers/response_processing_controller.rb
+++ b/app/controllers/response_processing_controller.rb
@@ -35,8 +35,10 @@ class ResponseProcessingController < ApplicationController
 
   def render_error_page(feedback_source)
     @hide_available_languages = false
-    @other_ways_description = current_transaction.other_ways_description
     @other_ways_text = current_transaction.other_ways_text
+    @other_ways_description = current_transaction.other_ways_description
+    @redirect_path = session[:selected_country] ? prove_identity_path : redirect_to_service_error_path
+
     render 'matching_error', status: 500, locals: { error_feedback_source: feedback_source }
   end
 end

--- a/app/views/failed_sign_in/country.html.erb
+++ b/app/views/failed_sign_in/country.html.erb
@@ -8,7 +8,7 @@
     <p><%= t 'hub.failed_country_sign_in.other_ways', other_ways_description: @other_ways_description %></p>
 
     <h2 class="heading-medium"><%= t 'hub.failed_country_sign_in.online' %></h2>
-    <p><%= link_to t('hub.failed_country_sign_in.online_link'), redirect_to_service_error_path %></p>
+    <p><%= link_to t('hub.failed_country_sign_in.online_link'), prove_identity_path %></p>
 
     <h2 class="heading-medium"><%= t 'hub.failed_country_sign_in.offline' %></h2>
     <p><%= raw @other_ways_text %></p>

--- a/app/views/response_processing/matching_error.html.erb
+++ b/app/views/response_processing/matching_error.html.erb
@@ -8,7 +8,7 @@
     <p><%= t('hub.response_processing.matching_error.other_ways', other_ways_description: @other_ways_description) %></p>
 
     <h2 class="heading-medium"><%= t 'hub.response_processing.matching_error.online' %></h2>
-    <p><%= link_to(t('hub.response_processing.matching_error.online_link'), redirect_to_service_error_path) %></p>
+    <p><%= link_to(t('hub.response_processing.matching_error.online_link'), @redirect_path) %></p>
 
     <h2 class="heading-medium"><%= t 'hub.response_processing.matching_error.offline' %></h2>
     <div class="other-ways-to-complete-transaction"><%= raw @other_ways_text %></div>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -416,7 +416,7 @@ cy:
       contact_details_intro: Cysylltwch â %{idp_name}
     failed_country_sign_in:
       title: Methu eich mewngofnodi
-      heading: "Your identity scheme in %{country_name} was unable to confirm your identity"
+      heading: Mae'r cynllun hunaniaeth yn eich gwlad wedi methu â chadarnhau eich hunaniaeth.
       other_ways: "Mae yna ffyrdd eraill y gallwch %{other_ways_description}."
       online_link: Ffyrdd eraill i brofi eich hunaniaeth ar-lein
       online: Ar-lein
@@ -450,8 +450,8 @@ cy:
       heading: Mae %{rp_name} yn prosesu eich manylion
       bear_with_us: Gallai hyn gymryd ychydig o eiliadau, diolch am eich amynedd.
       matching_error:
-        heading: Sorry, there is a problem with the service
-        other_ways: "Please try again later or see other ways you can %{other_ways_description}."
+        heading: Mae'n ddrwg gennym, mae yna broblem gyda'r gwasanaeth
+        other_ways: "Ceisiwch eto'n hwyrach neu edrychwch ar ffyrdd eraill y gallwch %{service_name}."
         online_link: Ffyrdd eraill i brofi eich hunaniaeth ar-lein
         online: Ar-lein
         offline: All-lein

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -33,8 +33,8 @@ cy:
     confirmation: cadarnhad
     failed_registration: cofrestru-wedi-methu
     failed_sign_in: mewngofnodi-wedi-methu
-    failed_uplift: methwyd-yr-ymgodiad
     failed_country_sign_in: methu-mewngofnodi-gwlad
+    failed_uplift: methwyd-yr-ymgodiad
     other_ways_to_access_service: ffyrdd-eraill-i-gael-mynediad-i'r-gwasanaeth
     forgot_company: wedi-anghofio-cwmni
     response_processing: prosesu-ymateb

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -33,6 +33,7 @@ en:
     confirmation: confirmation
     failed_registration: failed-registration
     failed_sign_in: failed-sign-in
+    failed_country_sign_in: failed-country-sign-in
     failed_uplift: failed-uplift
     other_ways_to_access_service: other-ways-to-access-service
     forgot_company: forgot-company

--- a/spec/api_test_helper.rb
+++ b/spec/api_test_helper.rb
@@ -28,7 +28,11 @@ module ApiTestHelper
   end
 
   def api_countries_endpoint(session_id)
-    policy_api_uri('/policy/countries/' + session_id)
+    policy_api_uri("/policy/countries/#{session_id}")
+  end
+
+  def api_select_country_endpoint(session_id, country_code)
+    policy_api_uri("/policy/countries/#{session_id}/#{country_code}")
   end
 
   def stub_transactions_list
@@ -119,6 +123,11 @@ module ApiTestHelper
     ]
 
     stub_request(:get, api_countries_endpoint(default_session_id)).to_return(body: countries.to_json, status: 200)
+  end
+
+  def stub_select_country_request(country_code)
+    stub_request(:post, api_select_country_endpoint(default_session_id, country_code))
+        .to_return(body: '')
   end
 
   def stub_session_country_authn_request(originating_ip, country_location, registration)

--- a/spec/controllers/redirect_to_country_controller_spec.rb
+++ b/spec/controllers/redirect_to_country_controller_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+require 'controller_helper'
+require 'api_test_helper'
+
+describe RedirectToCountryController do
+  let(:originating_ip) { '<PRINCIPAL IP ADDRESS COULD NOT BE DETERMINED>' }
+  before(:each) do
+    set_session_and_cookies_with_loa('LEVEL_2')
+    session[:transaction_supports_eidas] = true
+    stub_countries_list
+    stub_session_country_authn_request(originating_ip, redirect_to_country_path, false)
+  end
+
+  it 'deletes selected_idp from session' do
+    stub_select_country_request('YY')
+    session[:selected_idp] = 'stub-idp'
+
+    post :choose_a_country_submit, params: { locale: 'en', country: 'YY' }
+
+    expect(session[:selected_country]).to_not be_nil
+    expect(session[:selected_country].simple_id).to eq('YY')
+    expect(session[:selected_idp]).to be_nil
+  end
+end

--- a/spec/controllers/sign_in_controller_spec.rb
+++ b/spec/controllers/sign_in_controller_spec.rb
@@ -23,6 +23,18 @@ describe SignInController do
   end
 
   context '#select_idp' do
+    it 'deletes selected_country from session' do
+      stub_session_select_idp_request('http://idcorp.com')
+      stub_piwik_request('action_name' => 'Sign In - IDCorp')
+      session[:selected_country] = 'stub-country'
+
+      post :select_idp, params: { locale: 'en', 'entity_id' => 'http://idcorp.com' }
+
+      expect(session[:selected_idp]).to_not be_nil
+      expect(session[:selected_idp].simple_id).to eq('stub-idp-one')
+      expect(session[:selected_country]).to be_nil
+    end
+
     it 'will redirect to the path for the selected IDP' do
       stub_session_select_idp_request('http://idcorp.com')
       stub_piwik_request('action_name' => 'Sign In - IDCorp')

--- a/spec/features/user_visits_choose_a_country_page_spec.rb
+++ b/spec/features/user_visits_choose_a_country_page_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe 'When the user visits the choose a country page' do
 
   it 'should redirect to country page' do
     given_a_session_supporting_eidas
-    stub_select_country_request
+    stub_select_country_request('YY')
     stub_session_country_authn_request(originating_ip, redirect_to_country_path, false)
 
     visit '/choose-a-country'
@@ -83,7 +83,7 @@ RSpec.describe 'When the user visits the choose a country page' do
 
   it 'should redirect to country page when JS is enabled', js: true do
     given_a_session_supporting_eidas
-    stub_select_country_request
+    stub_select_country_request('YY')
     stub_session_country_authn_request(originating_ip, redirect_to_country_path, false)
 
     visit '/choose-a-country'
@@ -112,14 +112,5 @@ RSpec.describe 'When the user visits the choose a country page' do
 
     expect(page).to have_title t('hub.choose_a_country.title', locale: :cy)
     expect(page).to have_css 'html[lang=cy]'
-  end
-
-  def select_country_endpoint(session_id, country_code)
-    '/policy/countries/' + session_id + '/' + country_code
-  end
-
-  def stub_select_country_request
-    stub_request(:post, policy_api_uri(select_country_endpoint("my-session-id-cookie", "YY")))
-        .to_return(body: '')
   end
 end

--- a/spec/features/user_visits_failed_sign_in_page_spec.rb
+++ b/spec/features/user_visits_failed_sign_in_page_spec.rb
@@ -4,25 +4,61 @@ require 'api_test_helper'
 RSpec.describe 'When the user visits the failed sign in page' do
   before(:each) do
     set_session_and_session_cookies!
-    stub_api_idp_list_for_loa
-    page.set_rack_session(
-      selected_idp: { entity_id: 'http://idcorp.com', simple_id: 'stub-idp-one' }
-    )
   end
 
-  it 'includes expected content' do
-    visit '/failed-sign-in'
+  context '#idp' do
+    before(:each) do
+      stub_api_idp_list_for_loa
+      page.set_rack_session(
+          selected_idp: { entity_id: 'http://idcorp.com', simple_id: 'stub-idp-one' }
+      )
+    end
 
-    expect_feedback_source_to_be(page, 'FAILED_SIGN_IN_PAGE', '/failed-sign-in')
-    expect(page).to have_title t('hub.failed_sign_in.title')
-    expect(page).to have_content t('hub.failed_sign_in.heading', display_name: 'IDCorp')
-    expect(page.body).to include t('hub.failed_sign_in.reasons_html')
-    expect(page).to have_link t('hub.failed_sign_in.start_again'), href: start_path
+    it 'includes expected content' do
+      visit '/failed-sign-in'
+
+      expect_feedback_source_to_be(page, 'FAILED_SIGN_IN_PAGE', '/failed-sign-in')
+      expect(page).to have_title t('hub.failed_sign_in.title')
+      expect(page).to have_content t('hub.failed_sign_in.heading', display_name: 'IDCorp')
+      expect(page.body).to include t('hub.failed_sign_in.reasons_html')
+      expect(page).to have_link t('hub.failed_sign_in.start_again'), href: start_path
+    end
+
+    it 'displays the content in Welsh' do
+      visit '/mewngofnodi-wedi-methu'
+
+      expect(page).to have_css 'html[lang=cy]'
+    end
   end
 
-  it 'displays the content in Welsh' do
-    visit '/mewngofnodi-wedi-methu'
+  context '#country' do
+    before(:each) do
+      stub_countries_list
+      page.set_rack_session selected_country: { entity_id: 'http://stub-country.uk', simple_id: 'YY', enabled: true }
+    end
 
-    expect(page).to have_css 'html[lang=cy]'
+    it 'includes expected content' do
+      visit '/failed-country-sign-in'
+
+      expect_feedback_source_to_be(page, 'FAILED_COUNTRY_SIGN_IN_PAGE', '/failed-country-sign-in')
+      expect(page).to have_title t('hub.failed_country_sign_in.title')
+      expect(page).to have_content t('hub.failed_country_sign_in.heading', country_name: 'Stub Country')
+      expect(page.body).to have_content t('hub.failed_country_sign_in.online')
+      expect(page).to have_link t('hub.failed_country_sign_in.online_link'), href: prove_identity_path
+      expect(page.body).to have_content t('hub.failed_country_sign_in.offline')
+    end
+
+    it 'should redirect to prove-identity page on matching error for an eIDAS journey' do
+      visit '/failed-country-sign-in'
+      click_on t('hub.failed_country_sign_in.online_link')
+
+      expect(page).to have_current_path('/prove-identity')
+    end
+
+    it 'displays the content in Welsh' do
+      visit '/methu-mewngofnodi-gwlad'
+
+      expect(page).to have_css 'html[lang=cy]'
+    end
   end
 end

--- a/spec/features/user_visits_response_processing_page_spec.rb
+++ b/spec/features/user_visits_response_processing_page_spec.rb
@@ -26,4 +26,23 @@ RSpec.describe 'When the user visits the response processing page' do
     visit '/prosesu-ymateb'
     expect(page).to have_css 'html[lang=cy]'
   end
+
+  it 'should redirect to prove-identity page on matching error for an eIDAS journey' do
+    page.set_rack_session selected_country: 'stub-country'
+    stub_matching_outcome MatchingOutcomeResponse::SHOW_MATCHING_ERROR_PAGE
+
+    visit '/response-processing'
+    click_on t('hub.response_processing.matching_error.online_link')
+
+    expect(page).to have_current_path('/prove-identity')
+  end
+
+  it 'should redirect to redirect-to-service page on matching error for a Verify (IDP) journey' do
+    page.set_rack_session selected_idp: 'stub-idp'
+    stub_matching_outcome MatchingOutcomeResponse::SHOW_MATCHING_ERROR_PAGE
+
+    visit '/response-processing'
+
+    expect(page).to have_link t('hub.response_processing.matching_error.online_link'), href: '/redirect-to-service/error'
+  end
 end


### PR DESCRIPTION
Note: The matching_error.other_ways Welsh string does not include country name for reasons of Welsh morphology

Translation spreadsheet for reference here:
https://docs.google.com/spreadsheets/d/1PyGbtFbQT5_4dvqybvIwFq_BlBEvNQ7-tKG4ziwWExU/edit#gid=0