### PR TITLE
HUB-298: Update cancel page to match new fail page

### DIFF
--- a/app/controllers/cancelled_registration_loa1_controller.rb
+++ b/app/controllers/cancelled_registration_loa1_controller.rb
@@ -2,7 +2,7 @@ class CancelledRegistrationLoa1Controller < ApplicationController
   def index
     @idp = IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate(selected_identity_provider)
     @transaction = current_transaction
-    @other_ways_decorated = @transaction.other_ways_text
+    @other_ways_decorated = @transaction.other_ways_description
     @other_ways_decorated[0] = @other_ways_decorated[0].capitalize
 
     render :cancelled_registration_LOA1, locals: { transaction: @transaction }

--- a/app/controllers/cancelled_registration_loa1_controller.rb
+++ b/app/controllers/cancelled_registration_loa1_controller.rb
@@ -5,6 +5,6 @@ class CancelledRegistrationLoa1Controller < ApplicationController
     @other_ways_decorated = @transaction.other_ways_description
     @other_ways_decorated[0] = @other_ways_decorated[0].capitalize
 
-    render :cancelled_registration_LOA1, locals: { transaction: @transaction }
+    render :cancelled_registration_LOA1
   end
 end

--- a/app/controllers/cancelled_registration_loa1_controller.rb
+++ b/app/controllers/cancelled_registration_loa1_controller.rb
@@ -1,8 +1,10 @@
 class CancelledRegistrationLoa1Controller < ApplicationController
   def index
     @idp = IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate(selected_identity_provider)
-    @service_name = current_transaction.name
+    @transaction = current_transaction
+    @other_ways_decorated = @transaction.other_ways_text
+    @other_ways_decorated[0] = @other_ways_decorated[0].capitalize
 
-    render :cancelled_registration_LOA1
+    render :cancelled_registration_LOA1, locals: { transaction: @transaction }
   end
 end

--- a/app/controllers/cancelled_registration_loa2_controller.rb
+++ b/app/controllers/cancelled_registration_loa2_controller.rb
@@ -5,6 +5,6 @@ class CancelledRegistrationLoa2Controller < ApplicationController
     @other_ways_decorated = @transaction.other_ways_description
     @other_ways_decorated[0] = @other_ways_decorated[0].capitalize
 
-    render :cancelled_registration_LOA2, locals: { transaction: @transaction }
+    render :cancelled_registration_LOA2
   end
 end

--- a/app/controllers/cancelled_registration_loa2_controller.rb
+++ b/app/controllers/cancelled_registration_loa2_controller.rb
@@ -2,6 +2,8 @@ class CancelledRegistrationLoa2Controller < ApplicationController
   def index
     @idp = IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate(selected_identity_provider)
     @transaction = current_transaction
+    @other_ways_decorated = @transaction.other_ways_description
+    @other_ways_decorated[0] = @other_ways_decorated[0].capitalize
 
     render :cancelled_registration_LOA2, locals: { transaction: @transaction }
   end

--- a/app/controllers/cancelled_registration_loa2_controller.rb
+++ b/app/controllers/cancelled_registration_loa2_controller.rb
@@ -1,8 +1,8 @@
 class CancelledRegistrationLoa2Controller < ApplicationController
   def index
     @idp = IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate(selected_identity_provider)
-    @service_name = current_transaction.name
+    @transaction = current_transaction
 
-    render :cancelled_registration_LOA2
+    render :cancelled_registration_LOA2, locals: { transaction: @transaction }
   end
 end

--- a/app/views/cancelled_registration_loa1/cancelled_registration_LOA1.html.erb
+++ b/app/views/cancelled_registration_loa1/cancelled_registration_LOA1.html.erb
@@ -5,12 +5,27 @@
   <div class="column-two-thirds">
     <h1 class="heading-large"><%= t 'hub.cancelled_registration.heading', idp_name: @idp.display_name %></h1>
 
-    <p><%= t 'hub.cancelled_registration.next' %></p>
+    <p><%= t 'hub.cancelled_registration.what_next', service_name: @transaction.name%></p>
 
-    <ul class="list list-bullet">
-      <li><%= link_to t('hub.cancelled_registration.options.other_ways_to_verify', service_name: @service_name), other_ways_to_access_service_path %></li>
-      <li><%= link_to t('hub.cancelled_registration.options.verify_with_another_company'), choose_a_certified_company_path %></li>
-      <li><%= link_to t('hub.cancelled_registration.options.contact_verify'), feedback_path('feedback-source': feedback_source) %></li>
+    <h2 class="heading-medium"><%= t 'hub.cancelled_registration.try_another_summary' %></h2>
+
+    <div>
+      <p><%= t 'hub.cancelled_registration.try_another_text', idp_name: @idp.display_name %></p>
+      <%= link_to t('hub.cancelled_registration.about_choosing_a_company'), about_choosing_a_company_path%>
+    </div>
+
+    <h2 class="heading-medium"><%= t 'hub.cancelled_registration.other_ways_summary', other_ways_decorated: @other_ways_decorated %></h2>
+    <div>
+      <%= raw transaction.other_ways_text %>
+    </div>
+
+    <h2 class="heading-medium"><%= t 'hub.cancelled_registration.feedback_summary' %></h2>
+
+    <div>
+      <p><%= t 'hub.cancelled_registration.feedback_text' %></p>
+      <%= link_to t('hub.cancelled_registration.send_feedback'), feedback_path %>
+    </div>
+
     </ul>
   </div>
 </div>

--- a/app/views/cancelled_registration_loa1/cancelled_registration_LOA1.html.erb
+++ b/app/views/cancelled_registration_loa1/cancelled_registration_LOA1.html.erb
@@ -16,7 +16,7 @@
 
     <h2 class="heading-medium"><%= t 'hub.cancelled_registration.other_ways_summary', other_ways_decorated: @other_ways_decorated %></h2>
     <div>
-      <%= raw transaction.other_ways_text %>
+      <%= raw @transaction.other_ways_text %>
     </div>
 
     <h2 class="heading-medium"><%= t 'hub.cancelled_registration.feedback_summary' %></h2>

--- a/app/views/cancelled_registration_loa2/cancelled_registration_LOA2.html.erb
+++ b/app/views/cancelled_registration_loa2/cancelled_registration_LOA2.html.erb
@@ -5,13 +5,27 @@
   <div class="column-two-thirds">
     <h1 class="heading-large"><%= t 'hub.cancelled_registration.heading', idp_name: @idp.display_name %></h1>
 
-    <p><%= t 'hub.cancelled_registration.next' %></p>
+    <p><%= t 'hub.cancelled_registration.what_next', service_name: @transaction.name%></p>
 
-    <ul class="list list-bullet">
-      <li><%= link_to t('hub.cancelled_registration.options.other_ways_to_verify', service_name: @service_name), other_ways_to_access_service_path %></li>
-      <li><%= link_to t('hub.cancelled_registration.options.verify_with_another_company'), choose_a_certified_company_path %></li>
-      <li><%= link_to t('hub.cancelled_registration.options.verify_using_other_documents'), select_documents_path %></li>
-      <li><%= link_to t('hub.cancelled_registration.options.contact_verify'), feedback_path('feedback-source': feedback_source) %></li>
+    <h2 class="heading-medium"><%= t 'hub.cancelled_registration.try_another_summary' %></h2>
+
+    <div>
+      <p><%= t 'hub.cancelled_registration.try_another_text', idp_name: @idp.display_name %></p>
+      <%= link_to t('hub.cancelled_registration.about_choosing_a_company'), about_choosing_a_company_path%>
+    </div>
+
+    <h2 class="heading-medium", style="text-transform:capitalize"><%= t 'hub.cancelled_registration.other_ways_summary', other_ways_decorated: @other_ways_decorated %></h2>
+    <div>
+      <%= raw transaction.other_ways_text %>
+    </div>
+
+    <h2 class="heading-medium"><%= t 'hub.cancelled_registration.feedback_summary' %></h2>
+
+    <div>
+      <p><%= t 'hub.cancelled_registration.feedback_text' %></p>
+      <%= link_to t('hub.cancelled_registration.send_feedback'), feedback_path %>
+    </div>
+
     </ul>
   </div>
 </div>

--- a/app/views/cancelled_registration_loa2/cancelled_registration_LOA2.html.erb
+++ b/app/views/cancelled_registration_loa2/cancelled_registration_LOA2.html.erb
@@ -14,7 +14,7 @@
       <%= link_to t('hub.cancelled_registration.about_choosing_a_company'), about_choosing_a_company_path%>
     </div>
 
-    <h2 class="heading-medium", style="text-transform:capitalize"><%= t 'hub.cancelled_registration.other_ways_summary', other_ways_decorated: @other_ways_decorated %></h2>
+    <h2 class="heading-medium"><%= t 'hub.cancelled_registration.other_ways_summary', other_ways_decorated: @other_ways_decorated %></h2>
     <div>
       <%= raw transaction.other_ways_text %>
     </div>

--- a/app/views/cancelled_registration_loa2/cancelled_registration_LOA2.html.erb
+++ b/app/views/cancelled_registration_loa2/cancelled_registration_LOA2.html.erb
@@ -16,7 +16,7 @@
 
     <h2 class="heading-medium"><%= t 'hub.cancelled_registration.other_ways_summary', other_ways_decorated: @other_ways_decorated %></h2>
     <div>
-      <%= raw transaction.other_ways_text %>
+      <%= raw @transaction.other_ways_text %>
     </div>
 
     <h2 class="heading-medium"><%= t 'hub.cancelled_registration.feedback_summary' %></h2>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -525,7 +525,7 @@ cy:
       try_another_summary: 'Try another identity provider'
       try_another_text: 'Other companies use different methods from %{idp_name} and may stand a better chance of verifying your identity.'
       about_choosing_a_company: 'Find another company to verify you'
-      other_ways_summary: '%{other_ways_description} without using GOV.UK Verify'
+      other_ways_summary: '%{other_ways_decorated} without using GOV.UK Verify'
       feedback_summary: 'Send feedback to GOV.UK Verify'
       feedback_text: 'Ask a question, report a problem or suggest and improvement to GOV.UK Verify'
       send_feedback: 'Send feedback'

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -520,7 +520,15 @@ cy:
       details_link: newid eich atebion i'r cwestiynau
     cancelled_registration:
       title: Cofrestriad Verify Wedi'i Ganslo
-      heading: Mae dilysu eich hunaniaeth gyda %{idp_name} wedi cael ei ddiddymu
+      heading: "You cancelled your identity verification with %{idp_name}"
+      what_next: 'You can still %{service_name}'
+      try_another_summary: 'Try another identity provider'
+      try_another_text: 'Other companies use different methods from %{idp_name} and may stand a better chance of verifying your identity.'
+      about_choosing_a_company: 'Find another company to verify you'
+      other_ways_summary: '%{other_ways_description} without using GOV.UK Verify'
+      feedback_summary: 'Send feedback to GOV.UK Verify'
+      feedback_text: 'Ask a question, report a problem or suggest and improvement to GOV.UK Verify'
+      send_feedback: 'Send feedback'
       next: Beth ydych chi eisiau ei wneud nesaf?
       options:
         other_ways_to_verify: Darganfod ffyrdd eraill i %{service_name}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -513,8 +513,16 @@ en:
       details_link: change your answers to the questions
     cancelled_registration:
       title: Verify registration cancelled
-      heading: "Your identity verification with %{idp_name} has been cancelled"
+      heading: "You cancelled your identity verification with %{idp_name}"
       next: 'What do you want to do next?'
+      what_next: 'You can still %{service_name}'
+      try_another_summary: 'Try another identity provider'
+      try_another_text: 'Other companies use different methods from %{idp_name} and may stand a better chance of verifying your identity.'
+      about_choosing_a_company: 'Find another company to verify you'
+      other_ways_summary: '%{other_ways_decorated} without using GOV.UK Verify'
+      feedback_summary: 'Send feedback to GOV.UK Verify'
+      feedback_text: 'Ask a question, report a problem or suggest and improvement to GOV.UK Verify'
+      send_feedback: 'Send feedback'
       options:
         other_ways_to_verify: 'Find out the other ways to %{service_name}'
         verify_with_another_company: 'Verify with another certified company'

--- a/spec/features/user_visits_cancelled_registration_page_spec.rb
+++ b/spec/features/user_visits_cancelled_registration_page_spec.rb
@@ -9,28 +9,23 @@ RSpec.describe 'When user visits cancelled registration page' do
     set_selected_idp_in_session(entity_id: 'http://idcorp.com', simple_id: 'stub-idp-one')
   end
 
-  it 'the page is rendered with the correct links for LOA2 journey' do
+  it 'the page is rendered with the correct content for LOA2 journey' do
     set_loa_in_session('LEVEL_2')
 
     visit('/cancelled-registration')
 
     expect(page).to have_title t('hub.cancelled_registration.title')
-    expect(page).to have_link('Find out the other ways to test GOV.UK Verify user journeys', href: other_ways_to_access_service_path)
-    expect(page).to have_link t('hub.cancelled_registration.options.verify_with_another_company'), href: choose_a_certified_company_path
-    expect(page).to have_link t('hub.cancelled_registration.options.verify_using_other_documents'), href: select_documents_path
-    expect(page).to have_link t('hub.cancelled_registration.options.contact_verify'), href: "#{feedback_path}?feedback-source=CANCELLED_REGISTRATION"
+    expect(page).to have_link t('hub.cancelled_registration.send_feedback')
+    expect(page).to have_link t('hub.cancelled_registration.about_choosing_a_company'), href: about_choosing_a_company_path
   end
 
-  it 'the page is rendered with the correct links for LOA1 journey' do
+  it 'the page is rendered with the correct content for LOA1 journey' do
     set_loa_in_session('LEVEL_1')
 
     visit('/cancelled-registration')
 
     expect(page).to have_title t('hub.cancelled_registration.title')
-    expect(page).to have_link('Find out the other ways to test GOV.UK Verify user journeys', href: other_ways_to_access_service_path)
-    expect(page).to have_link t('hub.cancelled_registration.options.verify_with_another_company'), href: choose_a_certified_company_path
-    expect(page).to have_link t('hub.cancelled_registration.options.contact_verify'), href: "#{feedback_path}?feedback-source=CANCELLED_REGISTRATION"
-
-    expect(page).to_not have_link t('hub.cancelled_registration.options.verify_using_other_documents'), href: select_documents_path
+    expect(page).to have_link t('hub.cancelled_registration.send_feedback')
+    expect(page).to have_link t('hub.cancelled_registration.about_choosing_a_company'), href: about_choosing_a_company_path
   end
 end


### PR DESCRIPTION
We have recently updated the design of the fail page (HUB-257). Consequently, we have updated the cancel page to match this content. These commits will display the new content.

todo: Welsh translations for these content changes.

Co-authored-by: Callum Knights <callum.knights@digital.cabinet-office.gov.uk>