### PR TITLE
BAU Add logging for failed IDP response statuses

### DIFF
--- a/app/controllers/authn_response_controller.rb
+++ b/app/controllers/authn_response_controller.rb
@@ -32,6 +32,8 @@ class AuthnResponseController < SamlController
 
     return handle_idp_response(status, response) if ACCEPTED_IDP_RESPONSES.include?(status)
 
+    logger.info("IDP response status of '#{status}' for session ID '#{session[:verify_session_id]}' not in "\
+      "accepted IDP response statuses. Falling back to 'FAILED'")
     handle_idp_response(FAILED, response)
   end
 


### PR DESCRIPTION
For this Zendesk ticket: https://govuk.zendesk.com/agent/tickets/3571167

We've had a few users end up unexpectedly on the fail page after
logging in to an IDP. This will happen if the IDP sends back a few
different statuses, which we translate to `OTHER` in policy
and return to the frontend. We currently don't have any insight into 
when this happens. This should help.