### PR TITLE
ZD3584380: handle expired single idp cookie on continue-to-your-idp page

### DIFF
--- a/app/controllers/partials/single_idp_partial_controller.rb
+++ b/app/controllers/partials/single_idp_partial_controller.rb
@@ -1,0 +1,21 @@
+module SingleIdpPartialController
+  def single_idp_cookie
+    MultiJson.load(cookies.encrypted[CookieNames::VERIFY_SINGLE_IDP_JOURNEY])
+  rescue MultiJson::ParseError
+    nil
+  end
+
+  def valid_cookie?
+    if single_idp_cookie.nil?
+      # This is still valid behaviour, it can be the users session has genuinely expired,
+      # or that the session has been tampered with.
+      logger.warn "Single IDP cookies was not found or was malformed" + referrer_string
+      return false
+    end
+    true
+  end
+
+  def referrer_string
+    " - referrer: " + (request.nil? || request.referer.nil? ? "[could not get the referrer]" : request.referer)
+  end
+end

--- a/spec/controllers/redirect_to_idp_controller_spec.rb
+++ b/spec/controllers/redirect_to_idp_controller_spec.rb
@@ -10,6 +10,16 @@ describe RedirectToIdpController do
     session[:selected_idp_was_recommended] = [true, false].sample
   end
 
+  context 'single idp journey without cookies' do
+    subject { get :single_idp, params: { locale: 'en' } }
+
+    it 'renders a session timeout page' do
+      cookies.delete CookieNames::VERIFY_SINGLE_IDP_JOURNEY
+      expect(subject).to render_template(:session_timeout)
+      subject
+    end
+  end
+
   context 'continuing to idp with javascript disabled' do
     bobs_identity_service = { 'simple_id' => 'stub-idp-two',
                               'entity_id' => 'http://idcorp.com',
@@ -188,7 +198,7 @@ describe RedirectToIdpController do
         subject
       end
 
-      it 'reports idp sign in attempt details to piwik when a user followes the journey hint' do
+      it 'reports idp sign in attempt details to piwik when a user follows the journey hint' do
         session[:user_segments] = ['test-segment']
         session[:transaction_simple_id] = 'test-rp'
         session[:journey_type] = 'sign-in'


### PR DESCRIPTION
Move cookie checking code to single_idp_partial_controller as it is now used in two controllers.
Turn off caching for pages generated by single idp controller so that the proper page is shown if the user clicks back after cookie has expired.

Co-authored-by: Alexander Newton <alexander.newton@digital.cabinet-office.gov.uk>