### PR TITLE
BAU: Ban robots from indexing

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -17,6 +17,8 @@ module ApplicationHelper
   end
 
   def hide_from_search_engine?
+    response.set_header("X-Robots-Tag", "noindex") if !content_for(:show_to_search_engine)
+
     !content_for(:show_to_search_engine)
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -17,9 +17,10 @@ module ApplicationHelper
   end
 
   def hide_from_search_engine?
-    response.set_header("X-Robots-Tag", "noindex") if !content_for(:show_to_search_engine)
+    return false if content_for(:show_to_search_engine)
 
-    !content_for(:show_to_search_engine)
+    response.set_header("X-Robots-Tag", "noindex")
+    true
   end
 
   def feedback_source

--- a/app/views/feedback/disabled.html.erb
+++ b/app/views/feedback/disabled.html.erb
@@ -1,5 +1,4 @@
 <%= page_title 'hub.feedback_disabled.title' %>
-<% content_for :show_to_search_engine, true %>
 
 <div class="grid-row">
   <div class="column-two-thirds">

--- a/app/views/feedback/index.html.erb
+++ b/app/views/feedback/index.html.erb
@@ -1,5 +1,4 @@
 <%= page_title 'hub.feedback.title' %>
-<% content_for :show_to_search_engine, true %>
 
 <div class="grid-row">
   <div class="column-two-thirds">

--- a/app/views/feedback_landing/index.html.erb
+++ b/app/views/feedback_landing/index.html.erb
@@ -1,5 +1,4 @@
 <%= page_title 'hub.feedback_landing.title' %>
-<% content_for :show_to_search_engine, true %>
 <% content_for :feedback_source, flash['feedback_source'] %>
 
 <div class="grid-row">


### PR DESCRIPTION
Setting the meta tag is not enough on error pages as Googlebot doesn't read it.
This uses the existing flag to append the the response headers.

I also considered using the nginx rules, but it would be a bit more complex with the
conditions as we actually control which pages to index from frontend.

Also removed some of the flags on pages which I don't believe should be indexed. Like the feedback form?