### PR TITLE
BAU: find out whether errors are recoverable

### DIFF
--- a/app/controllers/partials/user_errors_partial_controller.rb
+++ b/app/controllers/partials/user_errors_partial_controller.rb
@@ -35,7 +35,6 @@ module UserErrorsPartialController
 
   # How often do we have the information needed to redirect the user back to the
   # service start page?
-  # TODO: if this works, start using RedirectToServiceController (or similar).
   def check_whether_recoverable
     begin
       if session && current_transaction

--- a/app/controllers/partials/user_errors_partial_controller.rb
+++ b/app/controllers/partials/user_errors_partial_controller.rb
@@ -33,13 +33,31 @@ module UserErrorsPartialController
     end
   end
 
+  # How often do we have the information needed to redirect the user back to the
+  # service start page?
+  # TODO: if this works, start using RedirectToServiceController (or similar).
+  def check_whether_recoverable
+    begin
+      if session && current_transaction
+        logger.info("Session may be recoverable; " +
+          "session_id: #{session[:verify_session_id]}, rp: #{current_transaction.rp_name}")
+      end
+    rescue StandardError => e
+      # We do not want to interfere with the normal error-handling behaviour, so
+      # catch all errors.
+      logger.info("Failed to recover: #{e.message}")
+    end
+  end
+
   def something_went_wrong(exception, status = :internal_server_error)
     logger.error(exception)
+    check_whether_recoverable
     render_error('something_went_wrong', status)
   end
 
   def something_went_wrong_warn(exception, status = :internal_server_error)
     logger.warn(exception)
+    check_whether_recoverable
     render_error('something_went_wrong', status)
   end
 


### PR DESCRIPTION
Add logging to test whether we have enough information to perform partial reecovery when users are shown the 'something has gone wrong' page. If this shows a good number of users could be helped, we'll redirect to a more helpful error page. Otherwise, this experiment should be reverted.

See https://trello.com/c/kl73OxUJ/241-improve-the-something-went-wrong-experience for more information.