### PR TITLE
BAU: Fix a page title bug

### DIFF
--- a/app/views/paused_registration/resume_with_idp.html.erb
+++ b/app/views/paused_registration/resume_with_idp.html.erb
@@ -1,4 +1,4 @@
-<%= page_title 'hub.paused_registration.resume.title' %>
+<%= page_title 'hub.paused_registration.resume.title', display_name: @idp.display_name %>
 <% content_for :body_classes, 'hub-start' %>
 <% content_for :feedback_source, 'RESUME_PAGE' %>
 


### PR DESCRIPTION
We were not passing the IDP name to the title placeholder, so the title got
rendered as "Continue verifying with %{display_name} - GOV.UK Verify - GOV.UK"