### PR TITLE
FIREBREAK: Rename test-rp

### DIFF
--- a/spec/api_test_helper.rb
+++ b/spec/api_test_helper.rb
@@ -59,31 +59,31 @@ module ApiTestHelper
 
   def stub_translations
     en_translation_data = '{
-        "name":"register for an identity profile",
+        "name":"test GOV.UK Verify user journeys",
         "rpName":"Test RP",
         "analyticsDescription":"analytics description for test-rp",
-        "otherWaysText":"<p>If you can’t verify your identity using GOV.UK Verify, you can register for an identity profile <a href=\"http://www.example.com\">here</a>.</p><p>Tell us your:</p><ul><li>name</li><li>age</li></ul><p>Include any other relevant details if you have them.</p>",
-        "otherWaysDescription":"register for an identity profile",
+        "otherWaysText":"<p>If you can’t verify your identity using GOV.UK Verify, you can test GOV.UK Verify user journeys <a href=\"http://www.example.com\">here</a>.</p><p>Tell us your:</p><ul><li>name</li><li>age</li></ul><p>Include any other relevant details if you have them.</p>",
+        "otherWaysDescription":"test GOV.UK Verify user journeys",
         "tailoredText":"External data source: EN: This is tailored text for test-rp",
         "taxonName":"Benefits"
       }'
     stub_request(:get, api_translations_endpoint('test-rp', 'en')).to_return(body: en_translation_data, status: 200)
     cy_translation_data = '{
-        "name":"Welsh register for an identity profile",
+        "name":"Welsh test GOV.UK Verify user journeys",
         "rpName":"Welsh Test RP",
         "analyticsDescription":"analytics description for test-rp",
-        "otherWaysText":"<p>Welsh If you can’t verify your identity using GOV.UK Verify, you can register for an identity profile <a href=\"http://www.example.com\">here</a>.</p><p>Tell us your:</p><ul><li>name</li><li>age</li></ul><p>Include any other relevant details if you have them.</p>",
-        "otherWaysDescription":"Welsh register for an identity profile",
+        "otherWaysText":"<p>Welsh If you can’t verify your identity using GOV.UK Verify, you can test GOV.UK Verify user journeys <a href=\"http://www.example.com\">here</a>.</p><p>Tell us your:</p><ul><li>name</li><li>age</li></ul><p>Include any other relevant details if you have them.</p>",
+        "otherWaysDescription":"Welsh test GOV.UK Verify user journeys",
         "tailoredText":"Welsh External data source: EN: This is tailored text for test-rp",
         "taxonName":"Welsh Benefits"
       }'
     stub_request(:get, api_translations_endpoint('test-rp', 'cy')).to_return(body: cy_translation_data, status: 200)
     test_rp_noc3_translations = '{
-        "name":"Register for an identity profile (forceauthn & no cycle3)",
+        "name":"Test GOV.UK Verify user journeys (forceauthn & no cycle3)",
         "rpName":"Test RP",
         "analyticsDescription":"analytics description for test-rp",
-        "otherWaysText":"<p>If you can’t verify your identity using GOV.UK Verify, you can register for an identity profile <a href=\"http://www.example.com\">here</a>.</p><p>Tell us your:</p><ul><li>name</li><li>age</li></ul><p>Include any other relevant details if you have them.</p>",
-        "otherWaysDescription":"register for an identity profile",
+        "otherWaysText":"<p>If you can’t verify your identity using GOV.UK Verify, you can test GOV.UK Verify user journeys <a href=\"http://www.example.com\">here</a>.</p><p>Tell us your:</p><ul><li>name</li><li>age</li></ul><p>Include any other relevant details if you have them.</p>",
+        "otherWaysDescription":"test GOV.UK Verify user journeys",
         "tailoredText":"External data source: EN: This is tailored text for test-rp",
         "taxonName":"Benefits"
       }'
@@ -96,11 +96,11 @@ module ApiTestHelper
     stub_request(:get, api_translations_endpoint('test-rp-no-ab-test', 'en')).to_return(body: en_translation_data, status: 200)
     stub_request(:get, api_translations_endpoint('test-rp-no-ab-test', 'cy')).to_return(body: '{}', status: 200)
     stub_request(:get, api_translations_endpoint('test-rp-no-demo', 'en')).to_return(body: '{
-        "name":"register for an identity profile",
+        "name":"test GOV.UK Verify user journeys",
         "rpName":"Test RP",
         "analyticsDescription":"analytics description for test-rp",
-        "otherWaysText":"<p>If you can’t verify your identity using GOV.UK Verify, you can register for an identity profile <a href=\"http://www.example.com\">here</a>.</p><p>Tell us your:</p><ul><li>name</li><li>age</li></ul><p>Include any other relevant details if you have them.</p>",
-        "otherWaysDescription":"register for an identity profile",
+        "otherWaysText":"<p>If you can’t verify your identity using GOV.UK Verify, you can test GOV.UK Verify user journeys <a href=\"http://www.example.com\">here</a>.</p><p>Tell us your:</p><ul><li>name</li><li>age</li></ul><p>Include any other relevant details if you have them.</p>",
+        "otherWaysDescription":"test GOV.UK Verify user journeys",
         "tailoredText":"External data source: EN: This is tailored text for test-rp",
         "taxonName":"Benefits",
         "customFailHeading":"This is a custom fail page.",
@@ -111,11 +111,11 @@ module ApiTestHelper
         "customFailContactDetailsIntro":"This is custom contact details."
       }', status: 200)
     stub_request(:get, api_translations_endpoint('test-rp-no-demo', 'cy')).to_return(body: '{
-        "name":"Register for an identity profile (forceauthn & no cycle3)",
+        "name":"Test GOV.UK Verify user journeys (forceauthn & no cycle3)",
         "rpName":"EN: Test RP",
         "analyticsDescription":"analytics description for test-rp",
-        "otherWaysText":"<p>If you can’t verify your identity using GOV.UK Verify, you can register for an identity profile <a href=\"http://www.example.com\">here</a>.</p><p>Tell us your:</p><ul><li>name</li><li>age</li></ul><p>Include any other relevant details if you have them.</p>",
-        "otherWaysDescription":"register for an identity profile",
+        "otherWaysText":"<p>If you can’t verify your identity using GOV.UK Verify, you can test GOV.UK Verify user journeys <a href=\"http://www.example.com\">here</a>.</p><p>Tell us your:</p><ul><li>name</li><li>age</li></ul><p>Include any other relevant details if you have them.</p>",
+        "otherWaysDescription":"test GOV.UK Verify user journeys",
         "tailoredText":"External data source: EN: This is tailored text for test-rp",
         "taxonName":"Benefits",
         "customFailHeading":"This is a custom fail page in welsh.",

--- a/spec/controllers/metadata_controller_spec.rb
+++ b/spec/controllers/metadata_controller_spec.rb
@@ -19,7 +19,7 @@ describe MetadataController do
       body.find { |rp| rp['serviceId'] == 'http://www.test-rp.gov.uk/SAML2/MD' }
 
     expect(test_rp_object.nil?).to be false
-    expect(test_rp_object['name']).to eq('register for an identity profile')
+    expect(test_rp_object['name']).to eq('test GOV.UK Verify user journeys')
     expect(test_rp_object['loa']).to eq('LEVEL_2')
     expect(test_rp_object['serviceCategory']).to eq('Benefits')
 
@@ -28,7 +28,7 @@ describe MetadataController do
 
     expect(another_test_rp_object.nil?).to be false
     expect(another_test_rp_object['name'])
-      .to eq('Register for an identity profile (forceauthn & no cycle3)')
+      .to eq('Test GOV.UK Verify user journeys (forceauthn & no cycle3)')
     expect(another_test_rp_object['loa']).to eq('LEVEL_2')
     expect(another_test_rp_object['serviceCategory']).to eq('Benefits')
   end

--- a/spec/features/user_encounters_error_page_spec.rb
+++ b/spec/features/user_encounters_error_page_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'user encounters error page' do
     click_button "saml-post"
     expect(page).to have_content t('errors.something_went_wrong.heading')
     expect(page).to have_css "#piwik-custom-url", text: "errors/generic-error"
-    expect(page).to have_link "register for an identity profile", href: "http://localhost:50130/test-rp"
+    expect(page).to have_link "test GOV.UK Verify user journeys", href: "http://localhost:50130/test-rp"
   end
 
   it 'will present the user with no list of transactions if we cant read the errors' do
@@ -113,7 +113,7 @@ RSpec.describe 'user encounters error page' do
       visit sign_in_path
       click_button 'IDCorp'
       expect(page).to have_content t('errors.something_went_wrong.heading')
-      expect(page).to have_link "register for an identity profile", href: "http://localhost:50130/test-rp"
+      expect(page).to have_link "test GOV.UK Verify user journeys", href: "http://localhost:50130/test-rp"
       expect(page).to have_css "#piwik-custom-url", text: "errors/generic-error"
       expect(page.status_code).to eq(500)
     end

--- a/spec/features/user_selects_an_unavailable_idp_for_signin_spec.rb
+++ b/spec/features/user_selects_an_unavailable_idp_for_signin_spec.rb
@@ -55,8 +55,8 @@ RSpec.describe 'when user visits sign-in page with an unavailable IDP configured
       expect(page).to have_title t('hub.certified_company_unavailable.title')
       expect(page).to have_link t('hub.certified_company_unavailable.verify_another_company_link'), href: about_certified_companies_path
 
-      expect(page).to have_content 'Other ways to register for an identity profile'
-      expect(page).to have_content 'If you can’t verify your identity using GOV.UK Verify, you can register for an identity profile'
+      expect(page).to have_content 'Other ways to test GOV.UK Verify user journeys'
+      expect(page).to have_content 'If you can’t verify your identity using GOV.UK Verify, you can test GOV.UK Verify user journeys'
       expect(page).to have_link 'here', href: 'http://www.example.com'
     end
 

--- a/spec/features/user_visits_about_identity_accounts_page_spec.rb
+++ b/spec/features/user_visits_about_identity_accounts_page_spec.rb
@@ -26,8 +26,8 @@ RSpec.describe 'When the user visits the about identity accounts page' do
 
     expect(page).to have_content t('hub.about_identity_accounts.summary')
     expect(page).to have_content t('hub.about_identity_accounts.details')
-    expect(page).to have_content 'register for an identity profile'
-    expect(page).to have_content 'Register for an identity profile (forceauthn & no cycle3)'
+    expect(page).to have_content 'test GOV.UK Verify user journeys'
+    expect(page).to have_content 'Test GOV.UK Verify user journeys (forceauthn & no cycle3)'
   end
 
   it 'will go to about choosing a company page when start now is clicked if user on LOA2 journey' do

--- a/spec/features/user_visits_cancelled_registration_page_spec.rb
+++ b/spec/features/user_visits_cancelled_registration_page_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'When user visits cancelled registration page' do
     visit('/cancelled-registration')
 
     expect(page).to have_title t('hub.cancelled_registration.title')
-    expect(page).to have_link('Find out the other ways to register for an identity profile', href: other_ways_to_access_service_path)
+    expect(page).to have_link('Find out the other ways to test GOV.UK Verify user journeys', href: other_ways_to_access_service_path)
     expect(page).to have_link t('hub.cancelled_registration.options.verify_with_another_company'), href: choose_a_certified_company_path
     expect(page).to have_link t('hub.cancelled_registration.options.verify_using_other_documents'), href: select_documents_path
     expect(page).to have_link t('hub.cancelled_registration.options.contact_verify'), href: "#{feedback_path}?feedback-source=CANCELLED_REGISTRATION"
@@ -27,7 +27,7 @@ RSpec.describe 'When user visits cancelled registration page' do
     visit('/cancelled-registration')
 
     expect(page).to have_title t('hub.cancelled_registration.title')
-    expect(page).to have_link('Find out the other ways to register for an identity profile', href: other_ways_to_access_service_path)
+    expect(page).to have_link('Find out the other ways to test GOV.UK Verify user journeys', href: other_ways_to_access_service_path)
     expect(page).to have_link t('hub.cancelled_registration.options.verify_with_another_company'), href: choose_a_certified_company_path
     expect(page).to have_link t('hub.cancelled_registration.options.contact_verify'), href: "#{feedback_path}?feedback-source=CANCELLED_REGISTRATION"
 

--- a/spec/features/user_visits_choose_a_country_page_spec.rb
+++ b/spec/features/user_visits_choose_a_country_page_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe 'When the user visits the choose a country page' do
     given_a_session_supporting_eidas
 
     visit '/choose-a-country'
-    click_on t('hub.choose_a_country.country_not_listed_link', other_ways_description: 'register for an identity profile')
+    click_on t('hub.choose_a_country.country_not_listed_link', other_ways_description: 'test GOV.UK Verify user journeys')
 
     expect(page).to have_current_path('/other-ways-to-access-service')
   end

--- a/spec/features/user_visits_confirm_your_identity_page_spec.rb
+++ b/spec/features/user_visits_confirm_your_identity_page_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe 'When the user visits the confirm-your-identity page' do
 
     it 'includes rp display name in text' do
       visit '/confirm-your-identity'
-      expect(page).to have_text t('hub.confirm_your_identity.need_to_signin_again', transaction_name: 'register for an identity profile')
+      expect(page).to have_text t('hub.confirm_your_identity.need_to_signin_again', transaction_name: 'test GOV.UK Verify user journeys')
     end
 
     it 'should include a link to sign-in in case listed idp is incorrect' do

--- a/spec/features/user_visits_confirmation_page_spec.rb
+++ b/spec/features/user_visits_confirmation_page_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'When user visits the confirmation page' do
     expect(page).to have_link t('hub.feedback.title'), href: '/feedback?feedback-source=CONFIRMATION_PAGE'
     expect(page).to have_title t('hub.confirmation.title')
     expect(page).to have_text t('hub.confirmation.message', display_name: 'IDCorp')
-    expect(page).to have_text t('hub.confirmation.continue_to_rp', transaction_name: 'register for an identity profile')
+    expect(page).to have_text t('hub.confirmation.continue_to_rp', transaction_name: 'test GOV.UK Verify user journeys')
   end
 
   it 'displays the IDP name' do

--- a/spec/features/user_visits_failed_registration_page_spec.rb
+++ b/spec/features/user_visits_failed_registration_page_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe 'When the user visits the failed registration page and' do
 
       expect_page_to_have_main_content
       expect(page).to have_content t('hub.failed_registration.other_ways_summary',
-                                          other_ways_description: 'register for an identity profile')
+                                          other_ways_description: 'test GOV.UK Verify user journeys')
       expect(page).to have_link t('hub.failed_registration.start_again'), href: select_documents_path
     end
 
@@ -59,7 +59,7 @@ RSpec.describe 'When the user visits the failed registration page and' do
 
       expect_page_to_have_main_content
       expect(page).to have_content t('hub.failed_registration.other_ways_summary',
-                                          other_ways_description: 'register for an identity profile')
+                                          other_ways_description: 'test GOV.UK Verify user journeys')
       expect(page).to have_link t('hub.failed_registration.start_again'), href: choose_a_certified_company_path
     end
   end

--- a/spec/features/user_visits_may_not_work_if_you_live_overseas_spec.rb
+++ b/spec/features/user_visits_may_not_work_if_you_live_overseas_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe 'When the user visits the may-not-work-if-you-live-overseas page'
     visit '/may-not-work-if-you-live-overseas'
 
     expect_feedback_source_to_be(page, 'MAY_NOT_WORK_IF_YOU_LIVE_OVERSEAS_PAGE', '/may-not-work-if-you-live-overseas')
-    expect(page).to have_content('If you can’t verify your identity using GOV.UK Verify, you can register for an identity profile here')
-    expect(page).to have_content('register for an identity profile')
+    expect(page).to have_content('If you can’t verify your identity using GOV.UK Verify, you can test GOV.UK Verify user journeys here')
+    expect(page).to have_content('test GOV.UK Verify user journeys')
     expect(page).to have_link 'here', href: 'http://www.example.com'
   end
 

--- a/spec/features/user_visits_prove_your_identity_page_spec.rb
+++ b/spec/features/user_visits_prove_your_identity_page_spec.rb
@@ -36,6 +36,6 @@ RSpec.describe 'When the user visits the prove identity page' do
     expect(page).to have_content t('errors.no_cookies.enable_cookies')
     expect(page).to have_http_status :forbidden
     expect(page).to have_link 'feedback', href: '/feedback?feedback-source=COOKIE_NOT_FOUND_PAGE'
-    expect(page).to have_link "register for an identity profile", href: "http://localhost:50130/test-rp"
+    expect(page).to have_link "test GOV.UK Verify user journeys", href: "http://localhost:50130/test-rp"
   end
 end

--- a/spec/features/user_visits_resume_registration_page_spec.rb
+++ b/spec/features/user_visits_resume_registration_page_spec.rb
@@ -4,7 +4,7 @@ require 'piwik_test_helper'
 
 RSpec.describe 'When the user visits the resume registration page and' do
   let(:idp_display_name) { 'IDCorp' }
-  let(:service_name) { 'register for an identity profile' }
+  let(:service_name) { 'test GOV.UK Verify user journeys' }
   let(:rp_entity_id) { 'http://www.test-rp.gov.uk/SAML2/MD' }
   let(:originating_ip) { '<PRINCIPAL IP ADDRESS COULD NOT BE DETERMINED>' }
   let(:idp_entity_id) { 'http://idcorp.com' }

--- a/spec/features/user_visits_start_page_spec.rb
+++ b/spec/features/user_visits_start_page_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe 'When the user visits the start page' do
       expect(page).to have_content t('errors.no_cookies.enable_cookies')
       expect(page).to have_http_status :forbidden
       expect(page).to have_link 'feedback', href: '/feedback?feedback-source=COOKIE_NOT_FOUND_PAGE'
-      expect(page).to have_link "register for an identity profile", href: "http://localhost:50130/test-rp"
+      expect(page).to have_link "test GOV.UK Verify user journeys", href: "http://localhost:50130/test-rp"
     end
 
     it 'will display the generic error when start time is missing from session' do
@@ -100,7 +100,7 @@ RSpec.describe 'When the user visits the start page' do
       page.set_rack_session(start_time: expired_start_time)
       visit '/start'
       expect(page).to have_content t('hub.transaction_list.title')
-      expect(page).to have_link 'register for an identity profile', href: 'http://localhost:50130/test-rp'
+      expect(page).to have_link 'test GOV.UK Verify user journeys', href: 'http://localhost:50130/test-rp'
       expect(page).to have_http_status :bad_request
       expect(page).to have_link 'feedback', href: '/feedback?feedback-source=EXPIRED_ERROR_PAGE'
     end

--- a/spec/features/user_visits_verify_will_not_work_for_you_page_spec.rb
+++ b/spec/features/user_visits_verify_will_not_work_for_you_page_spec.rb
@@ -26,8 +26,8 @@ RSpec.describe 'When the user visits the Verify will not work for you page' do
   it 'includes other ways text' do
     visit '/verify-will-not-work-for-you'
 
-    expect(page).to have_content('If you can’t verify your identity using GOV.UK Verify, you can register for an identity profile here')
-    expect(page).to have_content('register for an identity profile')
+    expect(page).to have_content('If you can’t verify your identity using GOV.UK Verify, you can test GOV.UK Verify user journeys here')
+    expect(page).to have_content('test GOV.UK Verify user journeys')
     expect(page).to have_link 'here', href: 'http://www.example.com'
   end
 end

--- a/spec/features/user_visits_why_might_this_not_work_for_me_page_spec.rb
+++ b/spec/features/user_visits_why_might_this_not_work_for_me_page_spec.rb
@@ -9,15 +9,15 @@ RSpec.describe 'When the user visits the why-might-this-not-work-for-me page' do
 
   it 'displays the page in Welsh' do
     visit '/pam-efallai-na-fydd-hyn-yn-gweithio-i-mi'
-    expect(page).to have_content('If you can’t verify your identity using GOV.UK Verify, you can register for an identity profile here')
+    expect(page).to have_content('If you can’t verify your identity using GOV.UK Verify, you can test GOV.UK Verify user journeys here')
     expect(page).to have_css 'html[lang=cy]'
   end
 
   it 'includes other ways text' do
     visit '/why-might-this-not-work-for-me'
 
-    expect(page).to have_content('If you can’t verify your identity using GOV.UK Verify, you can register for an identity profile here')
-    expect(page).to have_content('register for an identity profile')
+    expect(page).to have_content('If you can’t verify your identity using GOV.UK Verify, you can test GOV.UK Verify user journeys here')
+    expect(page).to have_content('test GOV.UK Verify user journeys')
     expect(page).to have_link 'here', href: 'http://www.example.com'
   end
 

--- a/spec/services/rp_translation_service_spec.rb
+++ b/spec/services/rp_translation_service_spec.rb
@@ -14,11 +14,11 @@ describe 'RpTranslationService' do
 
   it 'should update I18n with translations for a particular transaction in all locales' do
     translations = {
-      name: "register for an identity profile",
+      name: "test GOV.UK Verify user journeys",
       rp_name: "Test RP",
       analytics_description: "analytics description for test-rp",
-      other_ways_text: "<p>If you can’t verify your identity using GOV.UK Verify, you can register for an identity profile <a href=\"http://www.example.com\">here</a>.</p><p>Tell us your:</p><ul><li>name</li><li>age</li></ul><p>Include any other relevant details if you have them.</p>",
-      other_ways_description: "register for an identity profile",
+      other_ways_text: "<p>If you can’t verify your identity using GOV.UK Verify, you can test GOV.UK Verify user journeys <a href=\"http://www.example.com\">here</a>.</p><p>Tell us your:</p><ul><li>name</li><li>age</li></ul><p>Include any other relevant details if you have them.</p>",
+      other_ways_description: "test GOV.UK Verify user journeys",
       tailored_text: "External data source: EN: This is tailored text for test-rp",
       taxon_name: "Benefits",
       custom_fail_heading: '',
@@ -44,11 +44,11 @@ describe 'RpTranslationService' do
 
   it 'should keep existing translations when config proxy returns an empty hash' do
     translations = {
-        name: "register for an identity profile",
+        name: "test GOV.UK Verify user journeys",
         rp_name: "Test RP",
         analytics_description: "analytics description for test-rp",
-        other_ways_text: "<p>If you can’t verify your identity using GOV.UK Verify, you can register for an identity profile <a href=\"http://www.example.com\">here</a>.</p><p>Tell us your:</p><ul><li>name</li><li>age</li></ul><p>Include any other relevant details if you have them.</p>",
-        other_ways_description: "register for an identity profile",
+        other_ways_text: "<p>If you can’t verify your identity using GOV.UK Verify, you can test GOV.UK Verify user journeys <a href=\"http://www.example.com\">here</a>.</p><p>Tell us your:</p><ul><li>name</li><li>age</li></ul><p>Include any other relevant details if you have them.</p>",
+        other_ways_description: "test GOV.UK Verify user journeys",
         tailored_text: "External data source: EN: This is tailored text for test-rp",
         taxon_name: "Benefits",
         custom_fail_heading: '',
@@ -65,17 +65,17 @@ describe 'RpTranslationService' do
     translation_service.update_rp_translations('test-rp')
     translation_service.update_rp_translations('test-rp')
 
-    expect(I18n.t("rps.test-rp.name")).to eq("register for an identity profile")
+    expect(I18n.t("rps.test-rp.name")).to eq("test GOV.UK Verify user journeys")
     expect(I18n.t("rps.test-rp.rp_name")).to eq("Test RP")
   end
 
   it 'should only update individual translations when config proxy returns partial translations' do
     translations = {
-        name: "register for an identity profile",
+        name: "test GOV.UK Verify user journeys",
         rp_name: "Test RP",
         analytics_description: "analytics description for test-rp",
-        other_ways_text: "<p>If you can’t verify your identity using GOV.UK Verify, you can register for an identity profile <a href=\"http://www.example.com\">here</a>.</p><p>Tell us your:</p><ul><li>name</li><li>age</li></ul><p>Include any other relevant details if you have them.</p>",
-        other_ways_description: "register for an identity profile",
+        other_ways_text: "<p>If you can’t verify your identity using GOV.UK Verify, you can test GOV.UK Verify user journeys <a href=\"http://www.example.com\">here</a>.</p><p>Tell us your:</p><ul><li>name</li><li>age</li></ul><p>Include any other relevant details if you have them.</p>",
+        other_ways_description: "test GOV.UK Verify user journeys",
         tailored_text: "External data source: EN: This is tailored text for test-rp",
         taxon_name: "Benefits",
         custom_fail_heading: '',
@@ -95,7 +95,7 @@ describe 'RpTranslationService' do
     translation_service.update_rp_translations('test-rp')
     translation_service.update_rp_translations('test-rp')
 
-    expect(I18n.t("rps.test-rp.name")).to eq("register for an identity profile")
+    expect(I18n.t("rps.test-rp.name")).to eq("test GOV.UK Verify user journeys")
     expect(I18n.t("rps.test-rp.rp_name")).to eq("Updated Test RP")
   end
 end

--- a/stub/api/stub_api.rb
+++ b/stub/api/stub_api.rb
@@ -35,22 +35,22 @@ class StubApi < Sinatra::Base
   get '/config/transactions/:entity_id/translations/:locale' do
     if params['locale'] == 'en'
       '{
-        "name":"register for an identity profile",
+        "name":"test GOV.UK Verify user journeys",
         "rpName":"EN: Test RP",
         "analyticsDescription":"analytics description for test-rp",
-        "otherWaysText":"<p>If you can’t verify your identity using GOV.UK Verify, you can register for an identity profile <a href=\"http://www.example.com\">here</a>.</p><p>Tell us your:</p><ul><li>name</li><li>age</li></ul><p>Include any other relevant details if you have them.</p>",
-        "otherWaysDescription":"register for an identity profile",
+        "otherWaysText":"<p>If you can’t verify your identity using GOV.UK Verify, you can test GOV.UK Verify user journeys <a href=\"http://www.example.com\">here</a>.</p><p>Tell us your:</p><ul><li>name</li><li>age</li></ul><p>Include any other relevant details if you have them.</p>",
+        "otherWaysDescription":"test GOV.UK Verify user journeys",
         "tailoredText":"External data source: EN: This is tailored text for test-rp",
         "taxonName":"Benefits",
         "customFailHeading":"This is a custom fail page."
       }'
     else
       '{
-        "name":"register for an identity profile",
+        "name":"test GOV.UK Verify user journeys",
         "rpName":"CY: Test RP",
         "analyticsDescription":"analytics description for test-rp",
-        "otherWaysText":"<p>If you can’t verify your identity using GOV.UK Verify, you can register for an identity profile <a href=\"http://www.example.com\">here</a>.</p><p>Tell us your:</p><ul><li>name</li><li>age</li></ul><p>Include any other relevant details if you have them.</p>",
-        "otherWaysDescription":"register for an identity profile",
+        "otherWaysText":"<p>If you can’t verify your identity using GOV.UK Verify, you can test GOV.UK Verify user journeys <a href=\"http://www.example.com\">here</a>.</p><p>Tell us your:</p><ul><li>name</li><li>age</li></ul><p>Include any other relevant details if you have them.</p>",
+        "otherWaysDescription":"test GOV.UK Verify user journeys",
         "tailoredText":"External data source: CY: This is tailored text for test-rp",
         "taxonName":"Benefits",
         "customFailHeading":"This is a custom fail page in welsh."

--- a/stub/locales/rps/test-rp-non-eidas.yml
+++ b/stub/locales/rps/test-rp-non-eidas.yml
@@ -1,17 +1,17 @@
 en:
   rps:
     test-rp-non-eidas:
-      name: register for an identity profile
+      name: test GOV.UK Verify user journeys
       rp_name: Test RP
       analytics_description: analytics description for test-rp-non-eidas
       other_ways_text: |
-        <p>If you can’t verify your identity using GOV.UK Verify, you can register for an identity profile <a href="http://www.example.com">here</a>.</p>
+        <p>If you can’t verify your identity using GOV.UK Verify, you can test GOV.UK Verify user journeys <a href="http://www.example.com">here</a>.</p>
         <p>Tell us your:</p>
         <ul>
          <li>name</li>
          <li>age</li>
         </ul>
         <p>Include any other relevant details if you have them.</p>
-      other_ways_description: register for an identity profile
+      other_ways_description: test GOV.UK Verify user journeys
       tailored_text: <p>This is tailored text for test-rp</p>
       taxon_name: Benefits


### PR DESCRIPTION
Renaming test-rp name "register for an identity" profile to "test GOV.UK Verify user journeys" to make the content more readable.

Related PRs:
✅ https://github.com/alphagov/verify-acceptance-tests/pull/37
✅ https://github.com/alphagov/ida-hub-acceptance-tests/pull/107
✅ https://github.com/alphagov/verify-hub-federation-config/pull/202
✅ https://github.com/alphagov/verify-local-startup/pull/53
✅ https://github.com/alphagov/verify-stub-idp/pull/53
✅ https://github.com/alphagov/verify-test-rp/pull/19
