### PR TITLE
HUB-306: Add headless RP links to e-mail resume links (HUB-185)

### DIFF
--- a/app/models/display/rp/transaction_taxon_correlator.rb
+++ b/app/models/display/rp/transaction_taxon_correlator.rb
@@ -1,7 +1,7 @@
 module Display
   module Rp
     class TransactionTaxonCorrelator
-      Transaction = Struct.new(:name, :taxon, :homepage, :loa_list)
+      Transaction = Struct.new(:name, :taxon, :homepage, :loa_list, :headless_startpage)
       Taxon = Struct.new(:name, :transactions)
 
       def initialize(rp_display_repository, rps_with_homepage_link, rps_with_name_only)
@@ -26,12 +26,15 @@ module Display
 
       def map_to_transactions(data)
         data.map do |item|
-          display_data = @rp_display_repository.get_translations(item.fetch('simpleId'))
-          homepage = @rps_with_name_only.include?(item.fetch('simpleId')) ? nil : item.fetch('serviceHomepage', nil)
+          simple_id = item.fetch('simpleId')
+          display_data = @rp_display_repository.get_translations(simple_id)
+          name_only = @rps_with_name_only.include?(simple_id)
+          homepage = name_only ? nil : item.fetch('serviceHomepage', nil)
+          headless_startpage = name_only ? nil : item.fetch('headlessStartpage', nil)
           # if there's no homepage, move the transaction down to the 'Other service' taxon
           taxon = homepage.nil? ? other_services_translation : display_data.taxon
           loa_list = item.fetch('loaList')
-          Transaction.new(display_data.name, taxon, homepage, loa_list)
+          Transaction.new(display_data.name, taxon, homepage, loa_list, headless_startpage)
         end
       end
 

--- a/app/views/paused_registration/from_resume_link.html.erb
+++ b/app/views/paused_registration/from_resume_link.html.erb
@@ -8,6 +8,6 @@
     <p><%= t 'hub.paused_registration.from_resume_link.restart_instructions_html', idp_name: @idp_display_data.name %></p>
 
     <h2 class="heading-medium"><%= t 'hub.transaction_list.title' %></h2>
-    <%= render partial: 'shared/transaction_list' %>
+    <%= render partial: 'shared/transaction_list_prefer_headless_start' %>
   </div>
 </div>

--- a/app/views/shared/_transaction_list_prefer_headless_start.html.erb
+++ b/app/views/shared/_transaction_list_prefer_headless_start.html.erb
@@ -1,0 +1,20 @@
+<% taxons = transaction_taxon_list %>
+<% if taxons.any? %>
+  <% taxons.each do |taxon| %>
+    <h3 class="heading-small"><%= taxon.name %></h3>
+    <ul class="list">
+      <% taxon.transactions.each do |transaction| %>
+        <li>
+          <% if transaction.headless_startpage %>
+            <%= link_to transaction.name, transaction.headless_startpage %>
+          <% elsif transaction.homepage %>
+            <%= link_to transaction.name, transaction.homepage %>
+          <% else %>
+            <%= transaction.name %>
+            <p class="form-hint"><%= t 'hub.transaction_list.hint' %></p>
+          <% end %>
+        </li>
+      <% end %>
+    </ul>
+  <% end %>
+<% end %>

--- a/spec/api_test_helper.rb
+++ b/spec/api_test_helper.rb
@@ -37,10 +37,22 @@ module ApiTestHelper
 
   def stub_transactions_list
     transactions = [
-        { 'simpleId' => 'test-rp', 'serviceHomepage' => 'http://localhost:50130/test-rp', 'loaList' => ['LEVEL_2'] },
-        { 'simpleId' => 'test-rp-noc3', 'serviceHomepage' => 'http://localhost:50130/test-rp-noc3', 'loaList' => ['LEVEL_2'] },
-        { 'simpleId' => 'headless-rp', 'serviceHomepage' => 'http://localhost:50130/headless-rp', 'loaList' => ['LEVEL_2'] },
-        { 'simpleId' => 'test-rp-with-continue-on-fail', 'serviceHomepage' => 'http://localhost:50130/test-rp-with-continue-on-fail', 'loaList' => ['LEVEL_2'] }
+      {
+        'simpleId' => 'test-rp', 'serviceHomepage' => 'http://localhost:50130/test-rp',
+        'loaList' => ['LEVEL_2'], 'headlessStartpage' => 'http://localhost:50130/success?rp-name=test-rp'
+      },
+      {
+        'simpleId' => 'test-rp-noc3', 'serviceHomepage' => 'http://localhost:50130/test-rp-noc3',
+        'loaList' => ['LEVEL_2'], 'headlessStartpage' => nil
+      },
+      {
+        'simpleId' => 'headless-rp', 'serviceHomepage' => 'http://localhost:50130/headless-rp',
+        'loaList' => ['LEVEL_2'], 'headlessStartpage' => nil
+      },
+      {
+        'simpleId' => 'test-rp-with-continue-on-fail', 'serviceHomepage' => 'http://localhost:50130/test-rp-with-continue-on-fail',
+        'loaList' => ['LEVEL_2'], 'headlessStartpage' => 'http://localhost:50130/success?rp-name=test-rp-with-continue-on-fail'
+      }
     ]
 
     stub_request(:get, api_transactions_endpoint).to_return(body: transactions.to_json, status: 200)

--- a/spec/features/user_visits_an_idp_emailed_link_to_paused_page_spec.rb
+++ b/spec/features/user_visits_an_idp_emailed_link_to_paused_page_spec.rb
@@ -9,16 +9,25 @@ RSpec.describe 'When the user is sent to the paused registration page using a li
 
   before(:each) do
     stub_api_idp_list_for_sign_in
+    stub_transactions_list
     stub_translations
   end
 
   context 'and the IDP specified in the URL is valid' do
-    it 'renders page with a list of available services' do
-      stub_transaction_details
-      set_session_and_session_cookies!
+    it 'renders page with a list of available services with headless RP links where applicable' do
       visit '/paused/stub-idp-one'
 
+      expect(page).to have_title(t('hub.paused_registration.from_resume_link.title', idp_name: idp_display_name))
       expect(page).to have_content(t('hub.paused_registration.from_resume_link.heading', idp_name: idp_display_name))
+      expect(page).to have_link('test GOV.UK Verify user journeys', href: 'http://localhost:50130/success?rp-name=test-rp')
+    end
+
+    it 'renders page with a list of available services with RP homepage links when headless page not configured' do
+      visit '/paused/stub-idp-one'
+
+      expect(page).to have_title(t('hub.paused_registration.from_resume_link.title', idp_name: idp_display_name))
+      expect(page).to have_content(t('hub.paused_registration.from_resume_link.heading', idp_name: idp_display_name))
+      expect(page).to have_link 'Test GOV.UK Verify user journeys (forceauthn & no cycle3)', href: 'http://localhost:50130/test-rp-noc3'
     end
   end
 end


### PR DESCRIPTION
Add new partial to render RP list using headless links (if present).
Use new partial in resume link page.