### PR TITLE
ZD-3576498 avoid logging an error for a Single IDP journey interruption.

### DIFF
--- a/app/controllers/single_idp_journey_controller.rb
+++ b/app/controllers/single_idp_journey_controller.rb
@@ -138,7 +138,9 @@ private
     return false if cookie_value_is_missing(%w(idp_entity_id transaction_id uuid))
 
     unless cookie_matches_session?(transaction_id)
-      logger.error "The value of the Single IDP cookie does not match the session value of #{session[:transaction_entity_id]} for transaction_id #{transaction_id}" + referrer_string
+      # TODO: we think this should be noted in Piwik; probably does't need to be in the error log at all
+      logger.info "The value of the Single IDP cookie does not match the session value of #{session[:transaction_entity_id]}"\
+                      " for transaction_id #{transaction_id}" + referrer_string
       return false
     end
 

--- a/app/controllers/single_idp_journey_controller.rb
+++ b/app/controllers/single_idp_journey_controller.rb
@@ -140,7 +140,7 @@ private
     unless cookie_matches_session?(transaction_id)
       # TODO: we think this should be noted in Piwik; probably does't need to be in the error log at all
       logger.info "The value of the Single IDP cookie does not match the session value of #{session[:transaction_entity_id]}"\
-                      " for transaction_id #{transaction_id}" + referrer_string
+                      " for transaction_id #{transaction_id} with uuid #{uuid}"
       return false
     end
 

--- a/spec/controllers/single_idp_journey_controller_spec.rb
+++ b/spec/controllers/single_idp_journey_controller_spec.rb
@@ -214,7 +214,7 @@ describe SingleIdpJourneyController do
         uuid: UUID_ONE
       }
       cookies.encrypted[CookieNames::VERIFY_SINGLE_IDP_JOURNEY] = single_idp_cookie.to_json
-      expect(Rails.logger).to receive(:error).with(/The value of the Single IDP cookie does not match the session value of http:\/\/www.test-rp.gov.uk\/SAML2\/MD for transaction_id disabled-rp/)
+      expect(Rails.logger).to receive(:info).with(/The value of the Single IDP cookie does not match the session value of http:\/\/www.test-rp.gov.uk\/SAML2\/MD for transaction_id disabled-rp/)
       expect(subject).to redirect_to(start_path)
     end
 
@@ -237,7 +237,7 @@ describe SingleIdpJourneyController do
           uuid: UUID_ONE
       }
       cookies.encrypted[CookieNames::VERIFY_SINGLE_IDP_JOURNEY] = single_idp_cookie.to_json
-      expect(Rails.logger).to receive(:error).with(/The value of the Single IDP cookie does not match the session value of http:\/\/www.test-rp.gov.uk\/SAML2\/MD for transaction_id test-rp-noc3/)
+      expect(Rails.logger).to receive(:info).with(/The value of the Single IDP cookie does not match the session value of http:\/\/www.test-rp.gov.uk\/SAML2\/MD for transaction_id test-rp-noc3/)
       expect(subject).to redirect_to(start_path)
     end
   end


### PR DESCRIPTION
(Plan to do another PR with the piwik change, but I can't get it to work yet :/ )

 - these events are often (tho not always) a legitimate change of
   journey for the user, so we shouldn't log them as errors.

 - the information may still be useful in diagnosing cases where the
   user did not intend to change from one transaction to another,
   which is also a separate issue:
   https://govuk.zendesk.com/agent/tickets/3559335

https://trello.com/c/Xymb17Ua/39-single-idp-journey-interruptions-should-not-log-an-error
https://govuk.zendesk.com/agent/tickets/3576498