### PR TITLE
EID-1053: Fixing bug in eIDAS journey when user presses back after authentication fails.

### DIFF
--- a/app/controllers/failed_sign_in_controller.rb
+++ b/app/controllers/failed_sign_in_controller.rb
@@ -4,6 +4,7 @@ class FailedSignInController < ApplicationController
   end
 
   def country
+    session[:failed_country_sign_in] = true
     @entity = COUNTRY_DISPLAY_DECORATOR.decorate(selected_country)
     @other_ways_description = current_transaction.other_ways_description
     @other_ways_text = current_transaction.other_ways_text

--- a/app/controllers/partials/user_session_partial_controller.rb
+++ b/app/controllers/partials/user_session_partial_controller.rb
@@ -1,6 +1,7 @@
 module UserSessionPartialController
   def validate_session
     validation = session_validator.validate(cookies, session)
+
     unless validation.ok?
       logger.info(validation.message)
       render_error(validation.type, validation.status)

--- a/app/controllers/redirect_to_country_controller.rb
+++ b/app/controllers/redirect_to_country_controller.rb
@@ -5,6 +5,11 @@ class RedirectToCountryController < ApplicationController
   before_action :ensure_session_eidas_supported
 
   def choose_a_country_submit
+    if session[:failed_country_sign_in]
+      restart_journey
+      session.delete(:failed_country_sign_in)
+    end
+
     decorated_country = decorated_country(params[:country])
     if decorated_country.viewable?
       select_country(decorated_country)

--- a/spec/feature_helper.rb
+++ b/spec/feature_helper.rb
@@ -17,7 +17,10 @@ end
 require 'selenium/webdriver'
 Capybara.register_driver :firefox_headless do |app|
   options = ::Selenium::WebDriver::Firefox::Options.new
-  options.args << '--headless'
+  # Stop firefox getting upgraded to version 63 which does not work with Selenium.
+  options.add_preference('app.update.auto', false)
+  options.add_preference('app.update.enabled', false)
+  options.add_argument('--headless')
 
   Capybara::Selenium::Driver.new(app, browser: :firefox, options: options)
 end


### PR DESCRIPTION
Added new variable to the session so we can identify when the user has reached the failed to authenticate page.

When returning to return-to-country view it resets the session if we have failed before
Fixed the test runner to not upgrade firefox as there is currently a bug stopping it from function.