### PR TITLE
BAU Throw 400 if registering with disconnected IDP

### DIFF
--- a/spec/controllers/redirect_to_idp_warning_controller_spec.rb
+++ b/spec/controllers/redirect_to_idp_warning_controller_spec.rb
@@ -6,6 +6,7 @@ require 'piwik_test_helper'
 describe RedirectToIdpWarningController do
   before :each do
     stub_api_select_idp
+    stub_api_idp_list_for_loa
     stub_request(:get, INTERNAL_PIWIK.url).with(query: hash_including({}))
     set_session_and_cookies_with_loa('LEVEL_2')
     session[:selected_idp_was_recommended] = [true, false].sample
@@ -27,6 +28,25 @@ describe RedirectToIdpWarningController do
     it 'error page when no idp selected' do
       session[:selected_provider] = {}
 
+      expect(subject).to render_template('errors/something_went_wrong')
+    end
+
+    it 'error page when idp not providing registrations' do
+      stub_idp = [
+        {
+            'simpleId' => 'stub-idp-one',
+            'entityId' => 'http://idcorp.com',
+            'levelsOfAssurance' => %w(LEVEL_2),
+        },
+      ]
+      stub_api_idp_list_for_loa(stub_idp)
+      set_selected_idp(
+        'simple_id' => 'stub-idp-two',
+        'entity_id' => 'http://idcorp.com',
+        'levels_of_assurance' => %w(LEVEL_1 LEVEL_2)
+      )
+
+      expect(subject.status).to equal(400)
       expect(subject).to render_template('errors/something_went_wrong')
     end
   end

--- a/spec/features/user_visits_redirect_to_idp_warning_page_spec.rb
+++ b/spec/features/user_visits_redirect_to_idp_warning_page_spec.rb
@@ -59,6 +59,7 @@ RSpec.describe 'When the user visits the redirect to IDP warning page' do
   }
 
   before(:each) do
+    stub_api_idp_list_for_loa
     session = default_session.merge(user_segments: ['test-segment'])
     set_session_and_session_cookies!(session: session)
   end


### PR DESCRIPTION
See this Zendesk ticket: https://govuk.zendesk.com/agent/tickets/3474574

We had some 500s from users trying to register with IDPs that were no
longer offering registrations, via the `/redirect-to-idp-warning` page.
They probably used a bookmark, or a direct link after visiting the sign
in page to set one of the invalid suppliers in selected in their
session.