### PR TITLE
EID-1269: Handle unexpected error response from Hub better

### DIFF
--- a/lib/api/hub_response_handler.rb
+++ b/lib/api/hub_response_handler.rb
@@ -1,6 +1,8 @@
 module Api
   class HubResponseHandler
-    ERROR_MESSAGE_PATTERN = "Received %s with error message: %s, type: '%s' and id: '%s'".freeze
+    ERROR_MESSAGE_PATTERN = "Unexpected error whilst trying to communicate wth the Hub. " \
+                            "Received %s with error message: %s, type: '%s' and id: '%s'\n" \
+                            "The Hub may be unreachable. Check all services are running and are accessible".freeze
 
     def handle_response(response_status, response_body)
       if response_status.success?

--- a/spec/lib/api/hub_response_handler_spec.rb
+++ b/spec/lib/api/hub_response_handler_spec.rb
@@ -9,34 +9,34 @@ module Api
       it 'raises an error with message, id and type from the Hub response' do
         expect {
           response_handler.handle_response(HTTP::Response::Status[500], '{"clientMessage": "Failure", "exceptionType": "BAD THING", "errorId": "1234"}')
-        }.to raise_error UpstreamError, "Received 500 with error message: 'Failure', type: 'BAD THING' and id: '1234'"
+        }.to raise_error UpstreamError, /Received 500 with error message: 'Failure', type: 'BAD THING' and id: '1234'/
       end
 
       it 'raises an error when API response is not ok with JSON, but message missing' do
         expect {
           response_handler.handle_response(HTTP::Response::Status[500], '{}')
-        }.to raise_error Error, "Received 500 with error message: 'NONE', type: 'NONE' and id: 'NONE'"
+        }.to raise_error Error, /Received 500 with error message: 'NONE', type: 'NONE' and id: 'NONE'/
       end
 
       it 'raises a session error when type is set to SESSION_ERROR' do
         error_body = { clientMessage: 'Failure', errorId: '0', exceptionType: 'EXPECTED_SESSION_STARTED_STATE_ACTUAL_IDP_SELECTED_STATE' }
         expect {
           response_handler.handle_response(HTTP::Response::Status[400], error_body.to_json)
-        }.to raise_error SessionError, "Received 400 with error message: 'Failure', type: 'EXPECTED_SESSION_STARTED_STATE_ACTUAL_IDP_SELECTED_STATE' and id: '0'"
+        }.to raise_error SessionError, /Received 400 with error message: 'Failure', type: 'EXPECTED_SESSION_STARTED_STATE_ACTUAL_IDP_SELECTED_STATE' and id: '0'/
       end
 
       it 'raises a session timeout error when type is set to SESSION_TIMEOUT' do
         error_body = { clientMessage: 'Failure', errorId: '0', exceptionType: 'SESSION_TIMEOUT' }
         expect {
           response_handler.handle_response(HTTP::Response::Status[400], error_body.to_json)
-        }.to raise_error SessionTimeoutError, "Received 400 with error message: 'Failure', type: 'SESSION_TIMEOUT' and id: '0'"
+        }.to raise_error SessionTimeoutError, /Received 400 with error message: 'Failure', type: 'SESSION_TIMEOUT' and id: '0'/
       end
 
       it 'raises an upstream error when type is set, but not SESSION_TIMEOUT or SESSION_ERROR' do
         error_body = { clientMessage: 'Failure', errorId: '0', exceptionType: 'SERVER_ERROR' }
         expect {
           response_handler.handle_response(HTTP::Response::Status[400], error_body.to_json)
-        }.to raise_error UpstreamError, "Received 400 with error message: 'Failure', type: 'SERVER_ERROR' and id: '0'"
+        }.to raise_error UpstreamError, /Received 400 with error message: 'Failure', type: 'SERVER_ERROR' and id: '0'/
       end
     end
   end


### PR DESCRIPTION
Improve the generic error message when unexpected error is received from the Hub.

We had an incident recently where eIDAS was disabled in DR and the logs showed this message:
`Received 404 with error message: 'NONE', type: 'NONE' and id: 'NONE'`
This is not a great way to handle unexpected errors when sending a request to the Hub.

We already handle error responses from the Hub when they are known exceptions. These include anything to do with the logic and flow of a Verify journey. For any other issues, such as network errors or services being down, we throw an exception with a generic message. This message should reflect the fact that the problem is related to communication with the Hub rather than a problem with the user's journey.