### PR TITLE
BAU: Add simpleId to the returned results for SIDP

### DIFF
--- a/app/models/display/rp/service_list_data_correlator.rb
+++ b/app/models/display/rp/service_list_data_correlator.rb
@@ -1,7 +1,7 @@
 module Display
   module Rp
     class ServiceListDataCorrelator
-      Transaction = Struct.new(:name, :loa, :serviceCategory, :serviceId)
+      Transaction = Struct.new(:name, :loa, :serviceCategory, :serviceId, :simpleId)
 
       def initialize(rp_display_repository)
         @rp_display_repository = rp_display_repository
@@ -12,7 +12,7 @@ module Display
           simple_id = transaction.fetch('simpleId')
           display_data = @rp_display_repository.get_translations(simple_id)
           Transaction.new(display_data.name, transaction.fetch('loaList').min,
-                          display_data.taxon, transaction.fetch('entityId'))
+                          display_data.taxon, transaction.fetch('entityId'), simple_id)
         end
       rescue KeyError => e
         Rails.logger.error e

--- a/spec/models/display/rp/service_list_data_correlator_spec.rb
+++ b/spec/models/display/rp/service_list_data_correlator_spec.rb
@@ -99,25 +99,29 @@ module Display
             transaction_a_name,
             expected_public_simple_id_loa,
             public_taxon,
-            entityId
+            entityId,
+            public_simple_id
           ),
           ServiceListDataCorrelator::Transaction.new(
             transaction_2_name,
             expected_public_simple_id_2_loa,
             public_taxon_2,
-            entityId_2
+            entityId_2,
+            public_simple_id_2
           ),
           ServiceListDataCorrelator::Transaction.new(
             transaction_3_name,
             expected_public_simple_id_3_loa,
             public_taxon_3,
-            entityId_3
+            entityId_3,
+            public_simple_id_3
           ),
           ServiceListDataCorrelator::Transaction.new(
             transaction_4_name,
             expected_public_simple_id_4_loa,
             public_taxon_4,
-            entityId_4
+            entityId_4,
+            public_simple_id_4
           )
         ]
         expect(actual_result).to eq expected_result


### PR DESCRIPTION
In order to help IDPs to map services internally we expose
simpleId to use as a reference for their own mapping.

[Tech spec update here.](https://github.com/alphagov/verify-architecture/pull/67)