### PR TITLE
Improvement to rp display repository

### DIFF
--- a/app/models/display/rp_display_repository.rb
+++ b/app/models/display/rp_display_repository.rb
@@ -14,7 +14,10 @@ module Display
   private
 
     def find_or_create(simple_id)
-      @store[simple_id] ||= create_display_data(simple_id)
+      @store.compute_if_absent(simple_id) do
+        create_display_data(simple_id)
+      end
+      @store[simple_id]
     end
 
     def create_display_data(simple_id)

--- a/app/models/display/rp_display_repository.rb
+++ b/app/models/display/rp_display_repository.rb
@@ -8,32 +8,27 @@ module Display
     end
 
     def get_translations(transaction_simple_id)
-      find_or_create(transaction_simple_id).fetch!
+      find_or_create(transaction_simple_id).fetch do
+        create_display_data(transaction_simple_id)
+      end
     end
 
   private
 
     def find_or_create(simple_id)
       @store.compute_if_absent(simple_id) do
-        create_display_data(simple_id)
+        LoadingCache.new
       end
       @store[simple_id]
     end
 
     def create_display_data(simple_id)
-      display_data = Display::RpDisplayData.new(simple_id, @translator)
-      LoadingCache.new(display_data, translation_refresh_proc)
-    end
-
-    def translation_refresh_proc
-      @display_data_refresh_proc ||= ->(display_data) {
-        begin
-          RP_TRANSLATION_SERVICE.update_rp_translations(display_data.simple_id)
-        rescue StandardError => e
-          @logger.error(e)
-        end
-        display_data.tap(&:validate_content!)
-      }
+      begin
+        RP_TRANSLATION_SERVICE.update_rp_translations(simple_id)
+      rescue StandardError => e
+        @logger.error(e)
+      end
+      Display::RpDisplayData.new(simple_id, @translator).tap(&:validate_content!)
     end
   end
 end

--- a/lib/loading_cache.rb
+++ b/lib/loading_cache.rb
@@ -3,14 +3,13 @@ require 'date'
 
 class LoadingCache
   include Concurrent::Async
-  def initialize(object, refresh_proc)
+  def initialize
     @last_updated = :never
-    @object = object
-    @refresh_proc = refresh_proc
+    @cached_object = nil
   end
 
-  def fetch!
-    result = self.await.fetch_object!
+  def fetch(&blk)
+    result = self.await.fetch_object(&blk)
     if(result.fulfilled?)
       return result.value
     else
@@ -18,17 +17,17 @@ class LoadingCache
     end
   end
 
-  def fetch_object!
+  def fetch_object(&blk)
     if need_to_refresh?
-      refresh!
+      refresh(&blk)
     end
-    @object
+    @cached_object
   end
 
 private
 
-  def refresh!
-    @object = @refresh_proc.call(@object)
+  def refresh
+    @cached_object = yield
     @last_updated = DateTime.now
   end
 

--- a/spec/lib/loading_cache_spec.rb
+++ b/spec/lib/loading_cache_spec.rb
@@ -3,42 +3,31 @@ require 'loading_cache'
 
 RSpec.describe LoadingCache, type: :lib do
   it 'should call refresh_proc when accessing object from cache for first time' do
-    object = double(:object)
-    refresh_proc = double(:refresh_proc)
-    cache = LoadingCache.new(object, refresh_proc)
+    cache = LoadingCache.new
     refreshed_object = double(:refreshed_object)
-    expect(refresh_proc).to receive(:call).with(object).and_return(refreshed_object)
-    expect(cache.fetch!).to eql refreshed_object
+    expect(cache.fetch { refreshed_object }).to eql refreshed_object
   end
 
   it 'should not update a translations when translations were recently cached' do
-    object = double(:object)
-    refresh_proc = double(:refresh_proc)
-    cache = LoadingCache.new(object, refresh_proc)
+    cache = LoadingCache.new
     refreshed_object = double(:refreshed_object)
-    expect(refresh_proc).to receive(:call).with(object).and_return(refreshed_object).once
-    expect(cache.fetch!).to eql refreshed_object
-    expect(cache.fetch!).to eql refreshed_object
+    expect(cache.fetch { refreshed_object }).to eql refreshed_object
+    expect(cache.fetch { :something_else }).to eql refreshed_object
   end
 
   it 'should propogate refresh errors if they occur' do
     error = StandardError.new("Bad Display Data")
-    object = double(:object)
-    refresh_proc = double(:refresh_proc)
-    expect(refresh_proc).to receive(:call).and_raise(error)
-    cache = LoadingCache.new(object, refresh_proc)
-    expect { cache.fetch! }.to raise_error error
+    cache = LoadingCache.new
+    expect { cache.fetch { raise error } }.to raise_error error
   end
 
   it 'should refresh translations upstream when past lifetime' do
     expect(DateTime).to receive(:now).and_return(31.minutes.ago, 15.minutes.ago, DateTime.now, DateTime.now)
-    object = double(:object)
-    refresh_proc = double(:refresh_proc)
-    cache = LoadingCache.new(object, refresh_proc)
-    refreshed_object = double(:refreshed_object)
-    expect(refresh_proc).to receive(:call).and_return(object, refreshed_object).twice
-    expect(cache.fetch!).to eql object
-    expect(cache.fetch!).to eql object
-    expect(cache.fetch!).to eql refreshed_object
+    first_refeshed_object = double(:first_refeshed_object)
+    second_refeshed_object = double(:second_refeshed_object)
+    cache = LoadingCache.new
+    expect(cache.fetch { first_refeshed_object }).to eql first_refeshed_object
+    expect(cache.fetch { second_refeshed_object }).to eql first_refeshed_object
+    expect(cache.fetch { second_refeshed_object }).to eql second_refeshed_object
   end
 end


### PR DESCRIPTION
It's currently possible that two requests to the frotend could try to write into the repository's store at the same time when a value hasn't been set. This change introduces blocking calls to prevent two writes from happening the override  one another.

The `LoadingCache` was being passed an object at creation that could then be used to replace itself when a refesh event happenend. This was a little awkward so I've changed the interface to loading cache so that the way to refresh is passed to #fetch as a block. This is similar to how `Hash#fetch` works.