### PR TITLE
BAU: Refactor eIDAS button

### DIFF
--- a/app/views/choose_a_country/choose_a_country.html.erb
+++ b/app/views/choose_a_country/choose_a_country.html.erb
@@ -29,7 +29,13 @@
               <div class="scheme-button">
                 <%= form_tag choose_a_country_submit_path, :class => 'js-country-form' do %>
                   <%= hidden_field_tag :country, country.simple_id, class: 'js-country-simple-id' %>
-                  <button class="button"><%= t 'hub.choose_a_country.select_label' %><%= scheme.display_name %></button>
+                  <%= button_tag t('hub.choose_a_country.select_label', scheme_name: scheme.display_name),
+                             class: 'button',
+                             name: country.simple_id,
+                             id: nil,
+                             type: 'submit',
+                             value: scheme.display_name
+                  %>
                 <% end %>
               </div>
             </div>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -97,7 +97,7 @@ cy:
       country_not_listed_heading: Nid yw fy ngwlad wedi'i restru
       country_not_listed_description: Os nad yw eich cwmni wedi ymuno eto, mae
       country_not_listed_link: ffyrdd eraill i %{other_ways_description}.
-      select_label: "Dewis "
+      select_label: "Dewis %{scheme_name}"
     redirect_to_country:
       title: Ailgyfeirio i wlad
       heading: Mynd ymlaen i’r cam nesaf

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -94,7 +94,7 @@ en:
       country_not_listed_heading: My country isn't listed
       country_not_listed_description: "If your country hasn't joined yet, there are "
       country_not_listed_link: other ways to %{other_ways_description}.
-      select_label: "Select "
+      select_label: "Select %{scheme_name}"
     redirect_to_country:
       title: Redirect to country
       heading: Continue to next step


### PR DESCRIPTION
We're doing some E2E tests and currently it's difficult to pick a country using CSS
as they're all buttons. This change is using the Rails built-in
button tag to append name and value to the button.