### PR TITLE
BAU: kill service from any directory

### DIFF
--- a/kill-service.sh
+++ b/kill-service.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+cd "$(dirname "$0")"
+
 if [ -a './tmp/stub_api.pid' ]
 then
   kill "$(< ./tmp/stub_api.pid)"
@@ -11,4 +13,3 @@ then
   kill "$(< ./tmp/puma.pid)"
   rm ./tmp/puma.pid
 fi
-


### PR DESCRIPTION
Allow users to run kill-service.sh from any other directory. Copies the pattern in startup.sh