### PR TITLE
ZD3579186: Add error log for missing entity ID

### DIFF
--- a/app/models/session_validator.rb
+++ b/app/models/session_validator.rb
@@ -7,7 +7,8 @@ class SessionValidator
       TransactionSimpleIdPresence.new,
       SessionStartTimeValidator.new(session_duration),
       CookieSizeValidator.new,
-      RequestedLOAValidator.new
+      RequestedLOAValidator.new,
+      TransactionEntityIdPresence.new
     ]
   end
 

--- a/app/models/session_validator/transaction_entity_id_presence.rb
+++ b/app/models/session_validator/transaction_entity_id_presence.rb
@@ -1,0 +1,16 @@
+class SessionValidator
+  class TransactionEntityIdPresence
+    ERROR_MESSAGE = "Transaction entity ID can not be found in the user's session".freeze
+    def validate(_cookies, session)
+      # When confident of no false positives, remove the log and reinstate the validation failure.
+      # if session.include?(:transaction_entity_id)
+      #   SuccessfulValidation
+      # else
+      #   ValidationFailure.something_went_wrong(ERROR_MESSAGE)
+      # end
+
+      Rails.logger.error(ERROR_MESSAGE) unless session.include?(:transaction_entity_id)
+      SuccessfulValidation
+    end
+  end
+end

--- a/spec/features/user_visits_start_page_spec.rb
+++ b/spec/features/user_visits_start_page_spec.rb
@@ -40,7 +40,10 @@ RSpec.describe 'When the user visits the start page' do
     end
 
     it 'will display the generic error when start time is missing from session' do
-      set_session!(transaction_simple_id: 'test-rp', verify_session_id: 'my-session-id-cookie', identity_providers: [{ 'simple_id' => 'stub-idp-one' }])
+      set_session!(transaction_simple_id: 'test-rp',
+                   verify_session_id: 'my-session-id-cookie',
+                   identity_providers: [{ 'simple_id' => 'stub-idp-one' }],
+                   transaction_entity_id: 'test-rp')
       cookie_hash = create_cookie_hash
       allow(Rails.logger).to receive(:info)
       expect(Rails.logger).to receive(:info).with('start_time not in session').at_least(:once)


### PR DESCRIPTION
Transaction entity ID is required for the single IDP journey, and should always be available. Add log to catch any false positives of this new validation. Prepare for replacing log with validation error if there are no false positives. Commented out code will be re-instated by follow-on PR.

Co-authored-by: Benjamin Gill <benjamin.gill@digital.cabinet-office.gov.uk>