### PR TITLE
HUB-274: Add alternate start page for single IDP

### DIFF
--- a/app/controllers/partials/retrieve_federation_data_partial_controller.rb
+++ b/app/controllers/partials/retrieve_federation_data_partial_controller.rb
@@ -4,14 +4,14 @@ module RetrieveFederationDataPartialController
     list.select { |hash| hash.fetch('entityId') == entity_id }.first
   end
 
-  def get_service_choice_url(list, transaction_id)
+  def get_single_idp_url(list, transaction_id)
     selected_rp = get_selected_rp_from_entity_id(list, transaction_id)
-    get_rp_homepage(selected_rp)
+    get_rp_attribute(selected_rp, 'redirectUrl')
   end
 
-  def get_rp_homepage(selected_rp)
+  def get_rp_attribute(selected_rp, attribute)
     return nil if selected_rp.nil?
-    selected_rp.fetch('serviceHomepage', nil)
+    selected_rp.fetch(attribute, nil)
   end
 
   def get_idp_choice(list, idp_entity_id)

--- a/app/controllers/single_idp_journey_controller.rb
+++ b/app/controllers/single_idp_journey_controller.rb
@@ -51,7 +51,7 @@ class SingleIdpJourneyController < ApplicationController
       idp_entity_id = params['idpEntityId']
       uuid = params['singleIdpJourneyIdentifier'].to_s.downcase
 
-      rp_url = get_service_choice_url(get_service_list, transaction_id)
+      rp_url = get_single_idp_url(get_service_list, transaction_id)
 
       if rp_url.nil?
         redirect_to verify_services_path

--- a/spec/api_test_helper.rb
+++ b/spec/api_test_helper.rb
@@ -60,10 +60,10 @@ module ApiTestHelper
 
   def stub_transactions_for_single_idp_list
     transactions_for_single_idp_list = [
-        { 'simpleId' => 'test-rp',      'entityId' => 'http://www.test-rp.gov.uk/SAML2/MD', 'serviceHomepage' => 'http://localhost:50130/test-saml', 'loaList' => ['LEVEL_2'] },
-        { 'simpleId' => 'test-rp-noc3', 'entityId' => 'some-other-entity-id', 'serviceHomepage' => 'https://www.gov.uk/', 'loaList' => ['LEVEL_2'] },
-        { 'simpleId' => 'headless-rp',  'entityId' => 'some-entity-id', 'serviceHomepage' => 'http://localhost:50130/headless-rp', 'loaList' => ['LEVEL_2'] },
-        { 'simpleId' => 'test-rp-with-continue-on-fail', 'entityId' => 'some-entity-id', 'serviceHomepage' => 'http://localhost:50130/test-rp-with-continue-on-fail', 'loaList' => ['LEVEL_2'] }
+        { 'simpleId' => 'test-rp',      'entityId' => 'http://www.test-rp.gov.uk/SAML2/MD', 'redirectUrl' => 'http://localhost:50130/test-saml', 'loaList' => ['LEVEL_2'] },
+        { 'simpleId' => 'test-rp-noc3', 'entityId' => 'some-other-entity-id', 'redirectUrl' => 'https://www.gov.uk/', 'loaList' => ['LEVEL_2'] },
+        { 'simpleId' => 'headless-rp',  'entityId' => 'some-entity-id', 'redirectUrl' => 'http://localhost:50130/headless-rp', 'loaList' => ['LEVEL_2'] },
+        { 'simpleId' => 'test-rp-with-continue-on-fail', 'entityId' => 'some-entity-id', 'redirectUrl' => 'http://localhost:50130/test-rp-with-continue-on-fail', 'loaList' => ['LEVEL_2'] }
     ]
 
     stub_request(:get, api_transactions_for_single_idp_endpoint).to_return(body: transactions_for_single_idp_list.to_json, status: 200)

--- a/stub/api/stub_api.rb
+++ b/stub/api/stub_api.rb
@@ -183,13 +183,13 @@ class StubApi < Sinatra::Base
   get '/config/transactions/single-idp-enabled-list' do
     '[{
         "simpleId":"test-rp",
-        "serviceHomepage":"http://example.com/test-saml",
+        "redirectUrl":"http://example.com/test-saml",
         "loaList":["LEVEL_2"],
         "entityId":"http://www.test-rp.gov.uk/SAML2/MD"
       },
       {
         "simpleId": "loa1-test-rp",
-        "serviceHomepage":"http://example.com/test-rp-loa1",
+        "redirectUrl":"http://example.com/test-rp-loa1",
         "loaList":["LEVEL_1","LEVEL_2"],
         "entityId": "http://example.com/test-rp-loa1"
       }]'


### PR DESCRIPTION
Changed single idp endpoint to match change in hub, as well as a small refactor to the
retrieve_federation_data_partial_controller.

Co-authored-by: Chris Clayson <chris.clayson@digital.cabinet-office.gov.uk>