### PR TITLE
CVQ2-177: use rp display repo in service listers

### DIFF
--- a/app/models/display/display_data.rb
+++ b/app/models/display/display_data.rb
@@ -1,6 +1,7 @@
 module Display
   class DisplayData
     attr_reader :simple_id
+    attr_reader :translator
     def initialize(simple_id, translator)
       @simple_id = simple_id
       @translator = translator
@@ -14,7 +15,12 @@ module Display
           begin
             @translator.translate!("#{prefix}.#{simple_id}.#{field}")
           rescue I18n::MissingTranslationData => e
-            options.fetch(:default) { raise e }
+            default = options.fetch(:default) { raise e }
+            if default.is_a? Proc
+              instance_exec(&default)
+            else
+              default
+            end
           end
         end
         @localizable_fields ||= []

--- a/app/models/display/rp/display_data_correlator.rb
+++ b/app/models/display/rp/display_data_correlator.rb
@@ -8,8 +8,8 @@ module Display
       end
       Transaction = Struct.new(:name, :homepage, :loa_list)
 
-      def initialize(translator, rps_name_homepage, rps_name_only)
-        @translator = translator
+      def initialize(rp_display_repository, rps_name_homepage, rps_name_only)
+        @rp_display_repository = rp_display_repository
         @rps_name_homepage = rps_name_homepage
         @rps_name_only = rps_name_only
       end
@@ -38,7 +38,7 @@ module Display
 
       def translate_name(transaction)
         simple_id = transaction.fetch('simpleId')
-        @translator.translate!("rps.#{simple_id}.name")
+        @rp_display_repository.get_translations(simple_id).name
       end
 
       def filter_transactions(transactions, simple_ids)

--- a/app/models/display/rp_display_data.rb
+++ b/app/models/display/rp_display_data.rb
@@ -13,5 +13,7 @@ module Display
     content :custom_fail_try_another_summary, default: nil
     content :custom_fail_try_another_text, default: nil
     content :custom_fail_contact_details_intro, default: nil
+    content :taxon_name, default: -> { I18n.translate('hub.transaction_list.other_services') }
+    alias_method :taxon, :taxon_name
   end
 end

--- a/config/initializers/30_federation.rb
+++ b/config/initializers/30_federation.rb
@@ -40,11 +40,11 @@ Rails.application.config.after_initialize do
   rps_name_only = RP_CONFIG['transaction_type']['display_name_only'] || []
   REDIRECT_TO_RP_LIST = RP_CONFIG['redirect_to_rp'] || []
   SINGLE_IDP_ENABLED_RP_LIST = RP_CONFIG['single_idp_enabled'] || []
-  DATA_CORRELATOR = Display::Rp::DisplayDataCorrelator.new(I18n, rps_name_and_homepage.clone, rps_name_only.clone)
-  TRANSACTION_TAXON_CORRELATOR = Display::Rp::TransactionTaxonCorrelator.new(I18n, rps_name_and_homepage.clone, rps_name_only.clone)
+  DATA_CORRELATOR = Display::Rp::DisplayDataCorrelator.new(RP_DISPLAY_REPOSITORY, rps_name_and_homepage.clone, rps_name_only.clone)
+  TRANSACTION_TAXON_CORRELATOR = Display::Rp::TransactionTaxonCorrelator.new(RP_DISPLAY_REPOSITORY, rps_name_and_homepage.clone, rps_name_only.clone)
 
   SERVICE_LIST_DATA_CORRELATOR = Display::Rp::ServiceListDataCorrelator.new(
-    I18n,
+    RP_DISPLAY_REPOSITORY,
     rps_name_and_homepage.clone
   )
 

--- a/spec/models/display/display_data_spec.rb
+++ b/spec/models/display/display_data_spec.rb
@@ -49,12 +49,30 @@ module Display
         }.to raise_error NotImplementedError
       end
 
-      it 'will allow default values if translation is not found' do
-        derived_class = Class.new(Display::DisplayData) do
-          prefix :foo
-          content :bob, default: 'foobarbaz'
+      context "will support defaults" do
+        it 'as values if translation is not found' do
+          derived_class = Class.new(Display::DisplayData) do
+            prefix :foo
+            content :bob, default: 'foobarbaz'
+          end
+          expect(derived_class.new('simpleid', translator).bob).to eql 'foobarbaz'
         end
-        expect(derived_class.new('simpleid', translator).bob).to eql 'foobarbaz'
+
+        it 'as procs if translation is not found' do
+          derived_class = Class.new(Display::DisplayData) do
+            prefix :foo
+            content :bob, default: -> { "foobar" }
+          end
+          expect(derived_class.new('simpleid', translator).bob).to eql 'foobar'
+        end
+
+        it 'as procs that are instance_evaled if translation is not found' do
+          derived_class = Class.new(Display::DisplayData) do
+            prefix :foo
+            content :bob, default: -> { prefix.to_s + " foobar" }
+          end
+          expect(derived_class.new('simpleid', translator).bob).to eql 'foo foobar'
+        end
       end
 
       it 'content will not be shared between derived classes' do

--- a/spec/models/display/rp/display_data_correlator_spec.rb
+++ b/spec/models/display/rp/display_data_correlator_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 require 'rails_helper'
 require 'models/display/rp/display_data_correlator'
+require 'display/rp_display_repository'
 
 module Display
   module Rp
@@ -10,7 +11,24 @@ module Display
       let(:transaction_3_name) { 'Transaction 3' }
       let(:transaction_4_name) { 'Transaction 4' }
       let(:transaction_b_name) { 'Private Transaction B' }
-      let(:translator) { double(:translator) }
+      let(:transaction_a_display_data) do
+        instance_double("Display::RpDisplayData", name: transaction_a_name)
+      end
+      let(:transaction_b_display_data) do
+        instance_double("Display::RpDisplayData", name: transaction_b_name)
+      end
+      let(:transaction_2_display_data) do
+        instance_double("Display::RpDisplayData", name: transaction_2_name)
+      end
+      let(:transaction_3_display_data) do
+        instance_double("Display::RpDisplayData", name: transaction_3_name)
+      end
+      let(:transaction_4_display_data) do
+        instance_double("Display::RpDisplayData", name: transaction_4_name)
+      end
+      let(:rp_display_repository) do
+        instance_double("Display::RpDisplayRepository")
+      end
       let(:homepage) { 'http://transaction-a.com' }
       let(:homepage_2) { 'http://transaction-2.com' }
       let(:homepage_3) { 'http://transaction-3.com' }
@@ -30,15 +48,15 @@ module Display
 
 
       let(:display_data_correlator) {
-        DisplayDataCorrelator.new(translator, [public_simple_id], [private_simple_id])
+        DisplayDataCorrelator.new(rp_display_repository, [public_simple_id], [private_simple_id])
       }
 
       before(:each) do
-        allow(translator).to receive(:translate!).with('rps.test-rp.name').and_return(transaction_a_name)
-        allow(translator).to receive(:translate!).with('rps.test-rp-2.name').and_return(transaction_2_name)
-        allow(translator).to receive(:translate!).with('rps.test-rp-3.name').and_return(transaction_3_name)
-        allow(translator).to receive(:translate!).with('rps.test-rp-4.name').and_return(transaction_4_name)
-        allow(translator).to receive(:translate!).with('rps.some-simple-id.name').and_return(transaction_b_name)
+        allow(rp_display_repository).to receive(:get_translations).with('test-rp').and_return(transaction_a_display_data)
+        allow(rp_display_repository).to receive(:get_translations).with('test-rp-2').and_return(transaction_2_display_data)
+        allow(rp_display_repository).to receive(:get_translations).with('test-rp-3').and_return(transaction_3_display_data)
+        allow(rp_display_repository).to receive(:get_translations).with('test-rp-4').and_return(transaction_4_display_data)
+        allow(rp_display_repository).to receive(:get_translations).with('some-simple-id').and_return(transaction_b_display_data)
       end
 
       it 'returns the transactions with display name and homepage in the order listed in the relying_parties_config' do
@@ -48,7 +66,7 @@ module Display
               { 'simpleId' => public_simple_id_3, 'serviceHomepage' => homepage_3, 'loaList' => public_simple_id_3_loa },
               { 'simpleId' => public_simple_id_4, 'serviceHomepage' => homepage_4, 'loaList' => public_simple_id_4_loa },
         ]
-        correlator = DisplayDataCorrelator.new(translator, [public_simple_id_4, public_simple_id_2, public_simple_id, public_simple_id_3], [])
+        correlator = DisplayDataCorrelator.new(rp_display_repository, [public_simple_id_4, public_simple_id_2, public_simple_id, public_simple_id_3], [])
         actual_result = correlator.correlate(transaction_data)
         expected_result = DisplayDataCorrelator::Transactions.new(
           [
@@ -86,7 +104,7 @@ module Display
             { 'simpleId' => public_simple_id, 'serviceHomepage' => homepage, 'loaList' => public_simple_id_loa },
             { 'simpleId' => public_simple_id_2, 'serviceHomepage' => homepage_2, 'loaList' => public_simple_id_2_loa },
         ]
-        correlator = DisplayDataCorrelator.new(translator, [public_simple_id_2, public_simple_id], [])
+        correlator = DisplayDataCorrelator.new(rp_display_repository, [public_simple_id_2, public_simple_id], [])
         actual_result = correlator.retrieve_current_service(transaction_data, public_simple_id_2)
         expected_result = transaction_2_name
         expect(actual_result).to eq expected_result

--- a/spec/models/display/rp/service_list_data_correlator_spec.rb
+++ b/spec/models/display/rp/service_list_data_correlator_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 require 'rails_helper'
-require 'models/display/rp/service_list_data_correlator'
+require 'display/rp/service_list_data_correlator'
+require 'display/rp_display_data'
+require 'display/rp_display_repository'
 
 module Display
   module Rp
@@ -10,7 +12,6 @@ module Display
       let(:transaction_3_name) { 'Transaction 3' }
       let(:transaction_4_name) { 'Transaction 4' }
 
-      let(:translator) { I18n }
       let(:homepage) { 'http://transaction-a.com' }
       let(:homepage_2) { 'http://transaction-2.com' }
       let(:homepage_3) { 'http://transaction-3.com' }
@@ -41,33 +42,30 @@ module Display
       let(:public_taxon_3) { 'Taxon 3' }
       let(:public_taxon_4) { 'Taxon 4' }
 
+      let(:rp_display_repository) { instance_double("Display::RpDisplayRepository") }
+
       let(:service_list_data_correlator) do
-        ServiceListDataCorrelator.new(translator, [public_simple_id])
+        ServiceListDataCorrelator.new(rp_display_repository, [public_simple_id])
       end
 
-      def store_translation(rp, key, value)
-        I18n.backend.store_translations('en', 'rps' => { rp => { key => value } })
+      let(:display_data_1) do
+        instance_double("Display::RpDisplayData", name: transaction_a_name, taxon: public_taxon)
       end
-
-      before(:each) do
-        @old_backend = I18n.backend
-        I18n.backend = I18n::Backend::Simple.new
-        store_translation('test-rp', 'name', transaction_a_name)
-        store_translation('test-rp-2', 'name', transaction_2_name)
-        store_translation('test-rp-3', 'name', transaction_3_name)
-        store_translation('test-rp-4', 'name', transaction_4_name)
-
-        store_translation('test-rp', 'taxon_name', public_taxon)
-        store_translation('test-rp-2', 'taxon_name', public_taxon_2)
-        store_translation('test-rp-3', 'taxon_name', public_taxon_3)
-        store_translation('test-rp-4', 'taxon_name', public_taxon_4)
+      let(:display_data_2) do
+        instance_double("Display::RpDisplayData", name: transaction_2_name, taxon: public_taxon_2)
       end
-
-      after(:each) do
-        I18n.backend = @old_backend
+      let(:display_data_3) do
+        instance_double("Display::RpDisplayData", name: transaction_3_name, taxon: public_taxon_3)
+      end
+      let(:display_data_4) do
+        instance_double("Display::RpDisplayData", name: transaction_4_name, taxon: public_taxon_4)
       end
 
       it 'returns the transactions with display name, homepage, loa and simpleId' do
+        expect(rp_display_repository).to receive(:get_translations).with(public_simple_id).and_return(display_data_1)
+        expect(rp_display_repository).to receive(:get_translations).with(public_simple_id_2).and_return(display_data_2)
+        expect(rp_display_repository).to receive(:get_translations).with(public_simple_id_3).and_return(display_data_3)
+        expect(rp_display_repository).to receive(:get_translations).with(public_simple_id_4).and_return(display_data_4)
         transaction_data = [
           {
               'simpleId' => public_simple_id,
@@ -95,7 +93,7 @@ module Display
           },
         ]
         correlator = ServiceListDataCorrelator.new(
-          translator,
+          rp_display_repository,
           [
             public_simple_id_4,
             public_simple_id_2,


### PR DESCRIPTION
The Transactions listers`TransactionTaxonCorrelator`,
`ServiceListDataCorrelator`, and `DisplayDataCorrelator` were using
`I18n` directly to provide the content for the RP. This introduced a
problem where the lists were being generated but the correct localisation
 was not being fetched, if missing, from the ConfigService.
This meant that the Welsh version of the list was mostly being rendered
 in English despite the translations existing upstream.
Hooking the listers up to the `RP_DISPLAY_REPOSITORY` will guarantee
that the correct localisation is provided when generating these lists.

CVQ2-177: use RP Display Repository in DisplayDataCorrelator