### PR TITLE
BAU: Tiny change to privacy notice

### DIFF
--- a/app/views/static/privacy_notice.en.html.erb
+++ b/app/views/static/privacy_notice.en.html.erb
@@ -11,7 +11,7 @@ end %>
     <h1 class="heading-large">Privacy notice</h1>
     <p>Last updated: 24 May 2018</p>
     <h2 class="heading-medium" id="who-we-are">Who we are</h2>
-    <p>GOV.UK Verify is built and run by the Government Digital Service (GDS). GOV.UK Verify allows you to prove your identity when using digital government services like the service you used to <a href="https://www.gov.uk/log-in-file-self-assessment-tax-return">sign in and file your Self Assessment tax return</a>. This privacy notice explains what information we might collect, how it’s used and how it’s protected.
+    <p>GOV.UK Verify is built and run by the Government Digital Service (GDS). GOV.UK Verify allows you to prove your identity when using digital government services like the service you use to <a href="https://www.gov.uk/log-in-file-self-assessment-tax-return">sign in and file your Self Assessment tax return</a>. This privacy notice explains what information we might collect, how it’s used and how it’s protected.
     <h2 class="heading-medium" id="how-we-use-info">How we use information</h2>
     <p>GOV.UK Verify provides a ‘hub’ between services and ‘<a href="https://www.gov.uk/government/publications/introducing-govuk-verify/introducing-govuk-verify#companies-that-can-verify-your-identity">certified companies</a>’ who verify users’ identitieson behalf of government. Certified companies are organisations that have met government and industry standards to provide identity assurance services as part of GOV.UK Verify. We use personal data and other information to help you to transact securely with government services. This may include any of the following 6 things.</p>
     <ol class="list-number list">


### PR DESCRIPTION
Removed "d" from "used" in first paragraph. New copy should read "...prove
your identity when using digital government services like the service
you use to..."

solo: @rachelthecodesmith