### PR TITLE
BAU: Fix CSP policy for fonts

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -44,7 +44,7 @@ module VerifyFrontend
       'X-XSS-Protection' => '1; mode=block',
       'X-Content-Type-Options' => 'nosniff',
       'Content-Security-Policy' => "default-src 'self'; " +
-        "font-src data:; " +
+        "font-src 'self'; " +
         "img-src 'self'; " +
         "object-src 'none'; " +
         # the script digests are for the two inline scripts in govuk_template.gem:govuk_template.html.erb


### PR DESCRIPTION
After recent gem updates, the fonts are loaded differently and were
being blocked by our strict CSP.