### PR TITLE
EID-1001: Updated Welsh translations for eIDAS

### DIFF
--- a/app/views/static/privacy_notice.cy.html.erb
+++ b/app/views/static/privacy_notice.cy.html.erb
@@ -9,17 +9,17 @@ end %>
 <div class="grid-row">
   <div class="column-two-thirds">
     <h1 class="heading-large">Hysbysiad preifatrwydd</h1>
-    <p>Diweddarwyd ddiwethaf: 20 Mehefin 2018</p>
+    <p>Diweddarwyd ddiwethaf: 28 Medi 2018</p>
     <h2 class="heading-medium" id="who-we-are">Pwy ydym ni</h2>
-    <p>Mae GOV.UK Verify yn cael ei adeiladu a'i redeg gan Wasanaeth Digidol y Llywodraeth (GDS). Mae GOV.UK Verify yn caniatáu i chi brofi eich hunaniaeth wrth ddefnyddio gwasanaethau digidol y llywodraeth fel y gwasanaeth roeddech yn arfer <a href="https://www.gov.uk/cofrestru-ar-gyfer-a-chyflwynoch-ffurflen-dreth-hunanasesiad">mewngofnodi iddo a chyflwyno eich ffurflen dreth Hunanasesu</a>. Mae'r hysbysiad preifatrwydd hwn yn egluro pa wybodaeth y gallwn ei chasglu, sut mae'n cael ei ddefnyddio a sut mae'n cael ei ddiogelu.</p>
-    <h2 class="heading-medium" id="how-we-use-info">Sut rydym yn defnyddio gwybodaeth</h2>
-    <p>Mae GOV.UK Verify yn darparu 'canolbwynt' rhwng gwasanaethau a ‘<a href="https://www.gov.uk/government/publications/introducing-govuk-verify/introducing-govuk-verify#companies-that-can-verify-your-identity">chwmnïau ardystiedig</a>’ sy'n gwirio hunaniaeth defnyddwyr ar ran llywodraeth. Mae cwmnïau ardystiedig yn sefydliadau sydd wedi cwrdd â safonau'r llywodraeth ar diwydiant i ddarparu gwasanaethau sicrwydd hunaniaeth fel rhan o GOV.UK Verify. Rydym yn defnyddio data personol a gwybodaeth arall i'ch helpu i rhyngweithio'n ddiogel gyda gwasanaethau'r llywodraeth. Gall hyn gynnwys unrhyw un o'r 6 peth canlynol.</p>
+    <p>Mae GOV.UK Verify yn cael ei adeiladu a'i redeg gan Wasanaeth Digidol y Llywodraeth (GDS). Mae GOV.UK Verify yn caniatáu i chi brofi eich hunaniaeth wrth ddefnyddio gwasanaethau digidol y llywodraeth fel y gwasanaeth roeddech yn arfer <a href="https://www.gov.uk/cofrestru-ar-gyfer-a-chyflwynoch-ffurflen-dreth-hunanasesiad">mewngofnodi iddo a chyflwyno eich ffurflen dreth Hunanasesu</a>. Mae Gov.UK Verify wedi ei ymestyn i gydymffurfio â'r rheoliad eIDAS, sy'n caniatáu i ddefnyddwyr sydd â hunaniaeth ddigidol o rai gwledydd yr UE gael mynediad at wasanaethau'r llywodraeth yn y DU. Mae'r hysbysiad preifatrwydd hwn yn egluro pa wybodaeth y gallwn ei chasglu, sut mae'n cael ei ddefnyddio a sut mae'n cael ei ddiogelu.</p>
+    <h2 class="heading-medium" id="how-we-use-info">Sut rydym yn defnyddio gwybodaeth pan fyddwch yn defnyddio GOV.UK Verify</h2>
+    <p>Mae GOV.UK Verify yn darparu 'hyb' rhwng gwasanaethau a ‘<a href="https://www.gov.uk/government/publications/introducing-govuk-verify/introducing-govuk-verify#companies-that-can-verify-your-identity">chwmnïau ardystiedig</a>’ sy'n gwirio hunaniaeth defnyddwyr ar ran y llywodraeth. Mae cwmnïau ardystiedig yn sefydliadau sydd wedi cwrdd â safonau'r llywodraeth a diwydiant i ddarparu gwasanaethau sicrwydd hunaniaeth fel rhan o GOV.UK Verify. Rydym yn defnyddio data personol a gwybodaeth arall i'ch helpu i drafod yn ddiogel gyda gwasanaethau'r llywodraeth. Gall hyn gynnwys unrhyw un o'r gweithgareddau canlynol.</p>
     <ol class="list-number list">
       <li><h4 class="heading-small" id="sending-information">Anfon gwybodaeth i gwmnïau ardystiedig</h4>
         Gallai GOV.UK Verify drosglwyddo gwybodaeth am atebion a roddoch ar ganolbwynt GOV.UK Verify i gwmnïau ardystiedig. Mae hyn yn helpu cwmnïau ardystiedig i'ch tywys drwy'r broses ddilysu, gan ei gwneud yn symlach ac yn gyflymach.
       </li>
       <li><h4 class="heading-small" id="comp-send-info-to-hub">Cwmnïau ardystiedig yn anfon gwybodaeth i'r canolgwynt</h4>
-        Bydd y cwmni ardystiedig a ddewiswch yn anfon y data sydd wedi'i ddilysu amdanoch chi (eich enw, cyfeiriad a'ch dyddiad geni ynghyd â'ch rhyw os ydych chi'n dewis ei ddarparu) i'r canolbwynt, a bydd y canolbwynt yn ei anfon at y gwasanaeth llywodraeth rydych chi am gael mynediad iddo. Ni fydd y cwmni ardystiedig a ddefnyddiwch yn gwybod pa wasanaeth llywodraeth sydd wedi gofyn am y wybodaeth hon, ac ni fydd y gwasanaeth llywodraeth yn gwybod pa gwmni ardystiedig rydych wedi'i ddewis.
+        Bydd y cwmni sydd wedi'i ardystio a ddewiswch yn anfon y data dilys amdanoch chi (eich enw, eich cyfeiriad a'ch dyddiad geni ynghyd â'ch rhyw os ydych chi'n dewis ei roi) i'r hyb, a bydd y hyb yn ei anfon at y gwasanaeth llywodraeth rydych chi am ei gael mynediad iddo. Ni fydd y cwmni ardystiedig a ddefnyddiwch yn gwybod pa wasanaeth llywodraeth sydd wedi gofyn am y wybodaeth hon, ac ni fydd y gwasanaeth llywodraeth yn gwybod pa gwmni sydd wedi'i ardystio rydych wedi'i ddewis.
       </li>
       <li><h4 class="heading-small" id="document-checking-service">Gwirio dogfennau</h4>
         <p>Rydym hefyd yn darparu gwasanaeth gwirio dogfennau i gwmnïau ardystiedig fel y gallant ddilysu rhywfaint o'ch data gydag adrannau llywodraeth eraill megis:
@@ -31,26 +31,31 @@ end %>
         </ul>
         <p>Gwneir hyn trwy API ac ni all GOV.UK Verify gael mynediad iddo.</p>
       </li>
-      <li><h4 class="heading-small" id="user-support">Cymorth i ddefnyddwyr</h4>
-        Pan fyddwch yn cysylltu â thîm cymorth defnyddwyr GOV.UK Verify am gymorth, efallai y byddwn yn:
-        <ul class="list-bullet list">
-          <li>gofyn am ragor o wybodaeth gennych</li>
-          <li>trosglwyddo eich ymholiad neu'ch adborth i gwmni ardystiedig neu wasanaeth llywodraeth</li>
-        </ul>
-        Efallai y byddwn hefyd yn gofyn am adborth pellach i helpu i wella'r gwasanaeth.
-      </li>
-      <li><h4 class="heading-small" id="monitoring-and-reporting">Monitro ac adrodd</h4>
-        Rydym yn monitro ac yn adrodd ar GOV.UK Verify fel y gallwn adolygu a gwella'r gwasanaeth a ddarparwn i sefydliadau'r llywodraeth.
-      </li>
-      <li><h4 class="heading-small" id="identity-standards-and-fraud">Safonau hunaniaeth a thwyll</h4>
-        Rydym yn prosesu rhywfaint o ddata personol i helpu i atal twyll mewn gwasanaethau'r llywodraeth. Gwnawn hyn i gynnal safonau hunaniaeth y llywodraeth a chanfod twyll wrth wirio hunaniaeth.
-      </li>
     </ol>
+    <h2 class="heading-medium" id="how-we-use-information-for-digital-identity">Sut rydym yn defnyddio gwybodaeth pan fyddwch yn defnyddio hunaniaeth digidol o wlad Ewropeaidd arall</h2>
+    <p>Mae GOV.UK Verify yn darparu 'hyb' rhwng gwasanaethau'r llywodraeth a chynlluniau hunaniaeth ddigidol aelod-wladwriaethau'r UE. Os ydych y'n ddinesydd yr UE sydd wedi ymuno â chynllun adnabod arall, mae hyn yn eich galluogi i brofi eich hunaniaeth ar-lein a defnyddio gwasanaeth llywodraeth y DU. Defnyddiwn ddata personol a gwybodaeth arall i'ch helpu i drafod yn ddiogel gyda gwasanaethau'r llywodraeth. Gall hyn gynnwys unrhyw un o'r gweithgareddau canlynol.</p>
+    <ol class="list-number list">
+      <li><h4 class="heading-small" id="choose-digital-identity-scheme">Dewis cynllun hunaniaeth ddigidol</h4></li>
+      <p>Bydd hyb GOV.UK Verify yn gofyn i chi ddewis pa gynllun hunaniaeth ddigidol rydych chi am ei ddefnyddio.</p>
+      <li><h4 class="heading-small" id="eu-member-states-sending-information">Aelod-wladwriaethau'r UE sy'n anfon gwybodaeth i'r hyb</h4></li>
+      <p>Bydd y cynllun hunaniaeth ddigidol a ddewiswch yn anfon data dilys amdanoch chi (eich enw a'ch dyddiad geni) i'r hyb, a bydd y hyb yn ei anfon at y gwasanaeth llywodraeth yr hoffech ei gael. Ni fydd y cynllun hunaniaeth rydych yn ei ddefnyddio yn gwybod pa wasanaeth llywodraeth sydd wedi gofyn am y wybodaeth hon, ac ni fydd y gwasanaeth llywodraeth yn gwybod pa gynllun hunaniaeth rydych wedi'i ddewis.</p>
+    </ol>
+    <h2 class="heading-medium" id="how-we-use-information-for-monitoring">Sut rydym yn defnyddio gwybodaeth ar gyfer monitro a diogelwch</h2>
+    <h4 class="heading-small" id="user-support">Cymorth i ddefnyddwyr</h4>
+    <p>Pan fyddwch yn cysylltu â'r  tîm cymorth i ddefnyddwyr GOV.UK Verify am help, efallai y byddwn yn:</p>
+    <ul class="list-bullet list">
+      <li>gofyn am ragor o wybodaeth gennych</li>
+      <li>trosglwyddo eich ymholiad neu'ch adborth i gwmni ardystiedig neu wasanaeth llywodraeth</li>
+    </ul>
+    <p>Efallai y byddwn hefyd yn gofyn am adborth pellach i helpu wella'r gwasanaeth.</p>
+    <h4 class="heading-small" id="monitoring-and-reporting">Monitro ac adrodd</h4>
+    <p>Rydym yn monitro ac yn adrodd ar GOV.UK Verify fel y gallwn adolygu a gwella'r gwasanaeth a ddarparwn i sefydliadau'r llywodraeth.</p>
+    <h4 class="heading-small" id="identity-standards-and-fraud">Safonau hunaniaeth a thwyll</h4>
+    <p>Rydym yn prosesu rhywfaint o ddata personol i helpu atal twyll mewn gwasanaethau'r llywodraeth. Rydym yn gwneud hyn i gynnal safonau hunaniaeth y llywodraeth a chanfod twyll wrth wirio hunaniaeth.</p>
     <h2 class="heading-medium" id="what-information-we-process">Pa wybodaeth rydym yn ei brosesu</h2>
-    <p>Rydym yn prosesu gwybodaeth amdanoch chi pan fyddwch yn defnyddio GOV.UK Verify. Gall hyn gynnwys:</p>
-    <h4 class="heading-small" id="personal-data ">Data personol</h4>
-    <p>Rydym yn prosesu'r atebion a ddarparwch yng nghanolbwynt GOV.UK Verify i'ch helpu i ddewis cwmni ardystiedig.</p>
-    <p>Ar ôl i chi gael eich dilysu gan y cwmni ardystiedig byddwn yn trosglwyddo'ch data personol i'r gwasanaeth llywodraeth rydych am ei ddefnyddio. Yna bydd eich hunaniaeth sydd wedi'i ddilysu'n cael ei baru â chofnod mewn cronfa ddata'r llywodraeth.</p>
+    <p>Rydym yn prosesu gwybodaeth amdanoch wrth i chi ddefnyddio GOV.UK Verify. Gall hyn gynnwys y canlynol:</p>
+    <h4 class="heading-small" id="how-personal-data-is-used">Sut y defnyddir data personol wrth ymuno â GOV.UK Verify</h4>
+    <p>Ar ôl i chi gael ei ddilysu gan y cwmni ardystiedig, rydym yn trosglwyddo'ch data personol i'r gwasanaeth llywodraeth yr hoffech ei gael. Bydd eich hunaniaeth wedi'i dilysu yna yn cael ei gydweddu â chofnod yn y gronfa ddata gwasanaeth llywodraeth cyfatebol.</p>
     <p>Mae'r data hwn yn cynnwys:</p>
     <ul class="list-bullet list">
       <li>enw (gan gynnwys enwau blaenorol)</li>
@@ -68,6 +73,23 @@ end %>
       <li>Rhif Yswiriant Gwladol</li>
       <li>Cyfeirnod trethdalwr unigryw Cyllid a Thollau EM</li>
       <li>Adnabyddwr Busnes Sengl Asiantaeth Taliadau Gwledig</li>
+    </ul>
+    <h4 class="heading-small" id="how-personal-data-is-used-european">Sut mae data personol yn cael ei ddefnyddio wrth mewngofnodi â hunaniaeth ddigidol o wlad Ewropeaidd arall</h4>
+    <p>Ar ôl i'ch hunaniaeth ddigidol o wlad arall yr UE gael ei ddilysu, byddwn yn trosglwyddo'ch data personol i'r gwasanaeth llywodraeth rydych am ei ddefnyddio. Yna bydd eich hunaniaeth wedi'i dilysu yn cael ei baru â chofnod yn y gronfa ddata gwasanaeth llywodraeth cyfatebol.</p>
+    <p>Mae'r data hwn yn cynnwys:</p>
+    <ul class="list-bullet list">
+      <li>enw teuluol</li>
+      <li>enw cyntaf</li>
+      <li>dyddiad geni</li>
+      <li>adnabyddwr personol (PID)</li>
+    </ul>
+    <p>Mewn rhai sefyllfaoedd, efallai y byddwn hefyd yn gofyn am wybodaeth ychwanegol fel:</p>
+    <ul class="list-bullet list">
+      <li>rhif trwydded yrru</li>
+      <li>Rhif benthycwyr y Gofrestrfa Tir</li>
+      <li>Rhif Yswiriant Gwladol</li>
+      <li>Cyfeirnod trethdalwr unigryw Cyllid a Thollau EM</li>
+      <li>Adnabyddwr Busnes Sengl yr Asiantaeth Taliadau Gwledig</li>
     </ul>
     <h4 class="heading-small" id="user-support-questions-and-feedback">Cwestiynau cefnogi defnyddwyr ac adborth</h4>
     <p>Rydym yn prosesu cwestiynau neu adborth a anfonwch at gymorth defnyddwyr, gan gynnwys eich enw a'ch cyfeiriad e-bost, manylion eich ymholiad, a'r camau rydym wedi'u cymryd i helpu.</p>
@@ -87,9 +109,8 @@ end %>
       <li>rydym ei angen i ddarparu'r gwasanaeth hwn</li>
     </ul>
     <p>Yn gyffredinol, mae hyn yn golygu y byddwn ond yn dal eich data personol am o leiaf 1 flwyddyn ac uchafswm o 7 mlynedd.</p>
-    <h2 class="heading-medium" id="companies-and-government-organisations">Cwmnïau ardystiedig a sefydliadau'r llywodraeth</h2>
-    <p>Y sefydliadau'r llywodraeth a chwmnïau ardystiedig rydym yn bartneriaid gyda yw'r <a href="https://ico.org.uk/for-organisations/guide-to-data-protection/key-definitions/">rheolwyr data</a> a fydd hefyd yn prosesu'ch data at eu dibenion eu hunain. Ni ddisgrifir y dibenion hyn yn yr hysbysiad preifatrwydd hwn. Darllenwch eu polisïau preifatrwydd i ddysgu sut y maent yn prosesu'ch data a sut i arfer eich hawliau ynghylch sut maent yn ei wneud.
-    </p>
+    <h2 class="heading-medium" id="companies-and-government-organisations">Cwmnïau ardystiedig, cynlluniau hunaniaeth ddigidol mewn gwledydd Ewropeaidd eraill a sefydliadau'r llywodraeth</h2>
+    <p>Mae sefydliadau'r llywodraeth, cynlluniau hunaniaeth ddigidol mewn gwledydd Ewropeaidd eraill a chwmnïau ardystiedig rydym yn bartneriaid iddynt yw'r <a href="https://ico.org.uk/for-organisations/guide-to-data-protection/key-definitions/">rheolwyr data</a> a fydd hefyd yn prosesu'ch data at eu dibenion eu hunain. Ni ddisgrifir y dibenion hyn yn yr hysbysiad preifatrwydd hwn. Darllenwch eu polisïau preifatrwydd i ddysgu sut y maent yn prosesu'ch data a sut i arfer eich hawliau ynghylch sut maent yn ei wneud.</p>
     <h2 class="heading-medium" id="sharing-information-with-third-parties">Rhannu gwybodaeth gyda thrydydd partïon</h2>
     <p>Rydym yn rhannu gwybodaeth gyda gwasanaethau'r llywodraeth a chwmnïau ardystiedig i wirio'ch hunaniaeth a dim ond yn y ffyrdd a ddisgrifir yn yr hysbysiad preifatrwydd hwn. Ni fyddwn yn rhannu eich data personol gydag unrhyw sefydliadau eraill nac ar gyfer marchnata, ymchwil marchnad neu ddibenion masnachol.</p>
     <p>
@@ -99,7 +120,7 @@ end %>
     <p>Mae GOV.UK Verify yn prosesu eich data personol yn yr Ardal Economaidd Ewropeaidd (AEE).</p>
     <h2 class="heading-medium" id="links-to-other-websites">Dolenni i wefannau eraill</h2>
     <p>Mae GOV.UK Verify yn un o'r gwasanaethau ar GOV.UK ac mae ganddo gysylltiadau â gwefannau eraill. Dim ond i <a href="https://www.gov.uk/government/publications/introducing-govuk-verify">GOV.UK Verify</a> mae'r  hysbysiad preifatrwydd hwn yn berthnasol ac nid yw'n cwmpasu gwasanaethau a thrafodion eraill y llywodraeth rydym yn cysylltu â hwy.</p>
-    <h2 class="heading-medium" id="identity-assurance-principles">Egwyddorion Sicrwydd Hunaniaeth</h2>
+    <h2 class="heading-medium" id="identity-assurance-principles">Egwyddorion Sicrwydd Hunaniaeth wrth ymuno â GOV.UK Verify</h2>
     <p>Mae GOV.UK Verify wedi'i ddylunio i gydymffurfio â'r <a href="https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/361496/PCAG_IDA_Principles_3.1__4_.pdf">Egwyddorion Sicrwydd Hunaniaeth</a> a baratowyd gan <a href="https://www.gov.uk/government/groups/privacy-and-consumer-advisory-group">Grŵp Preifatrwydd a Chynghori Defnyddwyr</a> y Cabinet.
       Gallwch hefyd ddod o hyd i wybodaeth fanylach am y gwasanaeth ar <a href="https://identityassurance.blog.gov.uk/">flog GOV.UK Verify</a>.
     </p>
@@ -156,7 +177,7 @@ end %>
     </address>
     </p>
     <div class="meta-data group">
-      <p class="modified-date">Diweddarwyd ddiwethaf: 20 Mehefin 2018</p>
+      <p class="modified-date">Diweddarwyd ddiwethaf: 28 Medi 2018</p>
     </div>
   </div>
 </div>

--- a/app/views/static/privacy_notice.en.html.erb
+++ b/app/views/static/privacy_notice.en.html.erb
@@ -31,6 +31,7 @@ end %>
         </ul>
         <p>This is done via an API and cannot be accessed by GOV.UK Verify.</p>
       </li>
+    </ol>
     <h2 class="heading-medium" id="how-we-use-information-for-digital-identity">How we use information when you use a digital identity from another European country</h2>
     <p>GOV.UK Verify provides a ‘hub’ between government services and the digital identity schemes of EU member states. If you’re an EU citizen who has signed up to another identity scheme, this lets you prove your identity online and use a UK government service.We use personal data and other information to help you to transact securely with government services. This may include any of the following activities.</p>
     <ol class="list-number list">
@@ -56,48 +57,49 @@ end %>
     <h4 class="heading-small" id="how-personal-data-is-used">How personal data is used when signing in with GOV.UK Verify</h4>
     <p>After you’ve been verified by the certified company, we pass your personal data to the government service that you wish to access. Your verified identity will then be matched to a record in the corresponding government service database.</p>
     <p>This data includes:</p>
-        <ul class="list-bullet list">
-          <li>name (including previous names)</li>
-          <li>address (which may include previous addresses)</li>
-          <li>date of birth</li>
-          <li>age (range)</li>
-          <li>gender (optional)</li>
-          <li>IP address</li>
-          <li>personal identifier (PID)</li>
-        </ul>
-    <p>In some situations we may also ask for some additional information such as:
-        <ul class="list-bullet list">
-          <li>driving licence number</li>
-          <li>Land Registry borrowers number</li>
-          <li>National Insurance number</li>
-          <li>HM Revenue and Customs unique taxpayer reference</li>
-          <li>Rural Payments Agency Single Business Identifier</li>
-        </ul>
+    <ul class="list-bullet list">
+      <li>name (including previous names)</li>
+      <li>address (which may include previous addresses)</li>
+      <li>date of birth</li>
+      <li>age (range)</li>
+      <li>gender (optional)</li>
+      <li>IP address</li>
+      <li>personal identifier (PID)</li>
+    </ul>
+    <p>In some situations we may also ask for some additional information such as:</p>
+    <ul class="list-bullet list">
+      <li>driving licence number</li>
+      <li>Land Registry borrowers number</li>
+      <li>National Insurance number</li>
+      <li>HM Revenue and Customs unique taxpayer reference</li>
+      <li>Rural Payments Agency Single Business Identifier</li>
+    </ul>
     <h4 class="heading-small" id="how-personal-data-is-used-european">How personal data is used when signing in with a digital identity from another European country</h4>
-        <p>After your digital identity from another EU country has been authenticated, we’ll pass your personal data to the government service that you want to use. Your verified identity will then be matched to a record in the corresponding government service database.</p>
-        <p>This data includes:</p>
-            <ul class="list-bullet list">
-              <li>family name</li>
-              <li>first name</li>
-              <li>personal identifier (PID)</li>
-            </ul>
-        <p>In some situations we may also ask for some additional information such as:
-            <ul class="list-bullet list">
-              <li>driving licence number</li>
-              <li>Land Registry borrowers number</li>
-              <li>National Insurance number</li>
-              <li>HM Revenue and Customs unique taxpayer reference</li>
-              <li>Rural Payments Agency Single Business Identifier</li>
-            </ul>
-      <h4 class="heading-small" id="user-support-questions-and-feedback">User support questions and feedback</h4>
-        We process questions or feedback you send to user support, including your name and email address, details of your query, and actions we have taken to help.
-      <h4 class="heading-small" id="technical-information">Technical information</h4>
-        <p>When you connect to GOV.UK Verify, we collect other information that is used for monitoring, reporting and fraud prevention purposes. This includes:</p>
-          <ul class="list-bullet list">
-            <li>the IP address of the device you’re using to connect</li>
-            <li>the ‘device fingerprint’, which is information collected about a remote computing device for device identification</li>
-            <li>‘user agent string’, which is the type and version of browser and operating system</li>
-          </ul>
+    <p>After your digital identity from another EU country has been authenticated, we’ll pass your personal data to the government service that you want to use. Your verified identity will then be matched to a record in the corresponding government service database.</p>
+    <p>This data includes:</p>
+    <ul class="list-bullet list">
+      <li>family name</li>
+      <li>first name</li>
+      <li>date of birth</li>
+      <li>personal identifier (PID)</li>
+    </ul>
+    <p>In some situations we may also ask for some additional information such as:</p>
+    <ul class="list-bullet list">
+      <li>driving licence number</li>
+      <li>Land Registry borrowers number</li>
+      <li>National Insurance number</li>
+      <li>HM Revenue and Customs unique taxpayer reference</li>
+      <li>Rural Payments Agency Single Business Identifier</li>
+    </ul>
+    <h4 class="heading-small" id="user-support-questions-and-feedback">User support questions and feedback</h4>
+    We process questions or feedback you send to user support, including your name and email address, details of your query, and actions we have taken to help.
+    <h4 class="heading-small" id="technical-information">Technical information</h4>
+    <p>When you connect to GOV.UK Verify, we collect other information that is used for monitoring, reporting and fraud prevention purposes. This includes:</p>
+    <ul class="list-bullet list">
+      <li>the IP address of the device you’re using to connect</li>
+      <li>the ‘device fingerprint’, which is information collected about a remote computing device for device identification</li>
+      <li>‘user agent string’, which is the type and version of browser and operating system</li>
+    </ul>
     <h2 class="heading-medium" id="cookies-and-analytics">Cookies and analytics</h2>
     <p>You can read our full <a href="https://www.signin.service.gov.uk/cookies">cookie notice</a> to find out how we use cookies.</p>
     <h2 class="heading-medium" id="How-long-we-keep-your-data">How long we keep your data for</h2>


### PR DESCRIPTION
Updated the translations on the privacy notice along with fixing the page formatting.
    
Updated English privacy notice to to fix missing DOB for digital identity for another European country,
Also fixed some missing closing tags within the English privacy notice.
