### PR TITLE
bau: switch to firefox headless

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,7 @@ language: ruby
 cache:
   directories:
     - $HOME/.phantomjs 
-sudo: required #this is needed for the chromedriver to work
+env:
+    - MOZ_HEADLESS=1
 addons:
-  apt:
-    packages:
-      - google-chrome-stable
+    firefox: latest

--- a/Gemfile
+++ b/Gemfile
@@ -74,7 +74,7 @@ group :test, :development do
   gem 'thin'
 
   gem 'govuk-lint'
-  gem 'chromedriver-helper'
+  gem 'geckodriver-helper'
 end
 
 platforms :mswin, :mingw, :x64_mingw do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,9 +64,6 @@ GEM
       xpath (>= 2.0, < 4.0)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
-    chromedriver-helper (1.2.0)
-      archive-zip (~> 0.10)
-      nokogiri (~> 1.8)
     clamp (1.0.1)
     concurrent-ruby (1.0.5)
     connection_pool (2.2.1)
@@ -102,6 +99,8 @@ GEM
       pleaserun (~> 0.0.29)
       ruby-xz
       stud
+    geckodriver-helper (0.21.0)
+      archive-zip (~> 0.7)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
     govuk-lint (3.3.0)
@@ -354,10 +353,10 @@ DEPENDENCIES
   browser
   byebug
   capybara (~> 2.10)
-  chromedriver-helper
   connection_pool
   dotenv-rails
   email_validator
+  geckodriver-helper
   govuk-lint
   govuk_elements_rails
   govuk_frontend_toolkit

--- a/spec/feature_helper.rb
+++ b/spec/feature_helper.rb
@@ -15,7 +15,14 @@ RSpec.configure do |config|
 end
 
 require 'selenium/webdriver'
-Capybara.javascript_driver = :selenium_chrome_headless
+Capybara.register_driver :firefox_headless do |app|
+  options = ::Selenium::WebDriver::Firefox::Options.new
+  options.args << '--headless'
+
+  Capybara::Selenium::Driver.new(app, browser: :firefox, options: options)
+end
+
+Capybara.javascript_driver = :firefox_headless
 
 module FeatureHelper
   def current_time_in_millis


### PR DESCRIPTION
There's been some issues with running chromium headless on Jenkins so
this changes the browser back to Firefox but with its new headless
functionality and geckodriver support.