### PR TITLE
Make rp display repo threadsafe

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,7 +16,6 @@ class ApplicationController < ActionController::Base
   include TransactionsPartialController
   include AnalyticsPartialController
 
-  before_action :update_translations
   before_action :validate_session
   before_action :set_visitor_cookie
   # Prevent CSRF attacks by raising an exception.
@@ -51,9 +50,5 @@ private
 
   def store_originating_ip
     OriginatingIpStore.store(request)
-  end
-
-  def update_translations
-    RP_DISPLAY_REPOSITORY.update_translations(current_transaction_simple_id)
   end
 end

--- a/app/controllers/service_status_controller.rb
+++ b/app/controllers/service_status_controller.rb
@@ -1,5 +1,4 @@
 class ServiceStatusController < ApplicationController
-  skip_before_action :update_translations
   skip_before_action :validate_session
   skip_before_action :set_piwik_custom_variables
 

--- a/app/models/display/repository_factory.rb
+++ b/app/models/display/repository_factory.rb
@@ -18,7 +18,7 @@ module Display
     end
 
     def create_rp_repository
-      RpDisplayRepository.new(@translator)
+      RpDisplayRepository.new(@translator, Rails.logger)
     end
 
     def create_cycle_three_repository(directory)

--- a/app/models/display/rp_display_data.rb
+++ b/app/models/display/rp_display_data.rb
@@ -1,3 +1,4 @@
+require 'display/display_data'
 module Display
   class RpDisplayData < ::Display::DisplayData
     prefix :rps

--- a/app/models/display/rp_display_repository.rb
+++ b/app/models/display/rp_display_repository.rb
@@ -1,37 +1,79 @@
+require 'concurrent'
+require 'date'
 module Display
   class RpDisplayRepository
-    def initialize(translator)
+    def initialize(translator, logger)
       @translator = translator
-      @display_data = {}
-    end
-
-    def update_translations(simple_id)
-      if @display_data.empty?
-        transactions = RP_TRANSLATION_SERVICE.transactions
-        transactions.each do |transaction|
-          RP_TRANSLATION_SERVICE.update_rp_translations(transaction)
-          create_display_data(transaction)
-        end
-      else
-        RP_TRANSLATION_SERVICE.update_rp_translations(simple_id)
-      end
+      @logger = logger
+      @store = Concurrent::Map.new
     end
 
     def get_translations(transaction_simple_id)
-      unless @display_data.key?(transaction_simple_id)
-        update_translations(transaction_simple_id)
-        create_display_data(transaction_simple_id)
-      end
-
-      @display_data.fetch(transaction_simple_id)
+      find_or_create(transaction_simple_id).fetch!
     end
 
   private
 
+    def find_or_create(simple_id)
+      @store[simple_id] ||= create_display_data(simple_id)
+    end
+
     def create_display_data(simple_id)
       display_data = Display::RpDisplayData.new(simple_id, @translator)
-      display_data.validate_content!
-      @display_data[simple_id] = display_data
+      DisplayDataCache.new(display_data, @logger)
+    end
+
+    class DisplayDataCache
+      include Concurrent::Async
+      def initialize(display_data, logger)
+        @last_updated = :never
+        @display_data = display_data
+        @logger = logger
+      end
+
+      def fetch!
+        result = self.await.fetch_display_data!
+        if(result.fulfilled?)
+          return result.value
+        else
+          raise result.reason
+        end
+      end
+
+      def fetch_display_data!
+        if need_to_fetch_upstream?
+          fetch_upstream!
+        end
+        @display_data
+      end
+
+    private
+
+      def fetch_upstream!
+        begin
+          RP_TRANSLATION_SERVICE.update_rp_translations(@display_data.simple_id)
+        rescue StandardError => e
+          @logger.error(e)
+        end
+        @display_data.validate_content!
+        @last_updated = DateTime.now
+      end
+
+      def need_to_fetch_upstream?
+        never_updated? || expired?
+      end
+
+      def never_updated?
+        @last_updated == :never
+      end
+
+      def expired?
+        (@last_updated + lifetime).to_datetime < DateTime.now
+      end
+
+      def lifetime
+        @lifetime ||= 30.minutes
+      end
     end
   end
 end

--- a/app/services/rp_translation_service.rb
+++ b/app/services/rp_translation_service.rb
@@ -3,12 +3,6 @@ class RpTranslationService
     @locales = %w[en cy]
   end
 
-  def transactions
-    CONFIG_PROXY.transactions.map do |transaction|
-      transaction['simpleId']
-    end
-  end
-
   def update_rp_translations(transaction)
     @locales.each do |locale|
       translations = get_translations(transaction, locale)

--- a/lib/loading_cache.rb
+++ b/lib/loading_cache.rb
@@ -1,0 +1,50 @@
+require 'concurrent'
+require 'date'
+
+class LoadingCache
+  include Concurrent::Async
+  def initialize(object, refresh_proc)
+    @last_updated = :never
+    @object = object
+    @refresh_proc = refresh_proc
+  end
+
+  def fetch!
+    result = self.await.fetch_object!
+    if(result.fulfilled?)
+      return result.value
+    else
+      raise result.reason
+    end
+  end
+
+  def fetch_object!
+    if need_to_refresh?
+      refresh!
+    end
+    @object
+  end
+
+private
+
+  def refresh!
+    @object = @refresh_proc.call(@object)
+    @last_updated = DateTime.now
+  end
+
+  def need_to_refresh?
+    never_updated? || expired?
+  end
+
+  def never_updated?
+    @last_updated == :never
+  end
+
+  def expired?
+    (@last_updated + lifetime).to_datetime < DateTime.now
+  end
+
+  def lifetime
+    @lifetime ||= 30.minutes
+  end
+end

--- a/spec/lib/loading_cache_spec.rb
+++ b/spec/lib/loading_cache_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+require 'loading_cache'
+
+RSpec.describe LoadingCache, type: :lib do
+  it 'should call refresh_proc when accessing object from cache for first time' do
+    object = double(:object)
+    refresh_proc = double(:refresh_proc)
+    cache = LoadingCache.new(object, refresh_proc)
+    refreshed_object = double(:refreshed_object)
+    expect(refresh_proc).to receive(:call).with(object).and_return(refreshed_object)
+    expect(cache.fetch!).to eql refreshed_object
+  end
+
+  it 'should not update a translations when translations were recently cached' do
+    object = double(:object)
+    refresh_proc = double(:refresh_proc)
+    cache = LoadingCache.new(object, refresh_proc)
+    refreshed_object = double(:refreshed_object)
+    expect(refresh_proc).to receive(:call).with(object).and_return(refreshed_object).once
+    expect(cache.fetch!).to eql refreshed_object
+    expect(cache.fetch!).to eql refreshed_object
+  end
+
+  it 'should propogate refresh errors if they occur' do
+    error = StandardError.new("Bad Display Data")
+    object = double(:object)
+    refresh_proc = double(:refresh_proc)
+    expect(refresh_proc).to receive(:call).and_raise(error)
+    cache = LoadingCache.new(object, refresh_proc)
+    expect { cache.fetch! }.to raise_error error
+  end
+
+  it 'should refresh translations upstream when past lifetime' do
+    expect(DateTime).to receive(:now).and_return(31.minutes.ago, 15.minutes.ago, DateTime.now, DateTime.now)
+    object = double(:object)
+    refresh_proc = double(:refresh_proc)
+    cache = LoadingCache.new(object, refresh_proc)
+    refreshed_object = double(:refreshed_object)
+    expect(refresh_proc).to receive(:call).and_return(object, refreshed_object).twice
+    expect(cache.fetch!).to eql object
+    expect(cache.fetch!).to eql object
+    expect(cache.fetch!).to eql refreshed_object
+  end
+end

--- a/spec/models/display/rp_display_repository_spec.rb
+++ b/spec/models/display/rp_display_repository_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 require 'display/rp_display_repository'
 require 'display/rp_display_data'
 require 'rp_translation_service'
+require 'loading_cache'
 
 module Display
   describe RpDisplayRepository do

--- a/spec/models/display/rp_display_repository_spec.rb
+++ b/spec/models/display/rp_display_repository_spec.rb
@@ -1,69 +1,53 @@
-require 'feature_helper'
-require 'api_test_helper'
-require 'models/display/rp_display_repository'
+require 'spec_helper'
+require 'display/rp_display_repository'
+require 'display/rp_display_data'
+require 'rp_translation_service'
 
 module Display
   describe RpDisplayRepository do
+    let(:translator) { double("Display::FederationTranslator") }
+    let(:logger) { double(:logger) }
+    let(:rp_display_repo) { RpDisplayRepository.new(translator, logger) }
+    let(:rp_translation_service) { instance_double("RpTranslationService") }
     before(:each) do
-      @translations = {
-          name: "register for an identity profile",
-          rp_name: "Test RP",
-          analytics_description: "analytics description for test-rp",
-          other_ways_text: "<p>If you can’t verify your identity using GOV.UK Verify, you can register for an identity profile <a href=\"http://www.example.com\">here</a>.</p><p>Tell us your:</p><ul><li>name</li><li>age</li></ul><p>Include any other relevant details if you have them.</p>",
-          other_ways_description: "register for an identity profile",
-          tailored_text: "External data source: EN: This is tailored text for test-rp",
-          taxon_name: "Benefits",
-          custom_fail_heading: '',
-          custom_fail_what_next_content: '',
-          custom_fail_other_options: '',
-          custom_fail_try_another_summary: '',
-          custom_fail_try_another_text: '',
-          custom_fail_contact_details_intro: ''
-      }
-      @translator = class_double("I18n")
-      allow(@translator).to receive(:translate!).and_return("")
-
-      allow(RP_TRANSLATION_SERVICE).to receive(:transactions).and_return(['test-rp'])
-      allow(RP_TRANSLATION_SERVICE).to receive(:update_rp_translations).with('test-rp').and_return(@translations)
+      allow(translator).to receive(:translate!).and_return("")
+      stub_const("RP_TRANSLATION_SERVICE", rp_translation_service)
     end
 
-
-    it 'should update all translations when display data is empty' do
-      rp_display_repo = RpDisplayRepository.new(@translator)
-      rp_display_repo.update_translations 'test-rp'
-
-      expect(RP_TRANSLATION_SERVICE).to have_received(:transactions)
-      expect(rp_display_repo.instance_variable_get('@display_data').keys).to eq(['test-rp'])
-      expect(rp_display_repo.instance_variable_get('@display_data').fetch('test-rp')).to be_a(Display::RpDisplayData)
+    it 'should fetch translations when fetching new display data' do
+      expect(rp_translation_service).to receive(:update_rp_translations).with('test-rp').once
+      display_data = rp_display_repo.get_translations('test-rp')
+      expect(display_data).to be_a(Display::RpDisplayData)
     end
 
-    it 'should not update all translations when translations are already cached' do
-      rp_display_repo = RpDisplayRepository.new(@translator)
-      rp_display_repo.update_translations 'test-rp'
-      rp_display_repo.update_translations 'test-rp'
-
-      expect(RP_TRANSLATION_SERVICE).to have_received(:transactions).once
+    it 'should not update a translations when translations were recently cached' do
+      expect(rp_translation_service).to receive(:update_rp_translations).with('test-rp').once
+      display_data = rp_display_repo.get_translations('test-rp')
+      expect(display_data).to be_a(Display::RpDisplayData)
+      expect(rp_display_repo.get_translations('test-rp')).to be display_data
     end
 
-    it 'should get translations for a transaction when cached translations are available' do
-      rp_display_repo = RpDisplayRepository.new(@translator)
-      rp_display_repo.update_translations 'test-rp'
+    it 'should not propogate upstream errors, but log, when display_data is valid' do
+      expect(translator).to receive(:translate!).and_return("")
+      error = StandardError.new("FOOBAR")
+      expect(logger).to receive(:error).with(error)
+      expect(rp_translation_service).to receive(:update_rp_translations).and_raise(error)
+      expect { rp_display_repo.get_translations('test-rp') }.to_not raise_error
+    end
 
+    it 'should propogate upstream errors when display_data is invalid' do
+      error = StandardError.new("Bad Display Data")
+      expect(translator).to receive(:translate!).and_raise(error)
+      expect(rp_translation_service).to receive(:update_rp_translations)
+      expect { rp_display_repo.get_translations('test-rp') }.to raise_error error
+    end
+
+    it 'should refresh translations upstream when past lifetime' do
+      expect(DateTime).to receive(:now).and_return(31.minutes.ago, 15.minutes.ago, DateTime.now, DateTime.now)
+      expect(rp_translation_service).to receive(:update_rp_translations).with('test-rp').twice
       rp_display_repo.get_translations('test-rp')
-
-      expect(RP_TRANSLATION_SERVICE).to have_received(:update_rp_translations).with('test-rp').exactly(1).times
-    end
-
-    it 'should update translations for a particular transaction when no cached translations are available' do
-      allow(RP_TRANSLATION_SERVICE).to receive(:update_rp_translations).with('test-rp').and_return(@translations)
-      allow(RP_TRANSLATION_SERVICE).to receive(:update_rp_translations).with('new-rp').and_return({})
-
-      rp_display_repo = RpDisplayRepository.new(@translator)
-      rp_display_repo.update_translations 'test-rp'
-
-      rp_display_repo.get_translations('new-rp')
-
-      expect(RP_TRANSLATION_SERVICE).to have_received(:update_rp_translations).with('new-rp').exactly(1).times
+      rp_display_repo.get_translations('test-rp')
+      rp_display_repo.get_translations('test-rp')
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -43,4 +43,12 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
   config.include Rails.application.routes.url_helpers
+
+  require 'api_test_helper'
+  config.before(:each) do |test|
+    unless test.metadata[:skip_before]
+      stub_transactions_list
+      stub_translations
+    end
+  end
 end

--- a/spec/services/rp_translation_service_spec.rb
+++ b/spec/services/rp_translation_service_spec.rb
@@ -12,20 +12,6 @@ describe 'RpTranslationService' do
     I18n.backend = I18n::Backend::Simple.new
   end
 
-  it 'should call to config service to get transactions' do
-    translation_service = RpTranslationService.new
-    expect(config_proxy).to receive(:transactions).and_return(MultiJson.load('[{
-      "simpleId":"test-rp",
-      "entityId":"http://example.com/test-rp",
-      "serviceHomepage":"http://example.com/test-rp",
-      "loaList":["LEVEL_2"]
-    }]'))
-
-    transactions = translation_service.transactions
-
-    expect(transactions).to eq(['test-rp'])
-  end
-
   it 'should update I18n with translations for a particular transaction in all locales' do
     translations = {
       name: "register for an identity profile",

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -100,15 +100,11 @@ RSpec.configure do |config|
   config.before(:example) do
     I18n.locale = :en if defined? I18n
   end
-
-  config.before(:each) do |test|
-    unless test.metadata[:skip_before]
-      stub_transactions_list
-      stub_translations
-    end
-  end
 end
-
 $:.unshift File.expand_path('../../app/', __FILE__)
 $:.unshift File.expand_path('../../spec/support/', __FILE__)
 $:.unshift File.expand_path('../../app/models', __FILE__)
+$:.unshift File.expand_path('../../app/services', __FILE__)
+
+require 'active_support'
+require 'active_support/core_ext'


### PR DESCRIPTION
Implements a 'cache' inside the `RpDisplayRepository` that will refresh
the translations that support `RpDisplayData` every 30 minutes. The
refresh action on the cache allows for us to call off to config service
and fetch some new translations.

This removes the need for using the `before_action` in
`ApplicationController` to refresh a user's transaction's translations.

This also means that when we generate a transaction list each
transaction's display data will be refreshed if it has become stale.

One alternative to this approach might be to use the Rails.cache support
but I've decided to skip this for now as it looked a bit confusing with
the call into the translation service and it's not possible current to
cache the `display_data` object.

The caching behaviour has also been extract into `LoadingCache` which allows for more generic testing and should support using it elsewhere.