### PR TITLE
BAU: Ensure we know what the working directory is in startup.sh

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+
+cd "$(dirname "$0")"
+
 ./kill-service.sh
 
 if [ "$1" == '--stub-api' ]


### PR DESCRIPTION
startup.sh relies on relative paths. Ensure that we know what the current
working directory is.