### PR TITLE
HUB-7 Add Piwik event for unexpected single IDP journey

### DIFF
--- a/app/controllers/single_idp_journey_controller.rb
+++ b/app/controllers/single_idp_journey_controller.rb
@@ -138,7 +138,8 @@ private
     return false if cookie_value_is_missing(%w(idp_entity_id transaction_id uuid))
 
     unless cookie_matches_session?(transaction_id)
-      # TODO: we think this should be noted in Piwik; probably does't need to be in the error log at all
+      FEDERATION_REPORTER.report_unexpected_single_idp_journey(current_transaction, request, session[:transaction_entity_id], uuid)
+      # TODO: we think this should be noted in Piwik; probably doesn't need to be in the error log at all
       logger.info "The value of the Single IDP cookie does not match the session value of #{session[:transaction_entity_id]}"\
                       " for transaction_id #{transaction_id} with uuid #{uuid}"
       return false

--- a/app/models/analytics/federation_reporter.rb
+++ b/app/models/analytics/federation_reporter.rb
@@ -41,6 +41,16 @@ module Analytics
       )
     end
 
+    def report_unexpected_single_idp_journey(current_transaction, request, session_value, uuid)
+      report_action(
+        current_transaction,
+        request,
+        'The user unexpectedly entered the single idp journey',
+        Analytics::CustomVariable.build(:session_value, session_value)
+            .merge(Analytics::CustomVariable.build(:uuid, uuid))
+      )
+    end
+
     def report_ab_test(transaction_id, request, alternative_name)
       unless transaction_id.nil?
         current_transaction = RP_DISPLAY_REPOSITORY.get_translations(transaction_id)

--- a/lib/analytics/custom_variable.rb
+++ b/lib/analytics/custom_variable.rb
@@ -7,6 +7,8 @@ module Analytics
       cycle_three_attribute: { name: 'CYCLE_3', index: 4 },
       idp_selection: { name: 'IDP_SELECTION', index: 5 },
       ab_test: { name: 'AB_TEST', index: 6 },
+      session_value: { name: 'SESSION_VALUE', index: 7 },
+      uuid: { name: 'UUID', index: 8 },
     }.freeze
 
     def self.build(type, value)

--- a/spec/models/analytics/federation_reporter_spec.rb
+++ b/spec/models/analytics/federation_reporter_spec.rb
@@ -363,5 +363,22 @@ module Analytics
         federation_reporter.report_number_of_idps_recommended(current_transaction, request, 5)
       end
     end
+
+    describe '#report_unexpected_single_idp_journey' do
+      it 'should report an unexpected single idp journey' do
+        session_value = 'session_value'
+        uuid = 'uuid'
+        expect(analytics_reporter).to receive(:report_action)
+          .with(
+            request,
+            'The user unexpectedly entered the single idp journey',
+            1 => %w(RP description),
+            2 => %w(LOA_REQUESTED LEVEL_2),
+            7 => ['SESSION_VALUE', session_value],
+            8 => ['UUID', uuid]
+          )
+        federation_reporter.report_unexpected_single_idp_journey(current_transaction, request, session_value, uuid)
+      end
+    end
   end
 end


### PR DESCRIPTION
Add a new event type, and fire it when a user's cookie value isn't as expected. Make it easier to see when users are encountering this rather odd journey from the Piwik data.

Co-authored-by: John Watts <john.watts@digital.cabinet-office.gov.uk>