### PR TITLE
BAU: Adjust Rubocop rules

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,8 +16,17 @@ Style/MixinUsage:
     - 'config/routes.rb'
     - 'config/main_routes.rb'
 
+Layout/AccessModifierIndentation:
+  EnforcedStyle: 'outdent'
+
 Metrics/LineLength:
-  Max: 140
+  Max: 160
 
 Style/FrozenStringLiteralComment:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false
+
+Layout/LeadingCommentSpace:
   Enabled: false


### PR DESCRIPTION
Disable and adjust a few rules to align with our conventions:
  - `private` access modifiers align with `class` keyword (not methods)
  - Increase max line length to 160 characters
  - Don't require documentation comment for every class and module
  - Don't require comments to start with a space
