### PR TITLE
BAU: Add more reporting for SIDP

### DIFF
--- a/app/controllers/single_idp_journey_controller.rb
+++ b/app/controllers/single_idp_journey_controller.rb
@@ -138,7 +138,7 @@ private
     return false if cookie_value_is_missing(%w(idp_entity_id transaction_id uuid))
 
     unless cookie_matches_session?(transaction_id)
-      logger.error "The value of the Single IDP cookie does not match the session for transaction_id #{transaction_id}" + referrer_string
+      logger.error "The value of the Single IDP cookie does not match the session value of #{session[:transaction_entity_id]} for transaction_id #{transaction_id}" + referrer_string
       return false
     end
 

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -26,6 +26,7 @@ cy:
     unlikely_to_verify: anhebygol-i-ddilysu
     redirect_to_idp_warning: ailgyfeirio-i-rybudd-idp
     redirect_to_idp_question: ailgyfeirio-i-gwestiwn-idp
+    redirect_to_single_idp: redirect-to-single-idp-cy
     continue_to_your_idp: parhau-ich-idp
     idp_wont_work_for_you_one_doc: nid-yw-idp-yn-gweithio-i-chi-un-ddogfen
     privacy_notice: hysbysiad-preifatrwydd

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -26,6 +26,7 @@ en:
     unlikely_to_verify: unlikely-to-verify
     redirect_to_idp_warning: redirect-to-idp-warning
     redirect_to_idp_question: redirect-to-idp-question
+    redirect_to_single_idp: redirect-to-single-idp
     continue_to_your_idp: continue-to-your-idp
     idp_wont_work_for_you_one_doc: idp-wont-work-for-you-one-doc
     privacy_notice: privacy-notice

--- a/spec/controllers/single_idp_journey_controller_spec.rb
+++ b/spec/controllers/single_idp_journey_controller_spec.rb
@@ -214,7 +214,7 @@ describe SingleIdpJourneyController do
         uuid: UUID_ONE
       }
       cookies.encrypted[CookieNames::VERIFY_SINGLE_IDP_JOURNEY] = single_idp_cookie.to_json
-      expect(Rails.logger).to receive(:error).with(/The value of the Single IDP cookie does not match the session for transaction_id disabled-rp/)
+      expect(Rails.logger).to receive(:error).with(/The value of the Single IDP cookie does not match the session value of http:\/\/www.test-rp.gov.uk\/SAML2\/MD for transaction_id disabled-rp/)
       expect(subject).to redirect_to(start_path)
     end
 
@@ -237,7 +237,7 @@ describe SingleIdpJourneyController do
           uuid: UUID_ONE
       }
       cookies.encrypted[CookieNames::VERIFY_SINGLE_IDP_JOURNEY] = single_idp_cookie.to_json
-      expect(Rails.logger).to receive(:error).with(/The value of the Single IDP cookie does not match the session for transaction_id test-rp-noc3/)
+      expect(Rails.logger).to receive(:error).with(/The value of the Single IDP cookie does not match the session value of http:\/\/www.test-rp.gov.uk\/SAML2\/MD for transaction_id test-rp-noc3/)
       expect(subject).to redirect_to(start_path)
     end
   end


### PR DESCRIPTION
Adding some more information to the error message when session doesn't match
the cookie.
Also fixed the missing translation for the route.