### PR TITLE
HUB-363: Make the cycle3 timeout page work with EIDAS

### DIFF
--- a/app/controllers/further_information_controller.rb
+++ b/app/controllers/further_information_controller.rb
@@ -5,7 +5,7 @@ class FurtherInformationController < ApplicationController
     session_id = session[:verify_session_id]
     @cycle_three_attribute = FURTHER_INFORMATION_SERVICE.get_attribute_for_session(session_id).new({})
     @transaction_name = current_transaction.name
-    @idp_name = IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate(selected_identity_provider).display_name
+    @idp_name = selected_provider.display_name
   end
 
   def submit
@@ -25,8 +25,9 @@ class FurtherInformationController < ApplicationController
   end
 
   def timeout
-    @idp_name = IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate(selected_identity_provider).display_name
+    @idp_name = selected_provider.display_name
     @transaction_name = current_transaction.name
+    @journey_hint = user_journey_type?(JourneyType::VERIFY) ? 'submission_confirmation' : 'eidas_sign_in'
   end
 
   def cancel

--- a/app/controllers/partials/user_session_partial_controller.rb
+++ b/app/controllers/partials/user_session_partial_controller.rb
@@ -59,6 +59,14 @@ module UserSessionPartialController
     Country.from_session(selected_provider_data.identity_provider)
   end
 
+  def selected_provider
+    if current_selected_provider_data.is_selected_verify_idp?
+      IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate(selected_identity_provider)
+    else
+      COUNTRY_DISPLAY_DECORATOR.decorate(selected_country)
+    end
+  end
+
   def store_selected_idp_for_session(selected_idp)
     session[:selected_provider] = SelectedProviderData.new(JourneyType::VERIFY, selected_idp)
   end

--- a/app/views/further_information/timeout.html.erb
+++ b/app/views/further_information/timeout.html.erb
@@ -9,7 +9,7 @@
 
     <p><%= t 'hub.further_information.timeout.continue', service_name: @transaction_name, idp_name: @idp_name %></p>
 
-    <%= button_link_to t('hub.further_information.timeout.start_again', idp_name: @idp_name), initiate_journey_path(session[:transaction_simple_id], journey_hint: 'submission_confirmation') %>
+    <%= button_link_to t('hub.further_information.timeout.start_again', idp_name: @idp_name), initiate_journey_path(session[:transaction_simple_id], journey_hint: @journey_hint) %>
 
     <p><%= t 'hub.further_information.timeout.other_ways_text' %> <%= link_to t('hub.further_information.timeout.other_ways_link', service_name: @transaction_name), other_ways_to_access_service_path %></p>
   </div>


### PR DESCRIPTION
For the timeout modal we now display the IDP name, this was getting broken on the EIDAS
journey as there was no IDP name. This handles both cases