### PR TITLE
BAU: Explicitly allow robots to index all pages

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -3,3 +3,8 @@
 # To ban all spiders from the entire site uncomment the next two lines:
 # User-agent: *
 # Disallow: /
+
+# Explicitly allow all pages to be accessed by crawlers
+User-agent: *
+Disallow:
+Allow: /


### PR DESCRIPTION
We have `noindex` HTML tags on some pages to prevent them from being indexed. Robots need to be able to access those pages to see the tag.
Google thinks some of our pages are being blocked by `robots.txt` whilst we're actually allowing all robots on all pages.
Maybe an explicit Allow directive will fix this.

_Tested with Google's robots.txt tester tool_
