### PR TITLE
BAU: Fix timezone issue

### DIFF
--- a/app/controllers/further_information_controller.rb
+++ b/app/controllers/further_information_controller.rb
@@ -52,6 +52,6 @@ class FurtherInformationController < ApplicationController
 private
 
   def expired?
-    !session[:assertion_expiry].nil? && Time.parse(session[:assertion_expiry]) <= Time.now
+    !session[:assertion_expiry].nil? && Time.parse(session[:assertion_expiry]) <= Time.now.utc
   end
 end


### PR DESCRIPTION
Verify frontend is comparing notOnOrAfter field (assertion_expiry) against the current system clock. The clock can be in different timezone e.g. British Summer Time (GMT+0100). According to SAML specification, notOnOrAfter specifies the time instant at which the assertion has expired. The time value is encoded in UTC. This commit updates verify frontend to compare notOnOrAfter field against the system clock in UTC. This will prevent users from getting session timeout errors.

Author: @adityapahuja