### PR TITLE
 ZD3590202: handle loss of IDP cookie 

### DIFF
--- a/app/controllers/partials/idp_selection_partial_controller.rb
+++ b/app/controllers/partials/idp_selection_partial_controller.rb
@@ -23,7 +23,7 @@ module IdpSelectionPartialController
     end
 
     outbound_saml_message = SAML_PROXY_API.authn_request(session[:verify_session_id])
-    idp_request = idp_request_initilization(outbound_saml_message)
+    idp_request = idp_request_initialisation(outbound_saml_message)
     render json: idp_request
   end
 
@@ -33,7 +33,7 @@ module IdpSelectionPartialController
     FEDERATION_REPORTER.report_sign_in_idp_selection(current_transaction, request, session[:selected_idp_name])
 
     outbound_saml_message = SAML_PROXY_API.authn_request(session[:verify_session_id])
-    idp_request = idp_request_initilization(outbound_saml_message)
+    idp_request = idp_request_initialisation(outbound_saml_message)
     render json: idp_request
   end
 
@@ -43,7 +43,7 @@ module IdpSelectionPartialController
     report_user_idp_attempt_to_piwik
     report_idp_registration_to_piwik(recommended)
     outbound_saml_message = SAML_PROXY_API.authn_request(session[:verify_session_id])
-    idp_request = idp_request_initilization(outbound_saml_message)
+    idp_request = idp_request_initialisation(outbound_saml_message)
     render json: idp_request.to_json(methods: :hints)
   end
 
@@ -53,7 +53,7 @@ module IdpSelectionPartialController
     FEDERATION_REPORTER.report_single_idp_journey_selection(current_transaction, request, session[:selected_idp_name])
 
     outbound_saml_message = SAML_PROXY_API.authn_request(session[:verify_session_id])
-    idp_request = idp_request_initilization_for_single_idp_journey(outbound_saml_message, uuid)
+    idp_request = idp_request_initialisation_for_single_idp_journey(outbound_saml_message, uuid)
     render json: idp_request
   end
 
@@ -63,7 +63,7 @@ module IdpSelectionPartialController
     FEDERATION_REPORTER.report_idp_resume_journey_selection(current_transaction, request, session[:selected_idp_name])
 
     outbound_saml_message = SAML_PROXY_API.authn_request(session[:verify_session_id])
-    idp_request = idp_request_initilization(outbound_saml_message)
+    idp_request = idp_request_initialisation(outbound_saml_message)
     render json: idp_request
   end
 
@@ -92,7 +92,7 @@ module IdpSelectionPartialController
     )
   end
 
-  def idp_request_initilization(outbound_saml_message)
+  def idp_request_initialisation(outbound_saml_message)
     IdentityProviderRequest.new(
       outbound_saml_message,
       selected_identity_provider.simple_id,
@@ -100,7 +100,7 @@ module IdpSelectionPartialController
     )
   end
 
-  def idp_request_initilization_for_single_idp_journey(outbound_saml_message, uuid)
+  def idp_request_initialisation_for_single_idp_journey(outbound_saml_message, uuid)
     IdentityProviderRequest.new(
       outbound_saml_message,
       selected_identity_provider.simple_id,

--- a/app/controllers/partials/single_idp_partial_controller.rb
+++ b/app/controllers/partials/single_idp_partial_controller.rb
@@ -16,6 +16,6 @@ module SingleIdpPartialController
   end
 
   def referrer_string
-    " - referrer: " + (request.nil? || request.referer.nil? ? "[could not get the referrer]" : request.referer)
+    ' - referrer: ' + (request&.referer || '[could not get the referrer]')
   end
 end

--- a/app/controllers/redirect_to_idp_controller.rb
+++ b/app/controllers/redirect_to_idp_controller.rb
@@ -50,12 +50,12 @@ private
 
   def request_form
     saml_message = SAML_PROXY_API.authn_request(session[:verify_session_id])
-    @request = idp_request_initilization(saml_message)
+    @request = idp_request_initialisation(saml_message)
   end
 
   def request_form_for_single_idp_journey(uuid)
     saml_message = SAML_PROXY_API.authn_request(session[:verify_session_id])
-    @request = idp_request_initilization_for_single_idp_journey(saml_message, uuid)
+    @request = idp_request_initialisation_for_single_idp_journey(saml_message, uuid)
   end
 
   def recommended

--- a/app/controllers/single_idp_journey_controller.rb
+++ b/app/controllers/single_idp_journey_controller.rb
@@ -46,7 +46,7 @@ class SingleIdpJourneyController < ApplicationController
   def continue_ajax
     select_viewable_idp_for_single_idp_journey(params.fetch('entityId')) do |decorated_idp|
       select_idp(decorated_idp.entity_id, decorated_idp.display_name)
-      ajax_idp_redirection_single_idp_journey_request(single_idp_cookie.fetch('uuid', nil))
+      ajax_idp_redirection_single_idp_journey_request(single_idp_cookie&.fetch('uuid', nil))
     end
   end
 


### PR DESCRIPTION
Cope with users who mysteriously lose their single IDP cookie between landing on the 'continue to your IDP' page and clicking on the button.