### PR TITLE
HUB-363: Show user session timeout message based on NotOnOrAfter

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -27,6 +27,7 @@ window.GOVUK.interstitialQuestion.init();
 window.GOVUK.otherDocuments.init();
 window.GOVUK.piwikEventsTracking.init();
 window.GOVUK.details.init();
+window.GOVUK.modalDialog.init()
 
 /*
  Example of how to add JavaScript A/B code

--- a/app/assets/javascripts/modal_dialog.js
+++ b/app/assets/javascripts/modal_dialog.js
@@ -1,0 +1,333 @@
+;(function (global) {
+    'use strict'
+  
+    var GOVUK = global.GOVUK || {}
+    var $ = global.jQuery
+  
+    GOVUK.modalDialog = {
+      el: document.getElementById('js-modal-dialog'),
+      $el: $('#js-modal-dialog'),
+      $lastFocusedEl: null,
+      $openButton: $('#openModal'),
+      $closeButton: $('.modal-dialog .js-dialog-close'),
+      $cancelButton: $('.modal-dialog .js-dialog-cancel'),
+      dialogIsOpenClass: 'dialog-is-open',
+      timers: [],
+      // Timer specific markup. If these are not present, timeout and redirection are disabled
+      $timer: $('#js-modal-dialog .timer'),
+      $accessibleTimer: $('#js-modal-dialog .at-timer'),
+      // Timer specific settings. If these are not set, timeout and redirection are disabled
+      timeOutRedirectUrl: $('#js-modal-dialog').data('url-redirect'),
+      expiryTime: $('#js-modal-dialog').data('utc-expiry'),
+      secondsTimeOutModalVisible: $('#js-modal-dialog').data('seconds-modal-visible'),
+      modalText: $('#js-modal-dialog').data('text'),
+      modalExtraText: $('#js-modal-dialog').data('extra-text'),
+  
+      bindUIElements: function () {  
+        GOVUK.modalDialog.$openButton.on('click', function (e) {
+          GOVUK.modalDialog.openDialog()
+          return false
+        })
+  
+        GOVUK.modalDialog.$closeButton.on('click', function (e) {
+          e.preventDefault()
+          GOVUK.modalDialog.closeDialog()
+        })
+  
+        GOVUK.modalDialog.$cancelButton.on('click', function (e) {
+          _paq.push(['trackEvent', "Engagement", "Popup", "Popup signout"]);
+        })
+      },
+      isDialogOpen: function () {
+        return GOVUK.modalDialog.el['open']
+      },
+      isTimerSet: function () {
+        return GOVUK.modalDialog.$timer.length > 0 && GOVUK.modalDialog.$accessibleTimer.length > 0 && GOVUK.modalDialog.secondsTimeOutModalVisible && GOVUK.modalDialog.timeOutRedirectUrl
+      },
+      openDialog: function () {
+        if (!GOVUK.modalDialog.isDialogOpen()) {
+          $('html, body').addClass(GOVUK.modalDialog.dialogIsOpenClass)
+          GOVUK.modalDialog.saveLastFocusedEl()
+          GOVUK.modalDialog.makePageContentInert()
+          GOVUK.modalDialog.el.showModal()
+  
+          if (GOVUK.modalDialog.isTimerSet()) {
+            GOVUK.modalDialog.startTimer()
+          }
+          _paq.push(['trackEvent', "Engagement", "Popup", "Popup open"]);
+        }
+      },
+      closeDialog: function () {
+        if (GOVUK.modalDialog.isDialogOpen()) {
+          $('html, body').removeClass(GOVUK.modalDialog.dialogIsOpenClass)
+          GOVUK.modalDialog.el.close()
+          GOVUK.modalDialog.setFocusOnLastFocusedEl()
+          GOVUK.modalDialog.removeInertFromPageContent()
+          _paq.push(['trackEvent', "Engagement", "Popup", "Popup continue"]);
+  
+          if (GOVUK.modalDialog.isTimerSet()) {
+            GOVUK.modalDialog.clearTimers()
+          }
+        }
+      },
+      saveLastFocusedEl: function () {
+        GOVUK.modalDialog.$lastFocusedEl = document.activeElement
+        if (!GOVUK.modalDialog.$lastFocusedEl || GOVUK.modalDialog.$lastFocusedEl === document.body) {
+          GOVUK.modalDialog.$lastFocusedEl = null
+        } else if (document.querySelector) {
+          GOVUK.modalDialog.$lastFocusedEl = document.querySelector(':focus')
+        }
+      },
+      // Set focus back on last focused el when modal closed
+      setFocusOnLastFocusedEl: function () {
+        if (GOVUK.modalDialog.$lastFocusedEl) {
+          window.setTimeout(function () {
+            GOVUK.modalDialog.$lastFocusedEl.focus()
+          }, 0)
+        }
+      },
+      // Set page content to inert to indicate to screenreaders it's inactive
+      // NB: This will look for #content for toggling inert state
+      makePageContentInert: function () {
+        if (document.querySelector('#content')) {
+          document.querySelector('#content').inert = true
+          document.querySelector('#content').setAttribute('aria-hidden', 'true')
+        }
+      },
+      // Make page content active when modal is not open
+      // NB: This will look for #content for toggling inert state
+      removeInertFromPageContent: function () {
+        if (document.querySelector('#content')) {
+          document.querySelector('#content').inert = false
+          document.querySelector('#content').setAttribute('aria-hidden', 'false')
+        }
+      },
+      // Starts a timer. If modal not closed before time out + 3 seconds grace period, user is redirected.
+      startTimer: function () {
+        GOVUK.modalDialog.clearTimers() // Clear any other modal timers that might have been running
+        var $timer = GOVUK.modalDialog.$timer
+        var $accessibleTimer = GOVUK.modalDialog.$accessibleTimer
+        var seconds = GOVUK.modalDialog.secondsTimeOutModalVisible
+        var timerRunOnce = false
+        var iOS = /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream
+  
+        if (seconds) {
+          var secondsToTimeout = (new Date(GOVUK.modalDialog.expiryTime) - new Date()) / 1000
+          var seconds = secondsToTimeout < seconds ? secondsToTimeout : seconds
+          var minutes = parseInt(seconds / 60, 10)
+
+          $timer.text(minutes + ' minute' + (minutes > 1 ? 's' : ''));
+  
+          (function runTimer () {
+            var minutesLeft = parseInt(seconds / 60, 10)
+            var secondsLeft = parseInt(seconds % 60, 10)
+            var timerExpired = minutesLeft < 1 && secondsLeft < 1
+  
+            var minutesText = minutesLeft > 0 ? '<span class="tabular-numbers">' + minutesLeft + '</span> minute' + (minutesLeft > 1 ? 's' : '') + '' : ' '
+            var secondsText = secondsLeft >= 1 ? ' <span class="tabular-numbers">' + secondsLeft + '</span> second' + (secondsLeft > 1 ? 's' : '') + '' : ''
+            var atMinutesNumberAsText = ''
+            var atSecondsNumberAsText = ''
+  
+            try {
+              atMinutesNumberAsText = GOVUK.modalDialog.numberToWords(minutesLeft) // Attempt to convert numerics into text as iOS VoiceOver ccassionally stalled when encountering numbers
+              atSecondsNumberAsText = GOVUK.modalDialog.numberToWords(secondsLeft)
+            } catch (e) {
+              atMinutesNumberAsText = minutesLeft
+              atSecondsNumberAsText = secondsLeft
+            }
+  
+            var atMinutesText = minutesLeft > 0 ? atMinutesNumberAsText + ' minute' + (minutesLeft > 1 ? 's' : '') + '' : ''
+            var atSecondsText = secondsLeft >= 1 ? ' ' + atSecondsNumberAsText + ' second' + (secondsLeft > 1 ? 's' : '') + '' : ''
+  
+            // Below string will get read out by screen readers every time the timeout refreshes (every 15 secs. See below).
+            // Please add additional information in the modal body content or in below extraText which will get announced to AT the first time the time out opens
+            var text = GOVUK.modalDialog.modalText + ' ' + minutesText + secondsText + '. '
+            var atText = GOVUK.modalDialog.modalText + atMinutesText
+            if (atSecondsText) {
+              if (minutesLeft > 0) {
+                atText += ' and'
+              }
+              atText += atSecondsText + '.'
+            } else {
+              atText += '.'
+            }
+            var extraText = GOVUK.modalDialog.modalExtraText
+            if (timerExpired) {
+              $timer.text('You are about to be redirected.')
+              $accessibleTimer.text('You are about to be redirected.')
+              setTimeout(GOVUK.modalDialog.redirect, 3000)
+  
+            } else {
+              seconds--
+  
+              $timer.html(text + extraText)
+  
+              if (minutesLeft < 1 && secondsLeft < 20) {
+                $accessibleTimer.attr('aria-live', 'assertive')
+              }
+  
+              if (!timerRunOnce) {
+                // Read out the extra content only once. Don't read out on iOS VoiceOver which stalls on the longer text
+  
+                if (iOS) {
+                  $accessibleTimer.text(atText)
+                } else {
+                  $accessibleTimer.text(atText + extraText)
+                }
+                timerRunOnce = true
+              } else if (secondsLeft % 15 === 0) {
+                // Update screen reader friendly content every 15 secs
+                $accessibleTimer.text(atText)
+              }
+  
+              // JS doesn't allow resetting timers globally so timers need to be retained for resetting.
+              GOVUK.modalDialog.timers.push(setTimeout(runTimer, 1000))
+            }
+          })()
+        }
+      },
+      // Clears modal timer
+      clearTimers: function () {
+        for (var i = 0; i < GOVUK.modalDialog.timers.length; i++) {
+          clearTimeout(GOVUK.modalDialog.timers[i])
+        }
+      },
+      // Close modal when ESC pressed
+      escClose: function () {
+        $(document).keydown(function (e) {
+          if (GOVUK.modalDialog.isDialogOpen() && e.keyCode === 27) {
+            GOVUK.modalDialog.closeDialog()
+          }
+        })
+      },
+      // Shows modal after a specified time
+      timeTrigger: function () {
+        var warningStarts = new Date(GOVUK.modalDialog.expiryTime) - (GOVUK.modalDialog.secondsTimeOutModalVisible * 1000)
+        var afterSeconds = (warningStarts - new Date()) / 1000
+        var milliSeconds
+        var timer
+  
+        GOVUK.modalDialog.checkIfShouldHaveTimedOut()
+  
+        if (afterSeconds) {
+          milliSeconds = afterSeconds * 1000
+  
+          window.onload = resetTimer
+        }
+  
+        function resetTimer () {
+          clearTimeout(timer)
+  
+          timer = setTimeout(GOVUK.modalDialog.openDialog, milliSeconds)
+        }
+      },
+      // Do a timestamp comparison when the page regains focus to check if the user should have been timed out already
+      checkIfShouldHaveTimedOut: function () {
+        window.onfocus = function () {
+          // Debugging tip: Above event doesn't kick in in Chrome if you have Inspector panel open and have clicked on it
+          // as it is now the active element. Click on the window to make it active before moving to another tab.
+          if (new Date(GOVUK.modalDialog.expiryTime) < new Date()) {
+            GOVUK.modalDialog.redirect()
+          }
+        }
+      },
+      redirect: function () {
+        window.location.replace(GOVUK.modalDialog.timeOutRedirectUrl)
+      },
+      numberToWords: function (n) {
+        var string = n.toString()
+        var units
+        var tens
+        var scales
+        var start
+        var end
+        var chunks
+        var chunksLen
+        var chunk
+        var ints
+        var i
+        var word
+        var words = 'and'
+  
+        if (parseInt(string) === 0) {
+          return 'zero'
+        }
+  
+        /* Array of units as words */
+        units = [ '', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten', 'eleven', 'twelve', 'thirteen', 'fourteen', 'fifteen', 'sixteen', 'seventeen', 'eighteen', 'nineteen' ]
+  
+        /* Array of tens as words */
+        tens = [ '', '', 'twenty', 'thirty', 'forty', 'fifty', 'sixty', 'seventy', 'eighty', 'ninety' ]
+  
+        /* Array of scales as words */
+        scales = [ '', 'thousand', 'million', 'billion', 'trillion', 'quadrillion', 'quintillion', 'sextillion', 'septillion', 'octillion', 'nonillion', 'decillion', 'undecillion', 'duodecillion', 'tredecillion', 'quatttuor-decillion', 'quindecillion', 'sexdecillion', 'septen-decillion', 'octodecillion', 'novemdecillion', 'vigintillion', 'centillion' ]
+  
+        /* Split user arguemnt into 3 digit chunks from right to left */
+        start = string.length
+        chunks = []
+        while (start > 0) {
+          end = start
+          chunks.push(string.slice((start = Math.max(0, start - 3)), end))
+        }
+  
+        /* Check if function has enough scale words to be able to stringify the user argument */
+        chunksLen = chunks.length
+        if (chunksLen > scales.length) {
+          return ''
+        }
+  
+        /* Stringify each integer in each chunk */
+        words = []
+        for (i = 0; i < chunksLen; i++) {
+          chunk = parseInt(chunks[i])
+  
+          if (chunk) {
+            /* Split chunk into array of individual integers */
+            ints = chunks[i].split('').reverse().map(parseFloat)
+  
+            /* If tens integer is 1, i.e. 10, then add 10 to units integer */
+            if (ints[1] === 1) {
+              ints[0] += 10
+            }
+  
+            /* Add scale word if chunk is not zero and array item exists */
+            if ((word = scales[i])) {
+              words.push(word)
+            }
+  
+            /* Add unit word if array item exists */
+            if ((word = units[ints[0]])) {
+              words.push(word)
+            }
+  
+            /* Add tens word if array item exists */
+            if ((word = tens[ ints[1] ])) {
+              words.push(word)
+            }
+  
+            /* Add hundreds word if array item exists */
+            if ((word = units[ints[2]])) {
+              words.push(word + ' hundred')
+            }
+          }
+        }
+        return words.reverse().join(' ')
+      },
+      init: function () {
+        if (GOVUK.modalDialog.el) {
+          // Native dialog is not supported by browser so use polyfill
+          if (typeof HTMLDialogElement !== 'function') {
+            window.dialogPolyfill.registerDialog(GOVUK.modalDialog.el)
+          }
+          GOVUK.modalDialog.bindUIElements()
+          GOVUK.modalDialog.escClose()
+  
+          if (GOVUK.modalDialog.isTimerSet()) {
+            GOVUK.modalDialog.timeTrigger()
+          }
+        }
+      }
+    }
+    global.GOVUK = GOVUK
+  })(window); // eslint-disable-line semi
+  

--- a/app/assets/javascripts/vendor/dialog-polyfill.0.4.3.js
+++ b/app/assets/javascripts/vendor/dialog-polyfill.0.4.3.js
@@ -1,0 +1,522 @@
+(function () {
+    var supportCustomEvent = window.CustomEvent
+    if (!supportCustomEvent || typeof supportCustomEvent === 'object') {
+      supportCustomEvent = function CustomEvent (event, x) {
+        x = x || {}
+        var ev = document.createEvent('CustomEvent')
+        ev.initCustomEvent(event, !!x.bubbles, !!x.cancelable, x.detail || null)
+        return ev
+      }
+      supportCustomEvent.prototype = window.Event.prototype
+    }
+  
+    /**
+     * Finds the nearest <dialog> from the passed element.
+     *
+     * @param {Element} el to search from
+     * @return {HTMLDialogElement} dialog found
+     */
+    function findNearestDialog (el) {
+      while (el) {
+        if (el.nodeName.toUpperCase() == 'DIALOG') {
+          return /** @type {HTMLDialogElement} */ (el)
+        }
+        el = el.parentElement
+      }
+      return null
+    }
+  
+    /**
+     * Blur the specified element, as long as it's not the HTML body element.
+     * This works around an IE9/10 bug - blurring the body causes Windows to
+     * blur the whole application.
+     *
+     * @param {Element} el to blur
+     */
+    function safeBlur (el) {
+      if (el && el.blur && el != document.body) {
+        el.blur()
+      }
+    }
+  
+    /**
+     * @param {!NodeList} nodeList to search
+     * @param {Node} node to find
+     * @return {boolean} whether node is inside nodeList
+     */
+    function inNodeList (nodeList, node) {
+      for (var i = 0; i < nodeList.length; ++i) {
+        if (nodeList[i] == node) {
+          return true
+        }
+      }
+      return false
+    }
+  
+    /**
+     * @param {!HTMLDialogElement} dialog to upgrade
+     * @constructor
+     */
+    function dialogPolyfillInfo (dialog) {
+      this.dialog_ = dialog
+      this.replacedStyleTop_ = false
+      this.openAsModal_ = false
+  
+      // Set a11y role. Browsers that support dialog implicitly know this already.
+      if (!dialog.hasAttribute('role')) {
+        dialog.setAttribute('role', 'dialog')
+      }
+  
+      dialog.show = this.show.bind(this)
+      dialog.showModal = this.showModal.bind(this)
+      dialog.close = this.close.bind(this)
+  
+      if (!('returnValue' in dialog)) {
+        dialog.returnValue = ''
+      }
+  
+      this.maybeHideModal = this.maybeHideModal.bind(this)
+      if ('MutationObserver' in window) {
+        // IE11+, most other browsers.
+        var mo = new MutationObserver(this.maybeHideModal)
+        mo.observe(dialog, { attributes: true, attributeFilter: ['open'] })
+      } else {
+        dialog.addEventListener('DOMAttrModified', this.maybeHideModal)
+      }
+      // Note that the DOM is observed inside DialogManager while any dialog
+      // is being displayed as a modal, to catch modal removal from the DOM.
+  
+      Object.defineProperty(dialog, 'open', {
+        set: this.setOpen.bind(this),
+        get: dialog.hasAttribute.bind(dialog, 'open')
+      })
+  
+      this.backdrop_ = document.createElement('div')
+      this.backdrop_.className = 'backdrop'
+      this.backdropClick_ = this.backdropClick_.bind(this)
+    }
+  
+    dialogPolyfillInfo.prototype = {
+  
+      get dialog () {
+        return this.dialog_
+      },
+  
+      /**
+       * Maybe remove this dialog from the modal top layer. This is called when
+       * a modal dialog may no longer be tenable, e.g., when the dialog is no
+       * longer open or is no longer part of the DOM.
+       */
+      maybeHideModal: function () {
+        if (!this.openAsModal_) { return }
+        if (this.dialog_.hasAttribute('open') &&
+            document.body.contains(this.dialog_)) { return }
+  
+        this.openAsModal_ = false
+        this.dialog_.style.zIndex = ''
+  
+        // This won't match the native <dialog> exactly because if the user set
+        // top on a centered polyfill dialog, that top gets thrown away when the
+        // dialog is closed. Not sure it's possible to polyfill this perfectly.
+        if (this.replacedStyleTop_) {
+          this.dialog_.style.top = ''
+          this.replacedStyleTop_ = false
+        }
+  
+        // Optimistically clear the modal part of this <dialog>.
+        this.backdrop_.removeEventListener('click', this.backdropClick_)
+        if (this.backdrop_.parentElement) {
+          this.backdrop_.parentElement.removeChild(this.backdrop_)
+        }
+        dialogPolyfill.dm.removeDialog(this)
+      },
+  
+      /**
+       * @param {boolean} value whether to open or close this dialog
+       */
+      setOpen: function (value) {
+        if (value) {
+          this.dialog_.hasAttribute('open') || this.dialog_.setAttribute('open', '')
+        } else {
+          this.dialog_.removeAttribute('open')
+          this.maybeHideModal()  // nb. redundant with MutationObserver
+        }
+      },
+  
+      /**
+       * Handles clicks on the fake .backdrop element, redirecting them as if
+       * they were on the dialog itself.
+       *
+       * @param {!Event} e to redirect
+       */
+      backdropClick_: function (e) {
+        var redirectedEvent = document.createEvent('MouseEvents')
+        redirectedEvent.initMouseEvent(e.type, e.bubbles, e.cancelable, window,
+            e.detail, e.screenX, e.screenY, e.clientX, e.clientY, e.ctrlKey,
+            e.altKey, e.shiftKey, e.metaKey, e.button, e.relatedTarget)
+        this.dialog_.dispatchEvent(redirectedEvent)
+        e.stopPropagation()
+      },
+  
+      /**
+       * Focuses on the first focusable element within the dialog. This will always blur the current
+       * focus, even if nothing within the dialog is found.
+       */
+      focus_: function () {
+        // Find element with `autofocus` attribute, or fall back to the first form/tabindex control.
+        var target = this.dialog_.querySelector('[autofocus]:not([disabled])')
+        if (!target) {
+          // Note that this is 'any focusable area'. This list is probably not exhaustive, but the
+          // alternative involves stepping through and trying to focus everything.
+          var opts = ['button', 'input', 'keygen', 'select', 'textarea']
+          var query = opts.map(function (el) {
+            return el + ':not([disabled])'
+          })
+          // TODO(samthor): tabindex values that are not numeric are not focusable.
+          query.push('[tabindex]:not([disabled]):not([tabindex=""])')  // tabindex != "", not disabled
+          target = this.dialog_.querySelector(query.join(', '))
+        }
+        safeBlur(document.activeElement)
+        target && target.focus()
+      },
+  
+      /**
+       * Sets the zIndex for the backdrop and dialog.
+       *
+       * @param {number} backdropZ
+       * @param {number} dialogZ
+       */
+      updateZIndex: function (backdropZ, dialogZ) {
+        this.backdrop_.style.zIndex = backdropZ
+        this.dialog_.style.zIndex = dialogZ
+      },
+  
+      /**
+       * Shows the dialog. If the dialog is already open, this does nothing.
+       */
+      show: function () {
+        if (!this.dialog_.open) {
+          this.setOpen(true)
+          this.focus_()
+        }
+      },
+  
+      /**
+       * Show this dialog modally.
+       */
+      showModal: function () {
+        if (this.dialog_.hasAttribute('open')) {
+          throw new Error('Failed to execute \'showModal\' on dialog: The element is already open, and therefore cannot be opened modally.')
+        }
+        if (!document.body.contains(this.dialog_)) {
+          throw new Error('Failed to execute \'showModal\' on dialog: The element is not in a Document.')
+        }
+        if (!dialogPolyfill.dm.pushDialog(this)) {
+          throw new Error('Failed to execute \'showModal\' on dialog: There are too many open modal dialogs.')
+        }
+        this.show()
+        this.openAsModal_ = true
+  
+        // Optionally center vertically, relative to the current viewport.
+        if (dialogPolyfill.needsCentering(this.dialog_)) {
+          dialogPolyfill.reposition(this.dialog_)
+          this.replacedStyleTop_ = true
+        } else {
+          this.replacedStyleTop_ = false
+        }
+  
+        // Insert backdrop.
+        this.backdrop_.addEventListener('click', this.backdropClick_)
+        this.dialog_.parentNode.insertBefore(this.backdrop_,
+            this.dialog_.nextSibling)
+      },
+  
+      /**
+       * Closes this HTMLDialogElement. This is optional vs clearing the open
+       * attribute, however this fires a 'close' event.
+       *
+       * @param {string=} opt_returnValue to use as the returnValue
+       */
+      close: function (opt_returnValue) {
+        if (!this.dialog_.hasAttribute('open')) {
+          throw new Error('Failed to execute \'close\' on dialog: The element does not have an \'open\' attribute, and therefore cannot be closed.')
+        }
+        this.setOpen(false)
+  
+        // Leave returnValue untouched in case it was set directly on the element
+        if (opt_returnValue !== undefined) {
+          this.dialog_.returnValue = opt_returnValue
+        }
+  
+        // Triggering "close" event for any attached listeners on the <dialog>.
+        var closeEvent = new supportCustomEvent('close', {
+          bubbles: false,
+          cancelable: false
+        })
+        this.dialog_.dispatchEvent(closeEvent)
+      }
+  
+    }
+  
+    var dialogPolyfill = {}
+  
+    dialogPolyfill.reposition = function (element) {
+      var scrollTop = document.body.scrollTop || document.documentElement.scrollTop
+      var topValue = scrollTop + (window.innerHeight - element.offsetHeight) / 2
+      element.style.top = Math.max(scrollTop, topValue) + 'px'
+    }
+  
+    dialogPolyfill.isInlinePositionSetByStylesheet = function (element) {
+      for (var i = 0; i < document.styleSheets.length; ++i) {
+        var styleSheet = document.styleSheets[i]
+        var cssRules = null
+        // Some browsers throw on cssRules.
+        try {
+          cssRules = styleSheet.cssRules
+        } catch (e) {}
+        if (!cssRules) { continue }
+        for (var j = 0; j < cssRules.length; ++j) {
+          var rule = cssRules[j]
+          var selectedNodes = null
+          // Ignore errors on invalid selector texts.
+          try {
+            selectedNodes = document.querySelectorAll(rule.selectorText)
+          } catch (e) {}
+          if (!selectedNodes || !inNodeList(selectedNodes, element)) { continue }
+          var cssTop = rule.style.getPropertyValue('top')
+          var cssBottom = rule.style.getPropertyValue('bottom')
+          if ((cssTop && cssTop != 'auto') || (cssBottom && cssBottom != 'auto')) { return true }
+        }
+      }
+      return false
+    }
+  
+    dialogPolyfill.needsCentering = function (dialog) {
+      var computedStyle = window.getComputedStyle(dialog)
+      if (computedStyle.position != 'absolute') {
+        return false
+      }
+  
+      // We must determine whether the top/bottom specified value is non-auto.  In
+      // WebKit/Blink, checking computedStyle.top == 'auto' is sufficient, but
+      // Firefox returns the used value. So we do this crazy thing instead: check
+      // the inline style and then go through CSS rules.
+      if ((dialog.style.top != 'auto' && dialog.style.top != '') ||
+          (dialog.style.bottom != 'auto' && dialog.style.bottom != '')) { return false }
+      return !dialogPolyfill.isInlinePositionSetByStylesheet(dialog)
+    }
+  
+    /**
+     * @param {!Element} element to force upgrade
+     */
+    dialogPolyfill.forceRegisterDialog = function (element) {
+      if (element.showModal) {
+        console.warn('This browser already supports <dialog>, the polyfill ' +
+            'may not work correctly', element)
+      }
+      if (element.nodeName.toUpperCase() != 'DIALOG') {
+        throw new Error('Failed to register dialog: The element is not a dialog.')
+      }
+      new dialogPolyfillInfo(/** @type {!HTMLDialogElement} */ (element))
+    }
+  
+    /**
+     * @param {!Element} element to upgrade
+     */
+    dialogPolyfill.registerDialog = function (element) {
+      if (element.showModal) {
+        console.warn('Can\'t upgrade <dialog>: already supported', element)
+      } else {
+        dialogPolyfill.forceRegisterDialog(element)
+      }
+    }
+  
+    /**
+     * @constructor
+     */
+    dialogPolyfill.DialogManager = function () {
+      /** @type {!Array<!dialogPolyfillInfo>} */
+      this.pendingDialogStack = []
+  
+      // The overlay is used to simulate how a modal dialog blocks the document.
+      // The blocking dialog is positioned on top of the overlay, and the rest of
+      // the dialogs on the pending dialog stack are positioned below it. In the
+      // actual implementation, the modal dialog stacking is controlled by the
+      // top layer, where z-index has no effect.
+      this.overlay = document.createElement('div')
+      this.overlay.className = '_dialog_overlay'
+      this.overlay.addEventListener('click', function (e) {
+        e.stopPropagation()
+      })
+  
+      this.handleKey_ = this.handleKey_.bind(this)
+      this.handleFocus_ = this.handleFocus_.bind(this)
+      this.handleRemove_ = this.handleRemove_.bind(this)
+  
+      this.zIndexLow_ = 100000
+      this.zIndexHigh_ = 100000 + 150
+    }
+  
+    /**
+     * @return {Element} the top HTML dialog element, if any
+     */
+    dialogPolyfill.DialogManager.prototype.topDialogElement = function () {
+      if (this.pendingDialogStack.length) {
+        var t = this.pendingDialogStack[this.pendingDialogStack.length - 1]
+        return t.dialog
+      }
+      return null
+    }
+  
+    /**
+     * Called on the first modal dialog being shown. Adds the overlay and related
+     * handlers.
+     */
+    dialogPolyfill.DialogManager.prototype.blockDocument = function () {
+      document.body.appendChild(this.overlay)
+      document.body.addEventListener('focus', this.handleFocus_, true)
+      document.addEventListener('keydown', this.handleKey_)
+      document.addEventListener('DOMNodeRemoved', this.handleRemove_)
+    }
+  
+    /**
+     * Called on the first modal dialog being removed, i.e., when no more modal
+     * dialogs are visible.
+     */
+    dialogPolyfill.DialogManager.prototype.unblockDocument = function () {
+      document.body.removeChild(this.overlay)
+      document.body.removeEventListener('focus', this.handleFocus_, true)
+      document.removeEventListener('keydown', this.handleKey_)
+      document.removeEventListener('DOMNodeRemoved', this.handleRemove_)
+    }
+  
+    dialogPolyfill.DialogManager.prototype.updateStacking = function () {
+      var zIndex = this.zIndexLow_
+  
+      for (var i = 0; i < this.pendingDialogStack.length; i++) {
+        if (i == this.pendingDialogStack.length - 1) {
+          this.overlay.style.zIndex = zIndex++
+        }
+        this.pendingDialogStack[i].updateZIndex(zIndex++, zIndex++)
+      }
+    }
+  
+    dialogPolyfill.DialogManager.prototype.handleFocus_ = function (event) {
+      var candidate = findNearestDialog(/** @type {Element} */ (event.target))
+      if (candidate != this.topDialogElement()) {
+        event.preventDefault()
+        event.stopPropagation()
+        safeBlur(/** @type {Element} */ (event.target))
+        // TODO: Focus on the browser chrome (aka document) or the dialog itself
+        // depending on the tab direction.
+        return false
+      }
+    }
+  
+    dialogPolyfill.DialogManager.prototype.handleKey_ = function (event) {
+      if (event.keyCode == 27) {
+        event.preventDefault()
+        event.stopPropagation()
+        var cancelEvent = new supportCustomEvent('cancel', {
+          bubbles: false,
+          cancelable: true
+        })
+        var dialog = this.topDialogElement()
+        if (dialog.dispatchEvent(cancelEvent)) {
+          dialog.close()
+        }
+      }
+    }
+  
+    dialogPolyfill.DialogManager.prototype.handleRemove_ = function (event) {
+      if (event.target.nodeName.toUpperCase() != 'DIALOG') { return }
+  
+      var dialog = /** @type {HTMLDialogElement} */ (event.target)
+      if (!dialog.open) { return }
+  
+      // Find a dialogPolyfillInfo which matches the removed <dialog>.
+      this.pendingDialogStack.some(function (dpi) {
+        if (dpi.dialog == dialog) {
+          // This call will clear the dialogPolyfillInfo on this DialogManager
+          // as a side effect.
+          dpi.maybeHideModal()
+          return true
+        }
+      })
+    }
+  
+    /**
+     * @param {!dialogPolyfillInfo} dpi
+     * @return {boolean} whether the dialog was allowed
+     */
+    dialogPolyfill.DialogManager.prototype.pushDialog = function (dpi) {
+      var allowed = (this.zIndexHigh_ - this.zIndexLow_) / 2 - 1
+      if (this.pendingDialogStack.length >= allowed) {
+        return false
+      }
+      this.pendingDialogStack.push(dpi)
+      if (this.pendingDialogStack.length == 1) {
+        this.blockDocument()
+      }
+      this.updateStacking()
+      return true
+    }
+  
+    /**
+     * @param {dialogPolyfillInfo} dpi
+     */
+    dialogPolyfill.DialogManager.prototype.removeDialog = function (dpi) {
+      var index = this.pendingDialogStack.indexOf(dpi)
+      if (index == -1) { return }
+  
+      this.pendingDialogStack.splice(index, 1)
+      this.updateStacking()
+      if (this.pendingDialogStack.length == 0) {
+        this.unblockDocument()
+      }
+    }
+  
+    dialogPolyfill.dm = new dialogPolyfill.DialogManager()
+  
+    /**
+     * Global form 'dialog' method handler. Closes a dialog correctly on submit
+     * and possibly sets its return value.
+     */
+    document.addEventListener('submit', function (ev) {
+      var target = ev.target
+      if (!target || !target.hasAttribute('method')) { return }
+      if (target.getAttribute('method').toLowerCase() != 'dialog') { return }
+      ev.preventDefault()
+  
+      var dialog = findNearestDialog(/** @type {Element} */ (ev.target))
+      if (!dialog) { return }
+  
+      // FIXME: The original event doesn't contain the element used to submit the
+      // form (if any). Look in some possible places.
+      var returnValue
+      var cands = [document.activeElement, ev.explicitOriginalTarget]
+      var els = ['BUTTON', 'INPUT']
+      cands.some(function (cand) {
+        if (cand && cand.form == ev.target && els.indexOf(cand.nodeName.toUpperCase()) != -1) {
+          returnValue = cand.value
+          return true
+        }
+      })
+      dialog.close(returnValue)
+    }, true)
+  
+    dialogPolyfill['forceRegisterDialog'] = dialogPolyfill.forceRegisterDialog
+    dialogPolyfill['registerDialog'] = dialogPolyfill.registerDialog
+  
+    if (typeof module === 'object' && typeof module['exports'] === 'object') {
+      // CommonJS support
+      module['exports'] = dialogPolyfill
+    } else if (typeof define === 'function' && 'amd' in define) {
+      // AMD support
+      define(function () { return dialogPolyfill })
+    } else {
+      // all others
+      window['dialogPolyfill'] = dialogPolyfill
+    }
+  })()
+  

--- a/app/assets/stylesheets/_application.scss
+++ b/app/assets/stylesheets/_application.scss
@@ -8,6 +8,7 @@
 @import "helpers/feedback-link";
 @import "helpers/verify-logo";
 @import "helpers/js-show";
+@import "helpers/modal-dialog";
 
 // Specific pages
 @import "pages/slides";

--- a/app/assets/stylesheets/helpers/_modal-dialog.scss
+++ b/app/assets/stylesheets/helpers/_modal-dialog.scss
@@ -1,0 +1,162 @@
+.modal-dialog {
+  // Don't display modal if user doesn't have js. Can be overriden with .modal-dialog--no-js-persistent
+  display: none;
+
+  &--no-js-persistent {
+    display: inline-block;
+
+    .js-enabled & {
+      display: none;
+
+      &[open] {
+        display: inline-block;
+      }
+
+      .dialog-button {
+        display: inline-block;
+       }
+    }
+  }
+
+  .js-enabled &[open] {
+    display: inline-block;
+   }
+
+  &[open] {
+    overflow-x: hidden;
+    overflow-y: auto;
+    max-height: 90vh; //Don't make the dialog quite the viewport height
+    padding: 0;
+    margin-bottom: 0;
+    margin-top: 0;
+
+    // From https://github.com/GoogleChrome/dialog-polyfill to vertically center dialog
+    position: fixed;
+    top: 50% !important;
+    -webkit-transform: translate(0, -50%);
+    -ms-transform: translate(0, -50%);
+    transform: translate(0, -50%);
+
+    @include media(tablet) {
+      padding: 0;
+    }
+  }
+
+  &__inner {
+    padding: 20px;
+
+    @include media(tablet) {
+      padding: 30px;
+    }
+
+    &__text {
+
+      @include copy-19;
+      margin-bottom: 20px;
+    }
+
+    &__button {
+      font-size: 19px;
+    }
+
+    &__link {
+
+      @include copy-19;
+      background: none;
+      border: none;
+      vertical-align: middle;
+      margin-top: 20px;
+
+      @include media(mobile) {
+        text-align: center;
+        display: block;
+        margin-top: 25px;
+      }
+
+      @include media(tablet) {
+        position: absolute;
+        top: 50%;
+        transform: translateY(-50%);
+        padding: 0;
+        margin: 0 0 0 30px;
+      }
+
+      &:hover {
+        cursor: pointer;
+      }
+    }
+
+    &__block {
+      position: relative;
+    }
+  }
+
+  .dialog-title {
+    margin-top: 0;
+  }
+}
+
+// Stop background scrolling while dialog open.
+.dialog-is-open {
+  overflow: hidden;
+}
+
+// Modal dialog polyfill styles
+$border-color: #000000;
+$background-color: #ffffff;
+$dialog-backdrop-colour: rgba(0, 0, 0, 0.8);
+$dialog-border: 5px solid $border-color;
+
+dialog {
+  left: 0;
+  right: 0;
+  width: -moz-fit-content;
+  width: -webkit-fit-content;
+  width: fit-content;
+  height: -moz-fit-content;
+  height: -webkit-fit-content;
+  height: fit-content;
+  margin: auto;
+  padding: 1em;
+  background: $background-color;
+  color: $border-color;
+  display: none;
+  border: $dialog-border;
+
+  + .backdrop {
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    background: $dialog-backdrop-colour;
+  }
+
+  &[open] {
+    display: block;
+    box-sizing: border-box;
+    margin: 0 auto;
+    padding: 15px;
+    width: 90%;
+
+    @include media(tablet) {
+      padding: 30px;
+      margin: 30px auto;
+      max-width: 500px;
+    }
+
+    // Backdrop styles for browsers using polyfill
+    + .backdrop {
+      background: $dialog-backdrop-colour;
+    }
+    // Backdrop styles for browsers with native support
+    // NB: keep these two backdrop styles separate - safari didn't work when combined
+    &::backdrop {
+      background: $dialog-backdrop-colour;
+    }
+  }
+}
+
+.tabular-numbers {
+  font-family: $toolkit-font-stack-tabular;
+}

--- a/app/controllers/authn_response_controller.rb
+++ b/app/controllers/authn_response_controller.rb
@@ -53,7 +53,7 @@ private
   end
 
   def handle_idp_response(status, response)
-    success_not_on_or_after(status, response)
+    store_assertion_expiry(status, response)
     analytics_reporters(status, response)
     set_journey_status(status)
     clear_single_idp_cookie
@@ -98,6 +98,7 @@ private
     end
   end
 
+<<<<<<< HEAD
   def path_for_success(is_registration)
     is_registration || journey_type?(SINGLE_IDP_JOURNEY_TYPE) ? confirmation_path : response_processing_path
   end
@@ -112,6 +113,12 @@ private
       SUCCESS => path_for_success(is_registration),
       MATCHING_JOURNEY_SUCCESS => path_for_success(is_registration),
       NON_MATCHING_JOURNEY_SUCCESS => path_for_success_non_matching(is_registration),
+=======
+  def idp_redirects(status, response)
+    is_registration = response.is_registration
+    {
+      SUCCESS => is_registration || journey_type?(SINGLE_IDP_JOURNEY_TYPE) ? confirmation_path : response_processing_path,
+>>>>>>> HUB-368: Show user session timeout message based on not_on_or_after time
       CANCEL => is_registration ? cancelled_registration_path : start_path,
       FAILED_UPLIFT => failed_uplift_path,
       PENDING => paused_registration_path,
@@ -145,7 +152,7 @@ private
     cookies.delete CookieNames::VERIFY_SINGLE_IDP_JOURNEY
   end
 
-  def success_not_on_or_after(status, response)
-    session[:not_on_or_after] = response.not_on_or_after if status == SUCCESS
+  def store_assertion_expiry(status, response)
+    session[:assertion_expiry] = response.assertion_expiry if status == SUCCESS
   end
 end

--- a/app/controllers/authn_response_controller.rb
+++ b/app/controllers/authn_response_controller.rb
@@ -53,6 +53,7 @@ private
   end
 
   def handle_idp_response(status, response)
+    success_not_on_or_after(status, response)
     analytics_reporters(status, response)
     set_journey_status(status)
     clear_single_idp_cookie
@@ -142,5 +143,9 @@ private
 
   def clear_single_idp_cookie
     cookies.delete CookieNames::VERIFY_SINGLE_IDP_JOURNEY
+  end
+
+  def success_not_on_or_after(status, response)
+    session[:not_on_or_after] = response.not_on_or_after if status == SUCCESS
   end
 end

--- a/app/controllers/authn_response_controller.rb
+++ b/app/controllers/authn_response_controller.rb
@@ -98,7 +98,6 @@ private
     end
   end
 
-<<<<<<< HEAD
   def path_for_success(is_registration)
     is_registration || journey_type?(SINGLE_IDP_JOURNEY_TYPE) ? confirmation_path : response_processing_path
   end
@@ -113,12 +112,6 @@ private
       SUCCESS => path_for_success(is_registration),
       MATCHING_JOURNEY_SUCCESS => path_for_success(is_registration),
       NON_MATCHING_JOURNEY_SUCCESS => path_for_success_non_matching(is_registration),
-=======
-  def idp_redirects(status, response)
-    is_registration = response.is_registration
-    {
-      SUCCESS => is_registration || journey_type?(SINGLE_IDP_JOURNEY_TYPE) ? confirmation_path : response_processing_path,
->>>>>>> HUB-368: Show user session timeout message based on not_on_or_after time
       CANCEL => is_registration ? cancelled_registration_path : start_path,
       FAILED_UPLIFT => failed_uplift_path,
       PENDING => paused_registration_path,

--- a/app/controllers/further_information_controller.rb
+++ b/app/controllers/further_information_controller.rb
@@ -1,32 +1,32 @@
 class FurtherInformationController < ApplicationController
   def index
+    return redirect_to further_information_timeout_path if !session[:assertion_expiry].nil? && expired?
+
     session_id = session[:verify_session_id]
     @cycle_three_attribute = FURTHER_INFORMATION_SERVICE.get_attribute_for_session(session_id).new({})
     @transaction_name = current_transaction.name
+    @idp_name = IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate(selected_identity_provider).display_name
   end
 
   def submit
-    if !session[:assertion_expiry].nil? && expired?
-      redirect_to further_information_timeout_path
+    return redirect_to further_information_timeout_path if !session[:assertion_expiry].nil? && expired?
+
+    session_id = session[:verify_session_id]
+    cycle_three_attribute_class = FURTHER_INFORMATION_SERVICE.get_attribute_for_session(session_id)
+    @cycle_three_attribute = cycle_three_attribute_class.new(params['cycle_three_attribute'])
+    if @cycle_three_attribute.valid?
+      FURTHER_INFORMATION_SERVICE.submit(session_id, @cycle_three_attribute.sanitised_cycle_three_data)
+      FEDERATION_REPORTER.report_cycle_three(current_transaction, request, @cycle_three_attribute.simple_id)
+      redirect_to response_processing_path
     else
-      session_id = session[:verify_session_id]
-      cycle_three_attribute_class = FURTHER_INFORMATION_SERVICE.get_attribute_for_session(session_id)
-      @cycle_three_attribute = cycle_three_attribute_class.new(params['cycle_three_attribute'])
-      if @cycle_three_attribute.valid?
-        FURTHER_INFORMATION_SERVICE.submit(session_id, @cycle_three_attribute.sanitised_cycle_three_data)
-        FEDERATION_REPORTER.report_cycle_three(current_transaction, request, @cycle_three_attribute.simple_id)
-        redirect_to response_processing_path
-      else
-        @transaction_name = current_transaction.name
-        render 'index'
-      end
+      @transaction_name = current_transaction.name
+      render 'index'
     end
   end
 
   def timeout
     @idp_name = IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate(selected_identity_provider).display_name
     @transaction_name = current_transaction.name
-    render 'timeout'
   end
 
   def cancel
@@ -48,9 +48,9 @@ class FurtherInformationController < ApplicationController
     end
   end
 
-  private
+private
 
   def expired?
-    Time.parse(session[:assertion_expiry]) > Time.now
+    Time.parse(session[:assertion_expiry]) < Time.now
   end
 end

--- a/app/controllers/further_information_controller.rb
+++ b/app/controllers/further_information_controller.rb
@@ -1,6 +1,6 @@
 class FurtherInformationController < ApplicationController
   def index
-    return redirect_to further_information_timeout_path if !session[:assertion_expiry].nil? && expired?
+    return redirect_to further_information_timeout_path if expired?
 
     session_id = session[:verify_session_id]
     @cycle_three_attribute = FURTHER_INFORMATION_SERVICE.get_attribute_for_session(session_id).new({})
@@ -9,7 +9,7 @@ class FurtherInformationController < ApplicationController
   end
 
   def submit
-    return redirect_to further_information_timeout_path if !session[:assertion_expiry].nil? && expired?
+    return redirect_to further_information_timeout_path if expired?
 
     session_id = session[:verify_session_id]
     cycle_three_attribute_class = FURTHER_INFORMATION_SERVICE.get_attribute_for_session(session_id)
@@ -51,6 +51,6 @@ class FurtherInformationController < ApplicationController
 private
 
   def expired?
-    Time.parse(session[:assertion_expiry]) < Time.now
+    !session[:assertion_expiry].nil? && Time.parse(session[:assertion_expiry]) <= Time.now
   end
 end

--- a/app/models/feedback_source_mapper.rb
+++ b/app/models/feedback_source_mapper.rb
@@ -47,7 +47,8 @@ class FeedbackSourceMapper
       'CONFIRMING_IT_IS_YOU_PAGE' => 'confirming_it_is_you',
       'PROVE_IDENTITY_PAGE' => 'prove_identity',
       'CONTINUE_TO_YOUR_IDP_PAGE' => 'continue_to_your_idp',
-      'RESUME_PAGE' => 'resume_registration'
+      'RESUME_PAGE' => 'resume_registration',
+      'TIMEOUT_PAGE' => 'further_information_timeout'
   }.freeze
   end
 

--- a/app/models/idp_authn_response.rb
+++ b/app/models/idp_authn_response.rb
@@ -1,5 +1,5 @@
 class IdpAuthnResponse < Api::Response
-  attr_reader :idp_result, :is_registration, :loa_achieved, :not_on_or_after
+  attr_reader :idp_result, :is_registration, :loa_achieved, :assertion_expiry
   validates_presence_of :idp_result
   validates_inclusion_of :loa_achieved, in: ['LEVEL_1', 'LEVEL_2', nil]
   validates_inclusion_of :is_registration, in: [true, false]
@@ -8,6 +8,6 @@ class IdpAuthnResponse < Api::Response
     @idp_result = hash['result']
     @is_registration = hash['isRegistration']
     @loa_achieved = hash['loaAchieved']
-    @not_on_or_after = hash['notOnOrAfter']
+    @assertion_expiry = hash['notOnOrAfter']
   end
 end

--- a/app/models/idp_authn_response.rb
+++ b/app/models/idp_authn_response.rb
@@ -1,5 +1,5 @@
 class IdpAuthnResponse < Api::Response
-  attr_reader :idp_result, :is_registration, :loa_achieved
+  attr_reader :idp_result, :is_registration, :loa_achieved, :not_on_or_after
   validates_presence_of :idp_result
   validates_inclusion_of :loa_achieved, in: ['LEVEL_1', 'LEVEL_2', nil]
   validates_inclusion_of :is_registration, in: [true, false]
@@ -8,5 +8,6 @@ class IdpAuthnResponse < Api::Response
     @idp_result = hash['result']
     @is_registration = hash['isRegistration']
     @loa_achieved = hash['loaAchieved']
+    @not_on_or_after = hash['notOnOrAfter']
   end
 end

--- a/app/views/further_information/_modal_dialog.html.erb
+++ b/app/views/further_information/_modal_dialog.html.erb
@@ -1,0 +1,16 @@
+<dialog id="js-modal-dialog" data-utc-expiry="<%= session[:assertion_expiry] %>" data-seconds-modal-visible="300"
+data-url-redirect="<%= url_for(controller: 'further_information', action: 'timeout') %>" data-text="<%= t('hub.further_information.modal.text') %>" data-extra-text="<%= t('hub.further_information.modal.extra_text', idp_name: @idp_name) %>" class="modal-dialog dialog" role="dialog" aria-live="polite" aria-labelledby="dialog-title" aria-describedby="at-timer">
+  <div class="modal-dialog__inner">
+	  <h1 id="dialog-title" class="dialog-title heading-large">
+      <%= t('hub.further_information.modal.heading') %>
+    </h1>
+    <div class="modal-dialog__inner__text">
+      <div class="timer" aria-hidden="true" aria-relevant="additions"></div>
+      <div id="at-timer" class="at-timer visually-hidden" role="status"></div>
+    </div>
+    <div class="modal-dialog__inner__block">
+      <button class="button dialog-button modal-dialog__inner__button js-dialog-close"><%= t('hub.further_information.modal.button_continue') %></button>
+      <%= link_to t('hub.further_information.modal.button_signout'), further_information_timeout_path, :class => 'modal-dialog__inner__link js-dialog-cancel' %>
+    </div>
+  </div>
+</dialog>

--- a/app/views/further_information/index.html.erb
+++ b/app/views/further_information/index.html.erb
@@ -1,7 +1,7 @@
 <%= page_title 'hub.further_information.title', cycle_three_name: @cycle_three_attribute.field_name %>
 <% content_for :feedback_source, 'CYCLE_3_PAGE' %>
 
-<% if !session[:assertion_expiry].nil? %>
+<% unless session[:assertion_expiry].nil? %>
  <%= render partial: 'further_information/modal_dialog'%>
 <% end %>
 

--- a/app/views/further_information/index.html.erb
+++ b/app/views/further_information/index.html.erb
@@ -8,7 +8,6 @@
 <div class="grid-row">
   <div class="column-two-thirds">
     <h1 class="heading-large"><%= @transaction_name.slice(0,1).upcase + @transaction_name.slice(1..-1)%></h1>
-    <%= session[:assertion_expiry] %>
     <p><%= t('hub.further_information.first_time') %></p>
 
     <%= form_for @cycle_three_attribute, url: further_information_submit_path,

--- a/app/views/further_information/index.html.erb
+++ b/app/views/further_information/index.html.erb
@@ -1,6 +1,10 @@
 <%= page_title 'hub.further_information.title', cycle_three_name: @cycle_three_attribute.field_name %>
 <% content_for :feedback_source, 'CYCLE_3_PAGE' %>
 
+<% if !session[:assertion_expiry].nil? %>
+ <%= render partial: 'further_information/modal_dialog'%>
+<% end %>
+
 <div class="grid-row">
   <div class="column-two-thirds">
     <h1 class="heading-large"><%= @transaction_name.slice(0,1).upcase + @transaction_name.slice(1..-1)%></h1>

--- a/app/views/further_information/index.html.erb
+++ b/app/views/further_information/index.html.erb
@@ -4,6 +4,7 @@
 <div class="grid-row">
   <div class="column-two-thirds">
     <h1 class="heading-large"><%= @transaction_name.slice(0,1).upcase + @transaction_name.slice(1..-1)%></h1>
+    <%= session[:not_on_or_after] %>
     <p><%= t('hub.further_information.first_time') %></p>
 
     <%= form_for @cycle_three_attribute, url: further_information_submit_path,

--- a/app/views/further_information/index.html.erb
+++ b/app/views/further_information/index.html.erb
@@ -4,7 +4,7 @@
 <div class="grid-row">
   <div class="column-two-thirds">
     <h1 class="heading-large"><%= @transaction_name.slice(0,1).upcase + @transaction_name.slice(1..-1)%></h1>
-    <%= session[:not_on_or_after] %>
+    <%= session[:assertion_expiry] %>
     <p><%= t('hub.further_information.first_time') %></p>
 
     <%= form_for @cycle_three_attribute, url: further_information_submit_path,

--- a/app/views/further_information/timeout.html.erb
+++ b/app/views/further_information/timeout.html.erb
@@ -1,0 +1,16 @@
+<%= page_title 'hub.further_information.timeout.title' %>
+<% content_for :feedback_source, 'TIMEOUT_PAGE' %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <h1 class="heading-large"><%= t 'hub.further_information.timeout.heading' %></h1>
+
+    <p><%= t 'hub.further_information.timeout.intro' %></p>
+
+    <p><%= t 'hub.further_information.timeout.continue', service_name: @transaction_name, idp_name: @idp_name %></p>
+
+    <%= button_link_to t('hub.further_information.timeout.start_again', idp_name: @idp_name), start_path, id: 'startAgain' %>
+
+    <p><%= t 'hub.further_information.timeout.other_ways_text' %> <%= link_to t('hub.further_information.timeout.other_ways_link', service_name: @transaction_name), other_ways_to_access_service_path %></p>
+  </div>
+</div>

--- a/app/views/further_information/timeout.html.erb
+++ b/app/views/further_information/timeout.html.erb
@@ -9,7 +9,7 @@
 
     <p><%= t 'hub.further_information.timeout.continue', service_name: @transaction_name, idp_name: @idp_name %></p>
 
-    <%= button_link_to t('hub.further_information.timeout.start_again', idp_name: @idp_name), confirm_your_identity_path %>
+    <%= button_link_to t('hub.further_information.timeout.start_again', idp_name: @idp_name), initiate_journey_path(session[:transaction_simple_id], journey_hint: 'submission_confirmation') %>
 
     <p><%= t 'hub.further_information.timeout.other_ways_text' %> <%= link_to t('hub.further_information.timeout.other_ways_link', service_name: @transaction_name), other_ways_to_access_service_path %></p>
   </div>

--- a/app/views/further_information/timeout.html.erb
+++ b/app/views/further_information/timeout.html.erb
@@ -9,7 +9,7 @@
 
     <p><%= t 'hub.further_information.timeout.continue', service_name: @transaction_name, idp_name: @idp_name %></p>
 
-    <%= button_link_to t('hub.further_information.timeout.start_again', idp_name: @idp_name), start_path, id: 'startAgain' %>
+    <%= button_link_to t('hub.further_information.timeout.start_again', idp_name: @idp_name), confirm_your_identity_path %>
 
     <p><%= t 'hub.further_information.timeout.other_ways_text' %> <%= link_to t('hub.further_information.timeout.other_ways_link', service_name: @transaction_name), other_ways_to_access_service_path %></p>
   </div>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -51,6 +51,7 @@ cy:
     feedback_sent: adborth/adborth-wedi'i-anfon
     certified_company_unavailable: cwmni-ardystiedig-ddim-ar-gael
     further_information: gwybodaeth-bellach
+    further_information_timeout: gwybodaeth-bellach/timeout
     further_information_cancel: gwybodaeth-bellach/dileu
     further_information_null_attribute: gwybodaeth-bellach/null-attribute
     no_idps_available: dim-idps-ar-gael
@@ -512,6 +513,20 @@ cy:
       example_text: "Enghraifft: %{example}"
       attribute_validation_message: Rhowch %{cycle_three_name} dilys
       null_attribute: Nid oes gennyf %{cycle_three_name}
+      modal:
+        heading: You’ll be signed out soon
+        text: To keep your information safe, you’ll be automatically signed out in 
+        extra_text: You’ll then need to sign in again with %{idp_name}.
+        button_continue: Continue
+        button_signout: Sign out now
+      timeout:
+        title: "You've been signed out"
+        heading: "You've been signed out"
+        intro: "To keep your information safe, you've been signed out after a period of inactivity."
+        continue: "To continue to %{service_name}, you'll need to sign in again with %{idp_name}."
+        start_again: Sign in with %{idp_name}
+        other_ways_text: You can also see
+        other_ways_link: other ways to %{service_name}
     no_idps_available:
       title: Dim IDPS ar gael
       heading: Ni fydd GOV.UK Verify yn gweithio i chi

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -507,10 +507,16 @@ en:
       example_text: "Example: %{example}"
       attribute_validation_message: Enter a valid %{cycle_three_name}
       null_attribute: I don’t have an %{cycle_three_name}
+      modal:
+        heading: You’ll be signed out soon
+        text: To keep your information safe, you’ll be automatically signed out in 
+        extra_text: You’ll then need to sign in again with %{idp_name}.
+        button_continue: Continue
+        button_signout: Sign out now
       timeout:
         title: "You've been signed out"
         heading: "You've been signed out"
-        intro: "To keep your information safe, you've been signed out after 10 minutes of inactivity."
+        intro: "To keep your information safe, you've been signed out after a period of inactivity."
         continue: "To continue to %{service_name}, you'll need to sign in again with %{idp_name}."
         start_again: Sign in with %{idp_name}
         other_ways_text: You can also see

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,6 +51,7 @@ en:
     feedback_sent: feedback/feedback-sent
     certified_company_unavailable: certified-company-unavailable
     further_information: further-information
+    further_information_timeout: further-information/timeout
     further_information_cancel: further-information/cancel
     further_information_null_attribute: futher-information/null-attribute
     no_idps_available: no-idps-available
@@ -506,6 +507,14 @@ en:
       example_text: "Example: %{example}"
       attribute_validation_message: Enter a valid %{cycle_three_name}
       null_attribute: I don’t have an %{cycle_three_name}
+      timeout:
+        title: "You've been signed out"
+        heading: "You've been signed out"
+        intro: "To keep your information safe, you've been signed out after 10 minutes of inactivity."
+        continue: "To continue to %{service_name}, you'll need to sign in again with %{idp_name}."
+        start_again: Sign in with %{idp_name}
+        other_ways_text: You can also see
+        other_ways_link: other ways to %{service_name}
     no_idps_available:
       title: No IDPS available
       heading: GOV.UK Verify won’t work for you

--- a/config/main_routes.rb
+++ b/config/main_routes.rb
@@ -111,6 +111,7 @@ post 'feedback', to: 'feedback#submit', as: :feedback_submit
 get 'feedback_sent', to: 'feedback_sent#index', as: :feedback_sent
 get 'certified_company_unavailable/:company', to: 'certified_company_unavailable#index', as: :certified_company_unavailable
 get 'further_information', to: 'further_information#index', as: :further_information
+get 'further_information_timeout', to: 'further_information#timeout', as: :further_information_timeout
 post 'further_information', to: 'further_information#submit', as: :further_information_submit
 post 'further_information_cancel', to: 'further_information#cancel', as: :further_information_cancel
 post 'further_information_null_attribute', to: 'further_information#submit_null_attribute', as: :further_information_null_attribute_submit

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
     instance_eval(File.read(Rails.root.join("config/#{routes_name}.rb")))
   end
 
-  get 'initiate-journey/:transaction_simple_id', to: 'initiate_journey#index'
+  get 'initiate-journey/:transaction_simple_id', to: 'initiate_journey#index', as: :initiate_journey
   post 'SAML2/SSO' => 'authn_request#rp_request'
   post 'SAML2/SSO/Response/POST' => 'authn_response#idp_response'
   post 'SAML2/SSO/EidasResponse/POST' => 'authn_response#country_response'

--- a/spec/controllers/authn_response_controller_spec.rb
+++ b/spec/controllers/authn_response_controller_spec.rb
@@ -16,16 +16,18 @@ describe AuthnResponseController do
       include_examples 'idp_authn_response', 'registration', 'FAILED_UPLIFT', 'Failed Uplift - REGISTER_WITH_IDP', :failed_uplift_path
       include_examples 'idp_authn_response', 'registration', 'PENDING', 'Paused - REGISTER_WITH_IDP', :paused_registration_path
       include_examples 'idp_authn_response', 'registration', 'FAILED', 'Failure - REGISTER_WITH_IDP', :failed_registration_path
+      include_examples 'idp_authn_response', 'registration', 'FAILED', 'Failure - REGISTER_WITH_IDP', :failed_registration_path, '2018-09-03T10:02:07.566Z'
     end
 
     context 'sign_in' do
-      include_examples 'idp_authn_response', 'sign_in', 'SUCCESS', 'Success - SIGN_IN_WITH_IDP at LOA LEVEL_1', :response_processing_path
+      include_examples 'idp_authn_response', 'sign_in', 'SUCCESS', 'Success - SIGN_IN_WITH_IDP at LOA LEVEL_1', :response_processing_path, '2018-09-03T10:02:07.566Z'
       include_examples 'idp_authn_response', 'sign_in', 'MATCHING_JOURNEY_SUCCESS', 'Success Matching Journey - SIGN_IN_WITH_IDP at LOA LEVEL_1', :response_processing_path
       include_examples 'idp_authn_response', 'sign_in', 'NON_MATCHING_JOURNEY_SUCCESS', 'Success Non Matching Journey - SIGN_IN_WITH_IDP at LOA LEVEL_1', :redirect_to_service_signing_in_path
       include_examples 'idp_authn_response', 'sign_in', 'CANCEL', 'Cancel - SIGN_IN_WITH_IDP', :start_path
       include_examples 'idp_authn_response', 'sign_in', 'FAILED_UPLIFT', 'Failed Uplift - SIGN_IN_WITH_IDP', :failed_uplift_path
       include_examples 'idp_authn_response', 'sign_in', 'PENDING', 'Paused - SIGN_IN_WITH_IDP', :paused_registration_path
       include_examples 'idp_authn_response', 'sign_in', 'FAILED', 'Failure - SIGN_IN_WITH_IDP', :failed_sign_in_path
+      include_examples 'idp_authn_response', 'sign_in', 'FAILED', 'Failure - SIGN_IN_WITH_IDP', :failed_sign_in_path, '2018-09-03T10:02:07.566Z'
     end
 
     context 'resuming' do
@@ -174,36 +176,6 @@ describe AuthnResponseController do
       }
       it { should eq cookie_with_pending_status }
       it { expect(cookies.encrypted[CookieNames::VERIFY_SINGLE_IDP_JOURNEY]).to be_nil }
-    end
-  end
-  context 'notOnOrAfter' do
-    let(:saml_proxy_api) { double(:saml_proxy_api) }
-    let(:selected_entity) {
-      {
-          'entity_id' => 'https://acme.de/ServiceMetadata',
-          'simple_id' => 'DE',
-          'levels_of_assurance' => %w[LEVEL_1 LEVEL_2]
-      }
-    }
-
-    before(:each) do
-      stub_const('SAML_PROXY_API', saml_proxy_api)
-      set_session_and_cookies_with_loa('LEVEL_1')
-      set_selected_idp(selected_entity)
-    end
-    it 'is stored in session on success' do
-      allow(saml_proxy_api).to receive(:idp_authn_response).and_return(IdpAuthnResponse.new('result' => 'SUCCESS', 'isRegistration' => true, 'loaAchieved' => 'LEVEL_1', 'notOnOrAfter' => '2018-09-03T10:02:07.566Z'))
-      allow(subject).to receive(:report_to_analytics).with('Success - REGISTER_WITH_IDP at LOA LEVEL_1')
-      allow(subject).to receive(:report_user_outcome_to_piwik).with('SUCCESS')
-      post :idp_response, params: { 'RelayState' => 'my-session-id-cookie', 'SAMLResponse' => 'a-saml-response', locale: 'en' }
-      expect(session[:not_on_or_after]).to eq('2018-09-03T10:02:07.566Z')
-    end
-    it 'isnt stored in session on failure' do
-      allow(saml_proxy_api).to receive(:idp_authn_response).and_return(IdpAuthnResponse.new('result' => 'FAILED', 'isRegistration' => true, 'loaAchieved' => 'LEVEL_1', 'notOnOrAfter' => '2018-09-03T10:02:07.566Z'))
-      allow(subject).to receive(:report_to_analytics).with('Failure - REGISTER_WITH_IDP')
-      allow(subject).to receive(:report_user_outcome_to_piwik).with('FAILED')
-      post :idp_response, params: { 'RelayState' => 'my-session-id-cookie', 'SAMLResponse' => 'a-saml-response', locale: 'en' }
-      expect(session[:not_on_or_after]).to eq(nil)
     end
   end
 end

--- a/spec/controllers/further_information_controller_spec.rb
+++ b/spec/controllers/further_information_controller_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+require 'controller_helper'
+require 'api_test_helper'
+
+describe FurtherInformationController do
+  subject { get :index, params: { locale: 'en' } }
+
+  before :each do
+    set_selected_idp('entity_id' => 'http://idcorp.com', 'simple_id' => 'stub-idp-one')
+    set_session_and_cookies_with_loa('LEVEL_2')
+    stub_cycle_three_attribute_request("NationalInsuranceNumber")
+  end
+
+  it 'renders the further information page' do
+    expect(subject).to render_template(:index)
+  end
+
+  it 'redirects to the timeout page when the assertion has expired' do
+    session[:assertion_expiry] = 1.minute.ago.to_s
+    expect(subject).to redirect_to further_information_timeout_path
+  end
+
+  it 'does not redirect to the timeout page when the assertion has not expired yet' do
+    session[:assertion_expiry] = 1.minute.from_now.to_s
+    expect(subject).to render_template(:index)
+  end
+
+  it 'redirects to timeout page when attempting to submit an expired assertion' do
+    session[:assertion_expiry] = 1.minute.ago.to_s
+    post :submit, params: { locale: 'en' }
+    expect(response).to redirect_to further_information_timeout_path
+  end
+end

--- a/spec/features/user_visits_further_information_page_spec.rb
+++ b/spec/features/user_visits_further_information_page_spec.rb
@@ -160,6 +160,31 @@ RSpec.describe 'user visits further information page' do
       expect(page).to have_selector('#js-modal-dialog', visible: true)
     end
 
+    it 'can be closed when shown' do
+      page.set_rack_session(assertion_expiry: 4.minutes.from_now)
+      stub_cycle_three_attribute_request('NationalInsuranceNumber')
+
+      visit further_information_path
+
+      expect(page).to have_current_path(further_information_path)
+      expect(page).to have_selector('#js-modal-dialog', visible: true)
+
+      find(".js-dialog-close").click
+      expect(page).to have_selector('#js-modal-dialog', visible: false)
+    end
+
+    it 'can be closed and signed out when shown' do
+      page.set_rack_session(assertion_expiry: 4.minutes.from_now)
+      stub_cycle_three_attribute_request('NationalInsuranceNumber')
+
+      visit further_information_path
+
+      expect(page).to have_current_path(further_information_path)
+      expect(page).to have_selector('#js-modal-dialog', visible: true)
+      click_link t('hub.further_information.modal.button_signout')
+      expect(page).to have_current_path(further_information_timeout_path)
+    end
+
     it 'will show up automatically if the timeout limit reaches 5 mins' do
       page.set_rack_session(assertion_expiry: 303.seconds.from_now)
       stub_cycle_three_attribute_request('NationalInsuranceNumber')

--- a/spec/support/authn_response_examples.rb
+++ b/spec/support/authn_response_examples.rb
@@ -1,4 +1,4 @@
-shared_examples 'idp_authn_response' do |journey_hint, idp_result, piwik_action, redirect_path, not_on_or_after|
+shared_examples 'idp_authn_response' do |journey_hint, idp_result, piwik_action, redirect_path, assertion_expiry|
   let(:saml_proxy_api) { double(:saml_proxy_api) }
   let(:selected_entity) {
     {
@@ -17,11 +17,12 @@ shared_examples 'idp_authn_response' do |journey_hint, idp_result, piwik_action,
   end
 
   it "should redirect to #{redirect_path} on #{idp_result}" do
-    allow(saml_proxy_api).to receive(:idp_authn_response).and_return(IdpAuthnResponse.new('result' => idp_result, 'isRegistration' => (journey_hint == 'registration'), 'loaAchieved' => 'LEVEL_1', 'notOnOrAfter' => not_on_or_after))
+    expiry_time = assertion_expiry if idp_result == 'SUCCESS'
+    allow(saml_proxy_api).to receive(:idp_authn_response).and_return(IdpAuthnResponse.new('result' => idp_result, 'isRegistration' => (journey_hint == 'registration'), 'loaAchieved' => 'LEVEL_1', 'notOnOrAfter' => expiry_time))
     allow(subject).to receive(:report_to_analytics).with(piwik_action)
     allow(subject).to receive(:report_user_outcome_to_piwik).with(idp_result)
     post :idp_response, params: { 'RelayState' => 'my-session-id-cookie', 'SAMLResponse' => 'a-saml-response', locale: 'en' }
-    expect(session[:not_on_or_after]).to eq(not_on_or_after)
+    expect(session[:assertion_expiry]).to eq(expiry_time)
     expect(cookies.encrypted[CookieNames::VERIFY_SINGLE_IDP_JOURNEY]).to be_nil
     expect(subject).to redirect_to(send(redirect_path))
   end


### PR DESCRIPTION
With HUB-348 we exposed the NotOnOrAfter expiry date of the assertions sent by an IDP. This is to present this information to the user when they're close (<5mins) to the expiry time. And also prevent users to submits Cycle3 attributes with an expired assertion.

It's using amended `GOVUK.modalDialog` component to maintain accessibility of the modal box. The functionality has been changed to satisfy our requirements (triggered by a hard limit rather by inactivity).

It might be easier to review the PR commit by commit.