### PR TITLE
tocxYVRS: check for empty IDP response

### DIFF
--- a/app/controllers/authn_response_controller.rb
+++ b/app/controllers/authn_response_controller.rb
@@ -52,7 +52,10 @@ class AuthnResponseController < SamlController
 private
 
   def raise_error_if_session_mismatch(relay_state, session_id)
+    raise Errors::WarningLevelError, 'Empty IDP response' if params.empty?
+
     error_message = "Relay state should match session id. Relay state was #{relay_state.inspect}"
+    error_message += ' and SAML was missing' unless params.key?('SAMLResponse')
     raise Errors::WarningLevelError, error_message if relay_state != session_id
   end
 

--- a/spec/controllers/authn_response_controller_spec.rb
+++ b/spec/controllers/authn_response_controller_spec.rb
@@ -52,9 +52,16 @@ describe AuthnResponseController do
 
     it 'when relay state does not equal session id in the idp response' do
       set_session_and_cookies_with_loa('LEVEL_1')
-      session[:verify_session_id] = 'non-existent'
 
-      post :idp_response, params: { 'RelayState' => 'my-session-id-cookie', 'SAMLResponse' => 'a-saml-response', locale: 'en' }
+      post :idp_response, params: { 'RelayState' => 'wrong_session_id', 'SAMLResponse' => 'a-saml-response', locale: 'en' }
+
+      expect(subject).to render_template(:something_went_wrong)
+    end
+
+    it 'when idp response is empty' do
+      set_session_and_cookies_with_loa('LEVEL_1')
+
+      post :idp_response, params: {}
 
       expect(subject).to render_template(:something_went_wrong)
     end


### PR DESCRIPTION
Give more information on the IDP response received if the relay state is missing. Also update test to actually test an invalid relay state.

See https://trello.com/c/tocxYVRS/150-understand-and-fix-relay-state-was-nil-error