### PR TITLE
BAU: Stop relying on a user's browser system clock

### DIFF
--- a/app/assets/javascripts/modal_dialog.js
+++ b/app/assets/javascripts/modal_dialog.js
@@ -18,7 +18,7 @@
       $accessibleTimer: $('#js-modal-dialog .at-timer'),
       // Timer specific settings. If these are not set, timeout and redirection are disabled
       timeOutRedirectUrl: $('#js-modal-dialog').data('url-redirect'),
-      expiryTime: $('#js-modal-dialog').data('utc-expiry'),
+      expiryTime: new Date().getTime() + ($('#js-modal-dialog').data('seconds-to-timeout') * 1000),
       secondsTimeOutModalVisible: $('#js-modal-dialog').data('seconds-modal-visible'),
       modalText: $('#js-modal-dialog').data('text'),
       modalExtraText: $('#js-modal-dialog').data('extra-text'),

--- a/app/controllers/further_information_controller.rb
+++ b/app/controllers/further_information_controller.rb
@@ -1,5 +1,6 @@
 class FurtherInformationController < ApplicationController
   def index
+    @seconds_to_timeout = get_seconds_to_timeout
     return redirect_to further_information_timeout_path if expired?
 
     session_id = session[:verify_session_id]
@@ -19,6 +20,7 @@ class FurtherInformationController < ApplicationController
       FEDERATION_REPORTER.report_cycle_three(current_transaction, request, @cycle_three_attribute.simple_id)
       redirect_to response_processing_path
     else
+      @seconds_to_timeout = get_seconds_to_timeout
       @transaction_name = current_transaction.name
       render 'index'
     end
@@ -53,5 +55,9 @@ private
 
   def expired?
     !session[:assertion_expiry].nil? && Time.parse(session[:assertion_expiry]) <= Time.now
+  end
+
+  def get_seconds_to_timeout
+    (Time.parse(session[:assertion_expiry]) - Time.now.utc).to_i unless session[:assertion_expiry].nil?
   end
 end

--- a/app/views/further_information/_modal_dialog.html.erb
+++ b/app/views/further_information/_modal_dialog.html.erb
@@ -1,4 +1,4 @@
-<dialog id="js-modal-dialog" data-utc-expiry="<%= session[:assertion_expiry] %>" data-seconds-modal-visible="300"
+<dialog id="js-modal-dialog" data-seconds-to-timeout="<%= (Time.parse(session[:assertion_expiry]) - Time.now.utc).to_i %>" data-seconds-modal-visible="300"
 data-url-redirect="<%= url_for(controller: 'further_information', action: 'timeout') %>" data-text="<%= t('hub.further_information.modal.text') %>" data-extra-text="<%= t('hub.further_information.modal.extra_text', idp_name: @idp_name) %>" class="modal-dialog dialog" role="dialog" aria-live="polite" aria-labelledby="dialog-title" aria-describedby="at-timer">
   <div class="modal-dialog__inner">
 	  <h1 id="dialog-title" class="dialog-title heading-large">

--- a/app/views/further_information/_modal_dialog.html.erb
+++ b/app/views/further_information/_modal_dialog.html.erb
@@ -1,4 +1,4 @@
-<dialog id="js-modal-dialog" data-seconds-to-timeout="<%= (Time.parse(session[:assertion_expiry]) - Time.now.utc).to_i %>" data-seconds-modal-visible="300"
+<dialog id="js-modal-dialog" data-seconds-to-timeout="<%= @seconds_to_timeout %>" data-seconds-modal-visible="300"
 data-url-redirect="<%= url_for(controller: 'further_information', action: 'timeout') %>" data-text="<%= t('hub.further_information.modal.text') %>" data-extra-text="<%= t('hub.further_information.modal.extra_text', idp_name: @idp_name) %>" class="modal-dialog dialog" role="dialog" aria-live="polite" aria-labelledby="dialog-title" aria-describedby="at-timer">
   <div class="modal-dialog__inner">
 	  <h1 id="dialog-title" class="dialog-title heading-large">


### PR DESCRIPTION
Currently, Verify Frontend uses JavaScript to compare session's expiry time in UTC taken from the server against the user's browser system clock. The issue with this approach is that when the user's browser system clock is set to a wrong time unintentionally (e.g. adding 2 hours forward from the true time), the user will always be redirected to timeout page since the user's browser clock is always after the session's expiry time taken from the server. Verify Frontend should do session expiry validation on the server side instead of the client side.

This commit changes Verify Frontend to calculate the number of seconds it takes for the session to timeout or expire and provide it instead of the session's expiry time to the JavaScript. The JavaScript then uses it to add the timeout to the user's browser clock to obtain the session's expiry time. This changes will ensure that the user will not be redirected to the timeout page if the user's browser clock is set to wrong time.

Author: @adityapahuja