### PR TITLE
HUB-278: Update journey hint cookie to support P&R

### DIFF
--- a/app/controllers/authn_response_controller.rb
+++ b/app/controllers/authn_response_controller.rb
@@ -47,7 +47,7 @@ private
 
   def handle_idp_response(status, response)
     analytics_reporters(status, response)
-    set_journey_status(session[:selected_provider], status)
+    set_journey_status(status)
     redirect_to idp_redirects(status, response)
   end
 
@@ -60,8 +60,8 @@ private
     report_user_outcome_to_piwik(status)
   end
 
-  def set_journey_status(session_entity, status)
-    selected_entity = session_entity.try(:fetch, 'entity_id', nil)
+  def set_journey_status(status)
+    selected_entity = session[:selected_provider].try(:fetch, 'entity_id', nil)
     set_journey_hint_by_status(selected_entity, status)
   end
 

--- a/app/controllers/confirm_your_identity_controller.rb
+++ b/app/controllers/confirm_your_identity_controller.rb
@@ -6,18 +6,16 @@ class ConfirmYourIdentityController < ApplicationController
   include JourneyHintingPartialController
 
   def index
-    journey_hint = journey_hint_value
+    journey_hint_entity_id = attempted_entity_id
 
-    if journey_hint.nil?
+    if journey_hint_entity_id.nil?
       cookie_error('missing verify-front-journey-hint')
     else
-      entity_id = journey_hint['entity_id']
-
       @transaction_name = current_transaction.name
-      @identity_providers = entity_id.nil? ? [] : retrieve_decorated_singleton_idp_array_by_entity_id(current_identity_providers_for_loa, entity_id)
+      @identity_providers = journey_hint_entity_id.nil? ? [] : retrieve_decorated_singleton_idp_array_by_entity_id(current_identity_providers_for_loa, journey_hint_entity_id)
 
       if @identity_providers.empty?
-        cookie_error("invalid verify-front-journey-hint entity-id #{entity_id}")
+        cookie_error("invalid verify-front-journey-hint entity-id #{journey_hint_entity_id}")
       end
     end
   end

--- a/app/controllers/hint_controller.rb
+++ b/app/controllers/hint_controller.rb
@@ -9,7 +9,7 @@ class HintController < ApplicationController
   def ajax_request
     set_headers
 
-    entity_id = entity_id_of_journey_hint
+    entity_id = attempted_entity_id
 
     json_object = { 'status': 'OK', 'value': !entity_id.nil? }
 

--- a/app/controllers/partials/idp_selection_partial_controller.rb
+++ b/app/controllers/partials/idp_selection_partial_controller.rb
@@ -4,11 +4,11 @@ module IdpSelectionPartialController
   include JourneyHintingPartialController
 
   def set_journey_hint_followed(entity_id)
-    session[:user_followed_journey_hint] = user_followed_journey_hint(entity_id, 'SUCCESS') if has_journey_hint?
+    session[:user_followed_journey_hint] = user_followed_journey_hint(entity_id) if has_journey_hint?
   end
 
   def has_journey_hint?
-    !entity_id_of_journey_hint_for('SUCCESS').nil?
+    !success_entity_id.nil?
   end
 
   def ajax_idp_redirection_sign_in_request(entity_id)

--- a/app/controllers/partials/journey_hinting_partial_controller.rb
+++ b/app/controllers/partials/journey_hinting_partial_controller.rb
@@ -6,18 +6,21 @@ module JourneyHintingPartialController
     nil
   end
 
-  def entity_id_of_journey_hint
-    journey_hint = journey_hint_value
-    journey_hint.nil? ? nil : journey_hint['entity_id']
+  def attempted_entity_id
+    journey_hint_value.nil? ? nil : journey_hint_value['ATTEMPT']
   end
 
-  def entity_id_of_journey_hint_for(status)
-    journey_hint = journey_hint_value
-    journey_hint.nil? ? nil : journey_hint[status]
+  def success_entity_id
+    journey_hint_value.nil? ? nil : journey_hint_value['SUCCESS']
   end
 
-  def user_followed_journey_hint(entity_id_followed_by_user, status)
-    hinted_id = entity_id_of_journey_hint_for(status)
+  def last_status
+    journey_hint = journey_hint_value
+    journey_hint.nil? ? nil : journey_hint['STATE']
+  end
+
+  def user_followed_journey_hint(entity_id_followed_by_user)
+    hinted_id = success_entity_id
     !hinted_id.nil? && hinted_id == entity_id_followed_by_user
   end
 

--- a/app/controllers/partials/user_cookies_partial_controller.rb
+++ b/app/controllers/partials/user_cookies_partial_controller.rb
@@ -19,9 +19,8 @@ module UserCookiesPartialController
     }
   end
 
-  def set_journey_hint(idp_entity_id)
+  def set_attempt_journey_hint(idp_entity_id)
     journey_hint_value_hash = journey_hint_value || {}
-    journey_hint_value_hash['entity_id'] = idp_entity_id
     journey_hint_value_hash['ATTEMPT'] = idp_entity_id
 
     cookies.encrypted[CookieNames::VERIFY_FRONT_JOURNEY_HINT] = { value: journey_hint_value_hash.to_json,
@@ -31,7 +30,11 @@ module UserCookiesPartialController
   def set_journey_hint_by_status(idp_entity_id, status)
     return if idp_entity_id.nil?
     journey_hint_by_status_value = journey_hint_value || {}
-    journey_hint_by_status_value[status] = idp_entity_id
+    journey_hint_by_status_value = eat_journey_hint_cookie(journey_hint_by_status_value) unless journey_hint_by_status_value.empty?
+    journey_hint_by_status_value['SUCCESS'] = idp_entity_id if status == 'SUCCESS'
+    journey_hint_by_status_value['STATE'] = { IDP: idp_entity_id,
+                                              RP: session[:transaction_entity_id],
+                                              STATUS: status }
 
     cookies.encrypted[CookieNames::VERIFY_FRONT_JOURNEY_HINT] = { value: journey_hint_by_status_value.to_json, expires: 18.months.from_now }
   end
@@ -49,5 +52,16 @@ private
     MultiJson.load(cookies.encrypted[CookieNames::VERIFY_FRONT_JOURNEY_HINT])
   rescue MultiJson::ParseError
     nil
+  end
+
+  # Clean up users' existing cookies, remove in March 2020
+  def eat_journey_hint_cookie(cookie)
+    yummy_cookie = cookie
+
+    bad_crumbs = %w(CANCEL FAILED FAILED_UPLIFT PENDING OTHER entity_id)
+
+    bad_crumbs.each { |old_status| yummy_cookie.delete(old_status) }
+
+    yummy_cookie
   end
 end

--- a/app/controllers/redirect_to_idp_warning_controller.rb
+++ b/app/controllers/redirect_to_idp_warning_controller.rb
@@ -41,7 +41,7 @@ private
   def select_registration(idp)
     POLICY_PROXY.select_idp(session['verify_session_id'], idp.entity_id, session['requested_loa'], true)
     set_journey_hint_followed(idp.entity_id)
-    set_journey_hint(idp.entity_id)
+    set_attempt_journey_hint(idp.entity_id)
     register_idp_selections(idp.display_name)
   end
 

--- a/app/controllers/sign_in_controller.rb
+++ b/app/controllers/sign_in_controller.rb
@@ -6,7 +6,7 @@ class SignInController < ApplicationController
   include ViewableIdpPartialController
 
   def index
-    entity_id = entity_id_of_journey_hint_for('SUCCESS')
+    entity_id = success_entity_id
     @suggested_idp = entity_id.nil? ? [] : retrieve_decorated_singleton_idp_array_by_entity_id(current_identity_providers_for_sign_in, entity_id)
     unless @suggested_idp.empty?
       FEDERATION_REPORTER.report_sign_in_journey_hint_shown(current_transaction, request, @suggested_idp[0].display_name)
@@ -40,7 +40,7 @@ private
 
   def sign_in(entity_id, idp_name)
     POLICY_PROXY.select_idp(session[:verify_session_id], entity_id, session['requested_loa'])
-    set_journey_hint(entity_id)
+    set_attempt_journey_hint(entity_id)
     session[:selected_idp_name] = idp_name
   end
 

--- a/app/controllers/single_idp_journey_controller.rb
+++ b/app/controllers/single_idp_journey_controller.rb
@@ -106,7 +106,7 @@ private
 
   def select_idp(entity_id, idp_name)
     POLICY_PROXY.select_idp(session[:verify_session_id], entity_id, session['requested_loa'])
-    set_journey_hint(entity_id)
+    set_attempt_journey_hint(entity_id)
     session[:selected_idp_name] = idp_name
   end
 end

--- a/app/controllers/test_journey_hint_cookie_controller.rb
+++ b/app/controllers/test_journey_hint_cookie_controller.rb
@@ -10,7 +10,7 @@ class TestJourneyHintCookieController < ApplicationController
 
   def set_cookie
     if params['status'].blank?
-      set_journey_hint(params['entity-id'])
+      set_attempt_journey_hint(params['entity-id'])
     else
       set_journey_hint_by_status(params['entity-id'], params['status'])
     end

--- a/app/views/static/cookies.en.html.erb
+++ b/app/views/static/cookies.en.html.erb
@@ -51,7 +51,7 @@ end %>
     </tr>
     <tr>
       <td><var>verify-front-journey-hint</var></td>
-      <td>This identifies the certified company last used to access a government service with this browser on this device. We use this cookie to make it easier for you to sign in again with that certified company</td>
+      <td>This identifies the certified company last used to access a government service with this browser on this device. It can also identify the government service you were using. We use this cookie to make it easier for you to sign in again.</td>
       <td>18 months</td>
     </tr>
     <tr>

--- a/spec/controllers/authn_response_controller_spec.rb
+++ b/spec/controllers/authn_response_controller_spec.rb
@@ -123,13 +123,21 @@ describe AuthnResponseController do
 
     context 'receiving OTHER status' do
       let(:status) { 'OTHER' }
-      let(:cookie_with_failed_status) { { FAILED: 'http://idcorp.com' }.to_json }
+      let(:cookie_with_failed_status) {
+        { STATE: { IDP: 'http://idcorp.com',
+                   RP: 'http://www.test-rp.gov.uk/SAML2/MD',
+                   STATUS: 'FAILED' } }.to_json
+      }
       it { should eq cookie_with_failed_status }
     end
 
     context 'receiving PENDING status' do
       let(:status) { 'PENDING' }
-      let(:cookie_with_pending_status) { { PENDING: 'http://idcorp.com' }.to_json }
+      let(:cookie_with_pending_status) {
+        { STATE: { IDP: 'http://idcorp.com',
+                   RP: 'http://www.test-rp.gov.uk/SAML2/MD',
+                   STATUS: 'PENDING' } }.to_json
+      }
       it { should eq cookie_with_pending_status }
     end
   end

--- a/spec/controllers/hint_controller_spec.rb
+++ b/spec/controllers/hint_controller_spec.rb
@@ -9,7 +9,7 @@ describe HintController do
   context 'user has a journey hint present' do
     it 'json object should return true' do
       cookies.encrypted[CookieNames::VERIFY_FRONT_JOURNEY_HINT] = {
-        'entity_id' => 'http://idcorp.com',
+        'ATTEMPT' => 'http://idcorp.com',
       }.to_json
 
       body = JSON.parse(subject.body)
@@ -20,7 +20,7 @@ describe HintController do
 
     it 'json object should return true even if the value is not set' do
       cookies.encrypted[CookieNames::VERIFY_FRONT_JOURNEY_HINT] = {
-        'entity_id' => '',
+        'ATTEMPT' => '',
       }.to_json
 
       body = JSON.parse(subject.body)


### PR DESCRIPTION
Changed the cookie structure to log RP as well and only keep the latest state.
Added a temporary piece of code to clean existing cookies in users browsers.
Kept the ATTEMPT and SUCCESS states in to stay backwards compatible and
also make sure we know if there ever was a success.