### PR TITLE
dCnwuq3t: Add special text for UC users on IDP disconnection

### DIFF
--- a/app/controllers/sign_in_controller.rb
+++ b/app/controllers/sign_in_controller.rb
@@ -22,6 +22,8 @@ class SignInController < ApplicationController
     )
 
     @disconnected_idps = IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate_collection(current_disconnected_identity_providers_for_sign_in)
+    @idp_disconnected_alternative_html = current_transaction.idp_disconnected_alternative_html
+
     render :index
   end
 

--- a/app/controllers/sign_in_controller.rb
+++ b/app/controllers/sign_in_controller.rb
@@ -6,6 +6,7 @@ class SignInController < ApplicationController
   include IdpSelectionPartialController
   include ViewableIdpPartialController
   include AnalyticsCookiePartialController
+  include ActionView::Helpers::UrlHelper
 
   def index
     entity_id = success_entity_id

--- a/app/models/display/rp_display_data.rb
+++ b/app/models/display/rp_display_data.rb
@@ -14,7 +14,7 @@ module Display
     content :custom_fail_try_another_summary, default: nil
     content :custom_fail_try_another_text, default: nil
     content :custom_fail_contact_details_intro, default: nil
-    content :idp_disconnected_hint_html, default: ''
+    content :idp_disconnected_hint_html, default: nil
     content :taxon_name, default: -> { I18n.translate('hub.transaction_list.other_services') }
     alias_method :taxon, :taxon_name
   end

--- a/app/models/display/rp_display_data.rb
+++ b/app/models/display/rp_display_data.rb
@@ -14,7 +14,7 @@ module Display
     content :custom_fail_try_another_summary, default: nil
     content :custom_fail_try_another_text, default: nil
     content :custom_fail_contact_details_intro, default: nil
-    content :idp_disconnected_alternative_html, default: ''
+    content :idp_disconnected_hint_html, default: ''
     content :taxon_name, default: -> { I18n.translate('hub.transaction_list.other_services') }
     alias_method :taxon, :taxon_name
   end

--- a/app/models/display/rp_display_data.rb
+++ b/app/models/display/rp_display_data.rb
@@ -14,6 +14,7 @@ module Display
     content :custom_fail_try_another_summary, default: nil
     content :custom_fail_try_another_text, default: nil
     content :custom_fail_contact_details_intro, default: nil
+    content :idp_disconnected_alternative_html, default: ''
     content :taxon_name, default: -> { I18n.translate('hub.transaction_list.other_services') }
     alias_method :taxon, :taxon_name
   end

--- a/app/models/transaction_translation_response.rb
+++ b/app/models/transaction_translation_response.rb
@@ -21,7 +21,7 @@ class TransactionTranslationResponse < Api::Response
     @custom_fail_contact_details_intro = hash['customFailContactDetailsIntro']
     @single_idp_start_page_content_html = hash['singleIdpStartPageContent']
     @single_idp_start_page_title = hash['singleIdpStartPageTitle']
-    @idp_disconnected_alternative_html = hash['idpDisconnectedAlternativeHtml']
+    @idp_disconnected_hint_html = hash['idpDisconnectedAlternativeHtml']
   end
 
   def to_h
@@ -41,7 +41,7 @@ class TransactionTranslationResponse < Api::Response
       custom_fail_contact_details_intro: custom_fail_contact_details_intro,
       single_idp_start_page_content_html: @single_idp_start_page_content_html,
       single_idp_start_page_title: @single_idp_start_page_title,
-      idp_disconnected_alternative_html: @idp_disconnected_alternative_html
+      idp_disconnected_hint_html: @idp_disconnected_hint_html
     }
   end
 end

--- a/app/models/transaction_translation_response.rb
+++ b/app/models/transaction_translation_response.rb
@@ -2,7 +2,7 @@ class TransactionTranslationResponse < Api::Response
   attr_reader :name, :rp_name, :analytics_description, :other_ways_text, :other_ways_description, :tailored_text,
               :taxon_name, :custom_fail_heading, :custom_fail_what_next_content, :custom_fail_other_options,
               :custom_fail_try_another_summary, :custom_fail_try_another_text, :custom_fail_contact_details_intro,
-              :single_idp_start_page_content_html, :single_idp_start_page_title
+              :single_idp_start_page_content_html, :single_idp_start_page_title, :idp_disconnected_alternative_html
   validates :name, :rp_name, :analytics_description, :other_ways_text, :other_ways_description, :tailored_text, presence: true
 
   def initialize(hash)
@@ -21,6 +21,7 @@ class TransactionTranslationResponse < Api::Response
     @custom_fail_contact_details_intro = hash['customFailContactDetailsIntro']
     @single_idp_start_page_content_html = hash['singleIdpStartPageContent']
     @single_idp_start_page_title = hash['singleIdpStartPageTitle']
+    @idp_disconnected_alternative_html = hash['idpDisconnectedAlternativeHtml']
   end
 
   def to_h
@@ -39,7 +40,8 @@ class TransactionTranslationResponse < Api::Response
       custom_fail_try_another_text: custom_fail_try_another_text,
       custom_fail_contact_details_intro: custom_fail_contact_details_intro,
       single_idp_start_page_content_html: @single_idp_start_page_content_html,
-      single_idp_start_page_title: @single_idp_start_page_title
+      single_idp_start_page_title: @single_idp_start_page_title,
+      idp_disconnected_alternative_html: @idp_disconnected_alternative_html
     }
   end
 end

--- a/app/views/shared/_disconnected_suggested_idp_list.erb
+++ b/app/views/shared/_disconnected_suggested_idp_list.erb
@@ -13,6 +13,6 @@
 
   <div class="column-two-thirds company-disconnect-text">
     <h2 class="heading-medium"><%= t('hub.signin.company_no_longer_verifies_title', company: identity_provider.display_name) %></h2>
-    <p><%= raw t('hub.signin.company_no_longer_verifies_text', company: identity_provider.display_name, link: link_to(t('hub.signin.company_no_longer_verifies_link'), begin_registration_path)) %></p>
+    <p><%= raw t('hub.signin.company_no_longer_verifies_text', company: identity_provider.display_name, link: link_to(t('hub.signin.company_no_longer_verifies_link'), begin_registration_path), other_ways: @idp_disconnected_alternative_html) %></p>
   </div>
 </div>

--- a/app/views/shared/_disconnected_suggested_idp_list.erb
+++ b/app/views/shared/_disconnected_suggested_idp_list.erb
@@ -13,6 +13,6 @@
 
   <div class="column-two-thirds company-disconnect-text">
     <h2 class="heading-medium"><%= t('hub.signin.company_no_longer_verifies_title', company: identity_provider.display_name) %></h2>
-    <p><%= raw t('hub.signin.company_no_longer_verifies_text', company: identity_provider.display_name, link: link_to(t('hub.signin.company_no_longer_verifies_link'), begin_registration_path), other_ways: @idp_disconnected_alternative_html) %></p>
+    <p><%= raw @idp_disconnected_hint_html %></p>
   </div>
 </div>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -135,7 +135,7 @@ cy:
       about_link: Dechreuwch nawr
       registration_message_html: Os nad oes gennych gyfrif hunaniaeth, gallwch %{href}.
       last_certified: "Y cwmni ardystiedig diwethaf a ddefnyddiwyd ar y ddyfais hon oedd %{company_name}"
-      any_certified_company: "Gallwch ddefnyddio cyfrif hunaniaeth a sefydlwyd gennych gydag unrhyw yn o'r cwmnïau hyn:"
+      any_certified_company: "Gallwch ddefnyddio cyfrif hunaniaeth a sefydlwyd gennych gydag unrhyw un o'r cwmnïau hyn:"
       select_idp: Ddewis %{display_name}
       sign_in_idp: Llofnodi i mewn gyda %{display_name}
       forgot_company: Ni allaf gofio pa gwmni wnaeth fy nilysu

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -140,7 +140,7 @@ cy:
       sign_in_idp: Llofnodi i mewn gyda %{display_name}
       forgot_company: Ni allaf gofio pa gwmni wnaeth fy nilysu
       company_no_longer_verifies_title: "Nid yw %{company} bellach yn rhan o GOV.UK Verify"
-      company_no_longer_verifies_text: Os oes gennych gyfrif hunaniaeth gyda %{company}, bydd angen i chi o %{link}%{other_ways}.
+      company_no_longer_verifies_text: Os oes gennych gyfrif hunaniaeth gyda %{company}, bydd angen i chi o %{link}.
       company_no_longer_verifies_link: dilysu eich hunaniaeth gyda chwmni arall
     cookies:
       title: Cwcis

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -140,7 +140,7 @@ cy:
       sign_in_idp: Llofnodi i mewn gyda %{display_name}
       forgot_company: Ni allaf gofio pa gwmni wnaeth fy nilysu
       company_no_longer_verifies_title: "Nid yw %{company} bellach yn rhan o GOV.UK Verify"
-      company_no_longer_verifies_text: Os oes gennych gyfrif hunaniaeth gyda %{company}, bydd angen i chi o %{link}.
+      company_no_longer_verifies_text: Os oes gennych gyfrif hunaniaeth gyda %{company}, bydd angen i chi o %{link}%{other_ways}.
       company_no_longer_verifies_link: dilysu eich hunaniaeth gyda chwmni arall
     cookies:
       title: Cwcis

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -137,7 +137,7 @@ en:
       sign_in_idp: Sign in with %{display_name}
       forgot_company: I can’t remember which company verified me
       company_no_longer_verifies_title: "%{company} is no longer a part of GOV.UK Verify"
-      company_no_longer_verifies_text: If you have an identity account with %{company}, you’ll need to %{link}%{other_ways}.
+      company_no_longer_verifies_text: If you have an identity account with %{company}, you’ll need to %{link}.
       company_no_longer_verifies_link: verify your identity with another company
     cookies:
       title: Cookies

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -137,7 +137,7 @@ en:
       sign_in_idp: Sign in with %{display_name}
       forgot_company: I can’t remember which company verified me
       company_no_longer_verifies_title: "%{company} is no longer a part of GOV.UK Verify"
-      company_no_longer_verifies_text: If you have an identity account with %{company}, you’ll need to %{link}.
+      company_no_longer_verifies_text: If you have an identity account with %{company}, you’ll need to %{link}%{other_ways}.
       company_no_longer_verifies_link: verify your identity with another company
     cookies:
       title: Cookies

--- a/spec/api_test_helper.rb
+++ b/spec/api_test_helper.rb
@@ -83,7 +83,8 @@ module ApiTestHelper
         "tailoredText":"External data source: EN: This is tailored text for test-rp",
         "taxonName":"Benefits",
         "singleIdpStartPageTitle": "This is the Single IDP Start Page Title",
-        "singleIdpStartPageContent": "This is the Single IDP Start Page Content <a href=\'%<start_url>s\'>Sign In</a>"
+        "singleIdpStartPageContent": "This is the Single IDP Start Page Content <a href=\'%<start_url>s\'>Sign In</a>",
+        "idpDisconnectedAlternativeHtml": " or <a href=\"https://www.example.com\">go elsewhere</a>"
       }'
     stub_request(:get, api_translations_endpoint('test-rp', 'en')).to_return(body: en_translation_data, status: 200)
     cy_translation_data = '{

--- a/spec/api_test_helper.rb
+++ b/spec/api_test_helper.rb
@@ -56,6 +56,10 @@ module ApiTestHelper
       {
         'simpleId' => 'test-rp-with-continue-on-fail', 'serviceHomepage' => 'http://localhost:50130/test-rp-with-continue-on-fail',
         'loaList' => %w(LEVEL_2), 'headlessStartpage' => 'http://localhost:50130/success?rp-name=test-rp-with-continue-on-fail'
+      },
+      {
+        'simpleId' => 'test-rp-with-custom-hint', 'serviceHomepage' => 'http://localhost:50130/test-rp-with-custom-hint',
+        'loaList' => %w(LEVEL_2), 'headlessStartpage' => 'http://localhost:50130/success?rp-name=test-rp-with-custom-hint'
       }
     ]
 
@@ -83,8 +87,7 @@ module ApiTestHelper
         "tailoredText":"External data source: EN: This is tailored text for test-rp",
         "taxonName":"Benefits",
         "singleIdpStartPageTitle": "This is the Single IDP Start Page Title",
-        "singleIdpStartPageContent": "This is the Single IDP Start Page Content <a href=\'%<start_url>s\'>Sign In</a>",
-        "idpDisconnectedAlternativeHtml": " or <a href=\"https://www.example.com\">go elsewhere</a>"
+        "singleIdpStartPageContent": "This is the Single IDP Start Page Content <a href=\'%<start_url>s\'>Sign In</a>"
       }'
     stub_request(:get, api_translations_endpoint('test-rp', 'en')).to_return(body: en_translation_data, status: 200)
     cy_translation_data = '{
@@ -148,6 +151,19 @@ module ApiTestHelper
       }', status: 200)
     stub_request(:get, api_translations_endpoint('foobar', 'en')).to_return(body: en_translation_data, status: 200)
     stub_request(:get, api_translations_endpoint('foobar', 'cy')).to_return(body: '{}', status: 200)
+    stub_request(:get, api_translations_endpoint('test-rp-custom-hint', 'en')).to_return(body: '{
+        "name":"test GOV.UK Verify user journeys",
+        "rpName":"Test RP with custom hint",
+        "analyticsDescription":"analytics description for test-rp",
+        "otherWaysText":"<p>If you can’t verify your identity using GOV.UK Verify, you can test GOV.UK Verify user journeys <a href=\"http://www.example.com\">here</a>.</p><p>Tell us your:</p><ul><li>name</li><li>age</li></ul><p>Include any other relevant details if you have them.</p>",
+        "otherWaysDescription":"test GOV.UK Verify user journeys",
+        "tailoredText":"External data source: EN: This is tailored text for test-rp",
+        "taxonName":"Benefits",
+        "singleIdpStartPageTitle": "This is the Single IDP Start Page Title",
+        "singleIdpStartPageContent": "This is the Single IDP Start Page Content <a href=\'%<start_url>s\'>Sign In</a>",
+        "idpDisconnectedAlternativeHtml": "If you have an identity account with %<company>s, you’ll need to <a href=\"%<begin_registration_path>s\">verify your identity with another company</a> or <a href=\"https://www.universal-credit.service.gov.uk/sign-in\">sign in with your Universal Credit account</a>"
+      }', status: 200)
+    stub_request(:get, api_translations_endpoint('test-rp-custom-hint', 'cy')).to_return(body: ' {}', status: 200)
   end
 
   def stub_countries_list

--- a/spec/api_test_helper.rb
+++ b/spec/api_test_helper.rb
@@ -161,7 +161,7 @@ module ApiTestHelper
         "taxonName":"Benefits",
         "singleIdpStartPageTitle": "This is the Single IDP Start Page Title",
         "singleIdpStartPageContent": "This is the Single IDP Start Page Content <a href=\'%<start_url>s\'>Sign In</a>",
-        "idpDisconnectedAlternativeHtml": "If you have an identity account with %<company>s, you’ll need to <a href=\"%<begin_registration_path>s\">verify your identity with another company</a> or <a href=\"https://www.universal-credit.service.gov.uk/sign-in\">sign in with your Universal Credit account</a>"
+        "idpDisconnectedAlternativeHtml": "An alternative hint warning."
       }', status: 200)
     stub_request(:get, api_translations_endpoint('test-rp-custom-hint', 'cy')).to_return(body: ' {}', status: 200)
   end

--- a/spec/features/user_visits_sign_in_page_spec.rb
+++ b/spec/features/user_visits_sign_in_page_spec.rb
@@ -208,6 +208,7 @@ RSpec.describe 'user selects an IDP on the sign in page' do
         given_im_on_the_sign_in_page
 
         expect(page).to have_text "#{hinted_idp_name} is no longer a part of GOV.UK Verify"
+        expect(page).to have_text 'or go elsewhere'
         expect(page).to_not have_button("Select #{hinted_idp_name}")
       end
     end

--- a/spec/features/user_visits_sign_in_page_spec.rb
+++ b/spec/features/user_visits_sign_in_page_spec.rb
@@ -210,21 +210,21 @@ RSpec.describe 'user selects an IDP on the sign in page' do
         set_journey_hint_cookie('unavailable-entity-id', 'SUCCESS')
       end
 
-      it 'will show the user service-specific text when the hinted IDP is disconnected' do
-        given_api_requests_have_been_mocked!
-        given_im_on_the_sign_in_page_from_test_rp_with_custom_hint
-
-        expect(page).to have_text "#{hinted_idp_name} is no longer a part of GOV.UK Verify"
-        expect(page).to have_text 'sign in with your Universal Credit account'
-        expect(page).to_not have_button("Select #{hinted_idp_name}")
-      end
-
       it 'will tell the user the hinted IDP is disconnected' do
         given_api_requests_have_been_mocked!
         given_im_on_the_sign_in_page
 
         expect(page).to have_text "#{hinted_idp_name} is no longer a part of GOV.UK Verify"
-        expect(page).to_not have_text 'sign in with your Universal Credit account'
+        expect(page).to have_text "If you have an identity account with #{hinted_idp_name}, you’ll need to verify your identity with another company."
+        expect(page).to_not have_button("Select #{hinted_idp_name}")
+      end
+
+      it 'will show the user service-specific text when the hinted IDP is disconnected' do
+        given_api_requests_have_been_mocked!
+        given_im_on_the_sign_in_page_from_test_rp_with_custom_hint
+
+        expect(page).to have_text "#{hinted_idp_name} is no longer a part of GOV.UK Verify"
+        expect(page).to have_text 'An alternative hint warning.'
         expect(page).to_not have_button("Select #{hinted_idp_name}")
       end
     end


### PR DESCRIPTION
See https://trello.com/c/dCnwuq3t/112-use-cookie-to-remind-sign-in-users-that-those-rm-cs-will-no-longer-work

Co-authored-by: John Watts <john.watts@digital.cabinet-office.gov.uk>
Co-authored-by: Alex Newton <alex.newton@digital.cabinet-office.gov.uk>