### PR TITLE
New heading for when user cannot use Verify.

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -272,7 +272,7 @@ cy:
       choose_another_company: Mae'n rhaid i chi ddewis cwmni ardystiedig wahanol i wirio eich hunaniaeth.
       choose_another_certified_company_link: Dewiswch gwmni arall
     verify_will_not_work_for_you:
-      heading: Ni fydd GOV.UK Verify yn gweithio i chi
+      heading: Ni fyddwch yn gallu defnyddio GOV.UK Verify
       content_html: |
         <p>Yn seiliedig ar eich atebion, nid oes unrhyw un o'r darparwyr hunaniaeth (a elwir hefyd yn gwmnïau ardystiedig) sy'n gweithio gyda GOV.UK Verify yn gallu cadarnhau'ch hunaniaeth.</p>
     may_not_work_if_you_live_overseas:
@@ -309,7 +309,7 @@ cy:
       youll_also_need: Byddwch hefyd angen pasport y DU neu drwydded yrru’r DU.
     will_not_work_without_uk_address:
       title: Ni fydd GOV.UK Verify yn gweithio i chi
-      heading: Ni fydd GOV.UK Verify yn gweithio i chi
+      heading: Ni fyddwch yn gallu defnyddio GOV.UK Verify
       explanation: Rydych angen cyfeiriad presennol yn y DU i gael eich hunaniaeth wedi’i ddilysu.
       verify_wont_work_but_there_is_still_a_way: Ni all 'GOV.UK Verify' cadarnhau pwy ydych chi oherwydd mai angen o leiaf un cyfeiriad yn y DU arnoch.  %{other_ways_text}
     choose_a_certified_company:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -277,7 +277,7 @@ en:
       choose_another_company: You have to choose a different certified company to verify your identity.
       choose_another_certified_company_link: Choose another company
     verify_will_not_work_for_you:
-      heading: GOV.UK Verify will not work for you
+      heading: You won’t be able to use GOV.UK Verify
       content_html: |
         <p>Based on your answers, none of the identity providers (also called certified companies) that work with GOV.UK Verify are able to verify your identity.</p>
     may_not_work_if_you_live_overseas:
@@ -314,7 +314,7 @@ en:
       youll_also_need: You’ll also need a UK passport or a UK driving licence.
     will_not_work_without_uk_address:
       title: GOV.UK Verify will not work for you
-      heading: GOV.UK Verify will not work for you
+      heading: You won’t be able to use GOV.UK Verify
       explanation: You need a current UK address to get your identity verified.
     choose_a_certified_company:
       title: Choose a certified company


### PR DESCRIPTION
New heading "You won’t be able to use GOV.UK Verify" for when user cannot use Verify replaces "GOV.UK Verify will not work for you".

 - Welsh translations pending (from Land Registry perhaps?)

 - unclear if we should change the title of the page too

https://govuk.zendesk.com/agent/tickets/3622311
https://trello.com/c/GETxCo0p/142-sign-your-mortgage-deed-revision-to-page-content