### PR TITLE
HUB-267: Implement single-idp specific fail page

### DIFF
--- a/app/views/failed_registration/_continue_rp.html.erb
+++ b/app/views/failed_registration/_continue_rp.html.erb
@@ -9,23 +9,13 @@
 
 <%= button_link_to t('navigation.continue'), redirect_to_service_error_path %>
 
-<h2 class="heading-medium"><%= t 'hub.failed_registration.problems_verifying_your_identity' %></h2>
+<h2 class="heading-medium"><%= t 'hub.failed_registration.try_another_summary' %></h2>
+<div>
+  <p><%= t 'hub.failed_registration.try_another_text', idp_name: @idp.display_name %></p>
+  <%= link_to t('hub.failed_registration.try_another_company'), try_another_company_path %>
+</div>
 
-<%= t 'hub.failed_registration.reasons_html', idp_name: idp.display_name %>
-
-<p><%= t 'hub.failed_registration.what_to_do_next_intro' %></p>
-
-<details class="next-actions">
-  <summary><span class="summary"><%= t 'hub.failed_registration.contact_details_intro', idp_name: idp.display_name %></span></summary>
-  <div class="panel panel-border-narrow">
-    <%= raw idp.contact_details %>
-  </div>
-</details>
-
-<details class="next-actions">
-  <summary><span class="summary"><%= t 'hub.failed_registration.try_another_summary' %></span></summary>
-  <div class="panel panel-border-narrow">
-    <p><%= t 'hub.failed_registration.try_another_text', idp_name: @idp.display_name %></p>
-    <%= link_to t('hub.failed_registration.try_another_company'), try_another_company_path %>
-  </div>
-</details>
+<h2 class="heading-medium"><%= t 'hub.failed_registration.contact_details_intro', idp_name: idp.display_name %></h2>
+<div>
+  <%= raw idp.contact_details %>
+</div>

--- a/app/views/failed_registration/_custom_failed_registration.html.erb
+++ b/app/views/failed_registration/_custom_failed_registration.html.erb
@@ -6,17 +6,13 @@
   <%= raw transaction.custom_fail_other_options %>
 </h2>
 
-<details class="next-actions">
-  <summary><span class="summary"><%= raw transaction.custom_fail_try_another_summary %></span></summary>
-  <div class="panel panel-border-narrow">
-    <%= raw(transaction.custom_fail_try_another_text % { idp_name: idp.display_name }) %>
-    <%= link_to t('hub.failed_registration.start_again'), start_again_path %>
-  </div>
-</details>
+<h2 class="heading-medium"><%= raw transaction.custom_fail_try_another_summary %></h2>
+<div>
+  <%= raw(transaction.custom_fail_try_another_text % { idp_name: idp.display_name }) %>
+  <%= link_to t('hub.failed_registration.start_again'), start_again_path %>
+</div>
 
-<details class="next-actions">
-  <summary><span class="summary"><%= raw(transaction.custom_fail_contact_details_intro % { idp_name: idp.display_name }) %></span></summary>
-  <div class="panel panel-border-narrow">
-    <%= raw idp.contact_details %>
-  </div>
-</details>
+<h2 class="heading-medium"><%= raw(transaction.custom_fail_contact_details_intro % { idp_name: idp.display_name }) %></h2>
+<div>
+  <%= raw idp.contact_details %>
+</div>

--- a/app/views/failed_registration/_non_continue_rp.html.erb
+++ b/app/views/failed_registration/_non_continue_rp.html.erb
@@ -1,29 +1,19 @@
 <h1 class="heading-large"><%= t 'hub.failed_registration.heading', idp_name: idp.display_name %></h1>
 
-<%= t 'hub.failed_registration.reasons_html', idp_name: idp.display_name %>
+<%= t 'hub.failed_registration.reasons_html', service_name: @transaction.name %>
 
-<h2 class="heading-medium">
-  <%= t 'hub.failed_registration.what_to_do_next' %>
-</h2>
+<h2 class="heading-medium"><%= t 'hub.failed_registration.try_another_summary' %></h2>
+<div>
+  <p><%= t 'hub.failed_registration.try_another_text', idp_name: @idp.display_name %></p>
+  <%= link_to t('hub.failed_registration.start_again'), start_again_path %>
+</div>
 
-<details class="next-actions">
-  <summary><span class="summary"><%= t 'hub.failed_registration.other_ways_summary', other_ways_description: raw(transaction.other_ways_description) %></span></summary>
-  <div class="panel panel-border-narrow">
-    <%= raw transaction.other_ways_text %>
-  </div>
-</details>
+<h2 class="heading-medium"><%= t 'hub.failed_registration.other_ways_summary', other_ways_description: raw(transaction.other_ways_description) %></h2>
+<div>
+  <%= raw transaction.other_ways_text %>
+</div>
 
-<details class="next-actions">
-  <summary><span class="summary"><%= t 'hub.failed_registration.contact_details_intro', idp_name: idp.display_name %></span></summary>
-  <div class="panel panel-border-narrow">
-    <%= raw idp.contact_details %>
-  </div>
-</details>
-
-<details class="next-actions">
-  <summary><span class="summary"><%= t 'hub.failed_registration.try_another_summary' %></span></summary>
-  <div class="panel panel-border-narrow">
-    <p><%= t 'hub.failed_registration.try_another_text', idp_name: @idp.display_name %></p>
-    <%= link_to t('hub.failed_registration.start_again'), start_again_path %>
-  </div>
-</details>
+<h2 class="heading-medium"><%= t 'hub.failed_registration.contact_details_intro', idp_name: idp.display_name %></h2>
+<div>
+  <%= raw idp.contact_details %>
+</div>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -383,13 +383,7 @@ cy:
       title: Methu dilysu eich hunaniaeth
       heading: Roedd %{idp_name} yn methu dilysu eich hunaniaeth
       try_another_company: Rhowch gynnig ar gwmni ardystiedig arall
-      reasons_html: |
-        <p>Mae ychydig o resymau pam allai hyn ddigwydd, yn cynnwys:</p>
-        <ul class="list list-bullet">
-          <li>nid yw eich ateb i gwestiwn yn cyd fynd a chofnodion ar-lein</li>
-          <li>rydych yn ddiweddar wedi cael newid yn eich amgylchiadau, ac nid ydynt wedi cael eu diweddaru ar-lein</li>
-          <li>Nid oes gan %{idp_name} fynediad i ddigon o wybodaeth amdanoch chi</li>
-        </ul>
+      reasons_html: You can still %{service_name}
       what_to_do_next_intro: "Gallwch roi cynnig ar y canlynol:"
       what_to_do_next: Beth i’w wneud nesaf
       problems_verifying_your_identity: Problemau gyda dilysu eich hunaniaeth

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -377,13 +377,7 @@ en:
       title: Unable to verify your identity
       heading: "%{idp_name} was unable to verify your identity"
       try_another_company: Try another certified company
-      reasons_html: |
-        <p>There are a few reasons why this might happen, including:</p>
-        <ul class="list list-bullet">
-          <li>your answer to a question doesn't match online records</li>
-          <li>you've recently had a change in your circumstances, and they aren't up to date online</li>
-          <li>%{idp_name} doesn't have access to enough information about you</li>
-        </ul>
+      reasons_html: You can still %{service_name}
       what_to_do_next_intro: "You can try the following:"
       what_to_do_next: "What to do next"
       problems_verifying_your_identity: Problems verifying your identity

--- a/spec/controllers/authn_response_controller_spec.rb
+++ b/spec/controllers/authn_response_controller_spec.rb
@@ -32,6 +32,14 @@ describe AuthnResponseController do
       include_examples 'idp_authn_response', 'resuming', 'FAILED', 'Failure - RESUME_WITH_IDP', :failed_sign_in_path
     end
 
+    context 'single-idp' do
+      include_examples 'idp_authn_response', 'single-idp', 'SUCCESS', 'Success - SINGLE_IDP at LOA LEVEL_1', :response_processing_path
+      include_examples 'idp_authn_response', 'single-idp', 'CANCEL', 'Cancel - SINGLE_IDP', :start_path
+      include_examples 'idp_authn_response', 'single-idp', 'FAILED_UPLIFT', 'Failed Uplift - SINGLE_IDP', :failed_uplift_path
+      include_examples 'idp_authn_response', 'single-idp', 'PENDING', 'Paused - SINGLE_IDP', :paused_registration_path
+      include_examples 'idp_authn_response', 'single-idp', 'FAILED', 'Failure - SINGLE_IDP', :failed_registration_path
+    end
+
     it 'when relay state does not equal session id in the idp response' do
       set_session_and_cookies_with_loa('LEVEL_1')
       session[:verify_session_id] = 'non-existent'

--- a/spec/support/authn_response_examples.rb
+++ b/spec/support/authn_response_examples.rb
@@ -12,7 +12,7 @@ shared_examples 'idp_authn_response' do |journey_hint, idp_result, piwik_action,
     stub_const('SAML_PROXY_API', saml_proxy_api)
     set_session_and_cookies_with_loa('LEVEL_1')
     set_selected_idp(selected_entity)
-    session[:journey_type] = journey_hint if journey_hint == 'resuming'
+    session[:journey_type] = journey_hint
   end
 
   it "should redirect to #{redirect_path} on #{idp_result}" do


### PR DESCRIPTION
Update failed registration error page designs as per story.
Update AuthnResponseController to ensure single IDP journeys always go to regsitration failure regardless of journey type.