### PR TITLE
BAU: Ignore local.env file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 /log/*
 !/log/.keep
 /tmp
+.gems
 .idea
 *.swp
 local.env

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 /tmp
 .idea
 *.swp
+local.env
 
 verify-frontend.iml
 


### PR DESCRIPTION
local.env file is generated by generate-env.rb in verify-local-startup repo. This file is used for running application locally and it should not be in GitHub. Please note that .gitignore file will not ignore .env file.

Author: @adityapahuja