### PR TITLE
Add logging for successful and failed journeys

### DIFF
--- a/app/controllers/single_idp_journey_controller.rb
+++ b/app/controllers/single_idp_journey_controller.rb
@@ -54,6 +54,7 @@ class SingleIdpJourneyController < ApplicationController
       rp_url = get_service_choice_url(get_service_list, transaction_id)
 
       if rp_url.nil?
+        logger.error "Could not get the RP URL for single IDP with transaction_id #{transaction_id} " + referrer_string
         redirect_to verify_services_path
       elsif !valid_request?(transaction_id, idp_entity_id, uuid)
         redirect_to verify_services_path
@@ -69,7 +70,12 @@ class SingleIdpJourneyController < ApplicationController
 private
 
   def valid_uuid?(uuid)
-    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/.match?(uuid)
+    if /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/.match?(uuid)
+      true
+    else
+      logger.error "Single IDP UUID #{uuid} not valid" + referrer_string
+      false
+    end
   end
 
   def get_service_list
@@ -98,7 +104,11 @@ private
   end
 
   def valid_cookie?
-    !single_idp_cookie.nil?
+    if single_idp_cookie.nil?
+      logger.error "Single IDP cookies was not found or was malformed" + referrer_string
+      return false
+    end
+    true
   end
 
   def valid_selection?
@@ -107,16 +117,34 @@ private
     uuid = single_idp_cookie.fetch('uuid', nil)
     single_idp_rp_list = get_service_list
 
-    return false unless cookie_matches_session?(transaction_id)
-    return false unless valid_transaction?(single_idp_rp_list, transaction_id)
+    return false if cookie_value_is_missing(%w(idp_entity_id transaction_id uuid))
+
+    unless cookie_matches_session?(transaction_id)
+      logger.error "The value of the Single IDP cookie does not match the session for transaction_id #{transaction_id}" + referrer_string
+      return false
+    end
+
+    unless valid_transaction?(single_idp_rp_list, transaction_id)
+      logger.error "The Single IDP transaction is not valid for transaction_id #{transaction_id}" + referrer_string
+      return false
+    end
+
     valid_request?(transaction_id, idp_entity_id, uuid)
   end
 
   def valid_request?(transaction_id, idp_entity_id, uuid)
     single_idp_idp_list = get_idp_list(transaction_id)
 
-    return false if single_idp_idp_list.nil?
-    return false unless valid_idp_choice?(single_idp_idp_list, idp_entity_id)
+    if single_idp_idp_list.nil?
+      logger.error "The IDP list for single IDP is empty for transaction_id #{transaction_id}" + referrer_string
+      return false
+    end
+
+    unless valid_idp_choice?(single_idp_idp_list, idp_entity_id)
+      logger.error "The IDP is not valid or disabled for transaction_id #{transaction_id} and idp_entity_id #{idp_entity_id}" + referrer_string
+      return false
+    end
+
     valid_uuid?(uuid)
   end
 
@@ -134,10 +162,27 @@ private
     params_are_missing = false
     params_keys.each do |param_key|
       if params[param_key].nil?
+        logger.error "Single IDP parameter #{param_key} is missing" + referrer_string
         params_are_missing = true
         break
       end
     end
     params_are_missing
+  end
+
+  def cookie_value_is_missing(cookie_keys)
+    value_is_missing = false
+    cookie_keys.each do |cookie_key|
+      if single_idp_cookie.fetch(cookie_key, nil).nil?
+        logger.error "Single IDP cookie value for #{cookie_key} is missing" + referrer_string
+        value_is_missing = true
+        break
+      end
+    end
+    value_is_missing
+  end
+
+  def referrer_string
+    " - referrer: " + (request.nil? || request.referer.nil? ? "[could not get the referrer]" : request.referer)
   end
 end

--- a/app/controllers/single_idp_journey_controller.rb
+++ b/app/controllers/single_idp_journey_controller.rb
@@ -60,6 +60,7 @@ class SingleIdpJourneyController < ApplicationController
       else
         save_to_cookie(transaction_id, idp_entity_id, uuid)
         FEDERATION_REPORTER.report_started_single_idp_journey(request)
+        logger.info "Successful Single IDP redirect to RP URL #{rp_url} from IdpId #{idp_entity_id} with uuid #{uuid}"
         redirect_to(rp_url)
       end
     end

--- a/spec/controllers/single_idp_journey_controller_spec.rb
+++ b/spec/controllers/single_idp_journey_controller_spec.rb
@@ -69,6 +69,7 @@ describe SingleIdpJourneyController do
     describe 'no parameters provided' do
       subject { post :redirect_from_idp }
       it 'should redirect to the start page and not set a cookie when an incorrect rp is supplied' do
+        expect(Rails.logger).to receive(:error).with(/Single IDP parameter serviceId is missing/)
         expect(subject).to redirect_to(verify_services_path)
         expect(cookies.encrypted[CookieNames::VERIFY_SINGLE_IDP_JOURNEY]).to be(nil)
       end
@@ -83,6 +84,7 @@ describe SingleIdpJourneyController do
         }
       }
       it 'should redirect to the start page and not set a cookie when an incorrect rp is supplied' do
+        expect(Rails.logger).to receive(:error).with(/Single IDP parameter serviceId is missing/)
         expect(subject).to redirect_to(verify_services_path)
         expect(cookies.encrypted[CookieNames::VERIFY_SINGLE_IDP_JOURNEY]).to be(nil)
       end
@@ -98,6 +100,7 @@ describe SingleIdpJourneyController do
         }
       }
       it 'should redirect to the start page and not set a cookie when an incorrect rp is supplied' do
+        expect(Rails.logger).to receive(:error).with(/Could not get the RP URL for single IDP with transaction_id fake-test-rp/)
         expect(subject).to redirect_to(verify_services_path)
         expect(cookies.encrypted[CookieNames::VERIFY_SINGLE_IDP_JOURNEY]).to be(nil)
       end
@@ -113,6 +116,7 @@ describe SingleIdpJourneyController do
         }
       }
       it 'should redirect to the start page and not set a cookie when an incorrect idp is supplied' do
+        expect(Rails.logger).to receive(:error).with(/The IDP is not valid or disabled for transaction_id http:\/\/www.test-rp.gov.uk\/SAML2\/MD and idp_entity_id fake-stub-idp/)
         expect(subject).to redirect_to(verify_services_path)
         expect(cookies.encrypted[CookieNames::VERIFY_SINGLE_IDP_JOURNEY]).to be(nil)
       end
@@ -128,13 +132,14 @@ describe SingleIdpJourneyController do
         }
       }
       it 'redirects to start page without cookie when uuid has invalid characters' do
+        expect(Rails.logger).to receive(:error).with(/Single IDP UUID #{Regexp.quote(uuid_invalid_char)} not valid/)
         expect(subject).to redirect_to(verify_services_path)
         expect(cookies.encrypted[CookieNames::VERIFY_SINGLE_IDP_JOURNEY]).to be(nil)
       end
     end
 
     describe 'uuid is an invalid length' do
-      uuid_invalid_length = 'OooooOooow5c8d5ca-1aeb-42e1-81b8-5a5d66ef4288'
+      uuid_invalid_length = '5oooo5ooow5c8d5ca-1aeb-42e1-81b8-5a5d66ef4288'
       subject {
         post :redirect_from_idp, params: {
           serviceId: VALID_TEST_RP,
@@ -143,6 +148,7 @@ describe SingleIdpJourneyController do
         }
       }
       it 'redirects to start page without cookie when uuid has invalid length' do
+        expect(Rails.logger).to receive(:error).with(/Single IDP UUID #{Regexp.quote(uuid_invalid_length)} not valid/)
         expect(subject).to redirect_to(verify_services_path)
         expect(cookies.encrypted[CookieNames::VERIFY_SINGLE_IDP_JOURNEY]).to be(nil)
       end
@@ -169,11 +175,13 @@ describe SingleIdpJourneyController do
     end
 
     it 'should redirect to /start if cookie is missing' do
+      expect(Rails.logger).to receive(:error).with(/Single IDP cookies was not found or was malformed/)
       expect(subject).to redirect_to(start_path)
     end
 
     it 'should redirect to /start if cookie is corrupted' do
       cookies.encrypted[CookieNames::VERIFY_SINGLE_IDP_JOURNEY] = "blah"
+      expect(Rails.logger).to receive(:error).with(/Single IDP cookies was not found or was malformed/)
       expect(subject).to redirect_to(start_path)
     end
 
@@ -183,6 +191,7 @@ describe SingleIdpJourneyController do
         uuid: UUID_ONE
       }
       cookies.encrypted[CookieNames::VERIFY_SINGLE_IDP_JOURNEY] = single_idp_cookie.to_json
+      expect(Rails.logger).to receive(:error).with(/Single IDP cookie value for idp_entity_id is missing/)
       expect(subject).to redirect_to(start_path)
     end
 
@@ -193,6 +202,7 @@ describe SingleIdpJourneyController do
         uuid: UUID_ONE
       }
       cookies.encrypted[CookieNames::VERIFY_SINGLE_IDP_JOURNEY] = single_idp_cookie.to_json
+      expect(Rails.logger).to receive(:error).with(/The IDP is not valid or disabled for transaction_id http:\/\/www.test-rp.gov.uk\/SAML2\/MD and idp_entity_id disabled-idp/)
       expect(subject).to redirect_to(start_path)
     end
 
@@ -204,6 +214,7 @@ describe SingleIdpJourneyController do
         uuid: UUID_ONE
       }
       cookies.encrypted[CookieNames::VERIFY_SINGLE_IDP_JOURNEY] = single_idp_cookie.to_json
+      expect(Rails.logger).to receive(:error).with(/The value of the Single IDP cookie does not match the session for transaction_id disabled-rp/)
       expect(subject).to redirect_to(start_path)
     end
 
@@ -214,6 +225,7 @@ describe SingleIdpJourneyController do
         uuid: 'wrong-uuid'
       }
       cookies.encrypted[CookieNames::VERIFY_SINGLE_IDP_JOURNEY] = single_idp_cookie.to_json
+      expect(Rails.logger).to receive(:error).with(/Single IDP UUID wrong-uuid not valid/)
       expect(subject).to redirect_to(start_path)
     end
 
@@ -225,6 +237,7 @@ describe SingleIdpJourneyController do
           uuid: UUID_ONE
       }
       cookies.encrypted[CookieNames::VERIFY_SINGLE_IDP_JOURNEY] = single_idp_cookie.to_json
+      expect(Rails.logger).to receive(:error).with(/The value of the Single IDP cookie does not match the session for transaction_id test-rp-noc3/)
       expect(subject).to redirect_to(start_path)
     end
   end

--- a/spec/controllers/single_idp_journey_controller_spec.rb
+++ b/spec/controllers/single_idp_journey_controller_spec.rb
@@ -31,6 +31,7 @@ describe SingleIdpJourneyController do
         'SINGLE_IDP',
         'The user has started a single idp journey'
       )
+      expect(Rails.logger).to receive(:info).with("Successful Single IDP redirect to RP URL #{SINGLE_IDP_ENABLED_RP_LIST_MOCK[VALID_TEST_RP]['url']} from IdpId #{VALID_STUB_IDP} with uuid #{UUID_ONE}")
       expect(subject).to redirect_to(SINGLE_IDP_ENABLED_RP_LIST_MOCK[VALID_TEST_RP]['url'])
       expect(stub_piwik_request).to have_been_made.once
       expect(cookies.encrypted[CookieNames::VERIFY_SINGLE_IDP_JOURNEY])
@@ -54,6 +55,7 @@ describe SingleIdpJourneyController do
         'SINGLE_IDP',
         'The user has started a single idp journey'
       )
+      expect(Rails.logger).to receive(:info).with("Successful Single IDP redirect to RP URL #{SINGLE_IDP_ENABLED_RP_LIST_MOCK[VALID_TEST_RP]['url']} from IdpId #{VALID_STUB_IDP} with uuid #{UUID_ONE}")
       expect(subject).to redirect_to(SINGLE_IDP_ENABLED_RP_LIST_MOCK[VALID_TEST_RP]['url'])
       expect(stub_piwik_request).to have_been_made.once
       expect(cookies.encrypted[CookieNames::VERIFY_SINGLE_IDP_JOURNEY])


### PR DESCRIPTION
This mostly adds logging for failure cases, which are going to be the most interesting. Also, the referrer URL is included in those log entries.

Some considerations:
- I tried to keep the flow of the endpoint code as smooth as possible w/o adding too many disruptive logging statements - I indeed tried to "confine" them to the controller private methods
- In the testcases, I used regexp for the error message (rather than strings) so that I could ignore the referrer URL (which would have been `nil` in the test cases) and make things easier

Something I am not particularly happy about is that I tried to add logging for successful journeys in `continue_to_your_idp` but there were some technical issues with logging an info message there. However, we can use the existing logging to infer whether the journey was successful, so not too much of an issue.

Jira ticket https://govukverify.atlassian.net/secure/RapidBoard.jspa?rapidView=84&modal=detail&selectedIssue=HUB-275