### PR TITLE
EID-1463: Log missing single IDP params as warn rather than error

### DIFF
--- a/app/controllers/single_idp_journey_controller.rb
+++ b/app/controllers/single_idp_journey_controller.rb
@@ -181,7 +181,7 @@ private
   def params_are_missing(params_keys)
     params_keys.each do |param_key|
       if params[param_key].nil? || params[param_key].blank?
-        logger.error "Single IDP parameter #{param_key} is missing" + referrer_string
+        logger.warn "Single IDP parameter #{param_key} is missing" + referrer_string
         return true
       end
     end

--- a/spec/controllers/single_idp_journey_controller_spec.rb
+++ b/spec/controllers/single_idp_journey_controller_spec.rb
@@ -68,7 +68,7 @@ describe SingleIdpJourneyController do
     describe 'no parameters provided' do
       subject { post :redirect_from_idp }
       it 'should redirect to the start page and not set a cookie when an incorrect rp is supplied' do
-        expect(Rails.logger).to receive(:error).with(/Single IDP parameter serviceId is missing/)
+        expect(Rails.logger).to receive(:warn).with(/Single IDP parameter serviceId is missing/)
         expect(subject).to redirect_to(verify_services_path)
         expect(cookies.encrypted[CookieNames::VERIFY_SINGLE_IDP_JOURNEY]).to be(nil)
       end
@@ -83,7 +83,7 @@ describe SingleIdpJourneyController do
         }
       }
       it 'should redirect to the start page and not set a cookie when an incorrect rp is supplied' do
-        expect(Rails.logger).to receive(:error).with(/Single IDP parameter serviceId is missing/)
+        expect(Rails.logger).to receive(:warn).with(/Single IDP parameter serviceId is missing/)
         expect(subject).to redirect_to(verify_services_path)
         expect(cookies.encrypted[CookieNames::VERIFY_SINGLE_IDP_JOURNEY]).to be(nil)
       end


### PR DESCRIPTION
We handle missing params by redirecting users to another page so we don't need to see these logs in Sentry