### PR TITLE
EID-1389: Log AuthnRequest information in hub response handler when error from saml-proxy

### DIFF
--- a/app/controllers/authn_request_controller.rb
+++ b/app/controllers/authn_request_controller.rb
@@ -24,7 +24,7 @@ private
 
   def create_session
     reset_session
-
+    store_rp_request_data
     session_id = SAML_PROXY_API.create_session(params['SAMLRequest'], params['RelayState'])
     set_secure_cookie(CookieNames::SESSION_ID_COOKIE_NAME, session_id)
     set_session_id(session_id)
@@ -110,5 +110,11 @@ private
     return redirect_to start_path unless session[:transaction_supports_eidas]
 
     redirect_to prove_identity_path
+  end
+
+  def store_rp_request_data
+    RequestStore.store[:rp_referer] = request.referer
+    RequestStore.store[:rp_saml_request] = params.fetch('SAMLRequest', nil)
+    RequestStore.store[:rp_relay_state] = params.fetch('RelayState', nil)
   end
 end

--- a/lib/api/hub_response_handler.rb
+++ b/lib/api/hub_response_handler.rb
@@ -1,7 +1,7 @@
 module Api
   class HubResponseHandler
     ERROR_MESSAGE_PATTERN = "Unexpected error whilst trying to communicate wth the Hub. " \
-                            "Received %s with error message: %s, type: '%s' and id: '%s'\n" \
+                            "Received %s with error message: %s, type: '%s' and id: '%s', Referer: '%s'%s\n" \
                             "The Hub may be unreachable. Check all services are running and are accessible".freeze
 
     def handle_response(response_status, response_body)
@@ -33,7 +33,12 @@ module Api
       id = json.fetch('errorId', 'NONE')
       type = json.fetch('exceptionType', 'NONE')
       error_message = json.fetch('clientMessage', 'NONE')
-      ERROR_MESSAGE_PATTERN % [status, "'#{error_message}'", type, id]
+      rp_referer = RequestStore.store[:rp_referer]
+      rp_saml_request = ''
+      if 'INVALID_SAML'.eql? type
+        rp_saml_request = ", RelayState: '#{RequestStore.store[:rp_relay_state]}', SAML Request: '#{RequestStore.store[:rp_saml_request]}'"
+      end
+      ERROR_MESSAGE_PATTERN % [status, "'#{error_message}'", type, id, rp_referer, rp_saml_request]
     end
 
     def parse_json(body, status)


### PR DESCRIPTION
When the Hub receives an invalid SAML request from a Relying Party, the `saml-proxy` service will send a 400 response to Verify `frontend`. The `frontend` logs should contain more information to help Verify diagnose the reason for the invalid payloads from the Relying Party.

This PR provides more data in `frontend` logging:

* the HTTP Referer (in all cases, to identify RP)
* the RelayState from Relying Party, when `saml-proxy` errors with an `INVALID_SAML` message
* the base64 encoded AuthRequest, when `saml-proxy` errors with an `INVALID_SAML` message

These attributes are attached to the request-scoped `RequestStore` module.