### PR TITLE
BAU: Bugfix + add custom variable to single idp

### DIFF
--- a/app/controllers/single_idp_journey_controller.rb
+++ b/app/controllers/single_idp_journey_controller.rb
@@ -13,8 +13,8 @@ class SingleIdpJourneyController < ApplicationController
   include RetrieveFederationDataPartialController
 
   protect_from_forgery except: :redirect_from_idp
-  skip_before_action :validate_session, except: %i[index continue continue_ajax]
-  skip_before_action :set_piwik_custom_variables, except: %i[index continue continue_ajax]
+  skip_before_action :validate_session, only: :redirect_from_idp
+  skip_before_action :set_piwik_custom_variables, only: :redirect_from_idp
 
   def continue_to_your_idp
     if valid_cookie? && valid_selection?
@@ -22,6 +22,7 @@ class SingleIdpJourneyController < ApplicationController
       @service_name = current_transaction.name
       @uuid = single_idp_cookie.fetch('uuid', nil)
       session[:journey_type] = 'single-idp'
+      set_additional_piwik_custom_variable(:journey_type, 'SINGLE_IDP')
       render
     else
       redirect_to start_path

--- a/spec/features/user_visits_continue_to_your_idp_page_spec.rb
+++ b/spec/features/user_visits_continue_to_your_idp_page_spec.rb
@@ -27,13 +27,15 @@ RSpec.describe 'When the user visits the continue to your IDP page' do
       stub_api_idp_list_for_single_idp_journey
     end
 
-    it 'includes the appropriate feedback source and page title' do
+    it 'includes the appropriate feedback source, page title and piwik custom variable' do
       set_single_idp_journey_cookie
       visit '/continue-to-your-idp'
 
       expect(page).to have_current_path('/continue-to-your-idp')
       expect(page).to have_title t('hub.single_idp_journey.title', display_name: idp_display_name)
       expect_feedback_source_to_be(page, 'CONTINUE_TO_YOUR_IDP_PAGE', '/continue-to-your-idp')
+      piwik_custom_variable_single_idp_journey = '{"index":3,"name":"JOURNEY_TYPE","value":"SINGLE_IDP","scope":"visit"}'
+      expect(page).to have_content(piwik_custom_variable_single_idp_journey)
     end
 
     it 'supports the welsh language' do


### PR DESCRIPTION
We renamed the controller method but didn't update it in the skip_before_action exception,
so the page didn't have any custom variables and wasn't validated for session. Changing
the 'except' for 'only' to make it more readable since only one method requires skipping.
Additionally I'm adding the journey type custom variable to deal with the Piwik
race condition once we start using headless link for single idp.