### PR TITLE
BAU: Enable the single IDP feature by default

### DIFF
--- a/.env
+++ b/.env
@@ -31,6 +31,3 @@ ZENDESK_TOKEN=123
 SAML_PROXY_HOST=http://localhost:50220
 
 VERIFY_PRODUCT_PAGE=https://govuk-verify.cloudapps.digital/
-
-SINGLE_IDP_FEATURE=true
-

--- a/.env.test
+++ b/.env.test
@@ -6,4 +6,3 @@ METRICS_ENABLED=false
 PUBLIC_PIWIK_HOST=http://localhost:4242/piwik.php
 INTERNAL_PIWIK_HOST=http://localhost:4242/piwik.php
 PIWIK_SITE_ID=5
-SINGLE_IDP_FEATURE=true

--- a/config/initializers/00_configuration.rb
+++ b/config/initializers/00_configuration.rb
@@ -39,5 +39,5 @@ CONFIG = Configuration.load! do
   option_string 'saml_proxy_host', 'SAML_PROXY_HOST'
   option_bool 'feedback_disabled', 'FEEDBACK_DISABLED', default: false
   # Feature flags
-  option_bool 'single_idp_feature', 'SINGLE_IDP_FEATURE', default: false
+  option_bool 'single_idp_feature', 'SINGLE_IDP_FEATURE', default: true
 end


### PR DESCRIPTION
This is enabled everywhere except the performance testing environment and our
vagrant test boxes. Enable it everywhere by default.