### PR TITLE
bau: upgrade selenium and capybara

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,13 @@
 language: ruby
 before_script:
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
-  - sleep 3 # give xvfb some time to start
+  # - "export DISPLAY=:99.0"
+  # - "sh -e /etc/init.d/xvfb start"
+  # - sleep 3 # give xvfb some time to start
 cache:
   directories:
     - $HOME/.phantomjs 
+sudo: required #this is needed for the chromedriver to work
 addons:
-  firefox: "45.9.0esr"
+  apt:
+    packages:
+      - google-chrome-stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,4 @@
 language: ruby
-before_script:
-  # - "export DISPLAY=:99.0"
-  # - "sh -e /etc/init.d/xvfb start"
-  # - sleep 3 # give xvfb some time to start
 cache:
   directories:
     - $HOME/.phantomjs 

--- a/Gemfile
+++ b/Gemfile
@@ -74,6 +74,7 @@ group :test, :development do
   gem 'thin'
 
   gem 'govuk-lint'
+  gem 'chromedriver-helper'
 end
 
 platforms :mswin, :mingw, :x64_mingw do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,6 +40,8 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
+    archive-zip (0.11.0)
+      io-like (~> 0.3.0)
     arel (7.1.4)
     arr-pm (0.0.10)
       cabin (> 0)
@@ -53,15 +55,18 @@ GEM
     builder (3.2.3)
     byebug (9.1.0)
     cabin (0.9.0)
-    capybara (2.10.1)
+    capybara (2.18.0)
       addressable
-      mime-types (>= 1.16)
+      mini_mime (>= 0.1.3)
       nokogiri (>= 1.3.3)
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
-      xpath (~> 2.0)
-    childprocess (0.8.0)
+      xpath (>= 2.0, < 4.0)
+    childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
+    chromedriver-helper (1.2.0)
+      archive-zip (~> 0.10)
+      nokogiri (~> 1.8)
     clamp (1.0.1)
     concurrent-ruby (1.0.5)
     connection_pool (2.2.1)
@@ -151,9 +156,9 @@ GEM
     mail (2.7.0)
       mini_mime (>= 0.1.1)
     method_source (0.9.0)
-    mime-types (3.1)
+    mime-types (3.2.2)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2016.0521)
+    mime-types-data (3.2018.0812)
     mini_mime (1.0.0)
     mini_portile2 (2.3.0)
     minitest (5.11.3)
@@ -184,8 +189,8 @@ GEM
       mustache (= 0.99.8)
       stud
     powerpack (0.1.1)
-    public_suffix (2.0.4)
-    puma (3.6.0)
+    public_suffix (3.0.3)
+    puma (3.12.0)
     rack (2.0.5)
     rack-handlers (0.7.3)
       rack
@@ -285,10 +290,9 @@ GEM
     scss_lint (0.56.0)
       rake (>= 0.9, < 13)
       sass (~> 3.5.3)
-    selenium-webdriver (2.53.4)
+    selenium-webdriver (3.14.0)
       childprocess (~> 0.5)
-      rubyzip (~> 1.0)
-      websocket (~> 1.0)
+      rubyzip (~> 1.2)
     sentry-raven (2.7.1)
       faraday (>= 0.7.6, < 1.0)
     spring (2.0.2)
@@ -330,12 +334,11 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
-    websocket (1.2.3)
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
-    xpath (2.1.0)
-      nokogiri (~> 1.3)
+    xpath (3.1.0)
+      nokogiri (~> 1.8)
     zendesk_api (1.16.0)
       faraday (~> 0.9)
       hashie (>= 3.5.2, < 4.0.0)
@@ -351,6 +354,7 @@ DEPENDENCIES
   browser
   byebug
   capybara (~> 2.10)
+  chromedriver-helper
   connection_pool
   dotenv-rails
   email_validator
@@ -396,4 +400,4 @@ RUBY VERSION
    ruby 2.4.2p198
 
 BUNDLED WITH
-   1.16.1
+   1.16.4

--- a/README.md
+++ b/README.md
@@ -27,16 +27,7 @@ and start your journey from the test-rp.
 
 This will [lint the application code](https://github.com/alphagov/govuk-lint) and run the tests.
 
-If you need to run the javascript-enabled tests that require Firefox, you will need to have Firefox 47.0.1 installed.
-No other version of Firefox will do. The Managed Software Centre will constantly try and upgrade Firefox to an incompatible version.
-To get around this:
-
-1. Install [version 47.0.1](https://ftp.mozilla.org/pub/firefox/releases/47.0.1/mac/en-GB/Firefox%2047.0.1.dmg) somewhere (not your Applications directory!).
-2. Export the `FIREFOX_PATH` environment variable somewhere (like your `.bashrc`):
-
-    `export FIREFOX_PATH=/path/to/old/Firefox.app/Contents/MacOS/firefox-bin`
-
-3. Run the tests again. They should use the old version of Firefox and pass.
+If you need to run the javascript-enabled tests that require a browser, you will need to have Chrome installed. The stable release of Chrome should work.
 
 ## Editing .travis.yml
 

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,8 +1,6 @@
 #!/bin/bash -eu
 
 bundle
-export HEADLESS=true
-export DISPLAY=:0
 ./pre-commit.sh
 echo ${BUILD_NUMBER} > .build-number
 SECRET_KEY_BASE=no-secret RAILS_ENV=production dotenv bundle exec rake assets:precompile

--- a/spec/feature_helper.rb
+++ b/spec/feature_helper.rb
@@ -7,17 +7,6 @@ WebMock.disable_net_connect!(allow_localhost: true)
 
 RACK_COOKIE_DATE_FORMAT = "%a, %d %b %Y".freeze
 
-if ENV['HEADLESS'] == 'true'
-  require 'headless'
-  headless = Headless.new
-  headless.start
-  at_exit do
-    exit_status = $!.status if $!.is_a?(SystemExit)
-    headless.destroy
-    exit exit_status if exit_status
-  end
-end
-
 RSpec.configure do |config|
   config.before(:each, js: true) do
     page.driver.browser.manage.window.resize_to(1280, 1024)
@@ -25,15 +14,8 @@ RSpec.configure do |config|
   config.include AbstractController::Translation
 end
 
-Capybara.configure do |config|
-  config.server = :puma
-end
-
-Capybara.register_driver :selenium do |app|
-  require 'selenium/webdriver'
-  Selenium::WebDriver::Firefox::Binary.path = ENV['FIREFOX_PATH'] || Selenium::WebDriver::Firefox::Binary.path
-  Capybara::Selenium::Driver.new(app, browser: :firefox)
-end
+require 'selenium/webdriver'
+Capybara.javascript_driver = :selenium_chrome_headless
 
 module FeatureHelper
   def current_time_in_millis

--- a/spec/features/user_submits_feedback_page_spec.rb
+++ b/spec/features/user_submits_feedback_page_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature 'When the user submits the feedback page' do
 
       click_button t('hub.feedback.send_message')
       expect(page).to have_title t('hub.feedback_sent.title')
-      expect(page).to have_current_path(feedback_sent_path, only_path: true)
+      expect(page).to have_current_path(feedback_sent_path, ignore_query: true)
       expect(page).to have_content t('hub.feedback_sent.message_email')
       expect(page).to have_content session_not_valid_link
       expect(page).to have_content t('hub.transaction_list.title')
@@ -37,7 +37,7 @@ RSpec.feature 'When the user submits the feedback page' do
       choose 'feedback_form_reply_false'
 
       click_button t('hub.feedback.send_message')
-      expect(page).to have_current_path(feedback_sent_path, only_path: true)
+      expect(page).to have_current_path(feedback_sent_path, ignore_query: true)
       expect(page).to_not have_content t('hub.feedback_sent.message_email')
       expect(page).to have_content session_not_valid_link
       expect(page).to have_content t('hub.transaction_list.title')
@@ -99,7 +99,7 @@ RSpec.feature 'When the user submits the feedback page' do
       choose 'feedback_form_reply_false'
 
       click_button t('hub.feedback.send_message')
-      expect(page).to have_current_path(feedback_sent_path, only_path: true)
+      expect(page).to have_current_path(feedback_sent_path, ignore_query: true)
       expect(page).to_not have_content session_not_valid_link
       expect(page).to have_link t('hub.feedback_sent.session_valid_link'), href: start_path
     end
@@ -113,7 +113,7 @@ RSpec.feature 'When the user submits the feedback page' do
       choose 'feedback_form_reply_false'
 
       click_button t('hub.feedback.send_message')
-      expect(page).to have_current_path(feedback_sent_path, only_path: true)
+      expect(page).to have_current_path(feedback_sent_path, ignore_query: true)
       expect(page).to_not have_content session_not_valid_link
       expect(page).to have_link t('hub.feedback_sent.session_valid_link'), href: select_documents_path
     end
@@ -128,7 +128,7 @@ RSpec.feature 'When the user submits the feedback page' do
       choose 'feedback_form_reply_false'
 
       click_button t('hub.feedback.send_message')
-      expect(page).to have_current_path(feedback_sent_path, only_path: true)
+      expect(page).to have_current_path(feedback_sent_path, ignore_query: true)
       expect(page).to_not have_content session_not_valid_link
       expect(page).to have_link t('hub.feedback_sent.session_valid_link'), href: start_path
     end
@@ -141,7 +141,7 @@ RSpec.feature 'When the user submits the feedback page' do
       choose 'feedback_form_reply_false'
 
       click_button t('hub.feedback.send_message')
-      expect(page).to have_current_path(feedback_sent_path, only_path: true)
+      expect(page).to have_current_path(feedback_sent_path, ignore_query: true)
       expect(page).to_not have_content session_not_valid_link
       expect(page).to have_link t('hub.feedback_sent.session_valid_link'), href: start_path
     end

--- a/spec/features/user_visits_other_identity_documents_page_spec.rb
+++ b/spec/features/user_visits_other_identity_documents_page_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature 'When users visits other documents page' do
     choose 'other_identity_documents_form_non_uk_id_document_true', allow_label_click: true
     click_button t('navigation.continue')
 
-    expect(page).to have_current_path(select_phone_path, only_path: true)
+    expect(page).to have_current_path(select_phone_path, ignore_query: true)
   end
 
   it 'redirects user to select-phone page if selects no' do
@@ -19,7 +19,7 @@ RSpec.feature 'When users visits other documents page' do
     choose 'other_identity_documents_form_non_uk_id_document_false', allow_label_click: true
     click_button t('navigation.continue')
 
-    expect(page).to have_current_path(select_phone_path, only_path: true)
+    expect(page).to have_current_path(select_phone_path, ignore_query: true)
   end
 
   it 'should show a feedback link' do

--- a/spec/features/user_visits_other_identity_documents_page_variant_spec.rb
+++ b/spec/features/user_visits_other_identity_documents_page_variant_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature 'When users visits other documents page' do
     choose 'other_identity_documents_variant_form_smart_phone_true', allow_label_click: true
     click_button t('navigation.continue')
 
-    expect(page).to have_current_path(choose_a_certified_company_path, only_path: true)
+    expect(page).to have_current_path(choose_a_certified_company_path, ignore_query: true)
   end
 
   it 'redirects user to choose-a-certified-company page if selects yes and does not have smartphone' do
@@ -25,7 +25,7 @@ RSpec.feature 'When users visits other documents page' do
     choose 'other_identity_documents_variant_form_smart_phone_false', allow_label_click: true
     click_button t('navigation.continue')
 
-    expect(page).to have_current_path(choose_a_certified_company_path, only_path: true)
+    expect(page).to have_current_path(choose_a_certified_company_path, ignore_query: true)
   end
 
   it 'redirects user to choose-a-certified-company page if selects no' do
@@ -35,7 +35,7 @@ RSpec.feature 'When users visits other documents page' do
     choose 'other_identity_documents_variant_form_non_uk_id_document_false', allow_label_click: true
     click_button t('navigation.continue')
 
-    expect(page).to have_current_path(choose_a_certified_company_path, only_path: true)
+    expect(page).to have_current_path(choose_a_certified_company_path, ignore_query: true)
   end
 
   it 'should show a feedback link' do

--- a/spec/features/user_visits_select_phone_page_spec.rb
+++ b/spec/features/user_visits_select_phone_page_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe 'When the user visits the select phone page' do
       choose 'select_phone_form_smart_phone_true', allow_label_click: true
       click_button t('navigation.continue')
 
-      expect(page).to have_current_path(choose_a_certified_company_path, only_path: true)
+      expect(page).to have_current_path(choose_a_certified_company_path, ignore_query: true)
       expect(page.get_rack_session['selected_answers']).to eql(
         'device_type' => { 'device_type_other' => true },
         'phone' => { 'mobile_phone' => true, 'smart_phone' => true }
@@ -46,7 +46,7 @@ RSpec.describe 'When the user visits the select phone page' do
       choose 'select_phone_form_smart_phone_do_not_know', allow_label_click: true
       click_button t('navigation.continue')
 
-      expect(page).to have_current_path(choose_a_certified_company_path, only_path: true)
+      expect(page).to have_current_path(choose_a_certified_company_path, ignore_query: true)
       expect(page.get_rack_session['selected_answers']).to eql(
         'device_type' => { 'device_type_other' => true },
         'phone' => { 'mobile_phone' => true }

--- a/spec/mock_piwik_middleware.rb
+++ b/spec/mock_piwik_middleware.rb
@@ -1,14 +1,12 @@
 class MockPiwikMiddleware
-  def initialize(request_log)
-    @request_log = request_log
-  end
-
   def call(env)
     request = ActionDispatch::Request.new(env)
     if request.path == '/piwik.php'
       params = request.params
-      @request_log.log(params)
+      MockPiwikMiddleware.request_log.log(params)
     end
     ['200', {}, ['']]
   end
+
+  def self.request_log; end
 end


### PR DESCRIPTION
Changes:
- Upgrade selenium and capybara
- Switch to using headless chrome via chromedriver
- Fixes to tests that were failing due to Chrome honoring our CSP rules
- Updated .travis.yml to use Chrome