### PR TITLE
HUB-399: Create a SIDP customised start page for an RP in the hub

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -6,7 +6,11 @@ module ApplicationHelper
     en_title = [t(title_key, locale_data.merge(locale: :en)), extra_string, 'GOV.UK Verify', 'GOV.UK']
     en_title << session[:requested_loa] if session[:requested_loa]
     content_for :page_title, title
-    content_for :page_title_in_english, en_title.compact.join(' - ')
+    analytics_title en_title.compact.join(' - ')
+  end
+
+  def analytics_title(english_title)
+    content_for :page_title_in_english, english_title
     content_for :head do
       tag('meta', name: 'verify|title', content: content_for(:page_title_in_english))
     end

--- a/app/models/transaction_translation_response.rb
+++ b/app/models/transaction_translation_response.rb
@@ -1,5 +1,8 @@
 class TransactionTranslationResponse < Api::Response
-  attr_reader :name, :rp_name, :analytics_description, :other_ways_text, :other_ways_description, :tailored_text, :taxon_name, :custom_fail_heading, :custom_fail_what_next_content, :custom_fail_other_options, :custom_fail_try_another_summary, :custom_fail_try_another_text, :custom_fail_contact_details_intro
+  attr_reader :name, :rp_name, :analytics_description, :other_ways_text, :other_ways_description, :tailored_text,
+              :taxon_name, :custom_fail_heading, :custom_fail_what_next_content, :custom_fail_other_options,
+              :custom_fail_try_another_summary, :custom_fail_try_another_text, :custom_fail_contact_details_intro,
+              :single_idp_start_page_content_html, :single_idp_start_page_title
   validates :name, :rp_name, :analytics_description, :other_ways_text, :other_ways_description, :tailored_text, presence: true
 
   def initialize(hash)
@@ -16,6 +19,8 @@ class TransactionTranslationResponse < Api::Response
     @custom_fail_try_another_summary = hash['customFailTryAnotherSummary']
     @custom_fail_try_another_text = hash['customFailTryAnotherText']
     @custom_fail_contact_details_intro = hash['customFailContactDetailsIntro']
+    @single_idp_start_page_content_html = hash['singleIdpStartPageContent']
+    @single_idp_start_page_title = hash['singleIdpStartPageTitle']
   end
 
   def to_h
@@ -32,7 +37,9 @@ class TransactionTranslationResponse < Api::Response
       custom_fail_other_options: custom_fail_other_options,
       custom_fail_try_another_summary: custom_fail_try_another_summary,
       custom_fail_try_another_text: custom_fail_try_another_text,
-      custom_fail_contact_details_intro: custom_fail_contact_details_intro
+      custom_fail_contact_details_intro: custom_fail_contact_details_intro,
+      single_idp_start_page_content_html: @single_idp_start_page_content_html,
+      single_idp_start_page_title: @single_idp_start_page_title
     }
   end
 end

--- a/app/views/single_idp_journey/rp_start_page.html.erb
+++ b/app/views/single_idp_journey/rp_start_page.html.erb
@@ -1,0 +1,7 @@
+<%= content_for :page_title, @translation[:single_idp_start_page_title] %>
+<%= content_for :show_to_search_engine, false %>
+<%= analytics_title @english_translation[:single_idp_start_page_title] %>
+
+<div class="grid-row no-right-hand-logo">
+  <%= raw(@translation[:single_idp_start_page_content_html] % { start_url: @headless_start_page }) %>
+</div>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -61,6 +61,7 @@ cy:
     paused_registration: wedi-oedi
     resume_registration: ail-ddechrau-cofrestru
     paused_registration_resume_link: wedi-oedi/:idp
+    single_idp_start_page: single-start-welsh/:transaction_simple_id
   title:
     error: Error
   navigation:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -61,6 +61,7 @@ en:
     paused_registration: paused
     resume_registration: resume-registration
     paused_registration_resume_link: paused/:idp
+    single_idp_start_page: single-start/:transaction_simple_id
   title:
     error: Error
   navigation:

--- a/config/main_routes.rb
+++ b/config/main_routes.rb
@@ -126,4 +126,5 @@ if SINGLE_IDP_FEATURE
   get 'redirect_to_single_idp', to: 'redirect_to_idp#single_idp', as: :redirect_to_single_idp
   get 'continue_to_your_idp', to: 'single_idp_journey#continue_to_your_idp', as: :continue_to_your_idp
   post 'continue_to_your_idp', to: 'single_idp_journey#continue'
+  get 'single_idp_start_page', to: 'single_idp_journey#rp_start_page', as: :single_idp_start_page
 end

--- a/spec/api_test_helper.rb
+++ b/spec/api_test_helper.rb
@@ -81,7 +81,9 @@ module ApiTestHelper
         "otherWaysText":"<p>If you can’t verify your identity using GOV.UK Verify, you can test GOV.UK Verify user journeys <a href=\"http://www.example.com\">here</a>.</p><p>Tell us your:</p><ul><li>name</li><li>age</li></ul><p>Include any other relevant details if you have them.</p>",
         "otherWaysDescription":"test GOV.UK Verify user journeys",
         "tailoredText":"External data source: EN: This is tailored text for test-rp",
-        "taxonName":"Benefits"
+        "taxonName":"Benefits",
+        "singleIdpStartPageTitle": "This is the Single IDP Start Page Title",
+        "singleIdpStartPageContent": "This is the Single IDP Start Page Content <a href=\'%<start_url>s\'>Sign In</a>"
       }'
     stub_request(:get, api_translations_endpoint('test-rp', 'en')).to_return(body: en_translation_data, status: 200)
     cy_translation_data = '{
@@ -91,7 +93,9 @@ module ApiTestHelper
         "otherWaysText":"<p>Welsh If you can’t verify your identity using GOV.UK Verify, you can test GOV.UK Verify user journeys <a href=\"http://www.example.com\">here</a>.</p><p>Tell us your:</p><ul><li>name</li><li>age</li></ul><p>Include any other relevant details if you have them.</p>",
         "otherWaysDescription":"Welsh test GOV.UK Verify user journeys",
         "tailoredText":"Welsh External data source: EN: This is tailored text for test-rp",
-        "taxonName":"Welsh Benefits"
+        "taxonName":"Welsh Benefits",
+        "singleIdpStartPageTitle": "This is the Single IDP Start Page Title-Welsh",
+        "singleIdpStartPageContent": "This is the Single IDP Start Page Content in Welsh <a href=\'%<start_url>s\'>Sign In</a>"
       }'
     stub_request(:get, api_translations_endpoint('test-rp', 'cy')).to_return(body: cy_translation_data, status: 200)
     test_rp_noc3_translations = '{

--- a/spec/controllers/single_idp_journey_controller_spec.rb
+++ b/spec/controllers/single_idp_journey_controller_spec.rb
@@ -266,4 +266,29 @@ describe SingleIdpJourneyController do
       expect(subject).to redirect_to redirect_to_single_idp_path
     end
   end
+
+  context "#rp_start_page" do
+    before :each do
+      stub_transactions_list
+      stub_translations
+    end
+
+    it 'renders 404 error if invalid RP passed' do
+      get :rp_start_page, params: { locale: 'en', transaction_simple_id: 'bad-rp' }
+
+      expect(subject).to render_template 'errors/404'
+    end
+
+    it 'renders 404 error if RP does not have singleIdpStartPage content defined' do
+      get :rp_start_page, params: { locale: 'en', transaction_simple_id: 'test-rp-noc3' }
+
+      expect(subject).to render_template 'errors/404'
+    end
+
+    it 'renders correct page if RP has singleIdpStartPage content defined' do
+      get :rp_start_page, params: { locale: 'en', transaction_simple_id: 'test-rp' }
+
+      expect(subject).to render_template 'rp_start_page'
+    end
+  end
 end

--- a/spec/features/user_visits_rp_single_idp_start_page_spec.rb
+++ b/spec/features/user_visits_rp_single_idp_start_page_spec.rb
@@ -1,0 +1,13 @@
+require 'feature_helper'
+require 'api_test_helper'
+require 'cookie_names'
+
+RSpec.describe 'When the user visits the start page' do
+  it 'will display the start page in English' do
+    stub_transactions_list
+    stub_translations
+    visit '/single-start/test-rp'
+    expect(page).to have_content "This is the Single IDP Start Page Content"
+    expect(page).to have_link "Sign In", href: "http://localhost:50130/success?rp-name=test-rp"
+  end
+end


### PR DESCRIPTION
Add endpoint and route for Hub Hosted Customised Start Pages for Single IDP
Read new attribute from config service translations to display content.

Co-authored-by: Kerr Rainey <kerr.rainey@digital.cabinet-office.gov.uk>