### PR TITLE
HUB-293: Update reporting for P&R journey

### DIFF
--- a/app/controllers/authn_response_controller.rb
+++ b/app/controllers/authn_response_controller.rb
@@ -7,6 +7,8 @@ class AuthnResponseController < SamlController
 
   SIGNING_IN_STATE = 'SIGN_IN_WITH_IDP'
   REGISTERING_STATE = 'REGISTER_WITH_IDP'
+  RESUMING_STATE = 'RESUME_WITH_IDP'
+  SINGLE_IDP_STATE = 'SINGLE_IDP'
   SUCCESS = 'SUCCESS'
   CANCEL = 'CANCEL'
   FAILED = 'FAILED'
@@ -76,7 +78,15 @@ private
   end
 
   def user_state(response)
-    response.is_registration ? REGISTERING_STATE : SIGNING_IN_STATE
+    return REGISTERING_STATE if response.is_registration
+    case session[:journey_type]
+    when 'resuming'
+      RESUMING_STATE
+    when 'single-idp'
+      SINGLE_IDP_STATE
+    else
+      SIGNING_IN_STATE
+    end
   end
 
   def idp_redirects(status, response)

--- a/app/controllers/partials/analytics_partial_controller.rb
+++ b/app/controllers/partials/analytics_partial_controller.rb
@@ -12,6 +12,13 @@ module AnalyticsPartialController
     custom_variables_for_img_tracker
   end
 
+  def set_additional_piwik_custom_variable(key, value)
+    @piwik_custom_variables.push(Analytics::CustomVariable.build_for_js_client(key, value))
+
+    @piwik_custom_variables_img_tracker =
+      @piwik_custom_variables_img_tracker.merge(Analytics::CustomVariable.build(key, value))
+  end
+
   def delete_new_visit_flag
     http_redirect = 302
     http_see_other = 303

--- a/app/controllers/partials/idp_selection_partial_controller.rb
+++ b/app/controllers/partials/idp_selection_partial_controller.rb
@@ -57,6 +57,16 @@ module IdpSelectionPartialController
     render json: idp_request
   end
 
+  def ajax_idp_redirection_resume_journey_request
+    increase_attempt_number
+    report_user_idp_attempt_to_piwik
+    FEDERATION_REPORTER.report_idp_resume_journey_selection(current_transaction, request, session[:selected_idp_name])
+
+    outbound_saml_message = SAML_PROXY_API.authn_request(session[:verify_session_id])
+    idp_request = idp_request_initilization(outbound_saml_message)
+    render json: idp_request
+  end
+
   def report_user_idp_attempt_to_piwik
     FEDERATION_REPORTER.report_user_idp_attempt(
       current_transaction: current_transaction,

--- a/app/controllers/redirect_to_idp_controller.rb
+++ b/app/controllers/redirect_to_idp_controller.rb
@@ -23,6 +23,14 @@ class RedirectToIdpController < ApplicationController
     render :redirect_to_idp
   end
 
+  def resume
+    request_form
+    increase_attempt_number
+    report_user_idp_attempt_to_piwik
+    FEDERATION_REPORTER.report_idp_resume_journey_selection(current_transaction, request, session[:selected_idp_name])
+    render :redirect_to_idp
+  end
+
   def single_idp
     uuid = MultiJson.load(cookies.encrypted[CookieNames::VERIFY_SINGLE_IDP_JOURNEY]).fetch('uuid', nil)
     request_form_for_single_idp_journey(uuid)

--- a/app/models/analytics/federation_reporter.rb
+++ b/app/models/analytics/federation_reporter.rb
@@ -123,6 +123,14 @@ module Analytics
       )
     end
 
+    def report_idp_resume_journey_selection(current_transaction, request, idp_display_name)
+      report_action(
+        current_transaction,
+        request,
+        "Resume - #{idp_display_name}"
+      )
+    end
+
     def report_sign_in_idp_selection_after_journey_hint(current_transaction, request, idp_display_name, hint_followed)
       report_action(
         current_transaction,

--- a/app/views/paused_registration/resume.html.erb
+++ b/app/views/paused_registration/resume.html.erb
@@ -2,7 +2,7 @@
 <% content_for :body_classes, 'hub-start' %>
 <% content_for :feedback_source, 'RESUME_PAGE' %>
 
-<div class="grid-row js-continue-to-idp" data-location="<%= url_for(controller: 'sign_in', action: 'select_idp_ajax', locale: I18n.locale)  %>">
+<div class="grid-row js-continue-to-idp" data-location="<%= url_for(controller: 'paused_registration', action: 'resume_with_idp_ajax', locale: I18n.locale)  %>">
   <h1 class="heading-large"><%= t 'hub.paused_registration.resume.heading', display_name: @idp.display_name %></h1>
 
   <%= t 'hub.paused_registration.resume.intro', display_name: @idp.display_name, service_name: @transaction[:name] %>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -42,6 +42,7 @@ cy:
     response_processing: prosesu-ymateb
     redirect_to_idp_sign_in: ailgyfeirio-i-idp/mewngofnodi
     redirect_to_idp_register: ailgyfeirio-i-idp/cofrestru
+    redirect_to_idp_resume: ailgyfeirio-i-idp/ailddechrau
     redirect_to_service_signing_in: ailgyfeirio-i-gwasanaeth/mewngofnodi
     redirect_to_service_start_again: ailgyfeirio-i-gwasanaeth/dechrau-eto
     redirect_to_service_error: ailgyfeirio-i-gwasanaeth/gwall

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -42,6 +42,7 @@ en:
     response_processing: response-processing
     redirect_to_idp_sign_in: redirect-to-idp/sign-in
     redirect_to_idp_register: redirect-to-idp/register
+    redirect_to_idp_resume: redirect-to-idp/resume
     redirect_to_service_signing_in: redirect-to-service/signing-in
     redirect_to_service_start_again: redirect-to-service/start-again
     redirect_to_service_error: redirect-to-service/error

--- a/config/main_routes.rb
+++ b/config/main_routes.rb
@@ -79,6 +79,7 @@ get 'forgot_company', to: 'static#forgot_company', as: :forgot_company
 get 'response_processing', to: 'response_processing#index', as: :response_processing
 get 'redirect_to_idp_register', to: 'redirect_to_idp#register', as: :redirect_to_idp_register
 get 'redirect_to_idp_sign_in', to: 'redirect_to_idp#sign_in', as: :redirect_to_idp_sign_in
+get 'redirect_to_idp_resume', to: 'redirect_to_idp#resume', as: :redirect_to_idp_resume
 get 'redirect_to_service_signing_in' => 'redirect_to_service#signing_in', as: :redirect_to_service_signing_in
 get 'redirect_to_service_start_again' => 'redirect_to_service#start_again', as: :redirect_to_service_start_again
 get 'redirect_to_service_error' => 'redirect_to_service#error', as: :redirect_to_service_error
@@ -95,7 +96,7 @@ get 'no_idps_available', to: 'no_idps_available#index', as: :no_idps_available
 get 'cancelled_registration', to: 'cancelled_registration#index', as: :cancelled_registration
 get 'paused_registration', to: 'paused_registration#index', as: :paused_registration
 get 'resume_registration', to: 'paused_registration#resume', as: :resume_registration
-post 'resume_registration', to: 'sign_in#select_idp'
+post 'resume_registration', to: 'paused_registration#resume_with_idp', as: :resume_registration_submit
 
 if SINGLE_IDP_FEATURE
   get 'redirect_to_single_idp', to: 'redirect_to_idp#single_idp', as: :redirect_to_single_idp

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,6 +44,7 @@ Rails.application.routes.draw do
   put 'redirect-to-idp-warning', to: 'redirect_to_idp_warning#continue_ajax', as: :redirect_to_idp_warning_submit_ajax
   put 'select-idp', to: 'sign_in#select_idp_ajax', as: :select_idp_submit_ajax
   put 'redirect-to-country', to: 'redirect_to_country#choose_a_country_submit_ajax', as: :redirect_to_country_ajax
+  put 'resume-with-idp', to: 'paused_registration#resume_with_idp_ajax', as: :resume_with_idp_ajax
   # Used for tracking ab tests that start in Gov.uk
   get 'redirect-to-rp/:transaction_simple_id', to: 'redirect_to_rp#redirect_to_rp'
   get 'service-status', to: 'service_status#index', as: :service_status

--- a/spec/controllers/authn_response_controller_spec.rb
+++ b/spec/controllers/authn_response_controller_spec.rb
@@ -24,6 +24,14 @@ describe AuthnResponseController do
       include_examples 'idp_authn_response', 'sign_in', 'FAILED', 'Failure - SIGN_IN_WITH_IDP', :failed_sign_in_path
     end
 
+    context 'resuming' do
+      include_examples 'idp_authn_response', 'resuming', 'SUCCESS', 'Success - RESUME_WITH_IDP at LOA LEVEL_1', :response_processing_path
+      include_examples 'idp_authn_response', 'resuming', 'CANCEL', 'Cancel - RESUME_WITH_IDP', :start_path
+      include_examples 'idp_authn_response', 'resuming', 'FAILED_UPLIFT', 'Failed Uplift - RESUME_WITH_IDP', :failed_uplift_path
+      include_examples 'idp_authn_response', 'resuming', 'PENDING', 'Paused - RESUME_WITH_IDP', :paused_registration_path
+      include_examples 'idp_authn_response', 'resuming', 'FAILED', 'Failure - RESUME_WITH_IDP', :failed_sign_in_path
+    end
+
     it 'when relay state does not equal session id in the idp response' do
       set_session_and_cookies_with_loa('LEVEL_1')
       session[:verify_session_id] = 'non-existent'

--- a/spec/controllers/paused_registration_controller_spec.rb
+++ b/spec/controllers/paused_registration_controller_spec.rb
@@ -79,7 +79,7 @@ describe PausedRegistrationController do
       }
 
       cookies.encrypted[CookieNames::VERIFY_FRONT_JOURNEY_HINT] = front_journey_hint_cookie.to_json
-      expect(subject).to render_template(:resume_with_idp)
+      expect(subject).to render_template(:resume)
     end
 
     it 'redirects to start page when invalid/disabled IDP present in cookie' do

--- a/spec/features/user_visits_resume_registration_page_spec.rb
+++ b/spec/features/user_visits_resume_registration_page_spec.rb
@@ -36,6 +36,9 @@ RSpec.describe 'When the user visits the resume registration page and' do
       expect(page).to have_content t('hub.paused_registration.resume.heading', display_name: idp_display_name)
       expect(page).to have_button t('hub.paused_registration.resume.continue', display_name: idp_display_name)
       expect(page).to have_content t('hub.paused_registration.resume.alternative_other_ways', service_name: service_name)
+
+      piwik_custom_variable_resuming_journey = '{"index":3,"name":"JOURNEY_TYPE","value":"RESUMING","scope":"visit"}'
+      expect(page).to have_content(piwik_custom_variable_resuming_journey)
     end
   end
 
@@ -47,9 +50,9 @@ RSpec.describe 'When the user visits the resume registration page and' do
 
       click_button t('hub.paused_registration.resume.continue', display_name: idp_display_name)
 
-      expect(page).to have_current_path(redirect_to_idp_sign_in_path)
+      expect(page).to have_current_path(redirect_to_idp_resume_path)
       expect(select_idp_stub_request).to have_been_made.once
-      expect(stub_piwik_request('action_name' => "Sign In - #{idp_display_name}")).to have_been_made.once
+      expect(stub_piwik_request('action_name' => "Resume - #{idp_display_name}")).to have_been_made.once
     end
   end
 
@@ -58,10 +61,10 @@ RSpec.describe 'When the user visits the resume registration page and' do
       visit '/resume-registration'
       select_idp_stub_request
       stub_session_idp_authn_request(originating_ip, location, false)
-      expect_any_instance_of(SignInController).to receive(:select_idp_ajax).and_call_original
+      expect_any_instance_of(PausedRegistrationController).to receive(:resume_with_idp_ajax).and_call_original
 
       click_button t('hub.paused_registration.resume.continue', display_name: idp_display_name)
-      expect(stub_piwik_request('action_name' => "Sign In - #{idp_display_name}")).to have_been_made.once
+      expect(stub_piwik_request('action_name' => "Resume - #{idp_display_name}")).to have_been_made.once
       expect(page).to have_current_path(location)
       expect(page).to have_content("SAML Request is 'a-saml-request'")
       expect(page).to have_content("relay state is 'a-relay-state'")

--- a/spec/support/authn_response_examples.rb
+++ b/spec/support/authn_response_examples.rb
@@ -12,6 +12,7 @@ shared_examples 'idp_authn_response' do |journey_hint, idp_result, piwik_action,
     stub_const('SAML_PROXY_API', saml_proxy_api)
     set_session_and_cookies_with_loa('LEVEL_1')
     set_selected_idp(selected_entity)
+    session[:journey_type] = journey_hint if journey_hint == 'resuming'
   end
 
   it "should redirect to #{redirect_path} on #{idp_result}" do


### PR DESCRIPTION
Updating the reporting to add the custom variable for the resume page.
Changed the authn response reporting to report RESUME_WITH_IDP instead of SIGN_IN_WITH_IDP.
Switched the Resume button to start using resume method and reporting instead of the sign-in logic.