### PR TITLE
EID-1004: Fix transition between Verify and eIDAS journeys

### DIFF
--- a/app/controllers/choose_a_country_controller.rb
+++ b/app/controllers/choose_a_country_controller.rb
@@ -6,6 +6,7 @@ class ChooseACountryController < ApplicationController
   before_action :setup_countries
 
   def choose_a_country
+    POLICY_PROXY.restart_journey(session[:verify_session_id]) if is_provider_type?(JourneyType::VERIFY)
     @other_ways_description = current_transaction.other_ways_description
   end
 

--- a/app/controllers/choose_a_country_controller.rb
+++ b/app/controllers/choose_a_country_controller.rb
@@ -6,7 +6,7 @@ class ChooseACountryController < ApplicationController
   before_action :setup_countries
 
   def choose_a_country
-    POLICY_PROXY.restart_journey(session[:verify_session_id]) if is_provider_type?(JourneyType::VERIFY)
+    restart_journey if identity_provider_selected? && !user_journey_type?(JourneyType::EIDAS)
     @other_ways_description = current_transaction.other_ways_description
   end
 

--- a/app/controllers/partials/user_session_partial_controller.rb
+++ b/app/controllers/partials/user_session_partial_controller.rb
@@ -23,12 +23,6 @@ module UserSessionPartialController
     session[:transaction_homepage]
   end
 
-  def is_provider_type?(type)
-    selected_provider_data = SelectedProviderData.from_session(session[:selected_provider])
-    return false if selected_provider_data.nil?
-    type == selected_provider_data.journey_type
-  end
-
   def current_selected_provider_data
     selected_provider_data = SelectedProviderData.from_session(session[:selected_provider])
     raise(Errors::WarningLevelError, 'No selected identity provider data in session') if selected_provider_data.nil?
@@ -44,10 +38,19 @@ module UserSessionPartialController
     journey_type
   end
 
+  def user_journey_type?(journey_type)
+    journey_type == current_selected_provider_data.journey_type
+  end
+
   def selected_identity_provider
     selected_provider_data = current_selected_provider_data
     raise(Errors::WarningLevelError, 'No selected IDP in session') unless selected_provider_data.is_selected_verify_idp?
     IdentityProvider.from_session(selected_provider_data.identity_provider)
+  end
+
+  def identity_provider_selected?
+    selected_provider_data = SelectedProviderData.from_session(session[:selected_provider])
+    !selected_provider_data.nil?
   end
 
   def selected_country
@@ -62,5 +65,10 @@ module UserSessionPartialController
 
   def store_selected_country_for_session(selected_country)
     session[:selected_provider] = SelectedProviderData.new(JourneyType::EIDAS, selected_country)
+  end
+
+  def restart_journey
+    POLICY_PROXY.restart_journey(session[:verify_session_id])
+    session.delete(:selected_provider)
   end
 end

--- a/app/controllers/partials/user_session_partial_controller.rb
+++ b/app/controllers/partials/user_session_partial_controller.rb
@@ -23,6 +23,12 @@ module UserSessionPartialController
     session[:transaction_homepage]
   end
 
+  def is_provider_type?(type)
+    selected_provider_data = SelectedProviderData.from_session(session[:selected_provider])
+    return false if selected_provider_data.nil?
+    type == selected_provider_data.journey_type
+  end
+
   def current_selected_provider_data
     selected_provider_data = SelectedProviderData.from_session(session[:selected_provider])
     raise(Errors::WarningLevelError, 'No selected identity provider data in session') if selected_provider_data.nil?

--- a/app/controllers/prove_identity_controller.rb
+++ b/app/controllers/prove_identity_controller.rb
@@ -4,7 +4,7 @@ class ProveIdentityController < ApplicationController
   end
 
   def retry_eidas_journey
-    POLICY_PROXY.restart_eidas_journey(session[:verify_session_id])
+    POLICY_PROXY.restart_journey(session[:verify_session_id])
     redirect_to prove_identity_path
   end
 end

--- a/app/controllers/prove_identity_controller.rb
+++ b/app/controllers/prove_identity_controller.rb
@@ -4,7 +4,7 @@ class ProveIdentityController < ApplicationController
   end
 
   def retry_eidas_journey
-    POLICY_PROXY.restart_journey(session[:verify_session_id])
+    restart_journey if identity_provider_selected? && user_journey_type?(JourneyType::EIDAS)
     redirect_to prove_identity_path
   end
 end

--- a/app/controllers/start_controller.rb
+++ b/app/controllers/start_controller.rb
@@ -3,7 +3,7 @@ class StartController < ApplicationController
   before_action :set_device_type_evidence
 
   def index
-    POLICY_PROXY.restart_journey(session[:verify_session_id]) if is_provider_type?(JourneyType::EIDAS)
+    restart_journey if identity_provider_selected? && !user_journey_type?(JourneyType::VERIFY)
     @form = StartForm.new({})
 
     render :start

--- a/app/controllers/start_controller.rb
+++ b/app/controllers/start_controller.rb
@@ -3,6 +3,7 @@ class StartController < ApplicationController
   before_action :set_device_type_evidence
 
   def index
+    POLICY_PROXY.restart_journey(session[:verify_session_id]) if is_provider_type?(JourneyType::EIDAS)
     @form = StartForm.new({})
 
     render :start

--- a/app/models/policy_endpoints.rb
+++ b/app/models/policy_endpoints.rb
@@ -4,7 +4,7 @@ module PolicyEndpoints
   SIGN_IN_PROCESS_DETAILS_SUFFIX = 'sign-in-process-details'.freeze
   SELECT_IDP_SUFFIX = 'select-identity-provider'.freeze
   MATCHING_OUTCOME_SUFFIX = 'response-from-idp/response-processing-details'.freeze
-  RESTART_EIDAS_JOURNEY_SUFFIX = 'restart-eidas-journey'.freeze
+  RESTART_JOURNEY_SUFFIX = 'restart-journey'.freeze
   PARAM_PRINCIPAL_IP = 'principalIpAddress'.freeze
   PARAM_CYCLE_3_INPUT = 'cycle3Input'.freeze
   PARAM_SELECTED_ENTITY_ID = 'selectedIdpEntityId'.freeze
@@ -44,8 +44,8 @@ module PolicyEndpoints
     policy_endpoint(session_id, CYCLE_THREE_CANCEL_SUFFIX)
   end
 
-  def restart_eidas_journey_endpoint(session_id)
-    policy_endpoint(session_id, RESTART_EIDAS_JOURNEY_SUFFIX)
+  def restart_journey_endpoint(session_id)
+    policy_endpoint(session_id, RESTART_JOURNEY_SUFFIX)
   end
 
   def countries_endpoint(session_id)

--- a/app/models/policy_proxy.rb
+++ b/app/models/policy_proxy.rb
@@ -57,7 +57,7 @@ class PolicyProxy
     @api_client.post(select_a_country_endpoint(session_id, country), '')
   end
 
-  def restart_eidas_journey(session_id)
-    @api_client.post(restart_eidas_journey_endpoint(session_id), '')
+  def restart_journey(session_id)
+    @api_client.post(restart_journey_endpoint(session_id), '')
   end
 end

--- a/spec/api_test_helper.rb
+++ b/spec/api_test_helper.rb
@@ -316,7 +316,7 @@ module ApiTestHelper
   end
 
   def stub_restart_journey
-    stub_request(:post, policy_api_uri(restart_journey_endpoint(default_session_id))).to_return(status: 500)
+    stub_request(:post, policy_api_uri(restart_journey_endpoint(default_session_id))).to_return(status: 200)
   end
 
   def stub_api_no_docs_idps

--- a/spec/api_test_helper.rb
+++ b/spec/api_test_helper.rb
@@ -315,8 +315,8 @@ module ApiTestHelper
     stub_request(:post, policy_api_uri(select_idp_endpoint(default_session_id))).to_return(status: 201)
   end
 
-  def stub_restart_eidas_journey
-    stub_request(:post, policy_api_uri(restart_eidas_journey_endpoint(default_session_id))).to_return(status: 500)
+  def stub_restart_journey
+    stub_request(:post, policy_api_uri(restart_journey_endpoint(default_session_id))).to_return(status: 500)
   end
 
   def stub_api_no_docs_idps

--- a/spec/controller_helper.rb
+++ b/spec/controller_helper.rb
@@ -18,3 +18,7 @@ end
 def set_selected_country(selected_country)
   session[:selected_provider] = SelectedProviderData.new(JourneyType::EIDAS, selected_country)
 end
+
+def set_session_supports_eidas
+  session[:transaction_supports_eidas] = true
+end

--- a/spec/controllers/choose_a_country_controller_spec.rb
+++ b/spec/controllers/choose_a_country_controller_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+require 'controller_helper'
+require 'api_test_helper'
+require 'piwik_test_helper'
+
+describe ChooseACountryController do
+  before(:each) do
+    set_session_and_cookies_with_loa('LEVEL_2')
+    set_session_supports_eidas
+    stub_countries_list
+  end
+
+  context 'when choosing a country' do
+    let(:stub_restart_journey_request) { stub_restart_journey }
+
+    it 'will not restart journey if identity provider not selected' do
+      get :choose_a_country, params: { locale: 'en' }
+      expect(stub_restart_journey_request).to have_not_been_made
+      expect(session[:selected_provider]).to be_nil
+    end
+
+    it 'will not restart journey when country selected' do
+      set_selected_country 'stub-country'
+
+      get :choose_a_country, params: { locale: 'en' }
+      expect(stub_restart_journey_request).to have_not_been_made
+    end
+
+    it 'will restart journey when it is not eIDAS' do
+      set_selected_idp 'stub-idp'
+      stub_restart_journey
+
+      get :choose_a_country, params: { locale: 'en' }
+      expect(stub_restart_journey_request).to have_been_made.once
+      expect(session[:selected_provider]).to be_nil
+    end
+  end
+end

--- a/spec/controllers/prove_identity_controller_spec.rb
+++ b/spec/controllers/prove_identity_controller_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+require 'controller_helper'
+require 'api_test_helper'
+require 'piwik_test_helper'
+
+describe ProveIdentityController do
+  before(:each) do
+    set_session_and_cookies_with_loa('LEVEL_2')
+  end
+
+  it 'renders prove identity page' do
+    get :index, params: { locale: 'en' }
+    expect(subject).to render_template(:prove_identity)
+  end
+
+  context 'when restarting eIDAS journey' do
+    let(:stub_restart_journey_request) { stub_restart_journey }
+
+    it 'will not restart journey when it is not eIDAS' do
+      set_selected_idp 'stub-idp'
+
+      get :retry_eidas_journey, params: { locale: 'en' }
+
+      expect(subject).to redirect_to(prove_identity_path)
+      expect(stub_restart_journey_request).to have_not_been_made
+    end
+
+    it 'will restart journey when country selected' do
+      set_selected_country 'stub-country'
+      stub_restart_journey
+
+      get :retry_eidas_journey, params: { locale: 'en' }
+
+      expect(subject).to redirect_to(prove_identity_path)
+      expect(stub_restart_journey_request).to have_been_made.once
+      expect(session[:selected_provider]).to be_nil
+    end
+  end
+end

--- a/spec/controllers/start_controller_spec.rb
+++ b/spec/controllers/start_controller_spec.rb
@@ -8,9 +8,33 @@ describe StartController do
     set_session_and_cookies_with_loa('LEVEL_2')
   end
 
-  it 'renders LOA2 start page if service is level 2' do
-    get :index, params: { locale: 'en' }
-    expect(subject).to render_template(:start)
+  context 'when rendering start page' do
+    let(:stub_restart_journey_request) { stub_restart_journey }
+
+    it 'renders LOA2 start page if service is level 2' do
+      get :index, params: { locale: 'en' }
+      expect(subject).to render_template(:start)
+      expect(stub_restart_journey_request).to have_not_been_made
+    end
+
+    it 'will not restart journey when IDP selected' do
+      set_selected_idp 'stub-idp'
+
+      get :index, params: { locale: 'en' }
+      expect(subject).to render_template(:start)
+      expect(stub_restart_journey_request).to have_not_been_made
+    end
+
+    it 'will restart journey when it is not Verify' do
+      set_selected_country 'stub-country'
+      stub_restart_journey
+
+      get :index, params: { locale: 'en' }
+
+      expect(subject).to render_template(:start)
+      expect(stub_restart_journey_request).to have_been_made.once
+      expect(session[:selected_provider]).to be_nil
+    end
   end
 
   context 'when form is valid' do

--- a/spec/features/user_visits_failed_sign_in_page_spec.rb
+++ b/spec/features/user_visits_failed_sign_in_page_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe 'When the user visits the failed sign in page' do
   context '#country' do
     before(:each) do
       stub_countries_list
-      stub_restart_eidas_journey
+      stub_restart_journey
       set_selected_country_in_session(entity_id: 'http://stub-country.uk', simple_id: 'YY', enabled: true)
     end
 

--- a/spec/features/user_visits_failed_sign_in_page_spec.rb
+++ b/spec/features/user_visits_failed_sign_in_page_spec.rb
@@ -51,7 +51,8 @@ RSpec.describe 'When the user visits the failed sign in page' do
       visit '/failed-country-sign-in'
       click_on t('hub.failed_country_sign_in.online_link')
 
-      expect(page).to have_current_path(prove_identity_retry_path)
+      expect(page).to have_current_path(prove_identity_path)
+      expect(page.get_rack_session.key?('selected_provider')).to be_falsey
     end
 
     it 'displays the content in Welsh' do

--- a/spec/features/user_visits_prove_your_identity_page_spec.rb
+++ b/spec/features/user_visits_prove_your_identity_page_spec.rb
@@ -27,6 +27,73 @@ RSpec.describe 'When the user visits the prove identity page' do
       expect(page).to have_content t('hub.prove_identity.heading', locale: :cy)
       expect(page).to have_css 'html[lang=cy]'
     end
+
+    context 'when selecting Verify option' do
+      it 'should redirect to start page' do
+        visit '/prove-identity'
+        click_on t('hub.prove_identity.use_verify.button_text')
+
+        expect(page).to have_current_path(start_path)
+        expect(page.get_rack_session.key?('selected_provider')).to be_falsey
+      end
+
+      it 'should redirect to start page and not restart journey if IDP is selected' do
+        set_selected_idp_in_session('stub-idp')
+
+        visit '/prove-identity'
+        click_on t('hub.prove_identity.use_verify.button_text')
+
+        expect(page).to have_current_path(start_path)
+        expect(page.get_rack_session_key('selected_provider')['identity_provider']).to eq('stub-idp')
+      end
+
+      it 'should redirect to start page and restart journey if country is selected' do
+        set_selected_country_in_session('stub-country')
+        stub_restart_journey
+
+        visit '/prove-identity'
+        click_on t('hub.prove_identity.use_verify.button_text')
+
+        expect(page).to have_current_path(start_path)
+        expect(page.get_rack_session.key?('selected_provider')).to be_falsey
+      end
+    end
+
+    context 'when selecting eIDAS option' do
+      before(:each) do
+        page.set_rack_session transaction_supports_eidas: true
+        stub_countries_list
+      end
+
+      it 'should redirect to choose_a_country page' do
+        visit '/prove-identity'
+        click_on t('hub.prove_identity.use_eidas.button_text')
+
+        expect(page).to have_current_path(choose_a_country_path)
+        expect(page.get_rack_session.key?('selected_provider')).to be_falsey
+      end
+
+      it 'should redirect to choose_a_country page and not restart journey if country is selected' do
+        set_selected_country_in_session('stub-country')
+
+        visit '/prove-identity'
+        click_on t('hub.prove_identity.use_eidas.button_text')
+
+        expect(page).to have_current_path(choose_a_country_path)
+        expect(page.get_rack_session_key('selected_provider')['identity_provider']).to eq('stub-country')
+      end
+
+      it 'should redirect to choose_a_country page and restart journey if IDP is selected' do
+        set_selected_idp_in_session('stub-idp')
+        stub_restart_journey
+
+        visit '/prove-identity'
+        click_on t('hub.prove_identity.use_eidas.button_text')
+
+        expect(page).to have_current_path(choose_a_country_path)
+        expect(page.get_rack_session.key?('selected_provider')).to be_falsey
+      end
+    end
   end
 
   it 'will display the no cookies error when all cookies are missing' do

--- a/spec/features/user_visits_response_processing_page_spec.rb
+++ b/spec/features/user_visits_response_processing_page_spec.rb
@@ -35,7 +35,8 @@ RSpec.describe 'When the user visits the response processing page' do
     visit '/response-processing'
     click_on t('hub.response_processing.matching_error.online_link')
 
-    expect(page).to have_current_path(prove_identity_retry_path)
+    expect(page).to have_current_path(prove_identity_path)
+    expect(page.get_rack_session.key?('selected_provider')).to be_falsey
   end
 
   it 'should redirect to redirect-to-service page on matching error for a Verify (IDP) journey' do
@@ -44,6 +45,6 @@ RSpec.describe 'When the user visits the response processing page' do
 
     visit '/response-processing'
 
-    expect(page).to have_link t('hub.response_processing.matching_error.online_link'), href: '/redirect-to-service/error'
+    expect(page).to have_link t('hub.response_processing.matching_error.online_link'), href: redirect_to_service_error_path
   end
 end

--- a/spec/features/user_visits_response_processing_page_spec.rb
+++ b/spec/features/user_visits_response_processing_page_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'When the user visits the response processing page' do
   it 'should redirect to prove-identity page on matching error for an eIDAS journey' do
     set_selected_country_in_session(simple_id: 'stub-country')
     stub_matching_outcome MatchingOutcomeResponse::SHOW_MATCHING_ERROR_PAGE
-    stub_restart_eidas_journey
+    stub_restart_journey
 
     visit '/response-processing'
     click_on t('hub.response_processing.matching_error.online_link')


### PR DESCRIPTION
Currently, if a user selects a country or an IDP without completing verification and clicks the back button to the journey picker page and then attempts a different type of journey, they receive a "service unavailable" error page as Policy doesn't allow a transition between `IdpSelected` and `EidasCountrySelected` states. The solution to this is to allow the frontend to ask Policy to restart the journey back to `SessionStartedState` when a user goes back to the journey picker page (`/prove-identity`) and selects a different type of journey. We already allow this for some eIDAS states. This piece of work makes the interfaces more general so that we can apply the same to Verify journeys as well.

Summary of changes:
  - rename `restart-eidas-journey` Policy endpoint to `restart-journey`
  -  Add logic to only restart the journey from the journey picker page or eIDAS error page when necessary
  - Delete `selected_provider` from session when a journey has been restarted - this ensures correct behaviour on the journey picker page (`/prove-identity`)
  - Add tests to reflect the above changes

Note: This has to be released before the related Hub|Policy changes in alphagov/verify-hub#155