### PR TITLE
BAU: Fix for translations being on a separate thread

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -9,8 +9,11 @@ Rails.application.configure do
   # since you don't have to restart the web server when you make code changes.
   config.cache_classes = false
 
-  # Do not eager load code on boot.
-  config.eager_load = false
+  # Eager load code on boot. This eager loads most of Rails and
+  # your application in memory, allowing both threaded web servers
+  # and those relying on copy on write to perform better.
+  # Rake tasks automatically ignore this option for performance.
+  config.eager_load = true
 
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true


### PR DESCRIPTION
In dev env the eager_load is set to false which causes the
app the hang when it looses the reference to the TransactionTranslationResponse class. This is a quick fix.