### PR TITLE
BAU: Do not show onboarding services on the SIDP endpoint

### DIFF
--- a/app/controllers/metadata_controller.rb
+++ b/app/controllers/metadata_controller.rb
@@ -20,7 +20,9 @@ class MetadataController < ApplicationController
   end
 
   def service_list
-    transactions = transactions_for_service_list
+    transaction_list = transactions_for_service_list
+    displayed_transactions = RPS_NAME_AND_HOMEPAGE
+    transactions = displayed_transactions.map { |simple_id| transaction_list.select { |tx| tx['simpleId'] == simple_id } }.flatten
     render json: transactions
   end
 

--- a/config/initializers/30_federation.rb
+++ b/config/initializers/30_federation.rb
@@ -35,11 +35,11 @@ Rails.application.config.after_initialize do
   # RP/transactions config
   RP_CONFIG = YAML.load_file(CONFIG.rp_config)
   CONTINUE_ON_FAILED_REGISTRATION_RPS = RP_CONFIG.fetch('allow_continue_on_failed_registration', [])
-  rps_name_and_homepage = RP_CONFIG['transaction_type']['display_name_and_homepage'] || []
+  RPS_NAME_AND_HOMEPAGE = RP_CONFIG['transaction_type']['display_name_and_homepage'] || []
   rps_name_only = RP_CONFIG['transaction_type']['display_name_only'] || []
   REDIRECT_TO_RP_LIST = RP_CONFIG['redirect_to_rp'] || []
-  DATA_CORRELATOR = Display::Rp::DisplayDataCorrelator.new(RP_DISPLAY_REPOSITORY, rps_name_and_homepage.clone, rps_name_only.clone)
-  TRANSACTION_TAXON_CORRELATOR = Display::Rp::TransactionTaxonCorrelator.new(RP_DISPLAY_REPOSITORY, rps_name_and_homepage.clone, rps_name_only.clone)
+  DATA_CORRELATOR = Display::Rp::DisplayDataCorrelator.new(RP_DISPLAY_REPOSITORY, RPS_NAME_AND_HOMEPAGE.clone, rps_name_only.clone)
+  TRANSACTION_TAXON_CORRELATOR = Display::Rp::TransactionTaxonCorrelator.new(RP_DISPLAY_REPOSITORY, RPS_NAME_AND_HOMEPAGE.clone, rps_name_only.clone)
 
   SERVICE_LIST_DATA_CORRELATOR = Display::Rp::ServiceListDataCorrelator.new(RP_DISPLAY_REPOSITORY)
 

--- a/spec/controllers/metadata_controller_spec.rb
+++ b/spec/controllers/metadata_controller_spec.rb
@@ -6,12 +6,12 @@ require 'api_test_helper'
 describe MetadataController do
   subject { get :service_list, params: { locale: 'en' } }
 
-  it 'json array should contain 4 objects with correct values' do
+  it 'json array should contain 2 filtered out objects with correct values' do
     stub_transactions_for_single_idp_list
 
     body = JSON.parse(subject.body)
 
-    expect(body.size).to eq(4)
+    expect(body.size).to eq(2)
     expect(subject.content_type).to eq('application/json')
     expect(subject).to have_http_status(200)
 


### PR DESCRIPTION
To allow testing against test services we can enable them in the config. However,
then they will appear in the get-available-services endpoint along with the test ones.
This change filters out the test ones using the name_and_homepage list. In production this is the list: https://github.com/alphagov/verify-frontend-federation-config/blob/ece7721b9893d86be8964becd442adb0d3342ffa/configuration/relying_parties.yml#L25