### PR TITLE
0tLSIi4H: provide users with hint for disconnected IDP

### DIFF
--- a/app/assets/stylesheets/pages/_company.scss
+++ b/app/assets/stylesheets/pages/_company.scss
@@ -18,6 +18,18 @@
   }
 }
 
+.company-full-width {
+  overflow: auto;
+  margin: 15px;
+  border-bottom: 1px solid $border-colour;
+  text-align: center;
+
+  @include media (tablet) {
+    border: 5px solid $panel-colour;
+    margin-bottom: 30px;
+  }
+}
+
 .company.no-underline {
   border-bottom: none;
   padding-bottom: 30px;

--- a/app/assets/stylesheets/pages/_company.scss
+++ b/app/assets/stylesheets/pages/_company.scss
@@ -18,18 +18,6 @@
   }
 }
 
-.company-full-width {
-  overflow: auto;
-  margin: 15px;
-  border-bottom: 1px solid $border-colour;
-  text-align: center;
-
-  @include media (tablet) {
-    border: 5px solid $panel-colour;
-    margin-bottom: 30px;
-  }
-}
-
 .company.no-underline {
   border-bottom: none;
   padding-bottom: 30px;
@@ -92,6 +80,10 @@
 .company-about {
   @include core-16;
   margin-bottom: 0;
+}
+
+.company-disconnect-text {
+  text-align: left;
 }
 
 .idp-choice {

--- a/app/controllers/sign_in_controller.rb
+++ b/app/controllers/sign_in_controller.rb
@@ -9,9 +9,10 @@ class SignInController < ApplicationController
 
   def index
     entity_id = success_entity_id
-    @suggested_idp = entity_id.nil? ? [] : retrieve_decorated_singleton_idp_array_by_entity_id(current_identity_providers_for_sign_in, entity_id)
-    unless @suggested_idp.empty?
-      FEDERATION_REPORTER.report_sign_in_journey_hint_shown(current_transaction, request, @suggested_idp[0].display_name)
+    all_identity_providers = current_identity_providers_for_sign_in + current_disconnected_identity_providers_for_sign_in
+    @suggested_idp = entity_id && retrieve_decorated_singleton_idp_array_by_entity_id(all_identity_providers, entity_id).first
+    unless @suggested_idp.nil?
+      FEDERATION_REPORTER.report_sign_in_journey_hint_shown(current_transaction, request, @suggested_idp.display_name)
     end
 
     @identity_providers = IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate_collection(current_identity_providers_for_sign_in)
@@ -21,7 +22,6 @@ class SignInController < ApplicationController
     )
 
     @disconnected_idps = IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate_collection(current_disconnected_identity_providers_for_sign_in)
-
     render :index
   end
 

--- a/app/views/shared/_disconnected_suggested_idp_list.erb
+++ b/app/views/shared/_disconnected_suggested_idp_list.erb
@@ -1,21 +1,18 @@
-<%= hidden_field_tag 'entity_id', identity_provider.entity_id, id: nil, class: 'js-entity-id' %>
-<div  class="grid-row">
-  <div class="company-full-width" style="margin-top: auto">&nbsp;
-    <div class="column-one-third">
-      <div class="company-wrapper">
-        <div class="company-inner">
-          <div class="company-logo">
-            <div class="company-logo-inner">
-              <%= image_tag(identity_provider.logo_path, alt: idp_tagline(identity_provider)) %>
-            </div>
+<div class="column-full company">
+  <div class="column-one-third">
+    <div class="company-wrapper">
+      <div class="company-inner">
+        <div class="company-logo">
+          <div class="company-logo-inner">
+            <%= image_tag(identity_provider.logo_path, alt: idp_tagline(identity_provider)) %>
           </div>
         </div>
       </div>
     </div>
+  </div>
 
-    <div class="column-two-thirds" style="text-align: left;">
-      <h2 class="heading-medium" style="margin-top: auto"><%= t('hub.signin.company_no_longer_verifies_title', company: identity_provider.display_name) %></h2>
-      <p><%= raw t('hub.signin.company_no_longer_verifies_text', company: identity_provider.display_name, link: link_to(t('hub.signin.company_no_longer_verifies_link'), begin_registration_path)) %></p>
-    </div>
+  <div class="column-two-thirds company-disconnect-text">
+    <h2 class="heading-medium"><%= t('hub.signin.company_no_longer_verifies_title', company: identity_provider.display_name) %></h2>
+    <p><%= raw t('hub.signin.company_no_longer_verifies_text', company: identity_provider.display_name, link: link_to(t('hub.signin.company_no_longer_verifies_link'), begin_registration_path)) %></p>
   </div>
 </div>

--- a/app/views/shared/_disconnected_suggested_idp_list.erb
+++ b/app/views/shared/_disconnected_suggested_idp_list.erb
@@ -1,0 +1,21 @@
+<%= hidden_field_tag 'entity_id', identity_provider.entity_id, id: nil, class: 'js-entity-id' %>
+<div  class="grid-row">
+  <div class="company-full-width" style="margin-top: auto">&nbsp;
+    <div class="column-one-third">
+      <div class="company-wrapper">
+        <div class="company-inner">
+          <div class="company-logo">
+            <div class="company-logo-inner">
+              <%= image_tag(identity_provider.logo_path, alt: idp_tagline(identity_provider)) %>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="column-two-thirds" style="text-align: left;">
+      <h2 class="heading-medium" style="margin-top: auto"><%= t('hub.signin.company_no_longer_verifies_title', company: identity_provider.display_name) %></h2>
+      <p><%= raw t('hub.signin.company_no_longer_verifies_text', company: identity_provider.display_name, link: link_to(t('hub.signin.company_no_longer_verifies_link'), begin_registration_path)) %></p>
+    </div>
+  </div>
+</div>

--- a/app/views/sign_in/index.html.erb
+++ b/app/views/sign_in/index.html.erb
@@ -10,15 +10,21 @@
   </div>
 </div>
 
-<% if defined?(@suggested_idp) && !@suggested_idp.empty? %>
+<% unless @suggested_idp.nil? %>
   <div class="grid-row">
     <div class="column-two-thirds">
-      <p><%= t 'hub.signin.last_certified', company_name: @suggested_idp[0].display_name %></p>
+      <p><%= t 'hub.signin.last_certified', company_name: @suggested_idp.display_name %></p>
     </div>
   </div>
-  <div class="grid-row js-continue-to-idp" data-location="<%= url_for(controller: 'sign_in', action: 'select_idp_ajax', locale: I18n.locale) %>">
-    <%= render partial: 'shared/idp_list', locals: {identity_providers: @suggested_idp} %>
-  </div>
+
+  <% if @suggested_idp.authentication_enabled %>
+    <div class="grid-row js-continue-to-idp" data-location="<%= url_for(controller: 'sign_in', action: 'select_idp_ajax', locale: I18n.locale) %>">
+      <%= render partial: 'shared/idp_list', locals: {identity_providers: [@suggested_idp]} %>
+    </div>
+  <% else %>
+    <%= render partial: 'shared/disconnected_suggested_idp_list', locals: {identity_provider: @suggested_idp} %>
+  <% end %>
+
   <div class="grid-row">
     <div class="column-two-thirds">
       <p><%= t 'hub.signin.any_certified_company' %></p>

--- a/app/views/sign_in/index.html.erb
+++ b/app/views/sign_in/index.html.erb
@@ -22,7 +22,9 @@
       <%= render partial: 'shared/idp_list', locals: {identity_providers: [@suggested_idp]} %>
     </div>
   <% else %>
-    <%= render partial: 'shared/disconnected_suggested_idp_list', locals: {identity_provider: @suggested_idp} %>
+    <div  class="grid-row">
+      <%= render partial: 'shared/disconnected_suggested_idp_list', locals: {identity_provider: @suggested_idp} %>
+    </div>
   <% end %>
 
   <div class="grid-row">

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -135,10 +135,13 @@ cy:
       about_link: Dechreuwch nawr
       registration_message_html: Os nad oes gennych gyfrif hunaniaeth, gallwch %{href}.
       last_certified: "Y cwmni ardystiedig diwethaf a ddefnyddiwyd ar y ddyfais hon oedd %{company_name}"
-      any_certified_company: "Gallwch ddefnyddio cyfrif hunaniaeth rydych wedi'i sefydlu gydag unrhyw gwmni ardystiedig yn y gorffennol:"
+      any_certified_company: "Gallwch ddefnyddio cyfrif hunaniaeth a sefydlwyd gennych gydag unrhyw yn o'r cwmnïau hyn:"
       select_idp: Ddewis %{display_name}
       sign_in_idp: Llofnodi i mewn gyda %{display_name}
       forgot_company: Ni allaf gofio pa gwmni wnaeth fy nilysu
+      company_no_longer_verifies_title: "Nid yw %{company} bellach yn rhan o GOV.UK Verify"
+      company_no_longer_verifies_text: Os oes gennych gyfrif hunaniaeth gyda %{company}, bydd angen i chi o %{link}.
+      company_no_longer_verifies_link: dilysu eich hunaniaeth gyda chwmni arall
     cookies:
       title: Cwcis
     privacy_notice:
@@ -646,4 +649,3 @@ cy:
       other_ways: "Ceisiwch eto yn nes ymlaen neu ddewis ffordd arall i "
       other_ways_link: "profi eich hunaniaeth ar-lein"
     no_selection: Dylech ateb y cwestiynau
-    

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -132,10 +132,13 @@ en:
       about_link: set one up now
       registration_message_html: If you don’t have an identity account, you can %{href}.
       last_certified: The last certified company used on this device was %{company_name}.
-      any_certified_company: "You can use an identity account you set up with any certified company in the past:"
+      any_certified_company: "You can use an identity account you set up with any of these companies:"
       select_idp: Select %{display_name}
       sign_in_idp: Sign in with %{display_name}
       forgot_company: I can’t remember which company verified me
+      company_no_longer_verifies_title: "%{company} is no longer a part of GOV.UK Verify"
+      company_no_longer_verifies_text: If you have an identity account with %{company}, you’ll need to %{link}.
+      company_no_longer_verifies_link: verify your identity with another company
     cookies:
       title: Cookies
     privacy_notice:

--- a/spec/api_test_helper.rb
+++ b/spec/api_test_helper.rb
@@ -371,6 +371,7 @@ private
       { 'simpleId' => 'stub-idp-demo', 'entityId' => 'demo-entity-id', 'levelsOfAssurance' => %w(LEVEL_2) },
       { 'simpleId' => 'stub-idp-loa1', 'entityId' => 'loa1-entity-id', 'levelsOfAssurance' => %w(LEVEL_1 LEVEL_2) },
       { 'simpleId' => 'stub-idp-loa1-with-interstitial', 'entityId' => 'loa1-entity-id-with-interstitial', 'levelsOfAssurance' => %w(LEVEL_1) },
+      { 'simpleId' => 'stub-idp-unavailable', 'entityId' => 'unavailable-entity-id', 'levelsOfAssurance' => %w(LEVEL_1 LEVEL_2), "authenticationEnabled" => false }
     ]
   end
 end

--- a/spec/features/user_visits_sign_in_page_spec.rb
+++ b/spec/features/user_visits_sign_in_page_spec.rb
@@ -149,7 +149,7 @@ RSpec.describe 'user selects an IDP on the sign in page' do
         page.set_rack_session(transaction_simple_id: 'test-rp')
         given_api_requests_have_been_mocked!
         given_im_on_the_sign_in_page
-        expect(page).to have_text 'You can use an identity account you set up with any certified company in the past:'
+        expect(page).to have_text 'You can use an identity account you set up with any of these companies:'
         expect(page).to have_text "The last certified company used on this device was #{idp_display_name}."
         expect(page).to have_button("Select #{idp_display_name}", count: 2)
         then_piwik_was_sent_a_journey_hint_shown_event_for(idp_display_name)
@@ -182,7 +182,7 @@ RSpec.describe 'user selects an IDP on the sign in page' do
         given_api_requests_have_been_mocked!
         given_im_on_the_sign_in_page
         then_piwik_was_sent_a_journey_hint_shown_event_for(hinted_idp_name)
-        expect(page).to have_text 'You can use an identity account you set up with any certified company in the past:'
+        expect(page).to have_text 'You can use an identity account you set up with any of these companies:'
         expect(page).to have_text "The last certified company used on this device was #{hinted_idp_name}."
         expect(page).to have_button("Select #{hinted_idp_name}", count: 2)
 
@@ -193,6 +193,22 @@ RSpec.describe 'user selects an IDP on the sign in page' do
         and_the_language_hint_is_set
         and_the_hints_are_not_set
         expect(page.get_rack_session_key('selected_provider')['identity_provider']).to include('entity_id' => idp_entity_id, 'simple_id' => 'stub-idp-one', 'levels_of_assurance' => %w(LEVEL_2))
+      end
+    end
+
+    context 'with an idp-hint cookie for a disconnected IDP' do
+      hinted_idp_name = 'Unavailable IDP'
+
+      before :each do
+        set_journey_hint_cookie('unavailable-entity-id', 'SUCCESS')
+      end
+
+      it 'will tell the user the hinted IDP is disconnected' do
+        given_api_requests_have_been_mocked!
+        given_im_on_the_sign_in_page
+
+        expect(page).to have_text "#{hinted_idp_name} is no longer a part of GOV.UK Verify"
+        expect(page).to_not have_button("Select #{hinted_idp_name}")
       end
     end
   end


### PR DESCRIPTION
Inform users who may be expecting to see their IDP that said IDP is gone.

See https://trello.com/c/dCnwuq3t/112-use-cookie-to-remind-sign-in-users-that-those-rm-cs-will-no-longer-work

Co-authored-by: John Watts <john.watts@digital.cabinet-office.gov.uk>
Co-authored-by: Alex Newton <alex.newton@digital.cabinet-office.gov.uk>