### PR TITLE
ZD3590202: Add matomo event for missing/malformed cookie

### DIFF
--- a/app/controllers/partials/single_idp_partial_controller.rb
+++ b/app/controllers/partials/single_idp_partial_controller.rb
@@ -10,6 +10,9 @@ module SingleIdpPartialController
       # This is still valid behaviour, it can be the users session has genuinely expired,
       # or that the session has been tampered with.
       logger.warn "Single IDP cookies was not found or was malformed" + referrer_string
+      FEDERATION_REPORTER.report_single_idp_invalid_cookie(
+        current_transaction, request
+      )
       return false
     end
     true

--- a/app/models/analytics/federation_reporter.rb
+++ b/app/models/analytics/federation_reporter.rb
@@ -177,6 +177,16 @@ module Analytics
       )
     end
 
+    def report_single_idp_invalid_cookie(current_transaction, request)
+      report_event(
+        current_transaction,
+        request,
+        'Single IDP',
+        'invalid cookie',
+        'Missing or malformed cookie'
+      )
+    end
+
     def report_single_idp_service_mismatch(current_transaction, request, expected_service, actual_service, uuid)
       report_event(
         current_transaction,

--- a/spec/controllers/single_idp_journey_controller_spec.rb
+++ b/spec/controllers/single_idp_journey_controller_spec.rb
@@ -177,14 +177,18 @@ describe SingleIdpJourneyController do
     end
 
     it 'should redirect to /start if cookie is missing' do
+      stub_piwik_event = stub_piwik_report_single_idp_invalid_cookie
       expect(Rails.logger).to receive(:warn).with(/Single IDP cookies was not found or was malformed/)
       expect(subject).to redirect_to(start_path)
+      expect(stub_piwik_event).to(have_been_made.once)
     end
 
     it 'should redirect to /start if cookie is corrupted' do
+      stub_piwik_event = stub_piwik_report_single_idp_invalid_cookie
       cookies.encrypted[CookieNames::VERIFY_SINGLE_IDP_JOURNEY] = "blah"
       expect(Rails.logger).to receive(:warn).with(/Single IDP cookies was not found or was malformed/)
       expect(subject).to redirect_to(start_path)
+      expect(stub_piwik_event).to(have_been_made.once)
     end
 
     it 'should redirect to /start if cookie is missing some fields' do

--- a/spec/piwik_test_helper.rb
+++ b/spec/piwik_test_helper.rb
@@ -105,6 +105,16 @@ def stub_piwik_report_single_idp_success(service_id, uuid)
   stub_piwik_request(piwik_request, 'User-Agent' => 'Rails Testing')
 end
 
+def stub_piwik_report_single_idp_invalid_cookie
+  piwik_request = {
+    e_c: 'Single IDP',
+    action_name: 'trackEvent',
+    e_n: 'invalid cookie',
+    e_a: "Missing or malformed cookie"
+  }
+  stub_piwik_request(piwik_request, 'User-Agent' => 'Rails Testing')
+end
+
 def stub_piwik_report_single_idp_service_mismatch(expected_service, actual_service, uuid)
   piwik_request = {
     e_c: 'Single IDP',


### PR DESCRIPTION
Help us understand why (and how often) these errors are happening.