### PR TITLE
BAU: Fix Single IDP journey controller session validation issues

### DIFF
--- a/app/controllers/single_idp_journey_controller.rb
+++ b/app/controllers/single_idp_journey_controller.rb
@@ -19,8 +19,8 @@ class SingleIdpJourneyController < ApplicationController
   include SingleIdpPartialController
 
   protect_from_forgery except: :redirect_from_idp
-  skip_before_action :validate_session, only: %i{redirect_from_idp rp_start_page}
-  skip_before_action :set_piwik_custom_variables, only: %i{redirect_from_idp rp_start_page}
+  skip_before_action :validate_session, only: %i{:redirect_from_idp :rp_start_page}
+  skip_before_action :set_piwik_custom_variables, only: %i{:redirect_from_idp :rp_start_page}
 
   def continue_to_your_idp
     if valid_cookie? && valid_selection?


### PR DESCRIPTION
`skip_before_action` takes an array of symbols
