### PR TITLE
EID-1005: Fix mobile layout of country picker

### DIFF
--- a/app/assets/stylesheets/pages/_choose-a-country.scss
+++ b/app/assets/stylesheets/pages/_choose-a-country.scss
@@ -24,7 +24,7 @@
   }
 
   .scheme-logo {
-    width: 50%;
+    width: 40%;
     height: 100%;
     position: relative;
     display: inline-block;


### PR DESCRIPTION
- Previously the country scheme logos would wrap
  onto a new line when the layout was narrow.
  This was because they took up a fixed width.
- Mitigate this by not specifying a manual width
  which works for all layouts.

With:
![screen shot 2018-12-10 at 15 31 02](https://user-images.githubusercontent.com/4951176/49742881-66cd7b00-fc91-11e8-919d-6721bc176f6e.png)

Without:
![screen shot 2018-12-10 at 15 31 12](https://user-images.githubusercontent.com/4951176/49742897-6f25b600-fc91-11e8-9850-701c99456311.png)
