### PR TITLE
ZD-3643231: Do not accept requests without a SAML message

### DIFF
--- a/app/controllers/authn_request_controller.rb
+++ b/app/controllers/authn_request_controller.rb
@@ -1,5 +1,6 @@
 require 'ab_test/ab_test'
 require 'partials/journey_hinting_partial_controller'
+require 'partials/user_errors_partial_controller'
 
 class AuthnRequestController < SamlController
   include JourneyHintingPartialController
@@ -8,6 +9,8 @@ class AuthnRequestController < SamlController
   skip_before_action :set_piwik_custom_variables
 
   def rp_request
+    return if raise_error_if_params_invalid
+
     session_journey_hint_value = session.fetch(:journey_hint, nil)
     session_journey_hint_rp = session.fetch(:journey_hint_rp, nil)
     create_session
@@ -116,5 +119,9 @@ private
     RequestStore.store[:rp_referer] = request.referer
     RequestStore.store[:rp_saml_request] = params.fetch('SAMLRequest', nil)
     RequestStore.store[:rp_relay_state] = params.fetch('RelayState', nil)
+  end
+
+  def raise_error_if_params_invalid
+    session_error("Missing/empty SAML message from #{request.referer}") if params['SAMLRequest'].blank?
   end
 end

--- a/app/controllers/authn_request_controller.rb
+++ b/app/controllers/authn_request_controller.rb
@@ -122,6 +122,6 @@ private
   end
 
   def raise_error_if_params_invalid
-    session_error("Missing/empty SAML message from #{request.referer}") if params['SAMLRequest'].blank?
+    something_went_wrong_warn("Missing/empty SAML message from #{request.referer}", :bad_request) if params['SAMLRequest'].blank?
   end
 end

--- a/app/controllers/partials/user_errors_partial_controller.rb
+++ b/app/controllers/partials/user_errors_partial_controller.rb
@@ -38,9 +38,9 @@ module UserErrorsPartialController
     render_error('something_went_wrong', status)
   end
 
-  def something_went_wrong_warn(exception)
+  def something_went_wrong_warn(exception, status = :internal_server_error)
     logger.warn(exception)
-    render_error('something_went_wrong', :internal_server_error)
+    render_error('something_went_wrong', status)
   end
 
   def eidas_scheme_unavailable_error(exception)

--- a/spec/controllers/authn_request_controller_spec.rb
+++ b/spec/controllers/authn_request_controller_spec.rb
@@ -66,4 +66,19 @@ describe AuthnRequestController do
     post :rp_request, params: { 'SAMLRequest' => 'my-saml-request', 'RelayState' => 'my-relay-state' }
     expect(response).to redirect_to start_path
   end
+
+  it 'will show error page when SAMLRequest param is missing' do
+    post :rp_request, params: { 'RelayState' => 'my-relay-state' }
+    expect(response).to have_http_status :bad_request
+  end
+
+  it 'will show error page when SAMLRequest param is empty string' do
+    post :rp_request, params: { 'SAMLRequest' => '', 'RelayState' => 'my-relay-state' }
+    expect(response).to have_http_status :bad_request
+  end
+
+  it 'will show error page when SAMLRequest param is nil' do
+    post :rp_request, params: { 'SAMLRequest' => nil, 'RelayState' => 'my-relay-state' }
+    expect(response).to have_http_status :bad_request
+  end
 end


### PR DESCRIPTION
Currently, when the authn request comes in we pass it on to saml-proxy to validate.
However, if the request doesn't have a SAML, the saml-proxy service raises an exception.
This commit adds the validation to frontend so we fail earlier
and don't pass the request on to saml-proxy.