### PR TITLE
HUB-388: Extra IDP info AB test

### DIFF
--- a/app/assets/stylesheets/pages/_choose-a-certified-company.scss
+++ b/app/assets/stylesheets/pages/_choose-a-certified-company.scss
@@ -21,3 +21,25 @@
 .subtitle {
   color: $secondary-text-colour;
 }
+
+.ab-test-extra-idp-info-b {
+
+  form {
+    min-width: 250px;
+    float: left;
+  }
+
+  .idp-additional-info {
+    padding-top: 25px;
+
+    @media (max-width: 900px){
+      padding-top: 15px;
+    }
+  }
+
+  @media (max-width: $desktop-breakpoint){
+    form {
+      float: none;
+    }
+  }
+}

--- a/app/controllers/choose_a_certified_company_loa1_variant_controller.rb
+++ b/app/controllers/choose_a_certified_company_loa1_variant_controller.rb
@@ -1,0 +1,38 @@
+require 'partials/viewable_idp_partial_controller'
+
+class ChooseACertifiedCompanyLoa1VariantController < ApplicationController
+  include ChooseACertifiedCompanyAbout
+  include ViewableIdpPartialController
+
+  def index
+    @recommended_idps = IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate_collection(current_identity_providers_for_loa)
+    FEDERATION_REPORTER.report_number_of_idps_recommended(current_transaction, request, @recommended_idps.length)
+    render 'choose_a_certified_company/choose_a_certified_company_LOA1_variant'
+  end
+
+  def select_idp
+    if params[:entity_id].present?
+      selected_answer_store.store_selected_answers('interstitial', {})
+      select_viewable_idp_for_loa(params.fetch('entity_id')) do |decorated_idp|
+        session[:selected_idp_was_recommended] = true
+        redirect_to warning_or_question_page(decorated_idp)
+      end
+    else
+      render 'errors/something_went_wrong', status: 400
+    end
+  end
+
+private
+
+  def warning_or_question_page(decorated_idp)
+    if interstitial_question_flag_enabled_for(decorated_idp)
+      redirect_to_idp_question_path
+    else
+      redirect_to_idp_warning_path
+    end
+  end
+
+  def interstitial_question_flag_enabled_for(decorated_idp)
+    IDP_FEATURE_FLAGS_CHECKER.enabled?(:show_interstitial_question_loa1, decorated_idp.simple_id)
+  end
+end

--- a/app/controllers/choose_a_certified_company_loa2_variant_controller.rb
+++ b/app/controllers/choose_a_certified_company_loa2_variant_controller.rb
@@ -1,0 +1,49 @@
+require 'partials/viewable_idp_partial_controller'
+
+class ChooseACertifiedCompanyLoa2VariantController < ApplicationController
+  include ChooseACertifiedCompanyAbout
+  include ViewableIdpPartialController
+
+  def index
+    session[:selected_answers]&.delete('interstitial')
+    suggestions = recommendation_engine.get_suggested_idps(current_identity_providers_for_loa, selected_evidence, current_transaction_simple_id)
+    @recommended_idps = IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate_collection(suggestions[:recommended])
+    @non_recommended_idps = IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate_collection(suggestions[:unlikely])
+    session[:user_segments] = suggestions[:user_segments]
+    FEDERATION_REPORTER.report_number_of_idps_recommended(current_transaction, request, @recommended_idps.length)
+    render 'choose_a_certified_company/choose_a_certified_company_LOA2_variant'
+  end
+
+  def select_idp
+    if params[:entity_id].present?
+      select_viewable_idp_for_loa(params.fetch('entity_id')) do |decorated_idp|
+        session[:selected_idp_was_recommended] = recommendation_engine.recommended?(decorated_idp.identity_provider, current_identity_providers_for_loa, selected_evidence, current_transaction_simple_id)
+        redirect_to warning_or_question_page(decorated_idp)
+      end
+    else
+      render 'errors/something_went_wrong', status: 400
+    end
+  end
+
+private
+
+  def warning_or_question_page(decorated_idp)
+    if not_more_than_one_uk_doc_selected && interstitial_question_flag_enabled_for(decorated_idp)
+      redirect_to_idp_question_path
+    else
+      redirect_to_idp_warning_path
+    end
+  end
+
+  def not_more_than_one_uk_doc_selected
+    (%i[passport driving_licence] & selected_evidence).size <= 1
+  end
+
+  def interstitial_question_flag_enabled_for(decorated_idp)
+    IDP_FEATURE_FLAGS_CHECKER.enabled?(:show_interstitial_question, decorated_idp.simple_id)
+  end
+
+  def recommendation_engine
+    IDP_RECOMMENDATION_ENGINE
+  end
+end

--- a/app/models/display/idp_display_data.rb
+++ b/app/models/display/idp_display_data.rb
@@ -14,6 +14,7 @@ module Display
     content :interstitial_question, default: ''
     content :interstitial_explanation, default: ''
     content :mobile_app_installation, default: ''
+    content :additional_content, default: ''
 
     alias_method :about_content, :about
     alias_method :display_name, :name

--- a/app/models/display/viewable_identity_provider.rb
+++ b/app/models/display/viewable_identity_provider.rb
@@ -10,7 +10,7 @@ module Display
     delegate :model_name, to: :identity_provider
     delegate :to_key, to: :identity_provider
     delegate :authentication_enabled, to: :identity_provider
-    delegate :display_name, :about_content, :requirements, :special_no_docs_instructions, :no_docs_requirement, :contact_details, :interstitial_question, :interstitial_explanation, :mobile_app_installation, :tagline, to: :display_data
+    delegate :display_name, :about_content, :requirements, :special_no_docs_instructions, :no_docs_requirement, :contact_details, :interstitial_question, :interstitial_explanation, :mobile_app_installation, :tagline, :additional_content, to: :display_data
 
     def viewable?
       true

--- a/app/views/choose_a_certified_company/_idp_option_variant.html.erb
+++ b/app/views/choose_a_certified_company/_idp_option_variant.html.erb
@@ -1,0 +1,27 @@
+<div class="idp-choice ab-test-extra-idp-info-b">
+  <%= form_for(identity_provider, url: choose_a_certified_company_submit_path, html: {class: nil, id: nil}) do |f| %>
+    <%= hidden_field_tag 'entity_id', identity_provider.entity_id, id: nil %>
+    <div class="company-logo">
+      <div class="company-logo-img-container">
+        <%= image_submit_tag(identity_provider.logo_path, alt: "#{identity_provider.display_name} logo") %>
+      </div>
+      <p class="company-about">
+        <%= link_to(t('hub.choose_a_certified_company.about_idp', display_name: identity_provider.display_name), choose_a_certified_company_about_path(identity_provider.simple_id)) %>
+      </p>
+    </div>
+    <div class="idp-option">
+      <%= f.button t('hub.choose_a_certified_company.choose_idp', display_name: identity_provider.display_name),
+                    class: recommended ? 'button' : 'button-link',
+                    role: recommended ? nil : 'link',
+                    name: identity_provider.simple_id,
+                    id: nil,
+                    type: 'submit',
+                    value: identity_provider.display_name,
+                    'data-order': order
+      %>
+    </div>
+  <% end %>
+  <div class="idp-additional-info">
+    <span><%= identity_provider.additional_content %></span>
+  </div>
+</div>

--- a/app/views/choose_a_certified_company/choose_a_certified_company_LOA1_variant.html.erb
+++ b/app/views/choose_a_certified_company/choose_a_certified_company_LOA1_variant.html.erb
@@ -1,0 +1,24 @@
+<%= page_title 'hub.choose_a_certified_company.title' %>
+<% content_for :feedback_source, 'CHOOSE_A_CERTIFIED_COMPANY_PAGE' %>
+<% content_for :additional_javascript do %>
+    <%= javascript_include_tag 'piwik_idp_picker_tracking' %>
+<% end %>
+
+<div class="content-inner">
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      <h1 class="heading-large"><%= t 'hub.choose_a_certified_company.heading' %></h1>
+      <p><%= t 'hub.choose_a_certified_company.existing_customer' %></p>
+      <p><%= t 'hub.choose_a_certified_company.personal_information' %></p>
+
+      <ul class="list list-bullet">
+        <li><%= link_to(t('hub.choose_a_certified_company.why_companies'), why_companies_path) %></li>
+      </ul>
+    </div>
+  </div>
+  <div id="matching-idps">
+    <% @recommended_idps.each.with_index do |identity_provider, index| %>
+        <%= render partial: 'choose_a_certified_company/idp_option_variant', locals: {recommended: true, identity_provider: identity_provider, order: index + 1} %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/choose_a_certified_company/choose_a_certified_company_LOA2_variant.html.erb
+++ b/app/views/choose_a_certified_company/choose_a_certified_company_LOA2_variant.html.erb
@@ -1,0 +1,49 @@
+<%= page_title 'hub.choose_a_certified_company.title' %>
+<% content_for :feedback_source, 'CHOOSE_A_CERTIFIED_COMPANY_PAGE' %>
+<% content_for :additional_javascript do %>
+    <%= javascript_include_tag 'piwik_idp_picker_tracking' %>
+<% end %>
+
+<div class="content-inner">
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      <h1 class="heading-large"><%= t 'hub.choose_a_certified_company.heading' %></h1>
+      <p><%= t 'hub.choose_a_certified_company.existing_customer' %></p>
+      <p><%= t 'hub.choose_a_certified_company.personal_information' %></p>
+      <ul class="list list-bullet">
+        <li><%= link_to(t('hub.choose_a_certified_company.why_companies'), why_companies_path) %></li>
+      </ul>
+      <p class="large-top">
+        <%= t 'hub.choose_a_certified_company.idp_count_html',
+              company_count: t('hub.choose_a_certified_company.company_html', count: @recommended_idps.length) %>
+      </p>
+    </div>
+  </div>
+  <div id="matching-idps">
+    <% @recommended_idps.each.with_index do |identity_provider, index| %>
+      <%= render partial: 'choose_a_certified_company/idp_option_variant', locals: {recommended: true, identity_provider: identity_provider, order: index + 1} %>
+    <% end %>
+  </div>
+  <% if @non_recommended_idps.any? %>
+    <div id="non-matching-idps">
+      <div class="grid-row">
+        <div class="column-two-thirds">
+          <p class="large-top">
+            <%= t 'hub.choose_a_certified_company.filtered_idps_message_html',
+                  company_count: t('hub.choose_a_certified_company.company_html', count: @non_recommended_idps.length) %>
+          </p>
+        </div>
+      </div>
+      <details>
+        <summary>
+          <span class="summary"><%= t 'hub.choose_a_certified_company.show_all_companies' %></span>
+        </summary>
+        <div class="panel panel-border-narrow">
+          <% @non_recommended_idps.each.with_index do |identity_provider, index| %>
+            <%= render partial: 'choose_a_certified_company/idp_option', locals: {recommended: false, identity_provider: identity_provider, order: index + 1} %>
+          <% end %>
+        </div>
+      </details>
+    </div>
+  <% end %>
+</div>

--- a/config/main_routes.rb
+++ b/config/main_routes.rb
@@ -2,6 +2,12 @@ def add_routes(routes_name)
   instance_eval(File.read(Rails.root.join("config/#{routes_name}.rb")))
 end
 
+EXTRA_IDP_INFO_B = "extra_idp_info_b".freeze
+# HUB-388 Extra IDP info A/B test
+extra_idp_info_b_control_piwik = SelectRoute.new(EXTRA_IDP_INFO_B, 'control', is_start_of_test: true)
+extra_idp_info_b_variant_piwik = SelectRoute.new(EXTRA_IDP_INFO_B, 'variant', is_start_of_test: true)
+
+
 get 'sign_in', to: 'sign_in#index', as: :sign_in
 post 'sign_in', to: 'sign_in#select_idp', as: :sign_in_submit
 get 'begin_sign_in', to: 'start#sign_in', as: :begin_sign_in
@@ -10,7 +16,7 @@ constraints IsLoa1 do
   get 'start', to: 'start#index', as: :start
   post 'start', to: 'start#request_post', as: :start
   get 'begin_registration', to: 'start#register', as: :begin_registration
-  get 'choose_a_certified_company', to: 'choose_a_certified_company_loa1#index', as: :choose_a_certified_company
+  #get 'choose_a_certified_company', to: 'choose_a_certified_company_loa1#index', as: :choose_a_certified_company
   post 'choose_a_certified_company', to: 'choose_a_certified_company_loa1#select_idp', as: :choose_a_certified_company_submit
   get 'choose_a_certified_company/:company', to: 'choose_a_certified_company_loa1#about', as: :choose_a_certified_company_about
   get 'why_companies', to: 'why_companies_loa1#index', as: :why_companies
@@ -26,6 +32,13 @@ constraints IsLoa1 do
   get 'about_certified_companies', to: 'about_loa1#certified_companies', as: :about_certified_companies
   get 'about_identity_accounts', to: 'about_loa1#identity_accounts', as: :about_identity_accounts
   get 'about_choosing_a_company', to: 'about_loa1#choosing_a_company', as: :about_choosing_a_company
+
+  constraints extra_idp_info_b_control_piwik do
+    get 'choose_a_certified_company', to: 'choose_a_certified_company_loa1#index', as: :choose_a_certified_company
+  end
+  constraints extra_idp_info_b_variant_piwik do
+    get 'choose_a_certified_company', to: 'choose_a_certified_company_loa1_variant#index', as: :choose_a_certified_company
+  end
 end
 
 constraints IsLoa2 do
@@ -51,7 +64,7 @@ constraints IsLoa2 do
   get 'select_phone', to: 'select_phone#index', as: :select_phone
   post 'select_phone', to: 'select_phone#select_phone', as: :select_phone_submit
   get 'verify_will_not_work_for_you', to: 'select_phone#verify_will_not_work_for_you', as: :verify_will_not_work_for_you
-  get 'choose_a_certified_company', to: 'choose_a_certified_company_loa2#index', as: :choose_a_certified_company
+  #get 'choose_a_certified_company', to: 'choose_a_certified_company_loa2#index', as: :choose_a_certified_company
   post 'choose_a_certified_company', to: 'choose_a_certified_company_loa2#select_idp', as: :choose_a_certified_company_submit
   get 'choose_a_certified_company/:company', to: 'choose_a_certified_company_loa2#about', as: :choose_a_certified_company_about
   get 'why_companies', to: 'why_companies_loa2#index', as: :why_companies
@@ -63,6 +76,13 @@ constraints IsLoa2 do
   post 'redirect_to_idp_question', to: 'redirect_to_idp_question_loa2#continue', as: :redirect_to_idp_question_submit
   get 'idp_wont_work_for_you_one_doc', to: 'redirect_to_idp_question_loa2#idp_wont_work_for_you', as: :idp_wont_work_for_you_one_doc
   get 'confirmation', to: 'confirmation_loa2#index', as: :confirmation
+
+  constraints extra_idp_info_b_control_piwik do
+    get 'choose_a_certified_company', to: 'choose_a_certified_company_loa2#index', as: :choose_a_certified_company
+  end
+  constraints extra_idp_info_b_variant_piwik do
+    get 'choose_a_certified_company', to: 'choose_a_certified_company_loa2_variant#index', as: :choose_a_certified_company
+  end
 end
 
 get 'privacy_notice', to: 'static#privacy_notice', as: :privacy_notice

--- a/spec/controllers/choose_a_certified_company_loa1_variant_controller_spec.rb
+++ b/spec/controllers/choose_a_certified_company_loa1_variant_controller_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+require 'controller_helper'
+require 'api_test_helper'
+require 'piwik_test_helper'
+
+describe ChooseACertifiedCompanyLoa1VariantController do
+  let(:stub_idp_loa1) {
+    {
+        'simpleId' => 'stub-idp-loa1',
+        'entityId' => 'http://idcorp-loa1.com',
+        'levelsOfAssurance' => %w(LEVEL_1 LEVEL_2)
+    }.freeze
+  }
+
+  let(:stub_idp_loa1_with_interstitial) {
+    {
+        'simpleId' => 'stub-idp-loa1-with-interstitial',
+        'entityId' => 'http://idcorp-loa1-with-interstitial.com',
+        'levelsOfAssurance' => %w(LEVEL_1 LEVEL_2)
+    }.freeze
+  }
+
+  context '#index' do
+    before :each do
+      stub_api_idp_list_for_loa([stub_idp_loa1, stub_idp_loa1_with_interstitial], 'LEVEL_1')
+    end
+
+    it 'renders IDP list' do
+      set_session_and_cookies_with_loa('LEVEL_1', 'test-rp')
+      stub_piwik_request = stub_piwik_report_number_of_recommended_idps(2, 'LEVEL_1', 'analytics description for test-rp')
+
+      expect(IDENTITY_PROVIDER_DISPLAY_DECORATOR).to receive(:decorate_collection).once do |idps|
+        idps.each { |idp| expect(idp.levels_of_assurance).to include 'LEVEL_1' }
+      end
+
+      get :index, params: { locale: 'en' }
+
+      expect(subject).to render_template(:choose_a_certified_company_LOA1_variant)
+      expect(stub_piwik_request).to have_been_made.once
+    end
+  end
+end

--- a/spec/controllers/choose_a_certified_company_loa2_variant_controller_spec.rb
+++ b/spec/controllers/choose_a_certified_company_loa2_variant_controller_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+require 'controller_helper'
+require 'api_test_helper'
+require 'piwik_test_helper'
+
+describe ChooseACertifiedCompanyLoa2VariantController do
+  let(:stub_idp_loa1) {
+    {
+        'simpleId' => 'stub-idp-loa1',
+        'entityId' => 'http://idcorp-loa1.com',
+        'levelsOfAssurance' => %w(LEVEL_1 LEVEL_2)
+    }.freeze
+  }
+
+  let(:stub_idp_one_doc) {
+    {
+        'simpleId' => 'stub-idp-one-doc-question',
+        'entityId' => 'http://idcorp.com',
+        'levelsOfAssurance' => ['LEVEL_2']
+    }.freeze
+  }
+
+  context '#index' do
+    it 'renders the certified companies LOA2 template when LEVEL_2 is the requested LOA' do
+      set_session_and_cookies_with_loa('LEVEL_2')
+      stub_api_idp_list_for_loa([stub_idp_loa1, stub_idp_one_doc])
+      session[:selected_answers] = {
+        'documents' => { 'driving_licence' => true, 'mobile_phone' => true },
+        'device_type' => { 'device_type_other' => true }
+      }
+      stub_piwik_request = stub_piwik_report_number_of_recommended_idps(1, 'LEVEL_2', 'analytics description for test-rp')
+
+      expect(IDENTITY_PROVIDER_DISPLAY_DECORATOR).to receive(:decorate_collection).twice do |idps|
+        idps.each { |idp| expect(idp.levels_of_assurance).to include 'LEVEL_2' }
+      end
+
+      get :index, params: { locale: 'en' }
+
+      expect(subject).to render_template(:choose_a_certified_company_LOA2_variant)
+      expect(stub_piwik_request).to have_been_made.once
+    end
+
+    it 'removes interstitial answer when IDP picker page is rendered' do
+      set_session_and_cookies_with_loa('LEVEL_2')
+      stub_api_idp_list_for_loa([stub_idp_loa1, stub_idp_one_doc])
+      session[:selected_answers] = {
+        'documents' => { 'driving_licence' => true, 'mobile_phone' => true },
+        'device_type' => { 'device_type_other' => true },
+        'interstitial' => { 'interstitial_yes' => true }
+      }
+      stub_piwik_report_number_of_recommended_idps(1, 'LEVEL_2', 'analytics description for test-rp')
+
+      get :index, params: { locale: 'en' }
+
+      expect(session[:selected_answers]['interstitial']).to be_nil
+    end
+  end
+end

--- a/spec/features/user_sends_authn_request_spec.rb
+++ b/spec/features/user_sends_authn_request_spec.rb
@@ -95,7 +95,8 @@ describe 'user sends authn requests' do
       stub_session_creation
       ab_test_cookie_value = {
         'about_companies' => 'about_companies_with_logo',
-        'select_documents_v2' => 'select_documents_v2_control'
+        'select_documents_v2' => 'select_documents_v2_control',
+        'extra_idp_info_b' => 'extra_idp_info_b_control'
       }.to_json
       cookie_hash = create_cookie_hash.merge!(ab_test: CGI.escape(ab_test_cookie_value))
       set_cookies!(cookie_hash)

--- a/spec/features/user_visits_choose_a_certified_company_page_variant_spec.rb
+++ b/spec/features/user_visits_choose_a_certified_company_page_variant_spec.rb
@@ -1,0 +1,194 @@
+require 'feature_helper'
+require 'api_test_helper'
+
+describe 'When the user visits the choose a certified company page' do
+  before(:each) do
+    set_session_and_session_cookies!
+    stub_api_idp_list_for_loa(default_idps)
+    set_session_and_ab_session_cookies!('extra_idp_info_b' => 'extra_idp_info_b_variant')
+  end
+
+  context 'user has two docs and a mobile' do
+    selected_answers = {
+        device_type: { device_type_other: true },
+        documents: { passport: true, driving_licence: true },
+        phone: { mobile_phone: true }
+    }
+    before :each do
+      page.set_rack_session(
+        transaction_simple_id: 'test-rp',
+        selected_answers: selected_answers,
+      )
+    end
+
+    it 'includes the appropriate feedback source' do
+      visit '/choose-a-certified-company'
+
+      expect_feedback_source_to_be(page, 'CHOOSE_A_CERTIFIED_COMPANY_PAGE', '/choose-a-certified-company')
+    end
+
+    it 'displays recommended IDPs' do
+      visit '/choose-a-certified-company'
+
+      expect(page).to have_current_path(choose_a_certified_company_path)
+      expect(page).to have_content t('hub.choose_a_certified_company.idp_count_html', company_count: '3 companies')
+      within('#matching-idps') do
+        expect(page).to have_button('Choose IDCorp')
+      end
+    end
+
+    it 'does not show an IDP if the IDP profile has a subset of the user evidence, but not an exact match' do
+      additional_documents = selected_answers[:documents].clone
+      additional_documents[:driving_licence] = false
+      page.set_rack_session(
+        transaction_simple_id: 'test-rp',
+        selected_answers: {
+          selected_answers: additional_documents,
+          phone: selected_answers[:phone],
+          device_type: { device_type_other: true }
+        }
+      )
+
+      visit '/choose-a-certified-company'
+
+      within('#matching-idps') do
+        expect(page).to_not have_button('Choose IDCorp')
+      end
+    end
+
+    it 'redirects to the choose a certified company about page when selecting About link' do
+      visit '/choose-a-certified-company'
+
+      click_link 'About IDCorp'
+
+      expect(page).to have_current_path(choose_a_certified_company_about_path('stub-idp-one'))
+    end
+
+    it 'displays the page in Welsh' do
+      visit '/dewis-cwmni-ardystiedig'
+
+      expect(page).to have_title t('hub.choose_a_certified_company.title', locale: :cy)
+      expect(page).to have_css 'html[lang=cy]'
+    end
+  end
+
+  context 'user is from an LOA1 service' do
+    it 'only LEVEL_1 recommended IDPs are displayed' do
+      stub_api_idp_list_for_loa(default_idps, 'LEVEL_1')
+      page.set_rack_session(
+        transaction_simple_id: 'test-rp',
+        requested_loa: 'LEVEL_1',
+        selected_answers: {
+          device_type: { device_type_other: true },
+          documents: { passport: true, driving_licence: true },
+          phone: { mobile_phone: true }
+        },
+      )
+
+      visit '/choose-a-certified-company'
+
+      expect(page).to have_current_path(choose_a_certified_company_path)
+
+      within('#matching-idps') do
+        expect(page).to have_button('Choose LOA1 Corp')
+      end
+    end
+
+    it 'displays additional text for a specific IDP (ab test)' do
+      stub_api_idp_list_for_loa(default_idps, 'LEVEL_1')
+      page.set_rack_session(
+        transaction_simple_id: 'test-rp',
+        requested_loa: 'LEVEL_1',
+        selected_answers: {
+          device_type: { device_type_other: true },
+          documents: { passport: true, driving_licence: true },
+          phone: { mobile_phone: true }
+        },
+      )
+      visit '/choose-a-certified-company'
+
+      expect(page).to have_content("Additional content text")
+    end
+  end
+
+  it 'displays no IDPs if no recommendations' do
+    page.set_rack_session(
+      transaction_simple_id: 'test-rp',
+      selected_answers: {
+        device_type: { device_type_other: true },
+        documents: { passport: false }
+      },
+    )
+
+    visit '/choose-a-certified-company'
+
+    expect(page).to have_current_path(choose_a_certified_company_path)
+    expect(page).to_not have_css('#non-matching-idps')
+    expect(page).to have_content t('hub.choose_a_certified_company.idp_count_html', company_count: 'no companies')
+  end
+
+  it 'recommends some IDPs with a recommended profile, hides non-recommended profiles, and omits non-matching profiles' do
+    stub_api_no_docs_idps
+    page.set_rack_session(
+      transaction_simple_id: 'test-rp',
+      selected_answers: {
+        device_type: { device_type_other: true },
+        documents: { driving_licence: true },
+        phone: { mobile_phone: true }
+      },
+    )
+
+    visit '/choose-a-certified-company'
+
+    expect(page).to have_content t('hub.choose_a_certified_company.idp_count_html', company_count: '2 companies')
+    within('#matching-idps') do
+      expect(page).to have_button('Choose No Docs IDP')
+      expect(page).to have_button('Choose IDCorp')
+      expect(page).to_not have_button('Bob’s Identity Service')
+    end
+
+    within('#non-matching-idps') do
+      expect(page).to have_button('Bob’s Identity Service')
+    end
+
+    expect(page).to_not have_button('Choose Carol’s Secure ID')
+  end
+
+  context 'IDP profile is in a demo period' do
+    selected_answers = {
+      device_type: { device_type_other: true },
+      documents: { passport: true, driving_licence: true },
+      phone: { mobile_phone: true }
+    }
+
+    it 'shows the IDP if the RP is not protected' do
+      page.set_rack_session(
+        transaction_simple_id: 'test-rp',
+        selected_answers: selected_answers
+      )
+
+      visit '/choose-a-certified-company'
+
+      within('#matching-idps') do
+        expect(page).to have_button('Choose Bob’s Identity Service')
+      end
+    end
+
+    it 'shows the IDP as unlikely if the RP is protected' do
+      page.set_rack_session(
+        transaction_simple_id: 'test-rp-no-demo',
+        selected_answers: selected_answers
+      )
+
+      visit '/choose-a-certified-company'
+
+      within('#matching-idps') do
+        expect(page).to_not have_button('Choose Bob’s Identity Service')
+      end
+
+      within('#non-matching-idps') do
+        expect(page).to have_button('Choose Bob’s Identity Service')
+      end
+    end
+  end
+end

--- a/stub/ab_test.yml
+++ b/stub/ab_test.yml
@@ -31,3 +31,9 @@ experiments:
           percent: 0
         - name: 'no_logo_privacy'
           percent: 0
+  - extra_idp_info_b:
+      alternatives:
+        - name: 'control'
+          percent: 100
+        - name: 'variant'
+          percent: 0

--- a/stub/locales/idps/stub-idp-loa1-with-interstitial.yml
+++ b/stub/locales/idps/stub-idp-loa1-with-interstitial.yml
@@ -13,6 +13,7 @@ en:
         <h2 class="heading-medium">Are you sure you want to continue?</h2>
       interstitial_explanation: |
         <p>LOA1 Corp will not work for you.</p>
+      additional_content: Additional content text
 cy:
   idps:
     stub-idp-loa1-with-interstitial:
@@ -26,3 +27,4 @@ cy:
         <h2 class="heading-medium">Are you sure you want to continue?</h2>
       interstitial_explanation: |
         <p>LOA1 Corp will not work for you.</p>
+      additional_content: Additional content text in welsh


### PR DESCRIPTION
For specified IDPs we can add additional content. This is for the AB test.
When users are on a variant they see and additional content by the specified IDP.

Config: https://github.com/alphagov/verify-frontend-federation-config/pull/104