### PR TITLE
BAU: Bugfix for journey hints not being set

### DIFF
--- a/app/controllers/authn_response_controller.rb
+++ b/app/controllers/authn_response_controller.rb
@@ -61,7 +61,7 @@ private
   end
 
   def set_journey_status(status)
-    selected_entity = session[:selected_provider].try(:fetch, 'entity_id', nil)
+    selected_entity = selected_identity_provider.entity_id
     set_journey_hint_by_status(selected_entity, status)
   end
 

--- a/spec/features/localisation_set_from_different_sources_spec.rb
+++ b/spec/features/localisation_set_from_different_sources_spec.rb
@@ -2,6 +2,13 @@ require 'feature_helper'
 require 'api_test_helper'
 
 RSpec.describe 'locale is set based on multiple sources', type: :feature do
+  let(:selected_entity) {
+    {
+      'entity_id' => 'http://idcorp.com',
+      'simple_id' => 'stub-entity-one',
+      'levels_of_assurance' => %w(LEVEL_1 LEVEL_2)
+    }
+  }
   before(:each) do
     set_session_and_session_cookies!
     stub_api_idp_list_for_loa
@@ -45,6 +52,7 @@ RSpec.describe 'locale is set based on multiple sources', type: :feature do
       it "will render the response processing page in #{locale} after SAML response when locale cookie set to #{locale}" do
         set_locale_cookie_to(locale)
         session = set_session!
+        set_selected_idp_in_session(selected_entity)
         stub_matching_outcome
         stub_api_authn_response(session[:verify_session_id])
 
@@ -86,6 +94,7 @@ RSpec.describe 'locale is set based on multiple sources', type: :feature do
 
       it "will render the response processing page in #{form_locale} after SAML Response submission when locale cookie #{locale_cookie_message} and form param set to #{form_locale}" do
         session = set_session!
+        set_selected_idp_in_session(selected_entity)
         if cookie_locale
           set_locale_cookie_to(cookie_locale)
           expect(cookie_value(CookieNames::VERIFY_LOCALE)).to have_a_signed_value_of cookie_locale

--- a/spec/support/authn_response_examples.rb
+++ b/spec/support/authn_response_examples.rb
@@ -1,9 +1,17 @@
 shared_examples 'idp_authn_response' do |journey_hint, idp_result, piwik_action, redirect_path|
   let(:saml_proxy_api) { double(:saml_proxy_api) }
+  let(:selected_entity) {
+    {
+      'entity_id' => 'https://acme.de/ServiceMetadata',
+      'simple_id' => 'DE',
+      'levels_of_assurance' => %w[LEVEL_1 LEVEL_2]
+    }
+  }
 
   before(:each) do
     stub_const('SAML_PROXY_API', saml_proxy_api)
     set_session_and_cookies_with_loa('LEVEL_1')
+    set_selected_idp(selected_entity)
   end
 
   it "should redirect to #{redirect_path} on #{idp_result}" do


### PR DESCRIPTION
We've recently changed how we store selected IDP and selected Country in session.
At the same time we changed how we set the journey hint cookie using what's in the session.
When rebasing I missed the line where we read the value and used the old
syntax accessing the object. Which was returning nil and thus no hint was set.
This is to use the helper method to read from the session. It has a side
effect when processing authn response it is now strictly required to have a selected
IDP in the session. I think that's fine as it's part of the session anyway.
I updated the tests to setting the selected IDP.