### PR TITLE
EID-795: Switch to using the new selected_provider session var

### DIFF
--- a/app/controllers/authn_response_controller.rb
+++ b/app/controllers/authn_response_controller.rb
@@ -47,7 +47,7 @@ private
 
   def handle_idp_response(status, response)
     analytics_reporters(status, response)
-    set_journey_status(session[:selected_idp], status)
+    set_journey_status(session[:selected_provider], status)
     redirect_to idp_redirects(status, response)
   end
 

--- a/app/controllers/partials/user_session_partial_controller.rb
+++ b/app/controllers/partials/user_session_partial_controller.rb
@@ -26,7 +26,6 @@ module UserSessionPartialController
   def current_selected_provider_data
     selected_provider_data = SelectedProviderData.from_session(session[:selected_provider])
     raise(Errors::WarningLevelError, 'No selected identity provider data in session') if selected_provider_data.nil?
-
     selected_provider_data
   end
 
@@ -40,13 +39,15 @@ module UserSessionPartialController
   end
 
   def selected_identity_provider
-    raise(Errors::WarningLevelError, 'No selected IDP in session') if user_journey_type != JourneyType::VERIFY
-    IdentityProvider.from_session(current_selected_provider_data.identity_provider)
+    selected_provider_data = current_selected_provider_data
+    raise(Errors::WarningLevelError, 'No selected IDP in session') unless selected_provider_data.is_selected_verify_idp?
+    IdentityProvider.from_session(selected_provider_data.identity_provider)
   end
 
   def selected_country
-    raise(Errors::WarningLevelError, 'No selected Country in session') if user_journey_type != JourneyType::EIDAS
-    Country.from_session(current_selected_provider_data.identity_provider)
+    selected_provider_data = current_selected_provider_data
+    raise(Errors::WarningLevelError, 'No selected Country in session') unless selected_provider_data.is_selected_country?
+    Country.from_session(selected_provider_data.identity_provider)
   end
 
   def store_selected_idp_for_session(selected_idp)

--- a/app/controllers/partials/user_session_partial_controller.rb
+++ b/app/controllers/partials/user_session_partial_controller.rb
@@ -40,32 +40,20 @@ module UserSessionPartialController
   end
 
   def selected_identity_provider
-    selected_idp = session[:selected_idp]
-    raise(Errors::WarningLevelError, 'No selected IDP in session') if selected_idp.nil?
-
-    IdentityProvider.from_session(selected_idp)
+    raise(Errors::WarningLevelError, 'No selected IDP in session') if user_journey_type != JourneyType::VERIFY
+    IdentityProvider.from_session(current_selected_provider_data.identity_provider)
   end
 
   def selected_country
-    selected_country = session[:selected_country]
-    raise(Errors::WarningLevelError, 'No selected Country in session') if selected_country.nil?
-
-    Country.from_session(selected_country)
+    raise(Errors::WarningLevelError, 'No selected Country in session') if user_journey_type != JourneyType::EIDAS
+    Country.from_session(current_selected_provider_data.identity_provider)
   end
 
   def store_selected_idp_for_session(selected_idp)
     session[:selected_provider] = SelectedProviderData.new(JourneyType::VERIFY, selected_idp)
-
-    # TODO: Remove after the first release for EID-885
-    session.delete(:selected_country)
-    session[:selected_idp] = selected_idp
   end
 
   def store_selected_country_for_session(selected_country)
     session[:selected_provider] = SelectedProviderData.new(JourneyType::EIDAS, selected_country)
-
-    # TODO: Remove after the first release for EID-885
-    session.delete(:selected_idp)
-    session[:selected_country] = selected_country
   end
 end

--- a/app/controllers/paused_registration_controller.rb
+++ b/app/controllers/paused_registration_controller.rb
@@ -19,6 +19,6 @@ class PausedRegistrationController < ApplicationController
 private
 
   def session_is_valid
-    session_validator.validate(cookies, session).ok? && session.key?(:selected_idp)
+    session_validator.validate(cookies, session).ok? && session.key?(:selected_provider) && !selected_identity_provider.nil?
   end
 end

--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -19,6 +19,6 @@ class Country
 
   def self.from_session(object)
     return object if object.is_a? Country
-    new(object) if object.is_a?(Hash) || (object.is_a?(SelectedProviderData) && object.journey_type == JourneyType::EIDAS)
+    new(object) if object.is_a?(Hash) || (object.is_a?(SelectedProviderData) && object.is_selected_country?)
   end
 end

--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -19,6 +19,6 @@ class Country
 
   def self.from_session(object)
     return object if object.is_a? Country
-    new(object) if object.is_a? Hash
+    new(object) if object.is_a?(Hash) || (object.is_a?(SelectedProviderData) && object.journey_type == JourneyType::EIDAS)
   end
 end

--- a/app/models/identity_provider.rb
+++ b/app/models/identity_provider.rb
@@ -28,7 +28,7 @@ class IdentityProvider
 
   def self.from_session(object)
     return object if object.is_a? IdentityProvider
-    if object.is_a? Hash
+    if object.is_a?(Hash) || (object.is_a?(SelectedProviderData) && object.journey_type == JourneyType::VERIFY)
       new('simpleId' => object['simple_id'], 'entityId' => object['entity_id'], 'levelsOfAssurance' => object['levels_of_assurance'])
     end
   end

--- a/app/models/identity_provider.rb
+++ b/app/models/identity_provider.rb
@@ -28,7 +28,7 @@ class IdentityProvider
 
   def self.from_session(object)
     return object if object.is_a? IdentityProvider
-    if object.is_a?(Hash) || (object.is_a?(SelectedProviderData) && object.journey_type == JourneyType::VERIFY)
+    if object.is_a?(Hash) || (object.is_a?(SelectedProviderData) && object.is_selected_verify_idp?)
       new('simpleId' => object['simple_id'], 'entityId' => object['entity_id'], 'levelsOfAssurance' => object['levels_of_assurance'])
     end
   end

--- a/app/models/selected_provider_data.rb
+++ b/app/models/selected_provider_data.rb
@@ -1,7 +1,17 @@
-SelectedProviderData = Struct.new(
-  :journey_type,
-  :identity_provider
-) do
+class SelectedProviderData < SimpleDelegator
+  attr_reader :journey_type
+  attr_reader :identity_provider
+
+  def initialize(journey_type, identity_provider)
+    super(identity_provider)
+
+    @journey_type = journey_type
+    @identity_provider = identity_provider
+  end
+
+  def as_json(options = nil)
+    { journey_type: @journey_type.as_json(options), identity_provider: @identity_provider.as_json(options) }
+  end
 
   def self.from_session(object)
     return object if object.is_a? SelectedProviderData

--- a/app/models/selected_provider_data.rb
+++ b/app/models/selected_provider_data.rb
@@ -9,6 +9,14 @@ class SelectedProviderData < SimpleDelegator
     @identity_provider = identity_provider
   end
 
+  def is_selected_country?
+    @journey_type == JourneyType::EIDAS
+  end
+
+  def is_selected_verify_idp?
+    @journey_type == JourneyType::VERIFY
+  end
+
   def as_json(options = nil)
     { journey_type: @journey_type.as_json(options), identity_provider: @identity_provider.as_json(options) }
   end

--- a/spec/controller_helper.rb
+++ b/spec/controller_helper.rb
@@ -10,3 +10,11 @@ def set_session_and_cookies_with_loa(loa_requested, transaction_simple_id = 'tes
   cookies[CookieNames::SESSION_COOKIE_NAME] = 'my-session-cookie'
   cookies[CookieNames::SESSION_ID_COOKIE_NAME] = 'my-session-id-cookie'
 end
+
+def set_selected_idp(selected_idp)
+  session[:selected_provider] = SelectedProviderData.new(JourneyType::VERIFY, selected_idp)
+end
+
+def set_selected_country(selected_country)
+  session[:selected_provider] = SelectedProviderData.new(JourneyType::EIDAS, selected_country)
+end

--- a/spec/controllers/authn_response_controller_spec.rb
+++ b/spec/controllers/authn_response_controller_spec.rb
@@ -82,7 +82,7 @@ describe AuthnResponseController do
       set_session_and_cookies_with_loa('LEVEL_1')
       stub_piwik_request_with_rp_and_loa({}, 'LEVEL_1')
       allow(saml_proxy_api).to receive(:forward_country_authn_response).and_return(country_authn_response)
-      session[:selected_country] = selected_entity
+      set_selected_country(selected_entity)
     end
 
     subject(:cookie_after_request) do
@@ -116,7 +116,7 @@ describe AuthnResponseController do
     }
     before(:each) do
       allow(saml_proxy_api).to receive(:idp_authn_response).and_return(idp_authn_response)
-      session[:selected_idp] = selected_entity
+      set_selected_idp(selected_entity)
     end
 
     include_examples 'tracking cookie'

--- a/spec/controllers/cancelled_registration_loa1_controller_spec.rb
+++ b/spec/controllers/cancelled_registration_loa1_controller_spec.rb
@@ -6,7 +6,7 @@ describe CancelledRegistrationLoa1Controller do
   subject { get :index, params: { locale: 'en' } }
 
   before :each do
-    session[:selected_idp] = { 'entity_id' => 'http://idcorp.com', 'simple_id' => 'stub-idp-one', 'levels_of_assurance' => %w(LEVEL_1 LEVEL_2) }
+    set_selected_idp('entity_id' => 'http://idcorp.com', 'simple_id' => 'stub-idp-one', 'levels_of_assurance' => %w(LEVEL_1 LEVEL_2))
   end
 
   it 'renders the cancelled registration LOA1 template when LEVEL_1 is the requested LOA' do

--- a/spec/controllers/cancelled_registration_loa2_controller_spec.rb
+++ b/spec/controllers/cancelled_registration_loa2_controller_spec.rb
@@ -6,7 +6,7 @@ describe CancelledRegistrationLoa2Controller do
   subject { get :index, params: { locale: 'en' } }
 
   before :each do
-    session[:selected_idp] = { 'entity_id' => 'http://idcorp.com', 'simple_id' => 'stub-idp-one', 'levels_of_assurance' => %w(LEVEL_1 LEVEL_2) }
+    set_selected_idp('entity_id' => 'http://idcorp.com', 'simple_id' => 'stub-idp-one', 'levels_of_assurance' => %w(LEVEL_1 LEVEL_2))
   end
 
   it 'renders the cancelled registration LOA2 template when LEVEL_2 is the requested LOA' do

--- a/spec/controllers/choose_a_certified_company_loa1_controller_spec.rb
+++ b/spec/controllers/choose_a_certified_company_loa1_controller_spec.rb
@@ -64,7 +64,7 @@ describe ChooseACertifiedCompanyLoa1Controller do
     it 'sets selected IDP in user session' do
       post :select_idp, params: { locale: 'en', entity_id: 'http://idcorp-loa1.com' }
 
-      expect(session[:selected_idp].entity_id).to eql('http://idcorp-loa1.com')
+      expect(session[:selected_provider].entity_id).to eql('http://idcorp-loa1.com')
     end
 
     it 'checks whether IDP was recommended' do

--- a/spec/controllers/choose_a_certified_company_loa2_controller_spec.rb
+++ b/spec/controllers/choose_a_certified_company_loa2_controller_spec.rb
@@ -65,7 +65,7 @@ describe ChooseACertifiedCompanyLoa2Controller do
     it 'sets selected IDP in user session' do
       post :select_idp, params: { locale: 'en', entity_id: 'http://idcorp.com' }
 
-      expect(session[:selected_idp].entity_id).to eql('http://idcorp.com')
+      expect(session[:selected_provider].entity_id).to eql('http://idcorp.com')
     end
 
     it 'checks whether IDP was recommended' do

--- a/spec/controllers/confirmation_loa1_controller_spec.rb
+++ b/spec/controllers/confirmation_loa1_controller_spec.rb
@@ -8,7 +8,7 @@ describe ConfirmationLoa1Controller do
 
   context 'user has selected an idp' do
     before(:each) do
-      session[:selected_idp] = { 'entity_id' => 'http://idcorp.com', 'simple_id' => 'stub-idp-one', 'levels_of_assurance' => %w(LEVEL_1 LEVEL_2) }
+      set_selected_idp('entity_id' => 'http://idcorp.com', 'simple_id' => 'stub-idp-one', 'levels_of_assurance' => %w(LEVEL_1 LEVEL_2))
     end
 
     it 'renders the confirmation LOA1 template when LEVEL_1 is the requested LOA' do

--- a/spec/controllers/confirmation_loa2_controller_spec.rb
+++ b/spec/controllers/confirmation_loa2_controller_spec.rb
@@ -8,7 +8,7 @@ describe ConfirmationLoa2Controller do
 
   context 'user has selected an idp' do
     before(:each) do
-      session[:selected_idp] = { 'entity_id' => 'http://idcorp.com', 'simple_id' => 'stub-idp-one', 'levels_of_assurance' => %w(LEVEL_1 LEVEL_2) }
+      set_selected_idp('entity_id' => 'http://idcorp.com', 'simple_id' => 'stub-idp-one', 'levels_of_assurance' => %w(LEVEL_1 LEVEL_2))
     end
 
     it 'renders the confirmation LOA2 template when LEVEL_2 is the requested LOA' do

--- a/spec/controllers/failed_registration_loa1_controller_spec.rb
+++ b/spec/controllers/failed_registration_loa1_controller_spec.rb
@@ -8,7 +8,7 @@ describe FailedRegistrationLoa1Controller do
   A_NON_CONTINUE_ON_FAILED_REGISTRATION_RP = 'test-rp'.freeze
 
   before(:each) do
-    session[:selected_idp] = { 'entity_id' => 'http://idcorp.com', 'simple_id' => 'stub-idp-one', 'levels_of_assurance' => %w(LEVEL_1 LEVEL_2) }
+    set_selected_idp('entity_id' => 'http://idcorp.com', 'simple_id' => 'stub-idp-one', 'levels_of_assurance' => %w(LEVEL_1 LEVEL_2))
     session[:selected_idp_was_recommended] = false
   end
 

--- a/spec/controllers/failed_registration_loa2_controller_spec.rb
+++ b/spec/controllers/failed_registration_loa2_controller_spec.rb
@@ -10,7 +10,7 @@ describe FailedRegistrationLoa2Controller do
 
 
   before(:each) do
-    session[:selected_idp] = { 'entity_id' => 'http://idcorp.com', 'simple_id' => 'stub-idp-one', 'levels_of_assurance' => %w(LEVEL_1 LEVEL_2) }
+    set_selected_idp('entity_id' => 'http://idcorp.com', 'simple_id' => 'stub-idp-one', 'levels_of_assurance' => %w(LEVEL_1 LEVEL_2))
     session[:selected_idp_was_recommended] = true
   end
 

--- a/spec/controllers/paused_registration_controller_spec.rb
+++ b/spec/controllers/paused_registration_controller_spec.rb
@@ -5,7 +5,7 @@ require 'api_test_helper'
 
 describe PausedRegistrationController do
   before(:each) do
-    session[:selected_idp] = { 'entity_id' => 'http://idcorp.com', 'simple_id' => 'stub-idp-one', 'levels_of_assurance' => %w(LEVEL_1 LEVEL_2) }
+    set_selected_idp('entity_id' => 'http://idcorp.com', 'simple_id' => 'stub-idp-one', 'levels_of_assurance' => %w(LEVEL_1 LEVEL_2))
     set_session_and_cookies_with_loa('LEVEL_2', 'test-rp')
   end
 
@@ -16,7 +16,7 @@ describe PausedRegistrationController do
   end
 
   it 'should render paused registration without session page when there is no idp selected' do
-    session.delete(:selected_idp)
+    session.delete(:selected_provider)
 
     expect(subject).to render_template(:without_user_session)
   end

--- a/spec/controllers/redirect_to_idp_controller_spec.rb
+++ b/spec/controllers/redirect_to_idp_controller_spec.rb
@@ -26,7 +26,7 @@ describe RedirectToIdpController do
       idp_was_recommended = '(recommended)'
       evidence = { driving_licence: true, passport: true }
 
-      session[:selected_idp] = bobs_identity_service
+      set_selected_idp bobs_identity_service
       session[:selected_idp_name] = bobs_identity_service_idp_name
       session[:selected_idp_names] = [bobs_identity_service_idp_name]
       session[:selected_answers] = { 'documents' => evidence }
@@ -50,7 +50,7 @@ describe RedirectToIdpController do
       idp_was_recommended = '(idp recommendation key not set)'
       evidence = { driving_licence: true, passport: true }
 
-      session[:selected_idp] = bobs_identity_service
+      set_selected_idp bobs_identity_service
       session[:selected_idp_name] = bobs_identity_service_idp_name
       session[:selected_idp_names] = [bobs_identity_service_idp_name]
       session[:selected_answers] = { 'documents' => evidence }
@@ -86,7 +86,7 @@ describe RedirectToIdpController do
       it 'reports idp registration attempt details to piwik' do
         bobs_identity_service_idp_name = "Bob’s Identity Service"
 
-        session[:selected_idp] = bobs_identity_service
+        set_selected_idp bobs_identity_service
         session[:selected_idp_name] = bobs_identity_service_idp_name
         session[:user_segments] = ['test-segment']
         session[:transaction_simple_id] = 'test-rp'
@@ -109,7 +109,7 @@ describe RedirectToIdpController do
       it 'reports idp second attempt details to piwik' do
         bobs_identity_service_idp_name = "Bob’s Identity Service"
 
-        session[:selected_idp] = bobs_identity_service
+        set_selected_idp bobs_identity_service
         session[:selected_idp_name] = bobs_identity_service_idp_name
         session[:user_segments] = ['test-segment']
         session[:transaction_simple_id] = 'test-rp'
@@ -141,7 +141,7 @@ describe RedirectToIdpController do
         stub_session_idp_authn_request('<PRINCIPAL IP ADDRESS COULD NOT BE DETERMINED>', 'idp-location', false)
         stub_request(:get, INTERNAL_PIWIK.url).with(query: hash_including({}))
 
-        session[:selected_idp] = bobs_identity_service
+        set_selected_idp bobs_identity_service
         session[:selected_idp_name] = bobs_identity_service_idp_name
       end
 
@@ -222,7 +222,7 @@ describe RedirectToIdpController do
         stub_session_idp_authn_request('<PRINCIPAL IP ADDRESS COULD NOT BE DETERMINED>', 'idp-location', false)
         stub_request(:get, INTERNAL_PIWIK.url).with(query: hash_including({}))
 
-        session[:selected_idp] = bobs_identity_service
+        set_selected_idp bobs_identity_service
         session[:selected_idp_name] = bobs_identity_service_idp_name
       end
 

--- a/spec/controllers/redirect_to_idp_question_loa1_controller_spec.rb
+++ b/spec/controllers/redirect_to_idp_question_loa1_controller_spec.rb
@@ -10,7 +10,7 @@ describe RedirectToIdpQuestionLoa1Controller do
 
   before(:each) do
     set_session_and_cookies_with_loa('LEVEL_1')
-    session[:selected_idp] = { 'entity_id' => 'http://example.com/stub-idp-one-doc-question', 'simple_id' => 'stub-idp-one-doc-question', 'levels_of_assurance' => %w(LEVEL_1 LEVEL_2) }
+    set_selected_idp('entity_id' => 'http://example.com/stub-idp-one-doc-question', 'simple_id' => 'stub-idp-one-doc-question', 'levels_of_assurance' => %w(LEVEL_1 LEVEL_2))
     session[:selected_idp_was_recommended] = true
   end
 

--- a/spec/controllers/redirect_to_idp_question_loa2_controller_spec.rb
+++ b/spec/controllers/redirect_to_idp_question_loa2_controller_spec.rb
@@ -10,7 +10,7 @@ describe RedirectToIdpQuestionLoa2Controller do
 
   before(:each) do
     set_session_and_cookies_with_loa('LEVEL_1')
-    session[:selected_idp] = { 'entity_id' => 'http://example.com/stub-idp-one-doc-question', 'simple_id' => 'stub-idp-one-doc-question', 'levels_of_assurance' => %w(LEVEL_1 LEVEL_2) }
+    set_selected_idp('entity_id' => 'http://example.com/stub-idp-one-doc-question', 'simple_id' => 'stub-idp-one-doc-question', 'levels_of_assurance' => %w(LEVEL_1 LEVEL_2))
     session[:selected_idp_was_recommended] = true
   end
 

--- a/spec/controllers/redirect_to_idp_warning_controller_spec.rb
+++ b/spec/controllers/redirect_to_idp_warning_controller_spec.rb
@@ -15,15 +15,17 @@ describe RedirectToIdpWarningController do
     subject { get :index, params: { locale: 'en' } }
 
     it 'warning page when idp selected' do
-      session[:selected_idp] = { 'simple_id' => 'stub-idp-two',
-                                 'entity_id' => 'http://idcorp.com',
-                                 'levels_of_assurance' => %w(LEVEL_1 LEVEL_2) }
+      set_selected_idp(
+        'simple_id' => 'stub-idp-two',
+        'entity_id' => 'http://idcorp.com',
+        'levels_of_assurance' => %w(LEVEL_1 LEVEL_2)
+      )
 
       expect(subject).to render_template(:redirect_to_idp_warning)
     end
 
     it 'error page when no idp selected' do
-      session[:selected_idp] = {}
+      session[:selected_provider] = {}
 
       expect(subject).to render_template('errors/something_went_wrong')
     end
@@ -41,7 +43,7 @@ describe RedirectToIdpWarningController do
     subject { post :continue, params: { locale: 'en' } }
 
     it 'redirects to idp website' do
-      session[:selected_idp] = bobs_identity_service
+      set_selected_idp bobs_identity_service
 
       expect(subject).to redirect_to redirect_to_idp_register_path
     end

--- a/spec/controllers/sign_in_controller_spec.rb
+++ b/spec/controllers/sign_in_controller_spec.rb
@@ -35,7 +35,7 @@ describe SignInController do
       stub_piwik_request('action_name' => 'Sign In - IDCorp')
 
       post :select_idp, params: { locale: 'en', 'entity_id' => 'http://idcorp.com' }
-      expect(session[:selected_idp].simple_id).to eq('stub-idp-one')
+      expect(session[:selected_provider].simple_id).to eq('stub-idp-one')
       expect(subject).to redirect_to(redirect_to_idp_sign_in_path)
     end
 

--- a/spec/controllers/single_idp_journey_controller_spec.rb
+++ b/spec/controllers/single_idp_journey_controller_spec.rb
@@ -231,7 +231,7 @@ describe SingleIdpJourneyController do
       stub_api_select_idp
       stub_request(:get, INTERNAL_PIWIK.url).with(query: hash_including({}))
 
-      session[:selected_idp] = valid_idp
+      set_selected_idp(valid_idp)
       post :continue, params: { locale: 'en', entity_id: VALID_STUB_IDP }
 
       expect(subject).to redirect_to redirect_to_single_idp_path

--- a/spec/feature_helper.rb
+++ b/spec/feature_helper.rb
@@ -104,6 +104,18 @@ module FeatureHelper
     )
   end
 
+  def set_selected_idp_in_session(selected_idp)
+    page.set_rack_session(
+      selected_provider: SelectedProviderData.new(JourneyType::VERIFY, selected_idp)
+    )
+  end
+
+  def set_selected_country_in_session(selected_country)
+    page.set_rack_session(
+      selected_provider: SelectedProviderData.new(JourneyType::EIDAS, selected_country)
+    )
+  end
+
   def set_session_cookies!
     cookie_hash = create_cookie_hash
     set_cookies!(create_cookie_hash)

--- a/spec/features/user_sends_authn_response_spec.rb
+++ b/spec/features/user_sends_authn_response_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe 'User returns from an IDP with an AuthnResponse' do
     session[:verify_session_id]
   end
   let(:stub_session) {
+    set_selected_idp_in_session(entity_id: 'http://idcorp.com', simple_id: 'stub-idp-one')
     page.set_rack_session(
-      selected_idp: { entity_id: 'http://idcorp.com', simple_id: 'stub-idp-one' },
       selected_idp_was_recommended: true,
       transaction_simple_id: 'test-rp',
       transaction_homepage: 'www.example.com'
@@ -48,10 +48,8 @@ RSpec.describe 'User returns from an IDP with an AuthnResponse' do
   end
 
   it 'will redirect the user to /cancelled-registration when they cancel at the IDP' do
-    page.set_rack_session(
-      selected_idp: { entity_id: 'http://idcorp.com', simple_id: 'stub-idp-one' },
-      transaction_simple_id: 'test-rp'
-    )
+    set_selected_idp_in_session(entity_id: 'http://idcorp.com', simple_id: 'stub-idp-one')
+    page.set_rack_session transaction_simple_id: 'test-rp'
     api_request = stub_api_authn_response(session_id, 'result' => 'CANCEL', 'isRegistration' => true, 'loaAchieved' => nil)
     visit("/test-saml?session-id=#{session_id}")
     click_button 'saml-response-post'
@@ -61,10 +59,8 @@ RSpec.describe 'User returns from an IDP with an AuthnResponse' do
   end
 
   it 'will redirect the user to /failed-registration when they failed registration at the IDP' do
-    page.set_rack_session(
-      selected_idp: { entity_id: 'http://idcorp.com', simple_id: 'stub-idp-one' },
-      transaction_simple_id: 'test-rp'
-    )
+    set_selected_idp_in_session(entity_id: 'http://idcorp.com', simple_id: 'stub-idp-one')
+    page.set_rack_session transaction_simple_id: 'test-rp'
     api_request = stub_api_authn_response(session_id, 'result' => 'OTHER', 'isRegistration' => true, 'loaAchieved' => nil)
     visit("/test-saml?session-id=#{session_id}")
     click_button 'saml-response-post'
@@ -75,9 +71,7 @@ RSpec.describe 'User returns from an IDP with an AuthnResponse' do
 
   it 'will redirect the user to /failed-sign-in when they failed sign in at the IDP' do
     api_request = stub_api_authn_response(session_id, 'result' => 'OTHER', 'isRegistration' => false, 'loaAchieved' => nil)
-    page.set_rack_session(
-      selected_idp: { entity_id: 'http://idcorp.com', simple_id: 'stub-idp-one' }
-    )
+    set_selected_idp_in_session(entity_id: 'http://idcorp.com', simple_id: 'stub-idp-one')
 
     stub_request(:get, INTERNAL_PIWIK.url).with(query: hash_including({}))
     visit("/test-saml?session-id=#{session_id}")
@@ -105,9 +99,7 @@ RSpec.describe 'User returns from an IDP with an AuthnResponse' do
 
   it 'will redirect the user to /paused-registration on pending response' do
     stub_session
-    page.set_rack_session(
-      selected_idp: { entity_id: 'http://idcorp.com', simple_id: 'stub-idp-one' }
-    )
+    set_selected_idp_in_session(entity_id: 'http://idcorp.com', simple_id: 'stub-idp-one')
     stub_request(:get, INTERNAL_PIWIK.url).with(query: hash_including)
     stub_api_request = stub_api_authn_response(session_id, 'result' => 'PENDING', 'isRegistration' => true)
 

--- a/spec/features/user_visits_cancelled_registration_page_spec.rb
+++ b/spec/features/user_visits_cancelled_registration_page_spec.rb
@@ -5,10 +5,8 @@ require 'piwik_test_helper'
 RSpec.describe 'When user visits cancelled registration page' do
   before :each do
     set_session_and_session_cookies!
-    page.set_rack_session(
-      selected_idp: { entity_id: 'http://idcorp.com', simple_id: 'stub-idp-one' },
-      transaction_simple_id: 'test-rp'
-    )
+    page.set_rack_session transaction_simple_id: 'test-rp'
+    set_selected_idp_in_session(entity_id: 'http://idcorp.com', simple_id: 'stub-idp-one')
   end
 
   it 'the page is rendered with the correct links for LOA2 journey' do

--- a/spec/features/user_visits_confirm_your_identity_page_spec.rb
+++ b/spec/features/user_visits_confirm_your_identity_page_spec.rb
@@ -152,10 +152,10 @@ RSpec.describe 'When the user visits the confirm-your-identity page' do
 
     it 'will preserve the language from redirect-to-idp-warning' do
       page.set_rack_session(
-        selected_idp: { entity_id: 'http://idcorp.com', simple_id: 'stub-idp-one' },
         selected_idp_was_recommended: true,
         selected_answers: { phone: { mobile_phone: true, smart_phone: true }, documents: { passport: true } },
       )
+      set_selected_idp_in_session(entity_id: 'http://idcorp.com', simple_id: 'stub-idp-one')
       set_up_session('stub-idp-one')
 
       visit '/redirect-to-idp-warning'

--- a/spec/features/user_visits_confirmation_page_spec.rb
+++ b/spec/features/user_visits_confirmation_page_spec.rb
@@ -4,10 +4,10 @@ require 'api_test_helper'
 RSpec.describe 'When user visits the confirmation page' do
   before(:each) do
     page.set_rack_session(
-      selected_idp: { entity_id: 'http://idcorp.com', simple_id: 'stub-idp-one' },
       selected_idp_was_recommended: true,
       transaction_simple_id: 'test-rp'
     )
+    set_selected_idp_in_session(entity_id: 'http://idcorp.com', simple_id: 'stub-idp-one')
     set_session_and_session_cookies!
     stub_api_idp_list_for_loa
   end

--- a/spec/features/user_visits_failed_registration_page_spec.rb
+++ b/spec/features/user_visits_failed_registration_page_spec.rb
@@ -9,9 +9,7 @@ RSpec.describe 'When the user visits the failed registration page and' do
   before(:each) do
     set_session_and_session_cookies!
     stub_api_idp_list_for_loa
-    page.set_rack_session(
-      selected_idp: { entity_id: 'http://idcorp.com', simple_id: 'stub-idp-one' }
-    )
+    set_selected_idp_in_session(entity_id: 'http://idcorp.com', simple_id: 'stub-idp-one')
   end
 
   context 'relying party is allowed to continue on fail then page rendered' do

--- a/spec/features/user_visits_failed_sign_in_page_spec.rb
+++ b/spec/features/user_visits_failed_sign_in_page_spec.rb
@@ -4,25 +4,28 @@ require 'api_test_helper'
 RSpec.describe 'When the user visits the failed sign in page' do
   before(:each) do
     set_session_and_session_cookies!
-    stub_api_idp_list_for_loa
-    page.set_rack_session(
-      selected_idp: { entity_id: 'http://idcorp.com', simple_id: 'stub-idp-one' }
-    )
   end
 
-  it 'includes expected content' do
-    visit '/failed-sign-in'
+  context '#idp' do
+    before(:each) do
+      stub_api_idp_list_for_loa
+      set_selected_idp_in_session(entity_id: 'http://idcorp.com', simple_id: 'stub-idp-one')
+    end
 
-    expect_feedback_source_to_be(page, 'FAILED_SIGN_IN_PAGE', '/failed-sign-in')
-    expect(page).to have_title t('hub.failed_sign_in.title')
-    expect(page).to have_content t('hub.failed_sign_in.heading', display_name: 'IDCorp')
-    expect(page.body).to include t('hub.failed_sign_in.reasons_html')
-    expect(page).to have_link t('hub.failed_sign_in.start_again'), href: start_path
-  end
+    it 'includes expected content' do
+      visit '/failed-sign-in'
 
-  it 'displays the content in Welsh' do
-    visit '/mewngofnodi-wedi-methu'
+      expect_feedback_source_to_be(page, 'FAILED_SIGN_IN_PAGE', '/failed-sign-in')
+      expect(page).to have_title t('hub.failed_sign_in.title')
+      expect(page).to have_content t('hub.failed_sign_in.heading', display_name: 'IDCorp')
+      expect(page.body).to include t('hub.failed_sign_in.reasons_html')
+      expect(page).to have_link t('hub.failed_sign_in.start_again'), href: start_path
+    end
 
-    expect(page).to have_css 'html[lang=cy]'
+    it 'displays the content in Welsh' do
+      visit '/mewngofnodi-wedi-methu'
+
+      expect(page).to have_css 'html[lang=cy]'
+    end
   end
 end

--- a/spec/features/user_visits_redirect_to_idp_page_spec.rb
+++ b/spec/features/user_visits_redirect_to_idp_page_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe 'When the user visits the redirect to IDP page' do
   let(:selected_answers) { { phone: { mobile_phone: true, smart_phone: false }, documents: { passport: true } } }
   let(:idp_entity_id) { 'http://idcorp.com' }
   let(:given_a_session_with_a_hints_enabled_idp) {
+    set_selected_idp_in_session(entity_id: idp_entity_id, simple_id: 'stub-idp-one')
     page.set_rack_session(
-      selected_idp: { entity_id: idp_entity_id, simple_id: 'stub-idp-one' },
       selected_idp_name: "Demo IDP",
       selected_idp_names: ["IDP 1", "IDP 2"],
       selected_idp_was_recommended: true,
@@ -16,8 +16,8 @@ RSpec.describe 'When the user visits the redirect to IDP page' do
     )
   }
   let(:given_a_session_with_a_hints_disabled_idp) {
+    set_selected_idp_in_session(entity_id: idp_entity_id, simple_id: 'stub-idp-two')
     page.set_rack_session(
-      selected_idp: { entity_id: idp_entity_id, simple_id: 'stub-idp-two' },
       selected_idp_name: "Demo IDP",
       selected_idp_names: ["IDP 1", "IDP 2"],
       selected_idp_was_recommended: true,

--- a/spec/features/user_visits_redirect_to_idp_question_page_spec.rb
+++ b/spec/features/user_visits_redirect_to_idp_question_page_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe 'When the user visits the redirect to IDP question page' do
   let(:originating_ip) { '<PRINCIPAL IP ADDRESS COULD NOT BE DETERMINED>' }
   let(:idp_location) { '/test-idp-request-endpoint' }
   let(:given_an_idp_with_interstitial_question_needed) {
+    set_selected_idp_in_session(entity_id: 'stub-idp-one-doc-question', simple_id: 'stub-idp-one-doc-question')
     page.set_rack_session(
-      selected_idp: { entity_id: 'stub-idp-one-doc-question', simple_id: 'stub-idp-one-doc-question' },
       selected_idp_was_recommended: true,
       selected_answers: selected_answers,
     )

--- a/spec/features/user_visits_redirect_to_idp_warning_page_spec.rb
+++ b/spec/features/user_visits_redirect_to_idp_warning_page_spec.rb
@@ -9,43 +9,43 @@ RSpec.describe 'When the user visits the redirect to IDP warning page' do
   let(:selected_answers) { { 'phone' => { 'mobile_phone' => true, 'smart_phone' => true }, 'documents' => { 'passport' => true } } }
   let(:idp_entity_id) { 'http://idcorp.com' }
   let(:given_an_idp_with_no_display_data) {
+    set_selected_idp_in_session(entity_id: idp_entity_id, simple_id: 'stub-idp-x')
     page.set_rack_session(
-      selected_idp: { entity_id: idp_entity_id, simple_id: 'stub-idp-x' },
       selected_idp_was_recommended: true,
       selected_answers: selected_answers,
     )
   }
   let(:given_a_session_with_document_answers) {
+    set_selected_idp_in_session(entity_id: idp_entity_id, simple_id: 'stub-idp-one')
     page.set_rack_session(
-      selected_idp: { entity_id: idp_entity_id, simple_id: 'stub-idp-one' },
       selected_idp_was_recommended: true,
       selected_answers: selected_answers,
     )
   }
   let(:given_a_session_with_a_hints_disabled_idp) {
+    set_selected_idp_in_session(entity_id: idp_entity_id, simple_id: 'stub-idp-two')
     page.set_rack_session(
-      selected_idp: { entity_id: idp_entity_id, simple_id: 'stub-idp-two' },
       selected_idp_was_recommended: true,
       selected_answers: selected_answers,
     )
   }
   let(:given_a_session_with_non_recommended_idp) {
+    set_selected_idp_in_session(entity_id: idp_entity_id, simple_id: 'stub-idp-one')
     page.set_rack_session(
-      selected_idp: { entity_id: idp_entity_id, simple_id: 'stub-idp-one' },
       selected_idp_was_recommended: false,
       selected_answers: selected_answers,
     )
   }
   let(:given_a_session_with_no_document_answers) {
+    set_selected_idp_in_session(entity_id: 'http://idpnodocs.com', simple_id: 'stub-idp-no-docs')
     page.set_rack_session(
-      selected_idp: { entity_id: 'http://idpnodocs.com', simple_id: 'stub-idp-no-docs' },
       selected_idp_was_recommended: true,
       selected_answers: { phone: { mobile_phone: true, smart_phone: true }, documents: {} },
     )
   }
   let(:given_a_session_with_non_uk_id_document_answers) {
+    set_selected_idp_in_session(entity_id: 'http://idpwithnonukid.com', simple_id: 'stub-idp-four')
     page.set_rack_session(
-      selected_idp: { entity_id: 'http://idpwithnonukid.com', simple_id: 'stub-idp-four' },
       selected_idp_was_recommended: true,
       selected_answers: { phone: { mobile_phone: true, smart_phone: true }, documents: { non_uk_id_document: true } },
     )

--- a/spec/features/user_visits_select_phone_page_spec.rb
+++ b/spec/features/user_visits_select_phone_page_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe 'When the user visits the select phone page' do
     }
   }
   let(:given_a_session_with_document_evidence) {
+    set_selected_idp_in_session(entity_id: 'http://idcorp.com', simple_id: 'stub-idp-one')
     page.set_rack_session(
-      selected_idp: { entity_id: 'http://idcorp.com', simple_id: 'stub-idp-one' },
       selected_idp_was_recommended: true,
       selected_answers: selected_answers,
     )

--- a/spec/features/user_visits_sign_in_page_spec.rb
+++ b/spec/features/user_visits_sign_in_page_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe 'user selects an IDP on the sign in page' do
       and_piwik_was_sent_a_signin_event
       and_the_language_hint_is_set
       and_the_hints_are_not_set
-      expect(page.get_rack_session_key('selected_idp')).to include('entity_id' => idp_entity_id, 'simple_id' => 'stub-idp-one', 'levels_of_assurance' => %w(LEVEL_2))
+      expect(page.get_rack_session_key('selected_provider')['identity_provider']).to include('entity_id' => idp_entity_id, 'simple_id' => 'stub-idp-one', 'levels_of_assurance' => %w(LEVEL_2))
     end
 
     it 'will redirect the user to the about page of the registration journey and update the Piwik Custom Variables' do
@@ -165,7 +165,7 @@ RSpec.describe 'user selects an IDP on the sign in page' do
         and_piwik_was_sent_a_signin_hint_followed_event
         and_the_language_hint_is_set
         and_the_hints_are_not_set
-        expect(page.get_rack_session_key('selected_idp')).to include('entity_id' => idp_entity_id, 'simple_id' => 'stub-idp-one', 'levels_of_assurance' => %w(LEVEL_2))
+        expect(page.get_rack_session_key('selected_provider')['identity_provider']).to include('entity_id' => idp_entity_id, 'simple_id' => 'stub-idp-one', 'levels_of_assurance' => %w(LEVEL_2))
       end
     end
 
@@ -191,7 +191,7 @@ RSpec.describe 'user selects an IDP on the sign in page' do
         and_piwik_was_sent_a_signin_hint_ignored_event
         and_the_language_hint_is_set
         and_the_hints_are_not_set
-        expect(page.get_rack_session_key('selected_idp')).to include('entity_id' => idp_entity_id, 'simple_id' => 'stub-idp-one', 'levels_of_assurance' => %w(LEVEL_2))
+        expect(page.get_rack_session_key('selected_provider')['identity_provider']).to include('entity_id' => idp_entity_id, 'simple_id' => 'stub-idp-one', 'levels_of_assurance' => %w(LEVEL_2))
       end
     end
   end

--- a/spec/features/user_visits_the_choose_a_certified_company_about_idp_page_spec.rb
+++ b/spec/features/user_visits_the_choose_a_certified_company_about_idp_page_spec.rb
@@ -15,8 +15,8 @@ RSpec.feature 'user visits the choose a certified company about idp page', type:
     }
   }
   let(:given_a_session_with_selected_answers) {
+    set_selected_idp_in_session(entity_id: 'http://idcorp.com', simple_id: 'stub-idp-one')
     page.set_rack_session(
-      selected_idp: { entity_id: 'http://idcorp.com', simple_id: 'stub-idp-one' },
       selected_idp_was_recommended: true,
       selected_answers: selected_answers,
     )
@@ -29,7 +29,7 @@ RSpec.feature 'user visits the choose a certified company about idp page', type:
     expect(page).to have_content('ID Corp is the premier identity proofing service around.')
     click_button t('hub.choose_a_certified_company.choose_idp', display_name: t('idps.stub-idp-one.name'))
     expect(page).to have_current_path(redirect_to_idp_warning_path)
-    expect(page.get_rack_session_key('selected_idp')).to include('entity_id' => entity_id, 'simple_id' => 'stub-idp-one', 'levels_of_assurance' => %w(LEVEL_1 LEVEL_2))
+    expect(page.get_rack_session_key('selected_provider')['identity_provider']).to include('entity_id' => entity_id, 'simple_id' => 'stub-idp-one', 'levels_of_assurance' => %w(LEVEL_1 LEVEL_2))
     expect(page.get_rack_session_key('selected_idp_was_recommended')).to eql true
   end
 

--- a/spec/support/redirect_to_idp_question_examples.rb
+++ b/spec/support/redirect_to_idp_question_examples.rb
@@ -3,7 +3,7 @@ require 'piwik_test_helper'
 shared_examples 'redirect_to_idp_question' do |test_context, form_answer_description, form_variables, redirect_path|
   before(:each) do
     set_session_and_cookies_with_loa('LEVEL_1')
-    session[:selected_idp] = { 'entity_id' => 'http://example.com/stub-idp-one-doc-question', 'simple_id' => 'stub-idp-one-doc-question', 'levels_of_assurance' => %w(LEVEL_1 LEVEL_2) }
+    set_selected_idp('entity_id' => 'http://example.com/stub-idp-one-doc-question', 'simple_id' => 'stub-idp-one-doc-question', 'levels_of_assurance' => %w(LEVEL_1 LEVEL_2))
     session[:selected_idp_was_recommended] = true
     stub_piwik_request
   end

--- a/spec/support/will_it_work_for_me_examples.rb
+++ b/spec/support/will_it_work_for_me_examples.rb
@@ -3,7 +3,7 @@ require 'piwik_test_helper'
 shared_examples 'will_it_work_for_me' do |test_context, form_answer_description, form_variables, redirect_path|
   before(:each) do
     set_session_and_cookies_with_loa('LEVEL_1')
-    session[:selected_idp] = { 'entity_id' => 'http://idcorp.com', 'simple_id' => 'stub-idp-one', 'levels_of_assurance' => %w(LEVEL_1 LEVEL_2) }
+    set_selected_idp('entity_id' => 'http://idcorp.com', 'simple_id' => 'stub-idp-one', 'levels_of_assurance' => %w(LEVEL_1 LEVEL_2))
     session[:selected_idp_was_recommended] = true
   end
 


### PR DESCRIPTION
- Deleted the previously used `selected_idp` and `selected_country`
- Made the new `SelectedProviderData` object delegate to `identity_provider`, meaning that the new object can be used in virtually the same way in most cases and fewer code changes are required. The `identity_provider` attribute can either be an `IdentityProvider` or a `Country` - the new var will morph to act like the object it's initialised with
- Allow tests to set and read the new variable