### PR TITLE
GfHEPKRG: Handle Single IDP journey crashing when transaction entity …

### DIFF
--- a/app/models/session_validator/transaction_entity_id_presence.rb
+++ b/app/models/session_validator/transaction_entity_id_presence.rb
@@ -2,15 +2,11 @@ class SessionValidator
   class TransactionEntityIdPresence
     ERROR_MESSAGE = "Transaction entity ID can not be found in the user's session".freeze
     def validate(_cookies, session)
-      # When confident of no false positives, remove the log and reinstate the validation failure.
-      # if session.include?(:transaction_entity_id)
-      #   SuccessfulValidation
-      # else
-      #   ValidationFailure.something_went_wrong(ERROR_MESSAGE)
-      # end
-
-      Rails.logger.error(ERROR_MESSAGE) unless session.include?(:transaction_entity_id)
-      SuccessfulValidation
+      if session.include?(:transaction_entity_id)
+        SuccessfulValidation
+      else
+        ValidationFailure.something_went_wrong(ERROR_MESSAGE)
+      end
     end
   end
 end

--- a/spec/models/session_validator_spec.rb
+++ b/spec/models/session_validator_spec.rb
@@ -146,14 +146,10 @@ describe SessionValidator do
     cookies[CookieNames::SESSION_ID_COOKIE_NAME] = 'session_id'
     logger = double(:logger)
     stub_const('Rails', double(:rails, logger: logger))
-    expect(logger).to receive(:error).with(/Transaction entity ID/)
     validation = session_validator.validate(cookies, session)
-
-    # To be turned on once we're certain that this does not raise any false positives.
-    expect(validation).to be_ok # delete this line and uncomment the rest below
-    # expect(validation).to_not be_ok
-    # expect(validation.type).to eql :something_went_wrong
-    # expect(validation.message).to eql "Transaction entity ID can not be found in the user's session"
+    expect(validation).to_not be_ok
+    expect(validation.type).to eql :something_went_wrong
+    expect(validation.message).to eql "Transaction entity ID can not be found in the user's session"
   end
 
   it 'will log an error if the session cookie is getting too large' do


### PR DESCRIPTION
…id missing

Enable validation for missing transaction entity id.

Co-authored-by: Benjamin Gill <benjamin.gill@digital.cabinet-office.gov.uk>