### PR TITLE
HUB-358: Fix the alignment of IDP logos on the slides

### DIFF
--- a/app/assets/stylesheets/pages/_slides.scss
+++ b/app/assets/stylesheets/pages/_slides.scss
@@ -140,17 +140,16 @@
 // About certified companies
 .list-companies {
   margin-bottom: $gutter-half;
-
-  @include media(mobile) {
-    text-align: center;
-  }
+  text-align: center;
 
   li {
     @include inline-block;
     width: 49%;
 
     @include media (tablet) {
-      width: 24%;
+      width: 25%;
+      margin-left: $gutter-one-third;
+      margin-right: $gutter-one-third;
     }
   }
 


### PR DESCRIPTION
Alter _slides.css so that .list-companies text align is centred and .list-companies > li are 32% wide rather than 24%