### PR TITLE
FIREBREAK: Deploy PRs as temporary apps

### DIFF
--- a/Dockerfile.heroku
+++ b/Dockerfile.heroku
@@ -1,0 +1,31 @@
+FROM ruby:2.5.5
+
+ENV RAILS_SERVE_STATIC_FILES true
+ENV RAILS_LOG_TO_STDOUT true
+ENV RAILS_ENV production
+ENV SECRET_KEY_BASE notused
+ENV STUB_MODE true
+
+ADD Gemfile Gemfile
+
+RUN gem install --update bundler
+
+RUN bundle install --binstubs
+
+ADD . /verify-frontend/
+
+WORKDIR /verify-frontend
+
+RUN bundle config --global frozen 1 && \
+    bundle check || bundle install --without development test
+
+RUN echo 'heroku' > /verify-frontend/.build-number
+
+RUN bash -c 'source .env \
+             && export $(cut -d= -f1 .env) \
+             && bundle exec rake assets:precompile' \
+    && ln -s /verify-frontend/public/assets /assets
+
+# Puma needs these dockerignored dirs to write to
+RUN mkdir -p log tmp
+

--- a/Dockerfile.heroku
+++ b/Dockerfile.heroku
@@ -1,3 +1,5 @@
+# Dockerfile for Heroku Review App (deployed as part of a PR)
+
 FROM ruby:2.5.5
 
 ENV RAILS_SERVE_STATIC_FILES true

--- a/README.md
+++ b/README.md
@@ -39,3 +39,18 @@ On an OSX system this amounts to:
 brew install pre-commit
 pre-commit install
 ```
+
+## Deploying the application
+The application is deployed using our [CI/CD pipeline](https://deployer.tools.signin.service.gov.uk/teams/main/pipelines/deploy-verify-hub?groups=build-apps&groups=default). 
+Any changes merged to master are automatically deployed. This repo has an active branch protection for `master`. Any changes need to be raised via PR and approved by two other developers.
+
+## PR reviews
+When a PR is raised, it's automatically tested using Travis (runs the ./pre-commit.sh script on the branch and against master) which is configured in the [.travis file](/.travis). The test results are shown directly on the PR. 
+
+In addition to the Travis tests we have also enabled Codacy to check coding style. Again, the results are shown within the PR. Codacy is configured using the [.rubocop.yml file](/.rubocop.yml).
+
+The PR is also deployed to Heroku as [a review app](https://devcenter.heroku.com/articles/github-integration-review-apps). The app is destroyed when the PR is closed/merged or after 5 days of inactivity. It uses docker to run both the Rails app and the stub API server. The Heroku deployment is configured using the 4 files:
+* `Dockerfile.heroku` - to configure the docker image of frontend
+* `heroku.yml` - Heroku [deployment manifest](https://devcenter.heroku.com/articles/build-docker-images-heroku-yml) 
+* `app.json` - Heroku [application manifest](https://devcenter.heroku.com/articles/app-json-schema)
+* `heroku-startup.sh` - startup script used to start the app and api, with supplied port by Heroku

--- a/app.json
+++ b/app.json
@@ -1,0 +1,31 @@
+{
+  "description": "verify-frontend PR stub app",
+  "env": {
+    "CONFIG_API_HOST": "http://localhost:50199",
+    "POLICY_HOST": "http://localhost:50199",
+    "SAML_PROXY_HOST": "http://localhost:50199",
+    "ZDD_LATCH": "notused",
+    "PROMETHEUS_ENABLED": "false",
+    "METRICS_ENABLED": "false",
+    "ZENDESK_URL": "https://notused",
+    "ZENDESK_USERNAME": "notused",
+    "ZENDESK_TOKEN": "notused",
+    "CYCLE_3_DISPLAY_LOCALES": "stub/locales/cycle3",
+    "RULES_DIRECTORY": "stub/idp-rules",
+    "RP_CONFIG": "stub/relying_parties.yml",
+    "IDP_DISPLAY_LOCALES": "stub/locales/idps",
+    "CYCLE_THREE_ATTRIBUTES_DIRECTORY": "stub/attributes",
+    "AB_TEST_FILE": "stub/ab_test.yml",
+    "SEGMENT_DEFINITIONS": "stub/segment_definitions.yml",
+    "SECRET_KEY_BASE": "c3c3674815a6d38e2c8ca34962645095cbf69cd14a37d13384c574ee3ad1ba670c69c916ef0b0e04f7d9b7e27642b5c83fd1882db10089d9692f9e7a51fdc171",
+    "INTERNAL_PIWIK_HOST": "true",
+    "COUNTRY_DISPLAY_LOCALES": "stub/locales/countries",
+    "COUNTRY_FLAGS_DIRECTORY": "/eidas/country-flags",
+    "EIDAS_SCHEMES_DIRECTORY": "stub/eidas/schemes",
+    "EIDAS_SCHEME_LOGOS_DIRECTORY": "/eidas/scheme-logos",
+    "LOGO_DIRECTORY": "/stub-logos",
+    "WHITE_LOGO_DIRECTORY": "/stub-logos/white"
+  },
+  "name": "alphagov-verify-frontend",
+  "stack": "container"
+}

--- a/app/controllers/test_saml_controller.rb
+++ b/app/controllers/test_saml_controller.rb
@@ -1,6 +1,7 @@
 class TestSamlController < ApplicationController
   skip_before_action :validate_session
   skip_before_action :set_piwik_custom_variables
+  skip_before_action :verify_authenticity_token
   skip_after_action :store_locale_in_cookie
   layout 'test'
 

--- a/app/views/test_saml/idp_request.html.erb
+++ b/app/views/test_saml/idp_request.html.erb
@@ -1,8 +1,11 @@
-SAML Request is '<%= @saml_request %>'
-relay state is '<%= @relay_state %>'
-registration is '<%= @registration %>'
-hints are '<%= @hints %>'
-language hint was '<%= @language_hint %>'
+BANG! You're at an IDP!
+<br><br>
+The IDP received this: <br>
+SAML Request is '<%= @saml_request %>' <br>
+relay state is '<%= @relay_state %>' <br>
+registration is '<%= @registration %>' <br>
+hints are '<%= @hints %>' <br>
+language hint was '<%= @language_hint %>' <br>
 <% if !@single_idp.nil?%>
 single IDP journey uuid is '<%= @single_idp %>' 
 <% end %>

--- a/config/initializers/00_configuration.rb
+++ b/config/initializers/00_configuration.rb
@@ -40,5 +40,7 @@ CONFIG = Configuration.load! do
   option_bool 'feedback_disabled', 'FEEDBACK_DISABLED', default: false
   # Feature flags
   option_bool 'single_idp_feature', 'SINGLE_IDP_FEATURE', default: true
+
+  # Enables dev/test routes when compiled for a production env
   option_bool 'stub_mode', 'STUB_MODE', default: false
 end

--- a/config/initializers/00_configuration.rb
+++ b/config/initializers/00_configuration.rb
@@ -40,4 +40,5 @@ CONFIG = Configuration.load! do
   option_bool 'feedback_disabled', 'FEEDBACK_DISABLED', default: false
   # Feature flags
   option_bool 'single_idp_feature', 'SINGLE_IDP_FEATURE', default: true
+  option_bool 'stub_mode', 'STUB_MODE', default: false
 end

--- a/config/initializers/30_federation.rb
+++ b/config/initializers/30_federation.rb
@@ -57,4 +57,6 @@ Rails.application.config.after_initialize do
   IDP_FEATURE_FLAGS_CHECKER = IdpConfiguration::IdpFeatureFlagsLoader.new(YamlLoader.new)
                                  .load(CONFIG.rules_directory, %i[send_hints send_language_hint show_interstitial_question show_interstitial_question_loa1])
   SINGLE_IDP_FEATURE = CONFIG.single_idp_feature
+
+  STUB_MODE = CONFIG.stub_mode
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,9 +17,10 @@ Rails.application.routes.draw do
   post 'SAML2/SSO/EidasResponse/POST' => 'authn_response#country_response'
   match "/404", to: "errors#page_not_found", via: :all
 
-  if %w(test development).include? Rails.env
+  if %w(test development).include?(Rails.env) || STUB_MODE
     mount JasmineRails::Engine => '/specs' if defined?(JasmineRails)
     get 'test-saml' => 'test_saml#index'
+    get '/' => 'test_saml#index'
     post 'test-rp', to: proc { |_| [200, {}, ['OK']] }
     post 'test-idp-request-endpoint' => 'test_saml#idp_request'
     post 'test-initiate-journey' => 'test_saml#initiate_journey_session'

--- a/heroku-startup.sh
+++ b/heroku-startup.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+echo "Heroku instance"
+
+if [ "$1" == '--stub-api' ]
+then
+  echo "Starting stub-api server on port 50199"
+  export CONFIG_API_HOST=http://localhost:50199
+  export POLICY_HOST=http://localhost:50199
+  export SAML_PROXY_HOST=http://localhost:50199
+  (
+  export BUNDLE_GEMFILE=stub/api/Gemfile
+  bundle check || bundle install
+  bundle exec rackup  --daemonize --port 50199 --pid tmp/stub_api.pid stub/api/stub_api_conf.ru
+  )
+fi
+
+RAILS_ENV=production bundle exec puma -p $PORT

--- a/heroku.yml
+++ b/heroku.yml
@@ -1,0 +1,5 @@
+build:
+  docker:
+    web: Dockerfile.heroku
+run:
+  web: ./heroku-startup.sh --stub-api

--- a/stub/api/stub_api.rb
+++ b/stub/api/stub_api.rb
@@ -142,7 +142,7 @@ class StubApi < Sinatra::Base
 
   get '/SAML2/SSO/API/SENDER/AUTHN_REQ' do
     '{
-      "postEndpoint":"http://localhost:50300/test-saml",
+      "postEndpoint":"/test-idp-request-endpoint",
       "samlMessage":"blah",
       "relayState":"whatever",
       "registration":false
@@ -193,6 +193,11 @@ class StubApi < Sinatra::Base
         "loaList":["LEVEL_1","LEVEL_2"],
         "entityId": "http://example.com/test-rp-loa1"
       }]'
+  end
+
+  post '/policy/received-authn-request/my-relay-state/select-identity-provider' do
+    status 200
+    ''
   end
 
   get '/api/countries/blah' do


### PR DESCRIPTION
With the removal of the joint environment, we no longer have an environment where people (e.g. content designers) could go and review/try content changes.

This PR adds some Heroku config in order to allow us to automatically deploy PRs to a temporary environment. It makes use of [Heroku review apps](https://devcenter.heroku.com/articles/github-integration-review-apps). It also introduces a new config variable called `STUB_MODE` to enable the test/stub flows and routes while running in a production mode (in Heroku).

Next steps:
- [ ] configure a bot to integrate with Heroku to trigger these PR builds
- [ ] some work on the stubs to enable as many features as possible (e.g. eIDAS doesn't work)