### PR TITLE
HUB-294: Delete single idp cookie after any SAML response.

### DIFF
--- a/app/controllers/authn_response_controller.rb
+++ b/app/controllers/authn_response_controller.rb
@@ -50,6 +50,7 @@ private
   def handle_idp_response(status, response)
     analytics_reporters(status, response)
     set_journey_status(status)
+    clear_single_idp_cookie
     redirect_to idp_redirects(status, response)
   end
 
@@ -108,5 +109,9 @@ private
       FAILED_UPLIFT => failed_uplift_path,
       FAILED => is_registration ? failed_registration_path : failed_country_sign_in_path
     }.fetch(status)
+  end
+
+  def clear_single_idp_cookie
+    cookies.delete CookieNames::VERIFY_SINGLE_IDP_JOURNEY
   end
 end

--- a/spec/controllers/authn_response_controller_spec.rb
+++ b/spec/controllers/authn_response_controller_spec.rb
@@ -148,5 +148,16 @@ describe AuthnResponseController do
       }
       it { should eq cookie_with_pending_status }
     end
+
+    context 'receiving status with no single idp cookie set will not error' do
+      let(:status) { 'PENDING' }
+      let(:cookie_with_pending_status) {
+        { STATE: { IDP: 'http://idcorp.com',
+                   RP: 'http://www.test-rp.gov.uk/SAML2/MD',
+                   STATUS: 'PENDING' } }.to_json
+      }
+      it { should eq cookie_with_pending_status }
+      it { expect(cookies.encrypted[CookieNames::VERIFY_SINGLE_IDP_JOURNEY]).to be_nil }
+    end
   end
 end

--- a/spec/support/authn_response_examples.rb
+++ b/spec/support/authn_response_examples.rb
@@ -11,6 +11,7 @@ shared_examples 'idp_authn_response' do |journey_hint, idp_result, piwik_action,
   before(:each) do
     stub_const('SAML_PROXY_API', saml_proxy_api)
     set_session_and_cookies_with_loa('LEVEL_1')
+    cookies[CookieNames::VERIFY_SINGLE_IDP_JOURNEY] = 'pretend cookie'
     set_selected_idp(selected_entity)
     session[:journey_type] = journey_hint if journey_hint == 'resuming'
   end
@@ -20,6 +21,7 @@ shared_examples 'idp_authn_response' do |journey_hint, idp_result, piwik_action,
     allow(subject).to receive(:report_to_analytics).with(piwik_action)
     allow(subject).to receive(:report_user_outcome_to_piwik).with(idp_result)
     post :idp_response, params: { 'RelayState' => 'my-session-id-cookie', 'SAMLResponse' => 'a-saml-response', locale: 'en' }
+    expect(cookies.encrypted[CookieNames::VERIFY_SINGLE_IDP_JOURNEY]).to be_nil
     expect(subject).to redirect_to(send(redirect_path))
   end
 end


### PR DESCRIPTION
Add method to delete single idp journey cookie after all saml responses.

AC's:
The single IDP cookie is deleted when the user is on a single-idp journey and we receive any SAML response (SUCCESS, FAIL, PENDING ... ) from an IDP

The single IDP cookie is deleted when the user chooses a different IDP and we receive any SAML response from that IDP (SUCCESS, FAIL, PENDING ... ) from an IDP

The SIDP cookie is retained when the user closes the browser during the IDP portion of the journey

The SIDP cookie is retained when the user clicks Continue on the handover page, then clicks back from the IDP journey

solo: @rachelthecodesmith