### PR TITLE
BAU: Remove filter from transaction list for single idp

### DIFF
--- a/app/models/display/rp/service_list_data_correlator.rb
+++ b/app/models/display/rp/service_list_data_correlator.rb
@@ -3,13 +3,12 @@ module Display
     class ServiceListDataCorrelator
       Transaction = Struct.new(:name, :loa, :serviceCategory, :serviceId)
 
-      def initialize(rp_display_repository, rps_name_homepage)
+      def initialize(rp_display_repository)
         @rp_display_repository = rp_display_repository
-        @rps_name_homepage = rps_name_homepage
       end
 
-      def correlate(data)
-        filter_transactions(data, @rps_name_homepage).map do |transaction|
+      def correlate(transactions)
+        transactions.map do |transaction|
           simple_id = transaction.fetch('simpleId')
           display_data = @rp_display_repository.get_translations(simple_id)
           Transaction.new(display_data.name, transaction.fetch('loaList').min,
@@ -18,15 +17,6 @@ module Display
       rescue KeyError => e
         Rails.logger.error e
         []
-      end
-
-    private
-
-      def filter_transactions(transactions, simple_ids)
-        transactions = simple_ids.map do |simple_id|
-          transactions.select { |tx| tx['simpleId'] == simple_id }
-        end
-        transactions.flatten
       end
     end
   end

--- a/config/initializers/30_federation.rb
+++ b/config/initializers/30_federation.rb
@@ -42,10 +42,7 @@ Rails.application.config.after_initialize do
   DATA_CORRELATOR = Display::Rp::DisplayDataCorrelator.new(RP_DISPLAY_REPOSITORY, rps_name_and_homepage.clone, rps_name_only.clone)
   TRANSACTION_TAXON_CORRELATOR = Display::Rp::TransactionTaxonCorrelator.new(RP_DISPLAY_REPOSITORY, rps_name_and_homepage.clone, rps_name_only.clone)
 
-  SERVICE_LIST_DATA_CORRELATOR = Display::Rp::ServiceListDataCorrelator.new(
-    RP_DISPLAY_REPOSITORY,
-    rps_name_and_homepage.clone
-  )
+  SERVICE_LIST_DATA_CORRELATOR = Display::Rp::ServiceListDataCorrelator.new(RP_DISPLAY_REPOSITORY)
 
   # IDP Config
   IDP_CONFIG = YAML.load_file(CONFIG.idp_config)

--- a/spec/controllers/metadata_controller_spec.rb
+++ b/spec/controllers/metadata_controller_spec.rb
@@ -6,12 +6,12 @@ require 'api_test_helper'
 describe MetadataController do
   subject { get :service_list, params: { locale: 'en' } }
 
-  it 'json array should contain 2 objects with correct values' do
+  it 'json array should contain 4 objects with correct values' do
     stub_transactions_for_single_idp_list
 
     body = JSON.parse(subject.body)
 
-    expect(body.size).to eq(2)
+    expect(body.size).to eq(4)
     expect(subject.content_type).to eq('application/json')
     expect(subject).to have_http_status(200)
 

--- a/spec/models/display/rp/service_list_data_correlator_spec.rb
+++ b/spec/models/display/rp/service_list_data_correlator_spec.rb
@@ -45,7 +45,7 @@ module Display
       let(:rp_display_repository) { instance_double("Display::RpDisplayRepository") }
 
       let(:service_list_data_correlator) do
-        ServiceListDataCorrelator.new(rp_display_repository, [public_simple_id])
+        ServiceListDataCorrelator.new(rp_display_repository)
       end
 
       let(:display_data_1) do
@@ -92,22 +92,14 @@ module Display
               'entityId' => entityId_4
           },
         ]
-        correlator = ServiceListDataCorrelator.new(
-          rp_display_repository,
-          [
-            public_simple_id_4,
-            public_simple_id_2,
-            public_simple_id,
-            public_simple_id_3
-          ]
-        )
+        correlator = ServiceListDataCorrelator.new(rp_display_repository)
         actual_result = correlator.correlate(transaction_data)
         expected_result = [
           ServiceListDataCorrelator::Transaction.new(
-            transaction_4_name,
-            expected_public_simple_id_4_loa,
-            public_taxon_4,
-            entityId_4
+            transaction_a_name,
+            expected_public_simple_id_loa,
+            public_taxon,
+            entityId
           ),
           ServiceListDataCorrelator::Transaction.new(
             transaction_2_name,
@@ -116,16 +108,16 @@ module Display
             entityId_2
           ),
           ServiceListDataCorrelator::Transaction.new(
-            transaction_a_name,
-            expected_public_simple_id_loa,
-            public_taxon,
-            entityId
-          ),
-          ServiceListDataCorrelator::Transaction.new(
             transaction_3_name,
             expected_public_simple_id_3_loa,
             public_taxon_3,
             entityId_3
+          ),
+          ServiceListDataCorrelator::Transaction.new(
+            transaction_4_name,
+            expected_public_simple_id_4_loa,
+            public_taxon_4,
+            entityId_4
           )
         ]
         expect(actual_result).to eq expected_result


### PR DESCRIPTION
Single IDP list endpoint was returning only services listed in the name_homepage list.
This is not required and should return what the config service is returning.