### PR TITLE
EID-1053: Work around for bug in Firefox 63 which stops Selenium tests running.

### DIFF
--- a/spec/feature_helper.rb
+++ b/spec/feature_helper.rb
@@ -17,7 +17,10 @@ end
 require 'selenium/webdriver'
 Capybara.register_driver :firefox_headless do |app|
   options = ::Selenium::WebDriver::Firefox::Options.new
-  options.args << '--headless'
+  # Stop firefox getting upgraded to version 63 which does not work with Selenium.
+  options.add_preference('app.update.auto', false)
+  options.add_preference('app.update.enabled', false)
+  options.add_argument('--headless')
 
   Capybara::Selenium::Driver.new(app, browser: :firefox, options: options)
 end


### PR DESCRIPTION
Disabled auto upgrade on Firefox so a System Version of Firefox at 62 can be used.