### PR TITLE
EID-1076: Check `entity_id` param

### DIFF
--- a/app/controllers/choose_a_certified_company_loa1_controller.rb
+++ b/app/controllers/choose_a_certified_company_loa1_controller.rb
@@ -11,10 +11,14 @@ class ChooseACertifiedCompanyLoa1Controller < ApplicationController
   end
 
   def select_idp
-    selected_answer_store.store_selected_answers('interstitial', {})
-    select_viewable_idp_for_loa(params.fetch('entity_id')) do |decorated_idp|
-      session[:selected_idp_was_recommended] = true
-      redirect_to warning_or_question_page(decorated_idp)
+    if params[:entity_id].present?
+      selected_answer_store.store_selected_answers('interstitial', {})
+      select_viewable_idp_for_loa(params.fetch('entity_id')) do |decorated_idp|
+        session[:selected_idp_was_recommended] = true
+        redirect_to warning_or_question_page(decorated_idp)
+      end
+    else
+      render 'errors/something_went_wrong', status: 400
     end
   end
 

--- a/app/controllers/choose_a_certified_company_loa2_controller.rb
+++ b/app/controllers/choose_a_certified_company_loa2_controller.rb
@@ -15,9 +15,13 @@ class ChooseACertifiedCompanyLoa2Controller < ApplicationController
   end
 
   def select_idp
-    select_viewable_idp_for_loa(params.fetch('entity_id')) do |decorated_idp|
-      session[:selected_idp_was_recommended] = recommendation_engine.recommended?(decorated_idp.identity_provider, current_identity_providers_for_loa, selected_evidence, current_transaction_simple_id)
-      redirect_to warning_or_question_page(decorated_idp)
+    if params[:entity_id].present?
+      select_viewable_idp_for_loa(params.fetch('entity_id')) do |decorated_idp|
+        session[:selected_idp_was_recommended] = recommendation_engine.recommended?(decorated_idp.identity_provider, current_identity_providers_for_loa, selected_evidence, current_transaction_simple_id)
+        redirect_to warning_or_question_page(decorated_idp)
+      end
+    else
+      render 'errors/something_went_wrong', status: 400
     end
   end
 

--- a/spec/controllers/choose_a_certified_company_loa1_controller_spec.rb
+++ b/spec/controllers/choose_a_certified_company_loa1_controller_spec.rb
@@ -91,6 +91,13 @@ describe ChooseACertifiedCompanyLoa1Controller do
 
       expect(response).to have_http_status :not_found
     end
+
+    it 'returns 400 if `entity_id` param is not present' do
+      post :select_idp, params: { locale: 'en' }
+
+      expect(subject).to render_template 'errors/something_went_wrong'
+      expect(response).to have_http_status :bad_request
+    end
   end
 
   context '#about' do

--- a/spec/controllers/choose_a_certified_company_loa2_controller_spec.rb
+++ b/spec/controllers/choose_a_certified_company_loa2_controller_spec.rb
@@ -105,6 +105,13 @@ describe ChooseACertifiedCompanyLoa2Controller do
 
       expect(response).to have_http_status :not_found
     end
+
+    it 'returns 400 if `entity_id` param is not present' do
+      post :select_idp, params: { locale: 'en' }
+
+      expect(subject).to render_template 'errors/something_went_wrong'
+      expect(response).to have_http_status :bad_request
+    end
   end
 
   context '#about' do


### PR DESCRIPTION
We've had a few 500s come through on Sentry due to the `entity_id` param
not being present when posting to /choose_a_certified_company.

This adds a check to ensure that the parameter is present, and if not
returns a 400.