### PR TITLE
EID-1177: Add Welsh translation for eIDAS scheme unavailable page

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -639,8 +639,8 @@ cy:
       reason_one: bod y ddolen rydych wedi clicio arni wedi torri
       reason_two: rydych wedi rhoi cyfeiriad gwefan anghywir
     eidas_scheme_unavailable:
-      title: Identity scheme unavailable
-      heading: "Your identity scheme in %{country_name} is currently unavailable"
-      other_ways: "Try again later or choose another way to "
-      other_ways_link: "prove your identity online"
+      title: Cynllun hunaniaeth ddim ar gael
+      heading: Nid yw eich cynllun hunaniaeth ar gael ar hyn o bryd
+      other_ways: "Ceisiwch eto yn nes ymlaen neu ddewis ffordd arall i "
+      other_ways_link: "profi eich hunaniaeth ar-lein"
     no_selection: Dylech ateb y cwestiynau


### PR DESCRIPTION
Follow-up on EID-1060

[Translation spreadsheet](https://docs.google.com/spreadsheets/d/1PyGbtFbQT5_4dvqybvIwFq_BlBEvNQ7-tKG4ziwWExU/edit#gid=0)

_Note:_ Due to the Welsh morphology, the `in %{country_name}` had to be omitted since it's not easy to translate that programatically into Welsh.

![screen shot 2018-12-17 at 12 58 36](https://user-images.githubusercontent.com/3608562/50088659-87e71c00-01fb-11e9-8e5d-c015633ac7b8.png)