### PR TITLE
ZD-3565728 Alter layout of feedback tickets

### DIFF
--- a/app/models/feedback_service.rb
+++ b/app/models/feedback_service.rb
@@ -17,6 +17,12 @@ private
 
   ERROR_MESSAGE_TEMPLATE = %{User feedback received
 
+What were you trying to do?
+<%= form.what %>
+
+Please provide details of your question, problem or feedback:
+<%= form.details %>
+
 session id: <%= session_id %>
 
 From page: <%= form.referer %>
@@ -24,12 +30,6 @@ From page: <%= form.referer %>
 User agent: <%= form.user_agent %>
 
 Javascript enabled: <%= form.js_enabled? %>
-
-What were you trying to do?
-<%= form.what %>
-
-Please provide details of your question, problem or feedback:
-<%= form.details %>
 
 From user: <%= presented_name(form) %>
 With email: <%= presented_email(form) %>

--- a/spec/models/feedback_service_spec.rb
+++ b/spec/models/feedback_service_spec.rb
@@ -18,6 +18,12 @@ describe FeedbackService do
   let(:feedback_comment_value) {
     %{User feedback received
 
+What were you trying to do?
+#{what}
+
+Please provide details of your question, problem or feedback:
+#{details}
+
 session id: #{session_id}
 
 From page: #{referer}
@@ -25,12 +31,6 @@ From page: #{referer}
 User agent: #{user_agent}
 
 Javascript enabled: #{js_enabled}
-
-What were you trying to do?
-#{what}
-
-Please provide details of your question, problem or feedback:
-#{details}
 
 From user:\s
 With email: #{default_email}
@@ -40,6 +40,12 @@ With email: #{default_email}
   let(:enquiry_comment_value) {
     %{User feedback received
 
+What were you trying to do?
+#{what}
+
+Please provide details of your question, problem or feedback:
+#{details}
+
 session id: #{session_id}
 
 From page: #{referer}
@@ -47,12 +53,6 @@ From page: #{referer}
 User agent: #{user_agent}
 
 Javascript enabled: #{js_enabled}
-
-What were you trying to do?
-#{what}
-
-Please provide details of your question, problem or feedback:
-#{details}
 
 From user: #{name}
 With email: #{email}


### PR DESCRIPTION
Change template so that Zendesk agents can inspect tickets using tooltip rather than opening ticket.

Co-authored-by: Alan Carter <alan.carter@digital.cabinet-office.gov.uk>