### PR TITLE
BAU: Fix state transitions between eIDAS and Verify

### DIFF
--- a/app/controllers/choose_a_country_controller.rb
+++ b/app/controllers/choose_a_country_controller.rb
@@ -6,6 +6,7 @@ class ChooseACountryController < ApplicationController
   before_action :setup_countries
 
   def choose_a_country
+    POLICY_PROXY.restart_journey(session[:verify_session_id]) if is_provider_type?(JourneyType::VERIFY)
     @other_ways_description = current_transaction.other_ways_description
   end
 

--- a/app/controllers/partials/user_session_partial_controller.rb
+++ b/app/controllers/partials/user_session_partial_controller.rb
@@ -23,6 +23,12 @@ module UserSessionPartialController
     session[:transaction_homepage]
   end
 
+  def is_provider_type?(type)
+    selected_provider_data = SelectedProviderData.from_session(session[:selected_provider])
+    return false if selected_provider_data.nil?
+    type == selected_provider_data.journey_type
+  end
+
   def current_selected_provider_data
     selected_provider_data = SelectedProviderData.from_session(session[:selected_provider])
     raise(Errors::WarningLevelError, 'No selected identity provider data in session') if selected_provider_data.nil?

--- a/app/controllers/prove_identity_controller.rb
+++ b/app/controllers/prove_identity_controller.rb
@@ -4,7 +4,7 @@ class ProveIdentityController < ApplicationController
   end
 
   def retry_eidas_journey
-    POLICY_PROXY.restart_eidas_journey(session[:verify_session_id])
+    POLICY_PROXY.restart_journey(session[:verify_session_id])
     redirect_to prove_identity_path
   end
 end

--- a/app/controllers/start_controller.rb
+++ b/app/controllers/start_controller.rb
@@ -3,6 +3,7 @@ class StartController < ApplicationController
   before_action :set_device_type_evidence
 
   def index
+    POLICY_PROXY.restart_journey(session[:verify_session_id]) if is_provider_type?(JourneyType::EIDAS)
     @form = StartForm.new({})
 
     render :start

--- a/app/models/policy_endpoints.rb
+++ b/app/models/policy_endpoints.rb
@@ -4,7 +4,7 @@ module PolicyEndpoints
   SIGN_IN_PROCESS_DETAILS_SUFFIX = 'sign-in-process-details'.freeze
   SELECT_IDP_SUFFIX = 'select-identity-provider'.freeze
   MATCHING_OUTCOME_SUFFIX = 'response-from-idp/response-processing-details'.freeze
-  RESTART_EIDAS_JOURNEY_SUFFIX = 'restart-eidas-journey'.freeze
+  RESTART_JOURNEY_SUFFIX = 'restart-journey'.freeze
   PARAM_PRINCIPAL_IP = 'principalIpAddress'.freeze
   PARAM_CYCLE_3_INPUT = 'cycle3Input'.freeze
   PARAM_SELECTED_ENTITY_ID = 'selectedIdpEntityId'.freeze
@@ -44,8 +44,8 @@ module PolicyEndpoints
     policy_endpoint(session_id, CYCLE_THREE_CANCEL_SUFFIX)
   end
 
-  def restart_eidas_journey_endpoint(session_id)
-    policy_endpoint(session_id, RESTART_EIDAS_JOURNEY_SUFFIX)
+  def restart_journey_endpoint(session_id)
+    policy_endpoint(session_id, RESTART_JOURNEY_SUFFIX)
   end
 
   def countries_endpoint(session_id)

--- a/app/models/policy_proxy.rb
+++ b/app/models/policy_proxy.rb
@@ -57,7 +57,7 @@ class PolicyProxy
     @api_client.post(select_a_country_endpoint(session_id, country), '')
   end
 
-  def restart_eidas_journey(session_id)
-    @api_client.post(restart_eidas_journey_endpoint(session_id), '')
+  def restart_journey(session_id)
+    @api_client.post(restart_journey_endpoint(session_id), '')
   end
 end

--- a/spec/api_test_helper.rb
+++ b/spec/api_test_helper.rb
@@ -315,8 +315,8 @@ module ApiTestHelper
     stub_request(:post, policy_api_uri(select_idp_endpoint(default_session_id))).to_return(status: 201)
   end
 
-  def stub_restart_eidas_journey
-    stub_request(:post, policy_api_uri(restart_eidas_journey_endpoint(default_session_id))).to_return(status: 500)
+  def stub_restart_journey
+    stub_request(:post, policy_api_uri(restart_journey_endpoint(default_session_id))).to_return(status: 500)
   end
 
   def stub_api_no_docs_idps

--- a/spec/features/user_visits_failed_sign_in_page_spec.rb
+++ b/spec/features/user_visits_failed_sign_in_page_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe 'When the user visits the failed sign in page' do
   context '#country' do
     before(:each) do
       stub_countries_list
-      stub_restart_eidas_journey
+      stub_restart_journey
       set_selected_country_in_session(entity_id: 'http://stub-country.uk', simple_id: 'YY', enabled: true)
     end
 

--- a/spec/features/user_visits_response_processing_page_spec.rb
+++ b/spec/features/user_visits_response_processing_page_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'When the user visits the response processing page' do
   it 'should redirect to prove-identity page on matching error for an eIDAS journey' do
     set_selected_country_in_session(simple_id: 'stub-country')
     stub_matching_outcome MatchingOutcomeResponse::SHOW_MATCHING_ERROR_PAGE
-    stub_restart_eidas_journey
+    stub_restart_journey
 
     visit '/response-processing'
     click_on t('hub.response_processing.matching_error.online_link')


### PR DESCRIPTION
Currently hub doesn't support switching between a country and IDP.
We're seeing errors when people try a country, go back and select IDP (the state doesn't match).
This is to rename the restart endpoint to work for both
and run only if other type has been selected. This is the first part which fixes the transition from eidas to verify.