### PR TITLE
BAU: Deal with idp_name_history being nil

### DIFF
--- a/app/models/analytics/federation_reporter.rb
+++ b/app/models/analytics/federation_reporter.rb
@@ -99,6 +99,7 @@ module Analytics
     def report_idp_registration(current_transaction:, request:, idp_name:, idp_name_history:, evidence:, recommended:, user_segments:)
       list_of_evidence = evidence.sort.join(', ')
       list_of_segments = user_segments.nil? ? nil : user_segments.sort.join(', ')
+      idp_name_history ||= [idp_name]
       report_action(
         current_transaction,
         request,

--- a/spec/models/analytics/federation_reporter_spec.rb
+++ b/spec/models/analytics/federation_reporter_spec.rb
@@ -116,6 +116,26 @@ module Analytics
           user_segments: %w(segment1 segment2)
         )
       end
+
+      it 'should report default idp history to the chosen idp' do
+        expect(analytics_reporter).to receive(:report_action)
+          .with(
+            request,
+            "#{idp_name} was chosen for registration (recommended) with segment(s) segment1 and evidence passport",
+            1 => %w(RP description),
+            2 => %w(LOA_REQUESTED LEVEL_2),
+            5 => ['IDP_SELECTION', idp_name]
+          )
+        federation_reporter.report_idp_registration(
+          current_transaction: current_transaction,
+          request: request,
+          idp_name: idp_name,
+          idp_name_history: nil,
+          evidence: %w(passport),
+          recommended: '(recommended)',
+          user_segments: %w(segment1)
+        )
+      end
     end
 
     describe '#report_user_idp_attempt' do


### PR DESCRIPTION
The `idp_name_history` value in the user's session is sometimes
unset, possibly due to the single IDP journey. In this case, the
analytics reporter should just fall back to using the `idp_name` value.