### PR TITLE
ZD3588200: Turn down the logging on missing or expired cookies

### DIFF
--- a/app/controllers/single_idp_journey_controller.rb
+++ b/app/controllers/single_idp_journey_controller.rb
@@ -124,7 +124,9 @@ private
 
   def valid_cookie?
     if single_idp_cookie.nil?
-      logger.error "Single IDP cookies was not found or was malformed" + referrer_string
+      # This is still valid behaviour, it can be the users session has genuinely expired,
+      # or that the session has been tampered with.
+      logger.warn "Single IDP cookies was not found or was malformed" + referrer_string
       return false
     end
     true

--- a/spec/controllers/single_idp_journey_controller_spec.rb
+++ b/spec/controllers/single_idp_journey_controller_spec.rb
@@ -177,13 +177,13 @@ describe SingleIdpJourneyController do
     end
 
     it 'should redirect to /start if cookie is missing' do
-      expect(Rails.logger).to receive(:error).with(/Single IDP cookies was not found or was malformed/)
+      expect(Rails.logger).to receive(:warn).with(/Single IDP cookies was not found or was malformed/)
       expect(subject).to redirect_to(start_path)
     end
 
     it 'should redirect to /start if cookie is corrupted' do
       cookies.encrypted[CookieNames::VERIFY_SINGLE_IDP_JOURNEY] = "blah"
-      expect(Rails.logger).to receive(:error).with(/Single IDP cookies was not found or was malformed/)
+      expect(Rails.logger).to receive(:warn).with(/Single IDP cookies was not found or was malformed/)
       expect(subject).to redirect_to(start_path)
     end
 


### PR DESCRIPTION
This is to fix the Sentry alert triggered when an cookie expires and invalidates the session.

https://govuk.zendesk.com/agent/tickets/3588200