### PR TITLE
BAU: Small fixes to the resume page

### DIFF
--- a/app/controllers/paused_registration_controller.rb
+++ b/app/controllers/paused_registration_controller.rb
@@ -47,7 +47,7 @@ private
 
   def set_transaction_from_session
     @transaction = {
-        name: current_transaction.rp_name,
+        name: current_transaction.name,
         homepage: current_transaction_homepage
     }
   end

--- a/app/views/paused_registration/resume_with_idp.html.erb
+++ b/app/views/paused_registration/resume_with_idp.html.erb
@@ -3,9 +3,9 @@
 <% content_for :feedback_source, 'RESUME_PAGE' %>
 
 <div class="grid-row js-continue-to-idp" data-location="<%= url_for(controller: 'sign_in', action: 'select_idp_ajax', locale: I18n.locale)  %>">
-  <h1 class="heading-large"><%= t 'hub.paused_registration.resume.heading', display_name: @idp.display_name, rp_name: @transaction[:name] %></h1>
+  <h1 class="heading-large"><%= t 'hub.paused_registration.resume.heading', display_name: @idp.display_name %></h1>
 
-  <%= t 'hub.paused_registration.resume.intro', display_name: @idp.display_name, rp_name: @transaction[:name] %>
+  <%= t 'hub.paused_registration.resume.intro', display_name: @idp.display_name, service_name: @transaction[:name] %>
 
   <div class="actions">
     <%= form_tag('', class: 'js-idp-form') do %>
@@ -21,7 +21,7 @@
     <ul class="list-bullet list small-details">
       <li><%= link_to t('hub.paused_registration.resume.alternative_new_identity'), begin_registration_path %></li>
       <li><%= link_to t('hub.paused_registration.resume.alternative_start'), begin_sign_in_path %></li>
-      <li><%= link_to t('hub.paused_registration.resume.alternative_other_ways', rp_name: @transaction[:name]), other_ways_to_access_service_path %></li>
+      <li><%= link_to t('hub.paused_registration.resume.alternative_other_ways', service_name: @transaction[:name]), other_ways_to_access_service_path %></li>
     </ul>
   </div>
 

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -555,12 +555,12 @@ cy:
       resume:
         title: "Parhau i ddilysu gyda %{display_name}"
         heading: "Parhau i ddilysu gyda %{display_name}"
-        intro: "Bydd angen i chi orffen gwirio'ch hunaniaeth gyda %{display_name} i %{rp_name}"
+        intro: "Bydd angen i chi orffen gwirio'ch hunaniaeth gyda %{display_name} i %{service_name}."
         continue: "Parhewch gyda %{display_name}"
         alternatives: "Os nid chi oedd hyn, gallwch:"
         alternative_new_identity: "creu cyfrif hunaniaeth newydd"
         alternative_start: "mewngofnodi gyda chwmni ardystiedig arall"
-        alternative_other_ways: "gwelwch ffyrdd eraill i %{rp_name}"
+        alternative_other_ways: "gwelwch ffyrdd eraill i %{service_name}"
     single_idp_journey:
       title: Continue with %{display_name}
       heading: Prove your identity with %{display_name}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -549,12 +549,12 @@ en:
       resume:
         title: "Continue verifying with %{display_name}"
         heading: "Continue verifying with %{display_name}"
-        intro: "You'll need to finish verifying your identity with %{display_name} to %{rp_name}"
+        intro: "You'll need to finish verifying your identity with %{display_name} to %{service_name}."
         continue: "Continue with %{display_name}"
         alternatives: "If this wasn't you, you can:"
         alternative_new_identity: "create a new identity account"
         alternative_start: "sign in with another certified company"
-        alternative_other_ways: "see other ways to %{rp_name}"
+        alternative_other_ways: "see other ways to %{service_name}"
     single_idp_journey:
       title: Continue with %{display_name}
       heading: Prove your identity with %{display_name}

--- a/spec/features/user_visits_resume_registration_page_spec.rb
+++ b/spec/features/user_visits_resume_registration_page_spec.rb
@@ -4,7 +4,7 @@ require 'piwik_test_helper'
 
 RSpec.describe 'When the user visits the resume registration page and' do
   let(:idp_display_name) { 'IDCorp' }
-  let(:rp_display_name) { 'Test RP' }
+  let(:service_name) { 'register for an identity profile' }
   let(:originating_ip) { '<PRINCIPAL IP ADDRESS COULD NOT BE DETERMINED>' }
   let(:idp_entity_id) { 'http://idcorp.com' }
   let(:encrypted_entity_id) { 'an-encrypted-entity-id' }
@@ -30,10 +30,10 @@ RSpec.describe 'When the user visits the resume registration page and' do
     it 'displays correct text and button' do
       visit '/resume-registration'
 
-      expect(page).to have_content t('hub.paused_registration.resume.intro', rp_name: rp_display_name, display_name: idp_display_name)
-      expect(page).to have_content t('hub.paused_registration.resume.heading', rp_name: rp_display_name, display_name: idp_display_name)
+      expect(page).to have_content t('hub.paused_registration.resume.intro', service_name: service_name, display_name: idp_display_name)
+      expect(page).to have_content t('hub.paused_registration.resume.heading', display_name: idp_display_name)
       expect(page).to have_button t('hub.paused_registration.resume.continue', display_name: idp_display_name)
-      expect(page).to have_content t('hub.paused_registration.resume.alternative_other_ways', rp_name: rp_display_name)
+      expect(page).to have_content t('hub.paused_registration.resume.alternative_other_ways', service_name: service_name)
     end
   end
 


### PR DESCRIPTION
I believe the RP should refer to the service/transaction name instead of
the actual RP name. Also added a full stop at the sentence.