### PR TITLE
HUB-292: Show Single IDP users registration success page

### DIFF
--- a/app/controllers/authn_response_controller.rb
+++ b/app/controllers/authn_response_controller.rb
@@ -96,7 +96,7 @@ private
   def idp_redirects(status, response)
     is_registration = response.is_registration
     {
-      SUCCESS => is_registration ? confirmation_path : response_processing_path,
+      SUCCESS => is_registration || journey_type?(SINGLE_IDP_JOURNEY_TYPE) ? confirmation_path : response_processing_path,
       CANCEL => is_registration ? cancelled_registration_path : start_path,
       FAILED_UPLIFT => failed_uplift_path,
       PENDING => paused_registration_path,

--- a/spec/controllers/authn_response_controller_spec.rb
+++ b/spec/controllers/authn_response_controller_spec.rb
@@ -33,7 +33,7 @@ describe AuthnResponseController do
     end
 
     context 'single-idp' do
-      include_examples 'idp_authn_response', 'single-idp', 'SUCCESS', 'Success - SINGLE_IDP at LOA LEVEL_1', :response_processing_path
+      include_examples 'idp_authn_response', 'single-idp', 'SUCCESS', 'Success - SINGLE_IDP at LOA LEVEL_1', :confirmation_path
       include_examples 'idp_authn_response', 'single-idp', 'CANCEL', 'Cancel - SINGLE_IDP', :start_path
       include_examples 'idp_authn_response', 'single-idp', 'FAILED_UPLIFT', 'Failed Uplift - SINGLE_IDP', :failed_uplift_path
       include_examples 'idp_authn_response', 'single-idp', 'PENDING', 'Paused - SINGLE_IDP', :paused_registration_path


### PR DESCRIPTION
Update AuthnResponseController to redirect user appropriately on Single IDP journeys.