### PR TITLE
BAU: Fix Single IDP journey missing transaction entity ID errors

### DIFF
--- a/app/controllers/single_idp_journey_controller.rb
+++ b/app/controllers/single_idp_journey_controller.rb
@@ -37,6 +37,10 @@ class SingleIdpJourneyController < ApplicationController
   end
 
   def continue
+    unless session_is_valid?
+      something_went_wrong_warn("Invalid session in Single IDP journey")
+    end
+
     if params_are_missing(%w(entity_id))
       redirect_to start_path
     else
@@ -119,6 +123,10 @@ private
         uuid: uuid
     }
     set_single_idp_journey_cookie(data)
+  end
+
+  def session_is_valid?
+    session_validator.validate(cookies, session).ok?
   end
 
   def valid_selection?


### PR DESCRIPTION
For some reason, transaction entity ID is sometimes missing from the session. Check the session is valid and show error page if not.