### PR TITLE
Add copy for IDP disconnect

### DIFF
--- a/app/views/shared/_disconnected_idp_list.erb
+++ b/app/views/shared/_disconnected_idp_list.erb
@@ -3,7 +3,7 @@
     <h2 class="heading-medium"><%= t 'hub.certified_companies_disconnected.title' %></h2>
     <p><%=
       t('hub.certified_companies_disconnected.verify_another_company_html',
-        link: link_to(t('hub.certified_companies_disconnected.verify_another_company_link'), choose_a_certified_company_path)
+        link: link_to(t('hub.certified_companies_disconnected.verify_another_company_link'), begin_registration_path, id: 'begin-registration-route')
       )
     %></p>
   </div>

--- a/app/views/shared/_disconnected_idp_list.erb
+++ b/app/views/shared/_disconnected_idp_list.erb
@@ -2,7 +2,9 @@
   <div class="column-two-thirds">
     <h2 class="heading-medium"><%= t 'hub.certified_companies_disconnected.title' %></h2>
     <p><%=
-      t 'hub.certified_companies_disconnected.verify_another_company_html'
+      t('hub.certified_companies_disconnected.verify_another_company_html',
+        link: link_to(t('hub.certified_companies_disconnected.verify_another_company_link'), choose_a_certified_company_path)
+      )
     %></p>
   </div>
 </div>

--- a/app/views/shared/_disconnected_idp_list.erb
+++ b/app/views/shared/_disconnected_idp_list.erb
@@ -3,7 +3,7 @@
     <h2 class="heading-medium"><%= t 'hub.certified_companies_disconnected.title' %></h2>
     <p><%=
       t('hub.certified_companies_disconnected.verify_another_company_html',
-        link: link_to(t('hub.certified_companies_disconnected.verify_another_company_link'), begin_registration_path, id: 'begin-registration-route')
+        link: link_to(t('hub.certified_companies_disconnected.verify_another_company_link'), begin_registration_path, id: 'begin-registration-route-2')
       )
     %></p>
   </div>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -508,7 +508,7 @@ cy:
       verify_another_company_html: Er mwyn cael mynediad i wasanaethau'r llywodraeth, mae'n rhaid i chi %{link}.
       verify_another_company_link: ddilysu eich hunaniaeth gyda chwmni ardystiedig arall
     certified_companies_disconnected:
-      title: The following companies are no longer providing identity services as part of GOV.UK Verify.
+      title: The following companies are no longer providing identity services as part of GOV.UK Verify
       verify_another_company_html: If you have an identity account with one of these companies, you'll need to %{link}.
       verify_another_company_link: verify your identity with another certified company 
     further_information:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -508,8 +508,9 @@ cy:
       verify_another_company_html: Er mwyn cael mynediad i wasanaethau'r llywodraeth, mae'n rhaid i chi %{link}.
       verify_another_company_link: ddilysu eich hunaniaeth gyda chwmni ardystiedig arall
     certified_companies_disconnected:
-      title: Nid yw'r cwmnïau hyn ar gael dros dro gyda GOV.UK Verify
-      verify_another_company_html: Gallwch geisio nes ymlaen eto neu wirio'ch hunaniaeth gyda chwmni ardystiedig arall.
+      title: The following companies are no longer providing identity services as part of GOV.UK Verify.
+      verify_another_company_html: If you have an identity account with one of these companies, you'll need to %{link}.
+      verify_another_company_link: verify your identity with another certified company 
     further_information:
       title: Rhowch eich %{cycle_three_name}
       first_time: Hwn yw'r tro cyntaf i chi fewngofnodi.

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -508,9 +508,9 @@ cy:
       verify_another_company_html: Er mwyn cael mynediad i wasanaethau'r llywodraeth, mae'n rhaid i chi %{link}.
       verify_another_company_link: ddilysu eich hunaniaeth gyda chwmni ardystiedig arall
     certified_companies_disconnected:
-      title: The following companies are no longer providing identity services as part of GOV.UK Verify
-      verify_another_company_html: If you have an identity account with one of these companies, you'll need to %{link}.
-      verify_another_company_link: verify your identity with another certified company 
+      title: Nid yw'r cwmnïau canlynol bellach yn rhan o GOV.UK Verify
+      verify_another_company_html: Os oedd gennych gyfrif hunaniaeth gydag un o'r cwmnïau hyn, bydd angen i chi %{link}.
+      verify_another_company_link: dilysu eich hunaniaeth gyda chwmni arall
     further_information:
       title: Rhowch eich %{cycle_three_name}
       first_time: Hwn yw'r tro cyntaf i chi fewngofnodi.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -502,8 +502,9 @@ en:
       verify_another_company_html: To access government services, you must %{link}.
       verify_another_company_link: verify your identity with another certified company
     certified_companies_disconnected:
-      title: These companies are temporarily unavailable with GOV.UK Verify
-      verify_another_company_html: You can try again later or verify your identity with another certified company.
+      title: The following companies are no longer providing identity services as part of GOV.UK Verify.
+      verify_another_company_html: If you have an identity account with one of these companies, you'll need to %{link}.
+      verify_another_company_link: verify your identity with another certified company 
     further_information:
       title: Enter your %{cycle_three_name}
       first_time: This is the first time you’ve signed in.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -502,7 +502,7 @@ en:
       verify_another_company_html: To access government services, you must %{link}.
       verify_another_company_link: verify your identity with another certified company
     certified_companies_disconnected:
-      title: The following companies are no longer providing identity services as part of GOV.UK Verify.
+      title: The following companies are no longer providing identity services as part of GOV.UK Verify
       verify_another_company_html: If you have an identity account with one of these companies, you'll need to %{link}.
       verify_another_company_link: verify your identity with another certified company 
     further_information:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -502,9 +502,9 @@ en:
       verify_another_company_html: To access government services, you must %{link}.
       verify_another_company_link: verify your identity with another certified company
     certified_companies_disconnected:
-      title: The following companies are no longer providing identity services as part of GOV.UK Verify
-      verify_another_company_html: If you have an identity account with one of these companies, you'll need to %{link}.
-      verify_another_company_link: verify your identity with another certified company 
+      title: The following companies are no longer part of GOV.UK Verify
+      verify_another_company_html: If you had an identity account with one of these companies, you'll need to %{link}.
+      verify_another_company_link: verify your identity with a different company
     further_information:
       title: Enter your %{cycle_three_name}
       first_time: This is the first time you’ve signed in.


### PR DESCRIPTION
Royal Mail and Citizensafe come to the end of their continued assurance period on March 1st. Therefore, we need to have the copy in place to explain to users why they can no longer use those IDPs to log in any more.

I've not done any testing of this PR, and we need to get the Welsh translation before merging.

See https://trello.com/c/vi7RV11M