### PR TITLE
EID-1170: Work around for oddly shaped focus selectors

### DIFF
--- a/app/assets/stylesheets/_govuk-elements.scss
+++ b/app/assets/stylesheets/_govuk-elements.scss
@@ -53,3 +53,8 @@
 // @import "elements/phase-banner";                  // Alpha and beta banners and tags
 @import "elements/components";                    // GOV.UK prefixed styles - blue highlighted box
 @import "elements/shame";                         // Hacks and workarounds that will go away eventually
+
+// Work around for focus outline corruption within the gov uk template: EID-1170
+.form-group-error::after {
+  content: none;
+}


### PR DESCRIPTION
The issue is caused by the css element line 46 `govuk_frontend_toolkit-8.1.0/app/assets/stylesheets/_shims.scss` where it creates an `:after` element which has the content of `""`, if the content is set to `none` rather than `""` the focus selection box is the correct shape.
