### PR TITLE
BAU - replacing sass-ruby dependency with sassc as the former is deprecated

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'http', '~> 2.0.0'
 gem 'connection_pool'
 
 # Assets
-gem 'sass-rails', '~> 5.0'
+gem 'sassc', '~> 2.0.1'
 gem 'autoprefixer-rails'
 gem 'uglifier', '~> 2.7.0'
 gem 'jquery-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -290,12 +290,9 @@ GEM
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    sass-rails (5.0.7)
-      railties (>= 4.0.0, < 6)
-      sass (~> 3.1)
-      sprockets (>= 2.8, < 4.0)
-      sprockets-rails (>= 2.0, < 4.0)
-      tilt (>= 1.1, < 3)
+    sassc (2.0.1)
+      ffi (~> 1.9)
+      rake
     scss_lint (0.57.1)
       rake (>= 0.9, < 13)
       sass (~> 3.5, >= 3.5.5)
@@ -321,7 +318,6 @@ GEM
       rack (>= 1, < 3)
     thor (0.20.3)
     thread_safe (0.3.6)
-    tilt (2.0.9)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     uglifier (2.7.2)
@@ -389,7 +385,7 @@ DEPENDENCIES
   route_translator (~> 5.0)
   rspec (~> 3.5.0)
   rspec-rails (~> 3.5.0)
-  sass-rails (~> 5.0)
+  sassc (~> 2.0.1)
   selenium-webdriver
   sentry-raven
   spring


### PR DESCRIPTION
See http://sass.logdown.com/posts/7081811