### PR TITLE
HUB-7 report single idp service mismatch

### DIFF
--- a/app/controllers/single_idp_journey_controller.rb
+++ b/app/controllers/single_idp_journey_controller.rb
@@ -25,7 +25,7 @@ class SingleIdpJourneyController < ApplicationController
       @uuid = single_idp_cookie.fetch('uuid', nil)
       session[:journey_type] = 'single-idp'
       set_additional_piwik_custom_variable(:journey_type, 'SINGLE_IDP')
-      FEDERATION_REPORTER.report_single_idp_success(current_transaction, request, @service_name, @uuid)
+      FEDERATION_REPORTER.report_single_idp_success(current_transaction, request, session[:transaction_entity_id], @uuid)
       render
     else
       redirect_to start_path

--- a/app/controllers/single_idp_journey_controller.rb
+++ b/app/controllers/single_idp_journey_controller.rb
@@ -25,6 +25,7 @@ class SingleIdpJourneyController < ApplicationController
       @uuid = single_idp_cookie.fetch('uuid', nil)
       session[:journey_type] = 'single-idp'
       set_additional_piwik_custom_variable(:journey_type, 'SINGLE_IDP')
+      FEDERATION_REPORTER.report_single_idp_success(current_transaction, request, @service_name, @uuid)
       render
     else
       redirect_to start_path
@@ -138,8 +139,11 @@ private
     return false if cookie_value_is_missing(%w(idp_entity_id transaction_id uuid))
 
     unless cookie_matches_session?(transaction_id)
-      # TODO: we think this should be noted in Piwik; probably does't need to be in the error log at all
-      logger.info "The value of the Single IDP cookie does not match the session value of #{session[:transaction_entity_id]}"\
+      actual_service_identifier = session[:transaction_entity_id]
+      FEDERATION_REPORTER.report_single_idp_service_mismatch(
+        current_transaction, request, transaction_id, actual_service_identifier, uuid
+      )
+      logger.info "The value of the Single IDP cookie does not match the session value of #{actual_service_identifier}"\
                       " for transaction_id #{transaction_id} with uuid #{uuid}"
       return false
     end

--- a/app/models/analytics/federation_reporter.rb
+++ b/app/models/analytics/federation_reporter.rb
@@ -166,13 +166,13 @@ module Analytics
       )
     end
 
-    def report_single_idp_success(current_transaction, request, service_name, uuid)
+    def report_single_idp_success(current_transaction, request, service_id, uuid)
       report_event(
         current_transaction,
         request,
         'Single IDP',
-        'success',
-        "Service: #{service_name}, UUID: #{uuid}"
+        'redirected to IDP',
+        "Service: #{service_id}, UUID: #{uuid}"
       )
     end
 
@@ -182,7 +182,7 @@ module Analytics
         request,
         'Single IDP',
         'change of service',
-        %(Expected service: #{expected_service}, Actual service: #{actual_service}, UUID: #{uuid})
+        "Expected service: #{expected_service}, Actual service: #{actual_service}, UUID: #{uuid}"
       )
     end
 

--- a/app/models/analytics/federation_reporter.rb
+++ b/app/models/analytics/federation_reporter.rb
@@ -166,6 +166,26 @@ module Analytics
       )
     end
 
+    def report_single_idp_success(current_transaction, request, service_name, uuid)
+      report_event(
+        current_transaction,
+        request,
+        'Single IDP',
+        'success',
+        "Service: #{service_name}, UUID: #{uuid}"
+      )
+    end
+
+    def report_single_idp_service_mismatch(current_transaction, request, expected_service, actual_service, uuid)
+      report_event(
+        current_transaction,
+        request,
+        'Single IDP',
+        'change of service',
+        %(Expected service: #{expected_service}, Actual service: #{actual_service}, UUID: #{uuid})
+      )
+    end
+
     def report_action(current_transaction, request, action, extra_custom_vars = {})
       begin
         @analytics_reporter.report_action(

--- a/spec/models/analytics/federation_reporter_spec.rb
+++ b/spec/models/analytics/federation_reporter_spec.rb
@@ -363,5 +363,44 @@ module Analytics
         federation_reporter.report_number_of_idps_recommended(current_transaction, request, 5)
       end
     end
+
+    describe '#report_single_idp_success' do
+      it 'should record that we are successfully continuing to the user\'s IDP' do
+        service = 'service'
+        uuid = '123'
+        expect(analytics_reporter).to receive(:report_event)
+          .with(
+            request,
+            {
+              1 => %w(RP description),
+              2 => %w(LOA_REQUESTED LEVEL_2)
+            },
+            'Single IDP',
+            'success',
+            "Service: #{service}, UUID: #{uuid}"
+          )
+        federation_reporter.report_single_idp_success(current_transaction, request, service, uuid)
+      end
+    end
+
+    describe '#report_single_idp_service_mismatch' do
+      it 'should record the expected service and the service in the request' do
+        expected_service = 'original'
+        actual_service = 'current'
+        uuid = '123'
+        expect(analytics_reporter).to receive(:report_event)
+          .with(
+            request,
+            {
+              1 => %w(RP description),
+              2 => %w(LOA_REQUESTED LEVEL_2)
+            },
+            'Single IDP',
+            'change of service',
+            "Expected service: #{expected_service}, Actual service: #{actual_service}, UUID: #{uuid}"
+          )
+        federation_reporter.report_single_idp_service_mismatch(current_transaction, request, expected_service, actual_service, uuid)
+      end
+    end
   end
 end

--- a/spec/models/analytics/federation_reporter_spec.rb
+++ b/spec/models/analytics/federation_reporter_spec.rb
@@ -363,44 +363,5 @@ module Analytics
         federation_reporter.report_number_of_idps_recommended(current_transaction, request, 5)
       end
     end
-
-    describe '#report_single_idp_success' do
-      it 'should record that we are successfully continuing to the user\'s IDP' do
-        service = 'service'
-        uuid = '123'
-        expect(analytics_reporter).to receive(:report_event)
-          .with(
-            request,
-            {
-              1 => %w(RP description),
-              2 => %w(LOA_REQUESTED LEVEL_2)
-            },
-            'Single IDP',
-            'success',
-            "Service: #{service}, UUID: #{uuid}"
-          )
-        federation_reporter.report_single_idp_success(current_transaction, request, service, uuid)
-      end
-    end
-
-    describe '#report_single_idp_service_mismatch' do
-      it 'should record the expected service and the service in the request' do
-        expected_service = 'original'
-        actual_service = 'current'
-        uuid = '123'
-        expect(analytics_reporter).to receive(:report_event)
-          .with(
-            request,
-            {
-              1 => %w(RP description),
-              2 => %w(LOA_REQUESTED LEVEL_2)
-            },
-            'Single IDP',
-            'change of service',
-            "Expected service: #{expected_service}, Actual service: #{actual_service}, UUID: #{uuid}"
-          )
-        federation_reporter.report_single_idp_service_mismatch(current_transaction, request, expected_service, actual_service, uuid)
-      end
-    end
   end
 end

--- a/spec/piwik_test_helper.rb
+++ b/spec/piwik_test_helper.rb
@@ -87,12 +87,32 @@ end
 
 def stub_piwik_report_number_of_recommended_idps(number_of_recommended_idps, loa, transaction_analytics_description)
   piwik_request = {
-      e_c: 'Engagement',
-      action_name: 'trackEvent',
-      e_n: 'IDPs Recommended',
-      e_a: number_of_recommended_idps.to_s
+    e_c: 'Engagement',
+    action_name: 'trackEvent',
+    e_n: 'IDPs Recommended',
+    e_a: number_of_recommended_idps.to_s
   }
   stub_piwik_request(piwik_request, {}, loa, [], transaction_analytics_description)
+end
+
+def stub_piwik_report_single_idp_success(service_id, uuid)
+  piwik_request = {
+    e_c: 'Single IDP',
+    action_name: 'trackEvent',
+    e_n: 'redirected to IDP',
+    e_a: "Service: #{service_id}, UUID: #{uuid}"
+  }
+  stub_piwik_request(piwik_request, 'User-Agent' => 'Rails Testing')
+end
+
+def stub_piwik_report_single_idp_service_mismatch(expected_service, actual_service, uuid)
+  piwik_request = {
+    e_c: 'Single IDP',
+    action_name: 'trackEvent',
+    e_n: 'change of service',
+    e_a: "Expected service: #{expected_service}, Actual service: #{actual_service}, UUID: #{uuid}"
+  }
+  stub_piwik_request(piwik_request, 'User-Agent' => 'Rails Testing')
 end
 
 def stub_piwik_journey_type_request(journey_type, action_name, loa = 'LEVEL_2')


### PR DESCRIPTION
Add piwik event reporting to enable analysis of user journeys that start at one service and end at another.

Co-authored-by: Benjamin Gill <benjamin.gill@digital.cabinet-office.gov.uk>