### PR TITLE
Zendesk 3572104: fix init-journey when headless start unknown

### DIFF
--- a/app/controllers/initiate_journey_controller.rb
+++ b/app/controllers/initiate_journey_controller.rb
@@ -12,17 +12,18 @@ class InitiateJourneyController < ApplicationController
     journey_hint_value = params.fetch('journey_hint', nil)
 
     transaction = CONFIG_PROXY.get_transaction_by_simple_id(simple_id_value)
-    headless_start_page = transaction.nil? ? nil : transaction.fetch('headlessStartpage')
+    start_page = transaction.nil? ? nil : transaction.fetch('headlessStartpage') || transaction.fetch('serviceHomepage')
 
-    if !headless_start_page.nil?
+    if !start_page.nil?
       if valid_journey_hint?(journey_hint_value)
         session[:journey_hint] = journey_hint_value
         session[:journey_hint_rp] = simple_id_value
-        return redirect_to merge_query_params(headless_start_page, journey_hint_value)
+        return redirect_to merge_query_params(start_page, journey_hint_value)
       end
       logger.warn(invalid_parameters_message(simple_id_value, journey_hint_value))
-      return redirect_to headless_start_page
+      return redirect_to start_page
     end
+
     something_went_wrong(invalid_parameters_message(simple_id_value, journey_hint_value), 400)
   end
 

--- a/spec/controllers/initiate_journey_controller_spec.rb
+++ b/spec/controllers/initiate_journey_controller_spec.rb
@@ -24,10 +24,10 @@ describe InitiateJourneyController do
       expect(session[:journey_hint_rp]).to eq('test-rp')
     end
 
-    it 'should redirect to error page if headless startpage not defined for RP' do
+    it 'should redirect to service homepage if headless startpage not defined for RP' do
       get :index, params: { transaction_simple_id: 'test-rp-noc3', locale: 'en' }
 
-      expect(subject).to render_template("errors/something_went_wrong")
+      expect(subject).to redirect_to('http://localhost:50130/test-rp-noc3')
     end
   end
 


### PR DESCRIPTION
* if headless start page isn't known, we can redirect to the service's homepage instead
* fixes a crasher in live for timed-out sessions.

https://govuk.zendesk.com/agent/tickets/3572104