### PR TITLE
use official prometheus client repo again

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,12 +28,10 @@ gem 'statsd-ruby', '~> 1.3.0'
 
 # Use prometheus-client to expose metrics to prometheus
 #
-# prometheus/client_ruby is undergoing a massive rewrite in
-# https://github.com/prometheus/client_ruby/pull/95 - it will hit
-# upstream master soon, so to avoid us having to rewrite code let's
-# target the new client immediately (and then point at the official
-# client again when it's merged)
-gem 'prometheus-client', git: 'https://github.com/gocardless/prometheus_client_ruby.git', branch: 'pluggable_data_stores'
+# prometheus/client_ruby had a massive rewrite in
+# https://github.com/prometheus/client_ruby/pull/95 - it has landed in
+# master but not been released yet
+gem 'prometheus-client', git: 'https://github.com/prometheus/client_ruby.git'
 
 # Use sentry-raven for sending logs to Sentry via the raven protocol
 gem 'sentry-raven'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,6 @@
 GIT
-  remote: https://github.com/gocardless/prometheus_client_ruby.git
-  revision: 5dce3e5855f2aa67c65874c953878e124c23edcd
-  branch: pluggable_data_stores
+  remote: https://github.com/prometheus/client_ruby.git
+  revision: 460c2bbe70fb4434adaa2bdbeb7ff09e84abd0de
   specs:
     prometheus-client (0.9.0)
       concurrent-ruby


### PR DESCRIPTION
prometheus/client_ruby#95 has been merged (although not yet released
to rubygems) so we can use the official client git repo instead of the
gocardless fork.

This bumps us from 5dce3e5 (the latest commit on the gocardless
branch) to 460c2bb (the commit that merged the gocardless branch into
master) so it's a pretty minimal change.