### PR TITLE
Use prometheus client from rubygems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,9 +29,9 @@ gem 'statsd-ruby', '~> 1.3.0'
 # Use prometheus-client to expose metrics to prometheus
 #
 # prometheus/client_ruby had a massive rewrite in
-# https://github.com/prometheus/client_ruby/pull/95 - it has landed in
-# master but not been released yet
-gem 'prometheus-client', git: 'https://github.com/prometheus/client_ruby.git'
+# https://github.com/prometheus/client_ruby/pull/95
+# This is the prerelease version of that work
+gem 'prometheus-client', '~> 0.10.0.pre.alpha.1'
 
 # Use sentry-raven for sending logs to Sentry via the raven protocol
 gem 'sentry-raven'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,3 @@
-GIT
-  remote: https://github.com/prometheus/client_ruby.git
-  revision: 460c2bbe70fb4434adaa2bdbeb7ff09e84abd0de
-  specs:
-    prometheus-client (0.9.0)
-      concurrent-ruby
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -197,6 +190,8 @@ GEM
       insist
       mustache (= 0.99.8)
       stud
+    prometheus-client (0.10.0.pre.alpha.1)
+      concurrent-ruby
     psych (3.1.0)
     public_suffix (3.0.3)
     puma (3.12.1)
@@ -372,7 +367,7 @@ DEPENDENCIES
   mini_racer
   multi_json
   pkgr (~> 1.5.1)
-  prometheus-client!
+  prometheus-client (~> 0.10.0.pre.alpha.1)
   puma
   rack-handlers
   rack-test


### PR DESCRIPTION
The enormous rewrite from prometheus/client_ruby#95 has been merged,
and a prerelease version of it is now available on rubygems (as of
prometheus/client_ruby#124).  We should use the rubygems version
rather than the git version; when 0.10.0 is properly released we
should use that.