### PR TITLE
BAU: Add ZDD_LATCH configuration

### DIFF
--- a/conf.d/zdd_latch
+++ b/conf.d/zdd_latch
@@ -1,0 +1,1 @@
+export ZDD_LATCH=/ida/front/tmp/.service_unavailable

--- a/packaging/postinst.sh
+++ b/packaging/postinst.sh
@@ -6,6 +6,8 @@ mkdir -p /ida
 # We manage service restarts via the meta package
 ln -fs /opt/front/upstart/front.conf /etc/init/front.conf
 
+ln -fs /opt/front/conf.d/zdd_latch.conf /etc/front/conf.d/zdd_latch.conf
+
 # We want to ensure upstart realizes it's config may have changed.
 /sbin/initctl reload-configuration
 


### PR DESCRIPTION
The location of the ZDD marker file is currently configured externally. Package
its configuration up with the rest of the app.