### PR TITLE
BAU: Fix wrong html encoding

### DIFF
--- a/app/views/paused_registration/without_user_session.html.erb
+++ b/app/views/paused_registration/without_user_session.html.erb
@@ -5,7 +5,7 @@
   <div class="column-two-thirds">
     <h1 class="heading-large"><%= t 'hub.paused_registration.without_session.heading' %></h1>
 
-    <p><%= t 'hub.paused_registration.without_session.restart_instructions' %></p>
+    <p><%= t 'hub.paused_registration.without_session.restart_instructions_html' %></p>
 
     <h2 class="heading-medium"><%= t 'hub.transaction_list.title' %></h2>
     <%= render partial: 'shared/transaction_list' %>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -543,7 +543,7 @@ cy:
       without_session:
         title: Dilysu Wedi'i Oedi
         heading: Mae eich cwmni ardystiedig wedi arbed eich gwybodaeth.
-        restart_instructions: |
+        restart_instructions_html: |
           <p>To return you can:</p>
           <ul class="list list-bullet">
             <li>go back to the service you were using</li>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -537,7 +537,7 @@ en:
       without_session:
         title: Verification Paused
         heading: The certified company has saved your information
-        restart_instructions: |
+        restart_instructions_html: |
           <p>To return you can:</p>
           <ul class="list list-bullet">
             <li>go back to the service you were using</li>


### PR DESCRIPTION
The paused page for users without a session has a bug and
renders the encoded HTML as it's missing '_html' in name.