### PR TITLE
HUB-174: Show hub resume page to paused users

### DIFF
--- a/.env
+++ b/.env
@@ -33,4 +33,5 @@ SAML_PROXY_HOST=http://localhost:50220
 VERIFY_PRODUCT_PAGE=https://govuk-verify.cloudapps.digital/
 
 SINGLE_IDP_FEATURE=true
+PAUSE_AND_RESUME_FEATURE=true
 

--- a/.env.test
+++ b/.env.test
@@ -7,3 +7,4 @@ PUBLIC_PIWIK_HOST=http://localhost:4242/piwik.php
 INTERNAL_PIWIK_HOST=http://localhost:4242/piwik.php
 PIWIK_SITE_ID=5
 SINGLE_IDP_FEATURE=true
+PAUSE_AND_RESUME_FEATURE=true

--- a/app/controllers/authn_request_controller.rb
+++ b/app/controllers/authn_request_controller.rb
@@ -1,6 +1,8 @@
 require 'ab_test/ab_test'
+require 'partials/journey_hinting_partial_controller'
 
 class AuthnRequestController < SamlController
+  include JourneyHintingPartialController
   protect_from_forgery except: :rp_request
   skip_before_action :validate_session
   skip_before_action :set_piwik_custom_variables
@@ -67,6 +69,8 @@ private
   def redirect_for_journey_hint(hint)
     if !cookies.encrypted[CookieNames::VERIFY_SINGLE_IDP_JOURNEY].nil? && SINGLE_IDP_FEATURE
       redirect_to continue_to_your_idp_path
+    elsif PAUSE_AND_RESUME_FEATURE && is_last_status?('PENDING') && hint != 'submission_confirmation'
+      redirect_to resume_registration_path
     else
       case hint
       when 'uk_idp_start'

--- a/app/controllers/partials/journey_hinting_partial_controller.rb
+++ b/app/controllers/partials/journey_hinting_partial_controller.rb
@@ -19,6 +19,16 @@ module JourneyHintingPartialController
     journey_hint.nil? ? nil : journey_hint['STATE']
   end
 
+  def is_last_status?(status)
+    last_status_value = last_status
+    !last_status_value.nil? && last_status_value['STATUS'] == status
+  end
+
+  def last_idp
+    last_status_value = last_status
+    last_status_value.nil? ? nil : last_status_value.fetch('IDP', nil)
+  end
+
   def user_followed_journey_hint(entity_id_followed_by_user)
     hinted_id = success_entity_id
     !hinted_id.nil? && hinted_id == entity_id_followed_by_user

--- a/app/controllers/paused_registration_controller.rb
+++ b/app/controllers/paused_registration_controller.rb
@@ -1,18 +1,34 @@
+require 'partials/user_cookies_partial_controller'
+require 'partials/journey_hinting_partial_controller'
+require 'partials/viewable_idp_partial_controller'
+
+
 class PausedRegistrationController < ApplicationController
+  include JourneyHintingPartialController
+  include ViewableIdpPartialController
+
   # Validate the session manually within the action, as we don't want the normal 'no session' page.
-  skip_before_action :validate_session
-  skip_before_action :set_piwik_custom_variables
+  skip_before_action :validate_session, except: :resume
+  skip_before_action :set_piwik_custom_variables, except: :resume
+  layout 'slides', except: :index
 
   def index
     if session_is_valid
+      set_transaction_from_session
       @idp = IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate(selected_identity_provider)
-      @transaction = {
-          name: current_transaction.rp_name,
-          homepage: current_transaction_homepage
-      }
       render :with_user_session
     else
       render :without_user_session
+    end
+  end
+
+  def resume
+    set_transaction_from_session
+    @idp = get_idp_from_cookie
+    if @idp.nil?
+      redirect_to start_path
+    else
+      render :resume_with_idp
     end
   end
 
@@ -20,5 +36,19 @@ private
 
   def session_is_valid
     session_validator.validate(cookies, session).ok? && session.key?(:selected_provider) && !selected_identity_provider.nil?
+  end
+
+  def get_idp_from_cookie
+    last_idp_value = last_idp
+    unless last_idp_value.nil?
+      return retrieve_decorated_singleton_idp_array_by_entity_id(current_identity_providers_for_sign_in, last_idp_value)[0]
+    end
+  end
+
+  def set_transaction_from_session
+    @transaction = {
+        name: current_transaction.rp_name,
+        homepage: current_transaction_homepage
+    }
   end
 end

--- a/app/controllers/test_journey_hint_cookie_controller.rb
+++ b/app/controllers/test_journey_hint_cookie_controller.rb
@@ -1,10 +1,13 @@
+require 'partials/journey_hinting_partial_controller'
 class TestJourneyHintCookieController < ApplicationController
   skip_before_action :validate_session
   skip_before_action :set_piwik_custom_variables
   skip_after_action :store_locale_in_cookie
+  include JourneyHintingPartialController
   layout 'test'
 
   def index
+    @current_cookie = journey_hint_value.as_json
     render 'index'
   end
 

--- a/app/models/feedback_source_mapper.rb
+++ b/app/models/feedback_source_mapper.rb
@@ -46,7 +46,8 @@ class FeedbackSourceMapper
       'PROOF_OF_ADDRESS' => 'select_proof_of_address',
       'CONFIRMING_IT_IS_YOU_PAGE' => 'confirming_it_is_you',
       'PROVE_IDENTITY_PAGE' => 'prove_identity',
-      'CONTINUE_TO_YOUR_IDP_PAGE' => 'continue_to_your_idp'
+      'CONTINUE_TO_YOUR_IDP_PAGE' => 'continue_to_your_idp',
+      'RESUME_PAGE' => 'resume_registration'
   }.freeze
   end
 

--- a/app/views/paused_registration/resume_with_idp.html.erb
+++ b/app/views/paused_registration/resume_with_idp.html.erb
@@ -1,0 +1,29 @@
+<%= page_title 'hub.paused_registration.resume.title' %>
+<% content_for :body_classes, 'hub-start' %>
+<% content_for :feedback_source, 'RESUME_PAGE' %>
+
+<div class="grid-row js-continue-to-idp" data-location="<%= url_for(controller: 'sign_in', action: 'select_idp_ajax', locale: I18n.locale)  %>">
+  <h1 class="heading-large"><%= t 'hub.paused_registration.resume.heading', display_name: @idp.display_name, rp_name: @transaction[:name] %></h1>
+
+  <%= t 'hub.paused_registration.resume.intro', display_name: @idp.display_name, rp_name: @transaction[:name] %>
+
+  <div class="actions">
+    <%= form_tag('', class: 'js-idp-form') do %>
+      <%= hidden_field_tag 'entity_id', @idp.entity_id, id: nil, class: 'js-entity-id' %>
+      <%= button_tag t('hub.paused_registration.resume.continue', display_name: @idp.display_name),
+                     class: 'button',
+                     id: 'continue-to-idp-button',
+                     type: 'submit'
+      %>
+    <% end %>
+    <br>
+    <%= t('hub.paused_registration.resume.alternatives') %>
+    <ul class="list-bullet list small-details">
+      <li><%= link_to t('hub.paused_registration.resume.alternative_new_identity'), begin_registration_path %></li>
+      <li><%= link_to t('hub.paused_registration.resume.alternative_start'), begin_sign_in_path %></li>
+      <li><%= link_to t('hub.paused_registration.resume.alternative_other_ways', rp_name: @transaction[:name]), other_ways_to_access_service_path %></li>
+    </ul>
+  </div>
+
+  <%= render partial: 'shared/continue_to_idp_form' %>
+</div>

--- a/app/views/test_journey_hint_cookie/index.html.erb
+++ b/app/views/test_journey_hint_cookie/index.html.erb
@@ -1,3 +1,4 @@
+Current value: <%= @current_cookie %>
 <%= form_tag(test_journey_hint_path) do -%>
   <%= text_field_tag('entity-id') %>
   <%= text_field_tag('locale') %>

--- a/config/initializers/00_configuration.rb
+++ b/config/initializers/00_configuration.rb
@@ -40,4 +40,5 @@ CONFIG = Configuration.load! do
   option_bool 'feedback_disabled', 'FEEDBACK_DISABLED', default: false
   # Feature flags
   option_bool 'single_idp_feature', 'SINGLE_IDP_FEATURE', default: false
+  option_bool 'pause_and_resume_feature', 'PAUSE_AND_RESUME_FEATURE', default: false
 end

--- a/config/initializers/30_federation.rb
+++ b/config/initializers/30_federation.rb
@@ -66,4 +66,5 @@ Rails.application.config.after_initialize do
   IDP_FEATURE_FLAGS_CHECKER = IdpConfiguration::IdpFeatureFlagsLoader.new(YamlLoader.new)
                                  .load(CONFIG.rules_directory, %i[send_hints send_language_hint show_interstitial_question show_interstitial_question_loa1])
   SINGLE_IDP_FEATURE = CONFIG.single_idp_feature
+  PAUSE_AND_RESUME_FEATURE = CONFIG.pause_and_resume_feature
 end

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -56,6 +56,7 @@ cy:
     select_proof_of_address: tystiolaeth-o'ch-cyfeiriad
     confirming_it_is_you: cadarnhau-mai-chi-ydyw
     paused_registration: wedi-oedi
+    resume_registration: ail-ddechrau-cofrestru
   title:
     error: Error
   navigation:
@@ -544,13 +545,22 @@ cy:
         title: Dilysu Wedi'i Oedi
         heading: Mae eich cwmni ardystiedig wedi arbed eich gwybodaeth.
         restart_instructions_html: |
-          <p>To return you can:</p>
+          <p>I ddychwelyd gallwch:</p>
           <ul class="list list-bullet">
-            <li>go back to the service you were using</li>
-            <li>check for an email from the identity provider you chose</li>
-            <li>bookmark this page</li>
+            <li>ewch nôl i'r gwasanaeth oeddech yn ei ddefnyddio</li>
+            <li>gwiriwch am e-bost gan y darparwr hunaniaeth a ddewiswyd gennych</li>
+            <li>rhowch nod tudalen yma</li>
           </ul>
-          <p>You'll need the email or username and password you used to create an account.</p>
+          <p>Bydd angen yr e-bost neu'r enw defnyddiwr a'r cyfrinair a ddefnyddiwyd gennych i greu cyfrif.</p>
+      resume:
+        title: "Parhau i ddilysu gyda %{display_name}"
+        heading: "Parhau i ddilysu gyda %{display_name}"
+        intro: "Bydd angen i chi orffen gwirio'ch hunaniaeth gyda %{display_name} i %{rp_name}"
+        continue: "Parhewch gyda %{display_name}"
+        alternatives: "Os nid chi oedd hyn, gallwch:"
+        alternative_new_identity: "creu cyfrif hunaniaeth newydd"
+        alternative_start: "mewngofnodi gyda chwmni ardystiedig arall"
+        alternative_other_ways: "gwelwch ffyrdd eraill i %{rp_name}"
     single_idp_journey:
       title: Continue with %{display_name}
       heading: Prove your identity with %{display_name}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -56,6 +56,7 @@ en:
     select_proof_of_address: select-proof-of-address
     confirming_it_is_you: confirming-it-is-you
     paused_registration: paused
+    resume_registration: resume-registration
   title:
     error: Error
   navigation:
@@ -530,7 +531,7 @@ en:
             <li>go back to <a href=\"%{rp_start_page}\">%{rp_name}</a>.</li>
             <li>check for an email from %{idp_name}</li>
             <li>bookmark this page</li>
-            </ul>
+          </ul>
           <p>You'll need the email or username and password you used to create an account with %{idp_name}.</p>
         continue_verifying: 'Continue verifying with %{idp_name}'
         return_html: 'Or return to <a href=\"%{rp_start_page}\">%{rp_name}</a>.'
@@ -543,8 +544,17 @@ en:
             <li>go back to the service you were using</li>
             <li>check for an email from the identity provider you chose</li>
             <li>bookmark this page</li>
-            </ul>
+          </ul>
           <p>You'll need the email or username and password you used to create an account.</p>
+      resume:
+        title: "Continue verifying with %{display_name}"
+        heading: "Continue verifying with %{display_name}"
+        intro: "You'll need to finish verifying your identity with %{display_name} to %{rp_name}"
+        continue: "Continue with %{display_name}"
+        alternatives: "If this wasn't you, you can:"
+        alternative_new_identity: "create a new identity account"
+        alternative_start: "sign in with another certified company"
+        alternative_other_ways: "see other ways to %{rp_name}"
     single_idp_journey:
       title: Continue with %{display_name}
       heading: Prove your identity with %{display_name}

--- a/config/main_routes.rb
+++ b/config/main_routes.rb
@@ -94,6 +94,8 @@ post 'further_information_null_attribute', to: 'further_information#submit_null_
 get 'no_idps_available', to: 'no_idps_available#index', as: :no_idps_available
 get 'cancelled_registration', to: 'cancelled_registration#index', as: :cancelled_registration
 get 'paused_registration', to: 'paused_registration#index', as: :paused_registration
+get 'resume_registration', to: 'paused_registration#resume', as: :resume_registration
+post 'resume_registration', to: 'sign_in#select_idp'
 
 if SINGLE_IDP_FEATURE
   get 'redirect_to_single_idp', to: 'redirect_to_idp#single_idp', as: :redirect_to_single_idp

--- a/spec/controllers/authn_request_controller_spec.rb
+++ b/spec/controllers/authn_request_controller_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+require 'controller_helper'
+require 'api_test_helper'
+
+describe AuthnRequestController do
+  let(:valid_rp) { 'test-rp-no-demo' }
+  let(:valid_idp) { 'http://idcorp.com' }
+
+  before :each do
+    stub_session_creation
+  end
+
+  it 'will redirect the user to resume registration page if cookie state is PENDING' do
+    front_journey_hint_cookie = {
+        STATE: {
+            IDP: valid_idp,
+            RP: valid_rp,
+            STATUS: 'PENDING'
+        }
+    }
+
+    cookies.encrypted[CookieNames::VERIFY_FRONT_JOURNEY_HINT] = front_journey_hint_cookie.to_json
+    post :rp_request, params: { 'SAMLRequest' => 'my-saml-request', 'RelayState' => 'my-relay-state' }
+    expect(response).to redirect_to resume_registration_path
+  end
+
+  it 'will redirect the user to confirm your identity page if this is a non-repudiation even if cookie state is PENDING' do
+    front_journey_hint_cookie = {
+        STATE: {
+            IDP: valid_idp,
+            RP: valid_rp,
+            STATUS: 'PENDING'
+        }
+    }
+
+    cookies.encrypted[CookieNames::VERIFY_FRONT_JOURNEY_HINT] = front_journey_hint_cookie.to_json
+    post :rp_request, params: { 'SAMLRequest' => 'my-saml-request', 'RelayState' => 'my-relay-state', 'journey_hint' => 'submission_confirmation' }
+    expect(response).to redirect_to confirm_your_identity_path
+  end
+
+  it 'will redirect the user to default start page if cookie state is not PENDING' do
+    front_journey_hint_cookie = {
+        STATE: {
+            IDP: valid_idp,
+            RP: valid_rp,
+            STATUS: 'SUCCESS'
+        }
+    }
+
+    cookies.encrypted[CookieNames::VERIFY_FRONT_JOURNEY_HINT] = front_journey_hint_cookie.to_json
+    post :rp_request, params: { 'SAMLRequest' => 'my-saml-request', 'RelayState' => 'my-relay-state' }
+    expect(response).to redirect_to start_path
+  end
+
+  it 'will redirect the user to default start page if cookie state is missing' do
+    front_journey_hint_cookie = {
+
+    }
+
+    cookies.encrypted[CookieNames::VERIFY_FRONT_JOURNEY_HINT] = front_journey_hint_cookie.to_json
+    post :rp_request, params: { 'SAMLRequest' => 'my-saml-request', 'RelayState' => 'my-relay-state' }
+    expect(response).to redirect_to start_path
+  end
+
+  it 'will redirect the user to default start page if cookie is missing' do
+    post :rp_request, params: { 'SAMLRequest' => 'my-saml-request', 'RelayState' => 'my-relay-state' }
+    expect(response).to redirect_to start_path
+  end
+end

--- a/spec/controllers/paused_registration_controller_spec.rb
+++ b/spec/controllers/paused_registration_controller_spec.rb
@@ -4,20 +4,61 @@ require 'spec_helper'
 require 'api_test_helper'
 
 describe PausedRegistrationController do
+  let(:valid_rp) { 'test-rp-no-demo' }
+  let(:valid_idp) { 'http://idcorp.com' }
+
   before(:each) do
     set_selected_idp('entity_id' => 'http://idcorp.com', 'simple_id' => 'stub-idp-one', 'levels_of_assurance' => %w(LEVEL_1 LEVEL_2))
     set_session_and_cookies_with_loa('LEVEL_2', 'test-rp')
+    stub_api_idp_list_for_sign_in
   end
 
-  subject { get :index, params: { locale: 'en' } }
+  context 'user visits pause page' do
+    subject { get :index, params: { locale: 'en' } }
 
-  it 'renders paused registration page' do
-    expect(subject).to render_template(:with_user_session)
+    it 'renders paused registration page' do
+      expect(subject).to render_template(:with_user_session)
+    end
+
+    it 'should render paused registration without session page when there is no idp selected' do
+      session.delete(:selected_provider)
+
+      expect(subject).to render_template(:without_user_session)
+    end
   end
 
-  it 'should render paused registration without session page when there is no idp selected' do
-    session.delete(:selected_provider)
+  context 'user is redirected to resume page' do
+    subject { get :resume, params: { locale: 'en' } }
 
-    expect(subject).to render_template(:without_user_session)
+    it 'renders resume registration page if session present' do
+      front_journey_hint_cookie = {
+          STATE: {
+              IDP: valid_idp,
+              RP: valid_rp,
+              STATUS: 'PENDING'
+          }
+      }
+
+      cookies.encrypted[CookieNames::VERIFY_FRONT_JOURNEY_HINT] = front_journey_hint_cookie.to_json
+      expect(subject).to render_template(:resume_with_idp)
+    end
+
+    it 'redirects to start page when invalid/disabled IDP present in cookie' do
+      front_journey_hint_cookie = {
+          STATE: {
+              IDP: :'a-non-existent-idp-identifier',
+              RP: :valid_rp,
+              STATUS: 'PENDING'
+          }
+      }
+      cookies.encrypted[CookieNames::VERIFY_FRONT_JOURNEY_HINT] = front_journey_hint_cookie.to_json
+      expect(subject).to redirect_to start_path
+    end
+
+    it 'should render error page when user has no session' do
+      session.clear
+
+      expect(subject).to render_template(:something_went_wrong)
+    end
   end
 end

--- a/spec/features/user_visits_resume_registration_page_spec.rb
+++ b/spec/features/user_visits_resume_registration_page_spec.rb
@@ -1,0 +1,71 @@
+require 'feature_helper'
+require 'api_test_helper'
+require 'piwik_test_helper'
+
+RSpec.describe 'When the user visits the resume registration page and' do
+  let(:idp_display_name) { 'IDCorp' }
+  let(:rp_display_name) { 'Test RP' }
+  let(:originating_ip) { '<PRINCIPAL IP ADDRESS COULD NOT BE DETERMINED>' }
+  let(:idp_entity_id) { 'http://idcorp.com' }
+  let(:encrypted_entity_id) { 'an-encrypted-entity-id' }
+  let(:location) { '/test-idp-request-endpoint' }
+
+  let(:select_idp_stub_request) {
+    stub_session_select_idp_request(
+      encrypted_entity_id,
+      PolicyEndpoints::PARAM_SELECTED_ENTITY_ID => idp_entity_id, PolicyEndpoints::PARAM_PRINCIPAL_IP => originating_ip,
+      PolicyEndpoints::PARAM_REGISTRATION => false, PolicyEndpoints::PARAM_REQUESTED_LOA => 'LEVEL_2'
+    )
+  }
+
+  before(:each) do
+    set_session_and_session_cookies!
+    stub_api_idp_list_for_sign_in
+    set_selected_idp_in_session(entity_id: idp_entity_id, simple_id: 'stub-idp-one')
+    set_journey_hint_cookie(idp_entity_id, 'PENDING', 'en')
+    stub_translations
+  end
+
+  context 'and has a cookie containing a PENDING state and valid IDP identifiers' do
+    it 'displays correct text and button' do
+      visit '/resume-registration'
+
+      expect(page).to have_content t('hub.paused_registration.resume.intro', rp_name: rp_display_name, display_name: idp_display_name)
+      expect(page).to have_content t('hub.paused_registration.resume.heading', rp_name: rp_display_name, display_name: idp_display_name)
+      expect(page).to have_button t('hub.paused_registration.resume.continue', display_name: idp_display_name)
+      expect(page).to have_content t('hub.paused_registration.resume.alternative_other_ways', rp_name: rp_display_name)
+    end
+  end
+
+  context 'clicks continue to IDP with JS disabled' do
+    it 'goes to "redirect-to-idp" page on submit' do
+      visit '/resume-registration'
+      select_idp_stub_request
+      stub_session_idp_authn_request(originating_ip, location, false)
+
+      click_button t('hub.paused_registration.resume.continue', display_name: idp_display_name)
+
+      expect(page).to have_current_path(redirect_to_idp_sign_in_path)
+      expect(select_idp_stub_request).to have_been_made.once
+      expect(stub_piwik_request('action_name' => "Sign In - #{idp_display_name}")).to have_been_made.once
+    end
+  end
+
+  context 'clicks continue to IDP with JS enabled', js: true do
+    it 'will redirect the user to the IDP on Continue' do
+      visit '/resume-registration'
+      select_idp_stub_request
+      stub_session_idp_authn_request(originating_ip, location, false)
+      expect_any_instance_of(SignInController).to receive(:select_idp_ajax).and_call_original
+
+      click_button t('hub.paused_registration.resume.continue', display_name: idp_display_name)
+      expect(stub_piwik_request('action_name' => "Sign In - #{idp_display_name}")).to have_been_made.once
+      expect(page).to have_current_path(location)
+      expect(page).to have_content("SAML Request is 'a-saml-request'")
+      expect(page).to have_content("relay state is 'a-relay-state'")
+      expect(page).to have_content("registration is 'false'")
+      expect(page).to have_content("language hint was 'en'")
+      expect(select_idp_stub_request).to have_been_made.once
+    end
+  end
+end


### PR DESCRIPTION
Add resume page (similar to single IDP handover page)
Modify authn_request_controller to check cookie for pending status and redirect if present