### PR TITLE
HUB-380: Add Piwik Session ID and Journey Type to Audit

### DIFF
--- a/app/controllers/partials/analytics_cookie_partial_controller.rb
+++ b/app/controllers/partials/analytics_cookie_partial_controller.rb
@@ -1,0 +1,12 @@
+module AnalyticsCookiePartialController
+  def analytics_session_id
+    cookie_value = cookies.fetch(analytics_cookie_name, nil)
+    cookie_value.split('.').first unless cookie_value.nil?
+  end
+
+private
+
+  def analytics_cookie_name
+    cookies.each { |name, _value| return name if name.starts_with? CookieNames::ANALYTICS_SESSION_COOKIE_PREFIX }
+  end
+end

--- a/app/controllers/paused_registration_controller.rb
+++ b/app/controllers/paused_registration_controller.rb
@@ -3,7 +3,7 @@ require 'partials/journey_hinting_partial_controller'
 require 'partials/viewable_idp_partial_controller'
 require 'partials/retrieve_federation_data_partial_controller'
 require 'partials/idp_selection_partial_controller'
-require 'partials/user_cookies_partial_controller'
+require 'partials/analytics_cookie_partial_controller'
 
 class PausedRegistrationController < ApplicationController
   include JourneyHintingPartialController
@@ -11,6 +11,7 @@ class PausedRegistrationController < ApplicationController
   include RetrieveFederationDataPartialController
   include IdpSelectionPartialController
   include UserCookiesPartialController
+  include AnalyticsCookiePartialController
 
   # Validate the session manually within the action, as we don't want the normal 'no session' page.
   skip_before_action :validate_session, except: :resume
@@ -137,7 +138,7 @@ private
   end
 
   def select_resume(entity_id, idp_name)
-    POLICY_PROXY.select_idp(session[:verify_session_id], entity_id, session['requested_loa'])
+    POLICY_PROXY.select_idp(session[:verify_session_id], entity_id, session['requested_loa'], false, analytics_session_id, session[:journey_type])
     set_attempt_journey_hint(entity_id)
     session[:selected_idp_name] = idp_name
   end

--- a/app/controllers/redirect_to_idp_warning_controller.rb
+++ b/app/controllers/redirect_to_idp_warning_controller.rb
@@ -1,7 +1,9 @@
 require 'partials/idp_selection_partial_controller'
+require 'partials/analytics_cookie_partial_controller'
 
 class RedirectToIdpWarningController < ApplicationController
   include IdpSelectionPartialController
+  include AnalyticsCookiePartialController
 
   SELECTED_IDP_HISTORY_LENGTH = 5
   helper_method :user_has_no_docs_or_foreign_id_only?, :other_ways_description
@@ -39,7 +41,7 @@ class RedirectToIdpWarningController < ApplicationController
 private
 
   def select_registration(idp)
-    POLICY_PROXY.select_idp(session['verify_session_id'], idp.entity_id, session['requested_loa'], true)
+    POLICY_PROXY.select_idp(session['verify_session_id'], idp.entity_id, session['requested_loa'], true, analytics_session_id, session[:journey_type])
     set_journey_hint_followed(idp.entity_id)
     set_attempt_journey_hint(idp.entity_id)
     register_idp_selections(idp.display_name)

--- a/app/controllers/sign_in_controller.rb
+++ b/app/controllers/sign_in_controller.rb
@@ -1,9 +1,11 @@
 require 'partials/idp_selection_partial_controller'
 require 'partials/viewable_idp_partial_controller'
+require 'partials/analytics_cookie_partial_controller'
 
 class SignInController < ApplicationController
   include IdpSelectionPartialController
   include ViewableIdpPartialController
+  include AnalyticsCookiePartialController
 
   def index
     entity_id = success_entity_id
@@ -41,7 +43,7 @@ class SignInController < ApplicationController
 private
 
   def sign_in(entity_id, idp_name)
-    POLICY_PROXY.select_idp(session[:verify_session_id], entity_id, session['requested_loa'])
+    POLICY_PROXY.select_idp(session[:verify_session_id], entity_id, session['requested_loa'], false, analytics_session_id, session[:journey_type])
     set_attempt_journey_hint(entity_id)
     session[:selected_idp_name] = idp_name
   end

--- a/app/controllers/single_idp_journey_controller.rb
+++ b/app/controllers/single_idp_journey_controller.rb
@@ -4,6 +4,7 @@ require 'partials/user_cookies_partial_controller'
 require 'partials/idp_selection_partial_controller'
 require 'partials/viewable_idp_partial_controller'
 require 'partials/retrieve_federation_data_partial_controller'
+require 'partials/analytics_cookie_partial_controller'
 
 class SingleIdpJourneyController < ApplicationController
   layout 'slides'
@@ -11,6 +12,7 @@ class SingleIdpJourneyController < ApplicationController
   include IdpSelectionPartialController
   include ViewableIdpPartialController
   include RetrieveFederationDataPartialController
+  include AnalyticsCookiePartialController
 
   protect_from_forgery except: :redirect_from_idp
   skip_before_action :validate_session, only: :redirect_from_idp
@@ -153,7 +155,7 @@ private
   end
 
   def select_idp(entity_id, idp_name)
-    POLICY_PROXY.select_idp(session[:verify_session_id], entity_id, session['requested_loa'])
+    POLICY_PROXY.select_idp(session[:verify_session_id], entity_id, session['requested_loa'], false, analytics_session_id, session[:journey_type])
     set_attempt_journey_hint(entity_id)
     session[:selected_idp_name] = idp_name
   end

--- a/app/models/policy_endpoints.rb
+++ b/app/models/policy_endpoints.rb
@@ -10,6 +10,8 @@ module PolicyEndpoints
   PARAM_SELECTED_ENTITY_ID = 'selectedIdpEntityId'.freeze
   PARAM_REGISTRATION = 'registration'.freeze
   PARAM_REQUESTED_LOA = 'requestedLoa'.freeze
+  PARAM_ANALYTICS_SESSION_ID = 'analyticsSessionId'.freeze
+  PARAM_JOURNEY_TYPE = 'journeyType'.freeze
   CYCLE_THREE_SUFFIX = 'cycle-3-attribute'.freeze
   CYCLE_THREE_SUBMIT_SUFFIX = "#{CYCLE_THREE_SUFFIX}/submit".freeze
   CYCLE_THREE_CANCEL_SUFFIX = "#{CYCLE_THREE_SUFFIX}/cancel".freeze

--- a/app/models/policy_proxy.rb
+++ b/app/models/policy_proxy.rb
@@ -15,12 +15,14 @@ class PolicyProxy
     SignInProcessDetailsResponse.validated_response(response)
   end
 
-  def select_idp(session_id, entity_id, requested_loa, registration = false)
+  def select_idp(session_id, entity_id, requested_loa, registration = false, analytics_session_id = nil, journey_type = nil)
     body = {
       PARAM_SELECTED_ENTITY_ID => entity_id,
       PARAM_PRINCIPAL_IP => originating_ip,
       PARAM_REGISTRATION => registration,
-      PARAM_REQUESTED_LOA => requested_loa
+      PARAM_REQUESTED_LOA => requested_loa,
+      PARAM_ANALYTICS_SESSION_ID => analytics_session_id,
+      PARAM_JOURNEY_TYPE => journey_type
     }
 
     @api_client.post(select_idp_endpoint(session_id), body)

--- a/lib/cookie_names.rb
+++ b/lib/cookie_names.rb
@@ -8,6 +8,7 @@ module CookieNames
   NO_CURRENT_SESSION_VALUE = 'no-current-session'.freeze
   AB_TEST = 'ab_test'.freeze
   AB_TEST_TRIAL = 'ab_test_trial'.freeze
+  ANALYTICS_SESSION_COOKIE_PREFIX = '_pk_id.'.freeze
 
   def self.session_cookies
     [SESSION_ID_COOKIE_NAME, SESSION_COOKIE_NAME]

--- a/spec/feature_helper.rb
+++ b/spec/feature_helper.rb
@@ -79,6 +79,19 @@ module FeatureHelper
     }
   end
 
+  def create_cookie_hash_with_piwik_session
+    create_cookie_hash.merge('_pk_id.1.ffff' => piwik_session_cookie_value)
+  end
+
+  def piwik_session_cookie_value
+    session_id_value = piwik_session_id
+    "#{session_id_value}.1544441431.1.1544441431.1544441431."
+  end
+
+  def piwik_session_id
+    'cdf47f93f1419b32'
+  end
+
   def start_time_in_millis
     Time.now.to_i * 1000
   end

--- a/spec/features/idp_selections_reported_to_piwik_spec.rb
+++ b/spec/features/idp_selections_reported_to_piwik_spec.rb
@@ -92,6 +92,7 @@ def stub_idp_select_request(idp_entity_id)
   stub_session_select_idp_request(
     encrypted_entity_id,
     PolicyEndpoints::PARAM_SELECTED_ENTITY_ID => idp_entity_id, PolicyEndpoints::PARAM_PRINCIPAL_IP => originating_ip,
-    PolicyEndpoints::PARAM_REGISTRATION => true, PolicyEndpoints::PARAM_REQUESTED_LOA => 'LEVEL_2'
+    PolicyEndpoints::PARAM_REGISTRATION => true, PolicyEndpoints::PARAM_REQUESTED_LOA => 'LEVEL_2',
+    PolicyEndpoints::PARAM_ANALYTICS_SESSION_ID => nil, PolicyEndpoints::PARAM_JOURNEY_TYPE => nil
   )
 end

--- a/spec/features/user_visits_continue_to_your_idp_page_spec.rb
+++ b/spec/features/user_visits_continue_to_your_idp_page_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe 'When the user visits the continue to your IDP page' do
     stub_session_select_idp_request(
       encrypted_entity_id,
       PolicyEndpoints::PARAM_SELECTED_ENTITY_ID => idp_entity_id, PolicyEndpoints::PARAM_PRINCIPAL_IP => originating_ip,
-      PolicyEndpoints::PARAM_REGISTRATION => false, PolicyEndpoints::PARAM_REQUESTED_LOA => 'LEVEL_2'
+      PolicyEndpoints::PARAM_REGISTRATION => false, PolicyEndpoints::PARAM_REQUESTED_LOA => 'LEVEL_2',
+      PolicyEndpoints::PARAM_ANALYTICS_SESSION_ID => piwik_session_id, PolicyEndpoints::PARAM_JOURNEY_TYPE => 'single-idp'
     )
   }
   let(:set_single_idp_journey_cookie) {
@@ -22,7 +23,7 @@ RSpec.describe 'When the user visits the continue to your IDP page' do
 
   context 'javascript disabled' do
     before(:each) do
-      set_session_and_session_cookies!
+      set_session_and_session_cookies!(cookie_hash: create_cookie_hash_with_piwik_session)
       stub_transactions_for_single_idp_list
       stub_api_idp_list_for_single_idp_journey
     end
@@ -80,7 +81,7 @@ RSpec.describe 'When the user visits the continue to your IDP page' do
     end
 
     before(:each) do
-      set_session_and_session_cookies!(session: single_idp_session)
+      set_session_and_session_cookies!(cookie_hash: create_cookie_hash_with_piwik_session, session: single_idp_session)
       stub_transactions_for_single_idp_list
       stub_api_idp_list_for_single_idp_journey('some-other-entity-id')
       visit '/test-single-idp-journey'

--- a/spec/features/user_visits_redirect_to_idp_warning_page_spec.rb
+++ b/spec/features/user_visits_redirect_to_idp_warning_page_spec.rb
@@ -54,13 +54,14 @@ RSpec.describe 'When the user visits the redirect to IDP warning page' do
     stub_session_select_idp_request(
       encrypted_entity_id,
       PolicyEndpoints::PARAM_SELECTED_ENTITY_ID => idp_entity_id, PolicyEndpoints::PARAM_PRINCIPAL_IP => originating_ip,
-      PolicyEndpoints::PARAM_REGISTRATION => true, PolicyEndpoints::PARAM_REQUESTED_LOA => 'LEVEL_2'
+      PolicyEndpoints::PARAM_REGISTRATION => true, PolicyEndpoints::PARAM_REQUESTED_LOA => 'LEVEL_2',
+      PolicyEndpoints::PARAM_ANALYTICS_SESSION_ID => piwik_session_id, PolicyEndpoints::PARAM_JOURNEY_TYPE => nil
     )
   }
 
   before(:each) do
     session = default_session.merge(user_segments: ['test-segment'])
-    set_session_and_session_cookies!(session: session)
+    set_session_and_session_cookies!(cookie_hash: create_cookie_hash_with_piwik_session, session: session)
   end
 
   it 'includes the appropriate feedback source and page title' do

--- a/spec/features/user_visits_resume_registration_page_spec.rb
+++ b/spec/features/user_visits_resume_registration_page_spec.rb
@@ -15,12 +15,13 @@ RSpec.describe 'When the user visits the resume registration page and ' do
     stub_session_select_idp_request(
       encrypted_entity_id,
       PolicyEndpoints::PARAM_SELECTED_ENTITY_ID => idp_entity_id, PolicyEndpoints::PARAM_PRINCIPAL_IP => originating_ip,
-      PolicyEndpoints::PARAM_REGISTRATION => false, PolicyEndpoints::PARAM_REQUESTED_LOA => 'LEVEL_2'
+      PolicyEndpoints::PARAM_REGISTRATION => false, PolicyEndpoints::PARAM_REQUESTED_LOA => 'LEVEL_2',
+      PolicyEndpoints::PARAM_ANALYTICS_SESSION_ID => piwik_session_id, PolicyEndpoints::PARAM_JOURNEY_TYPE => 'resuming'
     )
   }
 
   before(:each) do
-    set_session_and_session_cookies!
+    set_session_and_session_cookies!(cookie_hash: create_cookie_hash_with_piwik_session)
     stub_api_idp_list_for_sign_in
     set_selected_idp_in_session(entity_id: idp_entity_id, simple_id: 'stub-idp-one')
     stub_translations

--- a/spec/features/user_visits_sign_in_page_spec.rb
+++ b/spec/features/user_visits_sign_in_page_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'user selects an IDP on the sign in page' do
   end
 
   def given_im_on_the_sign_in_page(locale = 'en')
-    set_session_and_session_cookies!
+    set_session_and_session_cookies!(cookie_hash: create_cookie_hash_with_piwik_session)
     stub_api_idp_list_for_sign_in
     visit "/#{t('routes.sign_in', locale: locale)}"
   end
@@ -36,7 +36,8 @@ RSpec.describe 'user selects an IDP on the sign in page' do
     expect(cookie_value('verify-front-journey-hint')).to_not be_nil
     expect(a_request(:post, policy_api_uri(select_idp_endpoint(default_session_id)))
              .with(body: { PolicyEndpoints::PARAM_SELECTED_ENTITY_ID => idp_entity_id, PolicyEndpoints::PARAM_PRINCIPAL_IP => originating_ip,
-                           PolicyEndpoints::PARAM_REGISTRATION => false, PolicyEndpoints::PARAM_REQUESTED_LOA => 'LEVEL_2' })).to have_been_made.once
+                           PolicyEndpoints::PARAM_REGISTRATION => false, PolicyEndpoints::PARAM_REQUESTED_LOA => 'LEVEL_2',
+                           PolicyEndpoints::PARAM_ANALYTICS_SESSION_ID => piwik_session_id, PolicyEndpoints::PARAM_JOURNEY_TYPE => nil })).to have_been_made.once
     expect(a_request(:get, saml_proxy_api_uri(authn_request_endpoint(default_session_id)))
              .with(headers: { 'X_FORWARDED_FOR' => originating_ip })).to have_been_made.once
   end

--- a/spec/models/policy_proxy_spec.rb
+++ b/spec/models/policy_proxy_spec.rb
@@ -18,31 +18,34 @@ describe PolicyProxy do
     it 'should select an IDP for the session' do
       ip_address = '1.1.1.1'
       body = { PolicyEndpoints::PARAM_SELECTED_ENTITY_ID => 'an-entity-id', PolicyEndpoints::PARAM_PRINCIPAL_IP => ip_address,
-               PolicyEndpoints::PARAM_REGISTRATION => false, PolicyEndpoints::PARAM_REQUESTED_LOA => 'LEVEL_2' }
+               PolicyEndpoints::PARAM_REGISTRATION => false, PolicyEndpoints::PARAM_REQUESTED_LOA => 'LEVEL_2',
+               PolicyEndpoints::PARAM_ANALYTICS_SESSION_ID => 'an-analytics-session-id', PolicyEndpoints::PARAM_JOURNEY_TYPE => 'a-journey-type' }
       expect(api_client).to receive(:post)
         .with(endpoint(PolicyProxy::SELECT_IDP_SUFFIX), body)
       expect(originating_ip_store).to receive(:get).and_return(ip_address)
-      policy_proxy.select_idp(session_id, 'an-entity-id', 'LEVEL_2')
+      policy_proxy.select_idp(session_id, 'an-entity-id', 'LEVEL_2', false, 'an-analytics-session-id', 'a-journey-type')
     end
 
     it 'should select an IDP for the session with LOA1' do
       ip_address = '1.1.1.1'
       body = { PolicyEndpoints::PARAM_SELECTED_ENTITY_ID => 'an-entity-id', PolicyEndpoints::PARAM_PRINCIPAL_IP => ip_address,
-               PolicyEndpoints::PARAM_REGISTRATION => false, PolicyEndpoints::PARAM_REQUESTED_LOA => 'LEVEL_1' }
+               PolicyEndpoints::PARAM_REGISTRATION => false, PolicyEndpoints::PARAM_REQUESTED_LOA => 'LEVEL_1',
+               PolicyEndpoints::PARAM_ANALYTICS_SESSION_ID => 'an-analytics-session-id', PolicyEndpoints::PARAM_JOURNEY_TYPE => 'a-journey-type' }
       expect(api_client).to receive(:post)
                                 .with(endpoint(PolicyProxy::SELECT_IDP_SUFFIX), body)
       expect(originating_ip_store).to receive(:get).and_return(ip_address)
-      policy_proxy.select_idp(session_id, 'an-entity-id', 'LEVEL_1')
+      policy_proxy.select_idp(session_id, 'an-entity-id', 'LEVEL_1', false, 'an-analytics-session-id', 'a-journey-type')
     end
 
     it 'should select an IDP for the session when registering' do
       ip_address = '1.1.1.1'
       body = { PolicyEndpoints::PARAM_SELECTED_ENTITY_ID => 'an-entity-id', PolicyEndpoints::PARAM_PRINCIPAL_IP => ip_address,
-               PolicyEndpoints::PARAM_REGISTRATION => true, PolicyEndpoints::PARAM_REQUESTED_LOA => 'LEVEL_2' }
+               PolicyEndpoints::PARAM_REGISTRATION => true, PolicyEndpoints::PARAM_REQUESTED_LOA => 'LEVEL_2',
+               PolicyEndpoints::PARAM_ANALYTICS_SESSION_ID => 'an-analytics-session-id', PolicyEndpoints::PARAM_JOURNEY_TYPE => 'a-journey-type' }
       expect(api_client).to receive(:post)
         .with(endpoint(PolicyProxy::SELECT_IDP_SUFFIX), body)
       expect(originating_ip_store).to receive(:get).and_return(ip_address)
-      policy_proxy.select_idp(session_id, 'an-entity-id', 'LEVEL_2', true,)
+      policy_proxy.select_idp(session_id, 'an-entity-id', 'LEVEL_2', true, 'an-analytics-session-id', 'a-journey-type')
     end
   end
 


### PR DESCRIPTION
Update PolicyProxy to send new variables to Policy Service

Co-authored-by: John Watts <john.watts@digital.cabinet-office.gov.uk>