### PR TITLE
BAU: Supply a default for `WHITE_LOGO_DIRECTORY`

### DIFF
--- a/config/initializers/00_configuration.rb
+++ b/config/initializers/00_configuration.rb
@@ -14,7 +14,7 @@ CONFIG = Configuration.load! do
   option_string 'config_api_host', 'CONFIG_API_HOST'
   option_string 'policy_host', 'POLICY_HOST'
   option_string 'logo_directory', 'LOGO_DIRECTORY', default: '/idp-logos'
-  option_string 'white_logo_directory', 'WHITE_LOGO_DIRECTORY'
+  option_string 'white_logo_directory', 'WHITE_LOGO_DIRECTORY', default: '/idp-logos/white'
   option_string 'zdd_file', 'ZDD_LATCH'
   option_string 'polling_wait_time', 'POLLING_WAIT_TIME', default: 6
   option_bool 'metrics_enabled', 'METRICS_ENABLED', default: true


### PR DESCRIPTION
We configure this externally, but it always has the same value. Supply a
sensible default.