### PR TITLE
BAU: Add a non-matching response for country

### DIFF
--- a/app/controllers/authn_response_controller.rb
+++ b/app/controllers/authn_response_controller.rb
@@ -21,7 +21,7 @@ class AuthnResponseController < SamlController
   RESUMING_JOURNEY_TYPE = 'resuming'
 
   ACCEPTED_IDP_RESPONSES = [SUCCESS, MATCHING_JOURNEY_SUCCESS, NON_MATCHING_JOURNEY_SUCCESS, CANCEL, FAILED_UPLIFT, PENDING].freeze
-  ACCEPTED_COUNTRY_RESPONSES = [SUCCESS, CANCEL, FAILED_UPLIFT].freeze
+  ACCEPTED_COUNTRY_RESPONSES = [SUCCESS, NON_MATCHING_JOURNEY_SUCCESS, CANCEL, FAILED_UPLIFT].freeze
 
   def idp_response
     raise_error_if_session_mismatch(params['RelayState'], session[:verify_session_id])
@@ -140,6 +140,7 @@ private
     is_registration = response.is_registration
     {
       SUCCESS => is_registration ? confirmation_path : response_processing_path,
+      NON_MATCHING_JOURNEY_SUCCESS => redirect_to_service_signing_in_path,
       CANCEL => is_registration ? failed_registration_path : start_path,
       FAILED_UPLIFT => failed_uplift_path,
       FAILED => is_registration ? failed_registration_path : failed_country_sign_in_path

--- a/spec/controllers/authn_response_controller_spec.rb
+++ b/spec/controllers/authn_response_controller_spec.rb
@@ -63,6 +63,7 @@ describe AuthnResponseController do
   context 'country' do
     context 'registration' do
       include_examples 'country_authn_response', 'registration', 'SUCCESS', :confirmation_path
+      include_examples 'country_authn_response', 'registration', 'NON_MATCHING_JOURNEY_SUCCESS', :redirect_to_service_signing_in_path
       include_examples 'country_authn_response', 'registration', 'CANCEL', :failed_registration_path
       include_examples 'country_authn_response', 'registration', 'FAILED_UPLIFT', :failed_uplift_path
       include_examples 'country_authn_response', 'registration', 'FAILED', :failed_registration_path
@@ -70,6 +71,7 @@ describe AuthnResponseController do
 
     context 'sign_in' do
       include_examples 'country_authn_response', 'sign_in', 'SUCCESS', :response_processing_path
+      include_examples 'country_authn_response', 'sign_in', 'NON_MATCHING_JOURNEY_SUCCESS', :redirect_to_service_signing_in_path
       include_examples 'country_authn_response', 'sign_in', 'CANCEL', :start_path
       include_examples 'country_authn_response', 'sign_in', 'FAILED_UPLIFT', :failed_uplift_path
       include_examples 'country_authn_response', 'sign_in', 'FAILED', :failed_country_sign_in_path


### PR DESCRIPTION
and enable the non-matching journey for eIDAS flows. 

When testing with no-matching, the response falls through as it's not in accepted responses.
Cross-checking with https://github.com/alphagov/verify-hub/blob/8802e2dc66976bfc0d2930f16059ff4c8c2c4668/hub/policy/src/test/java/uk/gov/ida/hub/policy/services/AuthnResponseFromCountryServiceTest.java#L227
I believe the NON_MATCHING_JOURNEY_SUCCESS should be on the list.