### PR TITLE
Allow cycle three page customisation with `intro_html`

### DIFF
--- a/app/models/cycle_three/cycle_three_attribute.rb
+++ b/app/models/cycle_three/cycle_three_attribute.rb
@@ -42,7 +42,7 @@ module CycleThree
       self.class.simple_id
     end
 
-    delegate :name, :field_name, :help_to_find, :example, to: :display_data
+    delegate :name, :field_name, :help_to_find, :example, :intro_html, to: :display_data
 
   private
 

--- a/app/models/display/cycle_three_display_data.rb
+++ b/app/models/display/cycle_three_display_data.rb
@@ -8,5 +8,6 @@ module Display
     content :field_name
     content :help_to_find
     content :example
+    content :intro_html, default: nil
   end
 end

--- a/app/views/further_information/index.html.erb
+++ b/app/views/further_information/index.html.erb
@@ -8,7 +8,11 @@
 <div class="grid-row">
   <div class="column-two-thirds">
     <h1 class="heading-large"><%= @transaction_name.slice(0,1).upcase + @transaction_name.slice(1..-1)%></h1>
-    <p><%= t('hub.further_information.first_time') %></p>
+    <% if @cycle_three_attribute.intro_html %>
+      <%= raw @cycle_three_attribute.intro_html %>
+    <% else %>
+      <p><%= t('hub.further_information.first_time') %></p>
+    <% end %>
 
     <%= form_for @cycle_three_attribute, url: further_information_submit_path,
                  html: { novalidate: true,

--- a/spec/features/user_visits_further_information_page_spec.rb
+++ b/spec/features/user_visits_further_information_page_spec.rb
@@ -28,10 +28,19 @@ RSpec.describe 'user visits further information page' do
     expect(page).to have_title t('hub.further_information.title', cycle_three_name: attribute_field_name)
     expect(page).to have_css '.form-label-bold', text: attribute_field_name
     expect(page).to have_css 'span.form-hint', text: t('hub.further_information.example_text', example: t('cycle3.NationalInsuranceNumber.example'))
+    expect(page).to have_content t('hub.further_information.first_time')
     expect(page).to have_content t('hub.further_information.help_with_your', cycle_three_name: attribute_name)
     expect(page).to have_content 'Your National Insurance number can be found on'
     expect(page).to have_content t('hub.further_information.cancel', transaction_name: rp_name)
     expect_feedback_source_to_be(page, 'CYCLE_3_PAGE', further_information_path)
+  end
+
+  it 'allows the introductory text to be customised' do
+    stub_cycle_three_attribute_request('DrivingLicenceNumber')
+    visit further_information_path
+
+    expect(page.body).to include t('cycle3.DrivingLicenceNumber.intro_html')
+    expect(page).not_to have_content t('hub.further_information.first_time')
   end
 
   it 'will submit valid driving license number' do

--- a/spec/models/cycle_three/cycle_three_attribute_spec.rb
+++ b/spec/models/cycle_three/cycle_three_attribute_spec.rb
@@ -16,6 +16,7 @@ module CycleThree
       field_name
       help_to_find
       example
+      intro_html
     ].each do |field|
       include_examples "delegates to display_data", field, CycleThreeAttribute
     end

--- a/spec/models/display/cycle_three_display_data_spec.rb
+++ b/spec/models/display/cycle_three_display_data_spec.rb
@@ -5,6 +5,7 @@ require 'display/display_data'
 module Display
   describe CycleThreeDisplayData do
     %i[
+      intro_html
       name
       field_name
       help_to_find

--- a/stub/locales/cycle3/DrivingLicenceNumber.yml
+++ b/stub/locales/cycle3/DrivingLicenceNumber.yml
@@ -1,6 +1,7 @@
 en:
   cycle3:
     DrivingLicenceNumber:
+      intro_html: <p>Now we need to link your identity to your Driving License.</p>
       name: driving licence number
       field_name: Driving licence number
       help_to_find: |


### PR DESCRIPTION
* Land Registry (HMLR) want to customise their 'sign your mortgage deed' service matching page.

https://trello.com/c/GETxCo0p/142-sign-your-mortgage-deed-revision-to-page-content
https://govuk.zendesk.com/agent/tickets/3622311