### PR TITLE
CVQ2-146 ZD-67992: frontend content changes

### DIFF
--- a/app/views/further_information/index.html.erb
+++ b/app/views/further_information/index.html.erb
@@ -3,7 +3,7 @@
 
 <div class="grid-row">
   <div class="column-two-thirds">
-    <h1 class="heading-large"><%= @transaction_name.capitalize %></h1>
+    <h1 class="heading-large"><%= @transaction_name.slice(0,1).upcase + @transaction_name.slice(1..-1)%></h1>
     <p><%= t('hub.further_information.first_time') %></p>
 
     <%= form_for @cycle_three_attribute, url: further_information_submit_path,
@@ -51,7 +51,7 @@
     <% end %>
     <div class="cancel-process">
       <%= form_tag(further_information_cancel_path) do %>
-        <%= button_tag t('hub.further_information.cancel', transaction_name: @transaction_name.capitalize),
+        <%= button_tag t('hub.further_information.cancel', transaction_name: @transaction_name),
                        id: 'cancel', class: 'button-link', role: 'link' %>
       <% end %>
     </div>

--- a/spec/features/user_visits_further_information_page_spec.rb
+++ b/spec/features/user_visits_further_information_page_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'user visits further information page' do
 
     visit further_information_path
 
-    rp_name = t('rps.test-rp.name').capitalize
+    rp_name = t('rps.test-rp.name')
 
     expect(page).to have_title t('hub.further_information.title', cycle_three_name: attribute_field_name)
     expect(page).to have_css '.form-label-bold', text: attribute_field_name
@@ -58,7 +58,7 @@ RSpec.describe 'user visits further information page' do
 
     visit further_information_path
 
-    rp_name = t('rps.test-rp.name').capitalize
+    rp_name = t('rps.test-rp.name')
     click_button t('hub.further_information.cancel', transaction_name: rp_name)
 
     expect(page.current_path).to eql(redirect_to_service_start_again_path)


### PR DESCRIPTION
- In response to an issue raised by RPA, this PR removes the
capitalisation on the further information page.
- The capitalise method makes all other letter lowercase so this has
been changed to a custom method that only capitalises the first letter
leaves the rest as defined by the RP
(thanks @jakubmiarka)

Co-Authored-By: Jakub Miarka
<jakub.miarka@digital.cabinet-office.gov.uk>