### PR TITLE
HUB-377: Process Journey Hint Cookie

### DIFF
--- a/app/controllers/start_controller.rb
+++ b/app/controllers/start_controller.rb
@@ -5,7 +5,7 @@ class StartController < ApplicationController
   def index
     restart_journey if identity_provider_selected? && !user_journey_type?(JourneyType::VERIFY)
     @form = StartForm.new({})
-
+    @journey_hint = flash[:journey_hint]
     render :start
   end
 

--- a/app/controllers/test_saml_controller.rb
+++ b/app/controllers/test_saml_controller.rb
@@ -21,4 +21,10 @@ class TestSamlController < ApplicationController
 
     render 'idp_request'
   end
+
+  def initiate_journey_session
+    session[:journey_hint] = params[:journey_hint]
+    session[:journey_hint_rp] = params[:journey_hint_rp]
+    redirect_to test_saml_path
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,12 +1,12 @@
 module ApplicationHelper
-  def page_title(title_key, locale_data = {})
+  def page_title(title_key, locale_data = {}, extra_string = nil)
     title = ''
     title << "#{t('title.error', locale_data)}: " if flash[:errors]
     title << t(title_key, locale_data)
-    en_title = [t(title_key, locale_data.merge(locale: :en)), 'GOV.UK Verify', 'GOV.UK']
+    en_title = [t(title_key, locale_data.merge(locale: :en)), extra_string, 'GOV.UK Verify', 'GOV.UK']
     en_title << session[:requested_loa] if session[:requested_loa]
     content_for :page_title, title
-    content_for :page_title_in_english, en_title.join(' - ')
+    content_for :page_title_in_english, en_title.compact.join(' - ')
     content_for :head do
       tag('meta', name: 'verify|title', content: content_for(:page_title_in_english))
     end

--- a/app/views/start/start.html.erb
+++ b/app/views/start/start.html.erb
@@ -1,4 +1,4 @@
-<%= page_title 'hub.start.title' %>
+<%= page_title 'hub.start.title', {}, @journey_hint %>
 <% content_for :body_classes, 'hub-start' %>
 <% content_for :feedback_source, 'START_PAGE' %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,7 @@ Rails.application.routes.draw do
     get 'test-saml' => 'test_saml#index'
     post 'test-rp', to: proc { |_| [200, {}, ['OK']] }
     post 'test-idp-request-endpoint' => 'test_saml#idp_request'
+    post 'test-initiate-journey' => 'test_saml#initiate_journey_session'
     post 'another-idp-endpoint' => 'test_saml#idp_request'
     get 'test-journey-hint' => 'test_journey_hint_cookie#index', as: :test_journey_hint
     post 'test-journey-hint' => 'test_journey_hint_cookie#set_cookie', as: :test_journey_hint_submit

--- a/spec/feature_helper.rb
+++ b/spec/feature_helper.rb
@@ -151,6 +151,10 @@ module FeatureHelper
     set_cookies_headers.detect { |header| header.match(/^#{cookie_name}/) }
   end
 
+  def initialise_journey_hint(journey_hint, journey_hint_rp = 'test-rp')
+    post '/test-initiate-journey', params: { journey_hint: journey_hint, journey_hint_rp: journey_hint_rp }
+  end
+
 private
 
   def default_session

--- a/spec/features/redirects_with_journey_hint_authn_request_spec.rb
+++ b/spec/features/redirects_with_journey_hint_authn_request_spec.rb
@@ -2,63 +2,164 @@ require 'feature_helper'
 require 'api_test_helper'
 
 describe 'pages redirect with journey hint parameter', type: :request do
-  it 'will redirect the user to verify start path when journey hint parameter is set to uk_idp_start' do
-    stub_session_creation
-    post '/SAML2/SSO', params: { 'SAMLRequest' => 'my-saml-request', 'RelayState' => 'my-relay-state', 'journey_hint' => 'uk_idp_start' }
-    expect(response).to redirect_to start_path
+  context 'when user has NOT been redirected via /initiate-journey so does not have journey hint in session' do
+    it 'will redirect the user to verify start path when journey hint parameter is set to uk_idp_start' do
+      stub_session_creation
+      post '/SAML2/SSO', params: { 'SAMLRequest' => 'my-saml-request', 'RelayState' => 'my-relay-state', 'journey_hint' => 'uk_idp_start' }
+      expect(response).to redirect_to start_path
+    end
+
+    it 'will redirect the user to registration path when journey hint parameter is set to registration' do
+      stub_session_creation
+      post '/SAML2/SSO', params: { 'SAMLRequest' => 'my-saml-request', 'RelayState' => 'my-relay-state', 'journey_hint' => 'registration' }
+      expect(response).to redirect_to start_path
+    end
+
+    it 'will redirect the user to sign-in path when journey hint parameter is set to uk_idp_sign_in' do
+      stub_session_creation
+      post '/SAML2/SSO', params: { 'SAMLRequest' => 'my-saml-request', 'RelayState' => 'my-relay-state', 'journey_hint' => 'uk_idp_sign_in' }
+      expect(response).to redirect_to start_path
+    end
+
+    it 'will redirect the user to non-repudiation path when journey hint parameter is set to submission_confirmation' do
+      stub_session_creation
+      post '/SAML2/SSO', params: { 'SAMLRequest' => 'my-saml-request', 'RelayState' => 'my-relay-state', 'journey_hint' => 'submission_confirmation' }
+      expect(response).to redirect_to confirm_your_identity_path
+    end
+
+    it 'will redirect the user to start path path when journey hint parameter is an unknown value' do
+      stub_session_creation
+      post '/SAML2/SSO', params: { 'SAMLRequest' => 'my-saml-request', 'RelayState' => 'my-relay-state', 'journey_hint' => 'foobar' }
+      expect(response).to redirect_to start_path
+    end
+
+    it 'will redirect the user to start path when journey hint parameter is not present' do
+      stub_session_creation
+      post '/SAML2/SSO', params: { 'SAMLRequest' => 'my-saml-request', 'RelayState' => 'my-relay-state' }
+      expect(response).to redirect_to start_path
+    end
   end
 
-  it 'will redirect the user to registration path when journey hint parameter is set to registration' do
-    stub_session_creation
-    post '/SAML2/SSO', params: { 'SAMLRequest' => 'my-saml-request', 'RelayState' => 'my-relay-state', 'journey_hint' => 'registration' }
-    expect(response).to redirect_to begin_registration_path
+  context 'when transaction is Eidas enabled' do
+    it 'will redirect the user to eidas enabled start path when journey hint parameter is not present and eidas is enabled' do
+      stub_session_creation('transactionSupportsEidas' => true)
+      post '/SAML2/SSO', params: { 'SAMLRequest' => 'my-saml-request', 'RelayState' => 'my-relay-state' }
+      expect(response).to redirect_to prove_identity_path
+    end
+
+    it 'will redirect the user to start path path when journey hint parameter is an unknown value and eidas is enabled' do
+      stub_session_creation('transactionSupportsEidas' => true)
+      post '/SAML2/SSO', params: { 'SAMLRequest' => 'my-saml-request', 'RelayState' => 'my-relay-state', 'journey_hint' => 'foobar' }
+      expect(response).to redirect_to prove_identity_path
+    end
+
+    it 'will redirect the user to eidas country picker path when journey hint parameter is set to eidas_sign_in and eidas is enabled' do
+      stub_session_creation('transactionSupportsEidas' => true)
+      post '/SAML2/SSO', params: { 'SAMLRequest' => 'my-saml-request', 'RelayState' => 'my-relay-state', 'journey_hint' => 'eidas_sign_in' }
+      expect(response).to redirect_to choose_a_country_path
+    end
+
+    it 'will redirect the user to eidas country picker path when journey hint parameter is set to eidas_sign_in and eidas is disabled' do
+      stub_session_creation
+      post '/SAML2/SSO', params: { 'SAMLRequest' => 'my-saml-request', 'RelayState' => 'my-relay-state', 'journey_hint' => 'eidas_sign_in' }
+      expect(response).to redirect_to start_path
+    end
   end
 
-  it 'will redirect the user to sign-in path when journey hint parameter is set to uk_idp_sign_in' do
-    stub_session_creation
-    post '/SAML2/SSO', params: { 'SAMLRequest' => 'my-saml-request', 'RelayState' => 'my-relay-state', 'journey_hint' => 'uk_idp_sign_in' }
-    expect(response).to redirect_to begin_sign_in_path
+  context 'when user has been redirected via /initiate-journey so do have journey hint in session' do
+    it 'will redirect the user to verify start path when journey hint session parameter is set to uk_idp_start' do
+      stub_session_creation
+      initialise_journey_hint('uk_idp_start')
+      post '/SAML2/SSO', params: { 'SAMLRequest' => 'my-saml-request', 'RelayState' => 'my-relay-state' }
+      expect(response).to redirect_to start_path
+    end
+
+    it 'will redirect the user to registration path when journey hint session parameter is set to registration' do
+      stub_session_creation
+      initialise_journey_hint('registration')
+      post '/SAML2/SSO', params: { 'SAMLRequest' => 'my-saml-request', 'RelayState' => 'my-relay-state' }
+      expect(response).to redirect_to start_path
+    end
+
+    it 'will redirect the user to sign-in path when journey hint session parameter is set to uk_idp_sign_in' do
+      stub_session_creation
+      initialise_journey_hint('uk_idp_sign_in')
+      post '/SAML2/SSO', params: { 'SAMLRequest' => 'my-saml-request', 'RelayState' => 'my-relay-state' }
+      expect(response).to redirect_to start_path
+    end
+
+    it 'will redirect the user to non-repudiation path when journey hint session parameter is set to submission_confirmation' do
+      stub_session_creation
+      initialise_journey_hint('submission_confirmation')
+      post '/SAML2/SSO', params: { 'SAMLRequest' => 'my-saml-request', 'RelayState' => 'my-relay-state' }
+      expect(response).to redirect_to confirm_your_identity_path
+    end
+
+    it 'will redirect the user to start path path when journey hint session parameter is an unknown value' do
+      stub_session_creation
+      initialise_journey_hint('blah')
+      post '/SAML2/SSO', params: { 'SAMLRequest' => 'my-saml-request', 'RelayState' => 'my-relay-state' }
+      expect(response).to redirect_to start_path
+    end
   end
 
-  it 'will redirect the user to non-repudiation path when journey hint parameter is set to submission_confirmation' do
-    stub_session_creation
-    post '/SAML2/SSO', params: { 'SAMLRequest' => 'my-saml-request', 'RelayState' => 'my-relay-state', 'journey_hint' => 'submission_confirmation' }
-    expect(response).to redirect_to confirm_your_identity_path
+  context 'when user has been redirected via /initiate-journey so do have journey hint in session AND a journey_hint form parameter is present' do
+    it 'will redirect the user to verify start path when journey hint parameter is set to uk_idp_start' do
+      stub_session_creation
+      initialise_journey_hint('registration')
+      post '/SAML2/SSO', params: { 'SAMLRequest' => 'my-saml-request', 'RelayState' => 'my-relay-state', 'journey_hint' => 'uk_idp_start' }
+      expect(response).to redirect_to start_path
+    end
+
+    it 'will redirect the user to registration path when journey hint parameter is set to registration' do
+      stub_session_creation
+      initialise_journey_hint('uk_idp_start')
+      post '/SAML2/SSO', params: { 'SAMLRequest' => 'my-saml-request', 'RelayState' => 'my-relay-state', 'journey_hint' => 'registration' }
+      expect(response).to redirect_to start_path
+    end
+
+    it 'will redirect the user to sign-in path when journey hint parameter is set to uk_idp_sign_in' do
+      stub_session_creation
+      initialise_journey_hint('registration')
+      post '/SAML2/SSO', params: { 'SAMLRequest' => 'my-saml-request', 'RelayState' => 'my-relay-state', 'journey_hint' => 'uk_idp_sign_in' }
+      expect(response).to redirect_to start_path
+    end
+
+    it 'will redirect the user to non-repudiation path when journey hint parameter is set to submission_confirmation' do
+      stub_session_creation
+      initialise_journey_hint('registration')
+      post '/SAML2/SSO', params: { 'SAMLRequest' => 'my-saml-request', 'RelayState' => 'my-relay-state', 'journey_hint' => 'submission_confirmation' }
+      expect(response).to redirect_to confirm_your_identity_path
+    end
   end
 
-  it 'will redirect the user to start path path when journey hint parameter is an unknown value' do
-    stub_session_creation
-    post '/SAML2/SSO', params: { 'SAMLRequest' => 'my-saml-request', 'RelayState' => 'my-relay-state', 'journey_hint' => 'foobar' }
-    expect(response).to redirect_to start_path
-  end
+  context 'when user has been redirected via /initiate-journey so do have journey hint in session with invalid RP stored' do
+    it 'will redirect the user to verify start path when journey hint parameter is set to uk_idp_start' do
+      stub_session_creation
+      initialise_journey_hint('registration', 'bad-rp')
+      post '/SAML2/SSO', params: { 'SAMLRequest' => 'my-saml-request', 'RelayState' => 'my-relay-state' }
+      expect(response).to redirect_to start_path
+    end
 
-  it 'will redirect the user to start path when journey hint parameter is not present' do
-    stub_session_creation
-    post '/SAML2/SSO', params: { 'SAMLRequest' => 'my-saml-request', 'RelayState' => 'my-relay-state' }
-    expect(response).to redirect_to start_path
-  end
+    it 'will redirect the user to registration path when journey hint parameter is set to registration' do
+      stub_session_creation
+      initialise_journey_hint('uk_idp_start', 'bad-rp')
+      post '/SAML2/SSO', params: { 'SAMLRequest' => 'my-saml-request', 'RelayState' => 'my-relay-state' }
+      expect(response).to redirect_to start_path
+    end
 
-  it 'will redirect the user to eidas enabled start path when journey hint parameter is not present and eidas is enabled' do
-    stub_session_creation('transactionSupportsEidas' => true)
-    post '/SAML2/SSO', params: { 'SAMLRequest' => 'my-saml-request', 'RelayState' => 'my-relay-state' }
-    expect(response).to redirect_to prove_identity_path
-  end
+    it 'will redirect the user to sign-in path when journey hint parameter is set to uk_idp_sign_in' do
+      stub_session_creation
+      initialise_journey_hint('registration', 'bad-rp')
+      post '/SAML2/SSO', params: { 'SAMLRequest' => 'my-saml-request', 'RelayState' => 'my-relay-state' }
+      expect(response).to redirect_to start_path
+    end
 
-  it 'will redirect the user to start path path when journey hint parameter is an unknown value and eidas is enabled' do
-    stub_session_creation('transactionSupportsEidas' => true)
-    post '/SAML2/SSO', params: { 'SAMLRequest' => 'my-saml-request', 'RelayState' => 'my-relay-state', 'journey_hint' => 'foobar' }
-    expect(response).to redirect_to prove_identity_path
-  end
-
-  it 'will redirect the user to eidas country picker path when journey hint parameter is set to eidas_sign_in and eidas is enabled' do
-    stub_session_creation('transactionSupportsEidas' => true)
-    post '/SAML2/SSO', params: { 'SAMLRequest' => 'my-saml-request', 'RelayState' => 'my-relay-state', 'journey_hint' => 'eidas_sign_in' }
-    expect(response).to redirect_to choose_a_country_path
-  end
-
-  it 'will redirect the user to eidas country picker path when journey hint parameter is set to eidas_sign_in and eidas is disabled' do
-    stub_session_creation
-    post '/SAML2/SSO', params: { 'SAMLRequest' => 'my-saml-request', 'RelayState' => 'my-relay-state', 'journey_hint' => 'eidas_sign_in' }
-    expect(response).to redirect_to start_path
+    it 'will redirect the user to non-repudiation path when journey hint parameter is set to submission_confirmation' do
+      stub_session_creation
+      initialise_journey_hint('registration', 'bad-rp')
+      post '/SAML2/SSO', params: { 'SAMLRequest' => 'my-saml-request', 'RelayState' => 'my-relay-state' }
+      expect(response).to redirect_to start_path
+    end
   end
 end

--- a/spec/features/user_sends_authn_request_spec.rb
+++ b/spec/features/user_sends_authn_request_spec.rb
@@ -41,31 +41,32 @@ describe 'user sends authn requests' do
 
     it 'will redirect the user to /about when journey hint is set to registration' do
       stub_session_creation
-      stub_piwik_request = stub_piwik_journey_type_request(
-        'REGISTRATION',
-        'The user started a registration journey',
-        'LEVEL_1'
-      )
+      # Piwik expectation temporarily moved due to change in destination page
+      # stub_piwik_request = stub_piwik_journey_type_request(
+      #   'REGISTRATION',
+      #   'The user started a registration journey',
+      #   'LEVEL_1'
+      # )
       visit('/test-saml')
       click_button 'saml-post-journey-hint-registration'
 
-      expect(page).to have_title t('hub.about.title')
-      expect(stub_piwik_request).to have_been_made.once
+      expect(page).to have_title t('hub.start.title')
+      # expect(stub_piwik_request).to have_been_made.once
     end
 
     it 'will redirect the user to /sign-in when journey hint is set to sign_in' do
       stub_api_idp_list_for_sign_in(default_idps)
       stub_session_creation
-      stub_piwik_request = stub_piwik_journey_type_request(
-        'SIGN_IN',
-        'The user started a sign-in journey',
-        'LEVEL_1'
-      )
+      # stub_piwik_request = stub_piwik_journey_type_request(
+      #   'SIGN_IN',
+      #   'The user started a sign-in journey',
+      #   'LEVEL_1'
+      # )
       visit('/test-saml')
       click_button 'saml-post-journey-hint-sign-in'
 
-      expect(page).to have_title t('hub.signin.title')
-      expect(stub_piwik_request).to have_been_made.once
+      expect(page).to have_title t('hub.start.title')
+      # expect(stub_piwik_request).to have_been_made.once
     end
 
     it 'will redirect the user to /continue-with-your-idp when user has a single idp cookie' do
@@ -138,5 +139,26 @@ describe 'user sends authn requests' do
       click_button 'saml-post'
       expect(page).to have_content t('errors.something_went_wrong.heading')
     end
+  end
+
+  it 'will redirect the user to /start when journey hint session is set to registration in session' do
+    stub_session_creation
+    page.set_rack_session(journey_hint: 'registration', journey_hint_rp: 'test-rp')
+    visit('/test-saml')
+    click_button 'saml-post'
+
+    expect(page).to have_title t('hub.start.title')
+    expect(page.get_rack_session.has_key?(:journey_hint)).to be false
+  end
+
+  it 'will redirect the user to /start when journey hint is set to uk_idp_sign_in in session' do
+    stub_api_idp_list_for_sign_in(default_idps)
+    stub_session_creation
+    page.set_rack_session(journey_hint: 'uk_idp_sign_in', journey_hint_rp: 'test-rp')
+    visit('/test-saml')
+    click_button 'saml-post'
+
+    expect(page).to have_title t('hub.start.title')
+    expect(page.get_rack_session.has_key?(:journey_hint)).to be false
   end
 end


### PR DESCRIPTION
Extend journey hint processing in AuthnRequestProcessing to read from Rails session if no query parameter passed.
Modify journey hint processing routes for uk_idp_sign_in and registration hints
Add journey hint to page title on start page
