### PR TITLE
HUB-276: Pause page content change

### DIFF
--- a/app/views/paused_registration/with_user_session.html.erb
+++ b/app/views/paused_registration/with_user_session.html.erb
@@ -5,8 +5,13 @@
   <div class="column-two-thirds">
     <h1 class="heading-large"><%= t 'hub.paused_registration.with_session.heading', idp_name: @idp.display_name %></h1>
 
-    <p><%= t 'hub.paused_registration.with_session.restart_instructions_html', rp_name: @transaction[:name], rp_start_page: @transaction[:homepage] %></p>
-    <p><%= t 'hub.paused_registration.with_session.username_and_password_instructions', idp_name: @idp.display_name %></p>
+    <p><%= t 'hub.paused_registration.with_session.restart_instructions_html', idp_name: @idp.display_name, rp_name: @transaction[:name], rp_start_page: @transaction[:homepage] %></p>
+
+    <div class="actions">
+      <%= button_link_to t('hub.paused_registration.with_session.continue_verifying', idp_name: @idp.display_name), @transaction[:homepage], id: 'next-button' %>
+    </div>
+
+    <p><%= t 'hub.paused_registration.with_session.return_html', rp_name: @transaction[:name], rp_start_page: @transaction[:homepage] %></p>
 
     <%= render 'shared/logos_container' unless @idp.nil? %>
   </div>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -527,9 +527,17 @@ cy:
     paused_registration:
       with_session:
         title: Dilysu Wedi'i Oedi
-        heading: "Mae %{idp_name} wedi arbed eich gwybodaeth"
-        restart_instructions_html: "Pan rydych yn barod i barhau i ddilysu pwy ydych chi, ewch yn ôl i <a href=\"%{rp_start_page}\">%{rp_name}</a>."
-        username_and_password_instructions: Byddwch angen yr enw defnyddiwr a chyfrinair y gwnaethoch eu creu i fewngofnodi i %{idp_name}.
+        heading: "Your %{idp_name} identity account has been saved"
+        restart_instructions_html: |
+          <p>To return you can:</p>
+          <ul class="list list-bullet">
+            <li>go back to <a href=\"%{rp_start_page}\">%{rp_name}</a>.</li>
+            <li>check for an email from %{idp_name}</li>
+            <li>bookmark this page</li>
+            </ul>
+          <p>You'll need the email or username and password you used to create an account with %{idp_name}.</p>
+        continue_verifying: 'Continue verifying with %{idp_name}'
+        return_html: 'Or return to <a href=\"%{rp_start_page}\">%{rp_name}</a>.'
       without_session:
         title: Dilysu Wedi'i Oedi
         heading: Mae eich cwmni ardystiedig wedi arbed eich gwybodaeth.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -520,9 +520,17 @@ en:
     paused_registration:
       with_session:
         title: Verification Paused
-        heading: "%{idp_name} has saved your information"
-        restart_instructions_html: "When you're ready to carry on verifying your identity, go back to <a href=\"%{rp_start_page}\">%{rp_name}</a>."
-        username_and_password_instructions: You'll need the username and password you created to sign in to %{idp_name}.
+        heading: "Your %{idp_name} identity account has been saved"
+        restart_instructions_html: |
+          <p>To return you can:</p>
+          <ul class="list list-bullet">
+            <li>go back to <a href=\"%{rp_start_page}\">%{rp_name}</a>.</li>
+            <li>check for an email from %{idp_name}</li>
+            <li>bookmark this page</li>
+            </ul>
+          <p>You'll need the email or username and password you used to create an account with %{idp_name}.</p>
+        continue_verifying: 'Continue verifying with %{idp_name}'
+        return_html: 'Or return to <a href=\"%{rp_start_page}\">%{rp_name}</a>.'
       without_session:
         title: Verification Paused
         heading: The certified company has saved your information


### PR DESCRIPTION
Changed the old pause page with_user_session with updated content, to streamline
the user experience a bit and make the call to action a little clearer.
Essentially added a styled button that currently sends the user back to their RP,
this will be changed shortly but that is another story (HUB-264), as well as changing
the wording of the other content.