### PR TITLE
refactor: use concerns to replace partial controllers

### DIFF
--- a/app/controllers/about_loa1_controller.rb
+++ b/app/controllers/about_loa1_controller.rb
@@ -1,7 +1,5 @@
-require 'partials/viewable_idp_partial_controller'
-
 class AboutLoa1Controller < ApplicationController
-  include ViewableIdpPartialController
+  include ViewableIdp
 
   layout 'slides', except: [:choosing_a_company]
 

--- a/app/controllers/about_loa2_controller.rb
+++ b/app/controllers/about_loa2_controller.rb
@@ -1,7 +1,5 @@
-require 'partials/viewable_idp_partial_controller'
-
 class AboutLoa2Controller < ApplicationController
-  include ViewableIdpPartialController
+  include ViewableIdp
 
   layout 'slides', except: [:choosing_a_company]
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,45 +1,22 @@
 require 'redirect_with_see_other'
 require 'cookies/cookies'
 require 'errors/warning_level_error'
-require 'partials/user_characteristics_partial_controller'
-require 'partials/user_errors_partial_controller'
-require 'partials/user_cookies_partial_controller'
-require 'partials/user_session_partial_controller'
-require 'partials/transactions_partial_controller'
-require 'partials/analytics_partial_controller'
 
 class ApplicationController < ActionController::Base
   include DeviceType
-  include UserErrorsPartialController
-  include UserCharacteristicsPartialController
-  include UserCookiesPartialController
-  include UserSessionPartialController
-  include TransactionsPartialController
-  include AnalyticsPartialController
+  include UserErrors
+  include UserCharacteristics
+  include UserCookies
+  include UserSession
+  include Transactions
+  include AnalyticsReporting
 
-  before_action :validate_session
-  before_action :set_visitor_cookie
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
   before_action :set_locale
   before_action :store_originating_ip
-  before_action :set_piwik_custom_variables
-  after_action :store_locale_in_cookie, if: -> { request.method == 'GET' }
-  after_action :delete_new_visit_flag
 
-  helper_method :transaction_taxon_list
-  helper_method :transactions_list
-  helper_method :current_transaction
-  helper_method :loa1_transactions_list
-  helper_method :loa2_transactions_list
-  helper_method :public_piwik
-
-  rescue_from StandardError, with: :something_went_wrong unless Rails.env == 'development'
-  rescue_from Errors::WarningLevelError, with: :something_went_wrong_warn
-  rescue_from Api::SessionError, with: :session_error
-  rescue_from Api::UpstreamError, with: :upstream_error
-  rescue_from Api::SessionTimeoutError, with: :session_timeout
 
   prepend RedirectWithSeeOther
 

--- a/app/controllers/authn_request_controller.rb
+++ b/app/controllers/authn_request_controller.rb
@@ -1,9 +1,7 @@
 require 'ab_test/ab_test'
-require 'partials/journey_hinting_partial_controller'
-require 'partials/user_errors_partial_controller'
 
 class AuthnRequestController < SamlController
-  include JourneyHintingPartialController
+  include JourneyHinting
   protect_from_forgery except: :rp_request
   skip_before_action :validate_session
   skip_before_action :set_piwik_custom_variables

--- a/app/controllers/authn_response_controller.rb
+++ b/app/controllers/authn_response_controller.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'partials/user_cookies_partial_controller'
 
 class AuthnResponseController < SamlController
   protect_from_forgery except: %i[idp_response country_response]

--- a/app/controllers/choose_a_certified_company_about.rb
+++ b/app/controllers/choose_a_certified_company_about.rb
@@ -1,7 +1,5 @@
-require 'partials/viewable_idp_partial_controller'
-
 module ChooseACertifiedCompanyAbout
-  include ViewableIdpPartialController
+  include ViewableIdp
 
   def about
     simple_id = params[:company]

--- a/app/controllers/choose_a_certified_company_loa1_controller.rb
+++ b/app/controllers/choose_a_certified_company_loa1_controller.rb
@@ -1,8 +1,6 @@
-require 'partials/viewable_idp_partial_controller'
-
 class ChooseACertifiedCompanyLoa1Controller < ApplicationController
   include ChooseACertifiedCompanyAbout
-  include ViewableIdpPartialController
+  include ViewableIdp
 
   def index
     @recommended_idps = IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate_collection(current_identity_providers_for_loa)

--- a/app/controllers/choose_a_certified_company_loa2_controller.rb
+++ b/app/controllers/choose_a_certified_company_loa2_controller.rb
@@ -1,8 +1,6 @@
-require 'partials/viewable_idp_partial_controller'
-
 class ChooseACertifiedCompanyLoa2Controller < ApplicationController
   include ChooseACertifiedCompanyAbout
-  include ViewableIdpPartialController
+  include ViewableIdp
 
   def index
     session[:selected_answers]&.delete('interstitial')

--- a/app/controllers/choose_a_country_controller.rb
+++ b/app/controllers/choose_a_country_controller.rb
@@ -1,7 +1,5 @@
-require 'partials/eidas_validation_partial_controller'
-
 class ChooseACountryController < ApplicationController
-  include EidasValidationPartialController
+  include EidasValidation
   before_action :ensure_session_eidas_supported
   before_action :setup_countries
 

--- a/app/controllers/concerns/analytics_cookie.rb
+++ b/app/controllers/concerns/analytics_cookie.rb
@@ -1,4 +1,6 @@
-module AnalyticsCookiePartialController
+module AnalyticsCookie
+  extend ActiveSupport::Concern
+
   def analytics_session_id
     cookie_value = cookies.fetch(analytics_cookie_name, nil)
     cookie_value.split('.').first unless cookie_value.nil?

--- a/app/controllers/concerns/analytics_reporting.rb
+++ b/app/controllers/concerns/analytics_reporting.rb
@@ -1,4 +1,12 @@
-module AnalyticsPartialController
+module AnalyticsReporting
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :set_piwik_custom_variables
+    after_action :delete_new_visit_flag
+    helper_method :public_piwik
+  end
+
   def public_piwik
     PUBLIC_PIWIK
   end

--- a/app/controllers/concerns/eidas_validation.rb
+++ b/app/controllers/concerns/eidas_validation.rb
@@ -1,4 +1,6 @@
-module EidasValidationPartialController
+module EidasValidation
+  extend ActiveSupport::Concern
+
   def ensure_session_eidas_supported
     txn_supports_eidas = session[:transaction_supports_eidas]
     unless txn_supports_eidas

--- a/app/controllers/concerns/idp_selection.rb
+++ b/app/controllers/concerns/idp_selection.rb
@@ -1,7 +1,7 @@
-require 'partials/journey_hinting_partial_controller'
+module IdpSelection
+  extend ActiveSupport::Concern
 
-module IdpSelectionPartialController
-  include JourneyHintingPartialController
+  include JourneyHinting
 
   def set_journey_hint_followed(entity_id)
     session[:user_followed_journey_hint] = user_followed_journey_hint(entity_id) if has_journey_hint?

--- a/app/controllers/concerns/journey_hinting.rb
+++ b/app/controllers/concerns/journey_hinting.rb
@@ -1,5 +1,7 @@
 # Shared methods for controllers which use the journey hint cookie to give users IDP suggestions
-module JourneyHintingPartialController
+module JourneyHinting
+  extend ActiveSupport::Concern
+
   PENDING_STATUS = 'PENDING'.freeze
 
   def journey_hint_value

--- a/app/controllers/concerns/retrieve_federation_data.rb
+++ b/app/controllers/concerns/retrieve_federation_data.rb
@@ -1,4 +1,5 @@
-module RetrieveFederationDataPartialController
+module RetrieveFederationData
+  extend ActiveSupport::Concern
   def get_selected_rp_from_entity_id(list, entity_id)
     return nil if list.nil?
 

--- a/app/controllers/concerns/single_idp.rb
+++ b/app/controllers/concerns/single_idp.rb
@@ -1,4 +1,5 @@
-module SingleIdpPartialController
+module SingleIdp
+  extend ActiveSupport::Concern
   def single_idp_cookie
     MultiJson.load(cookies.encrypted[CookieNames::VERIFY_SINGLE_IDP_JOURNEY])
   rescue MultiJson::ParseError

--- a/app/controllers/concerns/transactions.rb
+++ b/app/controllers/concerns/transactions.rb
@@ -1,4 +1,14 @@
-module TransactionsPartialController
+module Transactions
+  extend ActiveSupport::Concern
+
+  included do
+    helper_method :transaction_taxon_list
+    helper_method :transactions_list
+    helper_method :current_transaction
+    helper_method :loa1_transactions_list
+    helper_method :loa2_transactions_list
+  end
+
   def transaction_taxon_list
     TRANSACTION_TAXON_CORRELATOR.correlate(CONFIG_PROXY.transactions)
   end

--- a/app/controllers/concerns/user_characteristics.rb
+++ b/app/controllers/concerns/user_characteristics.rb
@@ -1,4 +1,6 @@
-module UserCharacteristicsPartialController
+module UserCharacteristics
+  extend ActiveSupport::Concern
+
   def selected_answer_store
     @selected_answer_store ||= SelectedAnswerStore.new(session)
   end

--- a/app/controllers/concerns/user_cookies.rb
+++ b/app/controllers/concerns/user_cookies.rb
@@ -1,4 +1,11 @@
-module UserCookiesPartialController
+module UserCookies
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :set_visitor_cookie
+    after_action :store_locale_in_cookie, if: -> { request.method == 'GET' }
+  end
+
   def set_secure_cookie(name, value)
     cookies[name] = {
         value: value,

--- a/app/controllers/concerns/user_errors.rb
+++ b/app/controllers/concerns/user_errors.rb
@@ -1,4 +1,14 @@
-module UserErrorsPartialController
+module UserErrors
+  extend ActiveSupport::Concern
+
+  included do
+    rescue_from StandardError, with: :something_went_wrong unless Rails.env == 'development'
+    rescue_from Errors::WarningLevelError, with: :something_went_wrong_warn
+    rescue_from Api::SessionError, with: :session_error
+    rescue_from Api::UpstreamError, with: :upstream_error
+    rescue_from Api::SessionTimeoutError, with: :session_timeout
+  end
+
   def render_error(partial, status)
     set_locale
     respond_to do |format|

--- a/app/controllers/concerns/user_session.rb
+++ b/app/controllers/concerns/user_session.rb
@@ -1,4 +1,9 @@
-module UserSessionPartialController
+module UserSession
+  extend ActiveSupport::Concern
+  included do
+    before_action :validate_session
+  end
+
   def validate_session
     validation = session_validator.validate(cookies, session)
     unless validation.ok?

--- a/app/controllers/concerns/viewable_idp.rb
+++ b/app/controllers/concerns/viewable_idp.rb
@@ -1,4 +1,6 @@
-module ViewableIdpPartialController
+module ViewableIdp
+  extend ActiveSupport::Concern
+
   def select_viewable_idp_for_sign_in(entity_id)
     for_viewable_idp(entity_id, current_available_identity_providers_for_sign_in) do |decorated_idp|
       store_selected_idp_for_session(decorated_idp.identity_provider)

--- a/app/controllers/confirm_your_identity_controller.rb
+++ b/app/controllers/confirm_your_identity_controller.rb
@@ -1,9 +1,6 @@
-require 'partials/viewable_idp_partial_controller'
-require 'partials/journey_hinting_partial_controller'
-
 class ConfirmYourIdentityController < ApplicationController
-  include ViewableIdpPartialController
-  include JourneyHintingPartialController
+  include ViewableIdp
+  include JourneyHinting
 
   def index
     journey_hint_entity_id = attempted_entity_id

--- a/app/controllers/hint_controller.rb
+++ b/app/controllers/hint_controller.rb
@@ -1,7 +1,5 @@
-require 'partials/journey_hinting_partial_controller'
-
 class HintController < ApplicationController
-  include JourneyHintingPartialController
+  include JourneyHinting
   skip_before_action :validate_session
   skip_before_action :set_piwik_custom_variables
   skip_before_action :verify_authenticity_token

--- a/app/controllers/initiate_journey_controller.rb
+++ b/app/controllers/initiate_journey_controller.rb
@@ -1,7 +1,5 @@
-require 'partials/user_errors_partial_controller'
-
 class InitiateJourneyController < ApplicationController
-  include UserErrorsPartialController
+  include UserErrors
 
   skip_before_action :validate_session
   skip_before_action :set_piwik_custom_variables

--- a/app/controllers/paused_registration_controller.rb
+++ b/app/controllers/paused_registration_controller.rb
@@ -1,17 +1,10 @@
-require 'partials/user_cookies_partial_controller'
-require 'partials/journey_hinting_partial_controller'
-require 'partials/viewable_idp_partial_controller'
-require 'partials/retrieve_federation_data_partial_controller'
-require 'partials/idp_selection_partial_controller'
-require 'partials/analytics_cookie_partial_controller'
-
 class PausedRegistrationController < ApplicationController
-  include JourneyHintingPartialController
-  include ViewableIdpPartialController
-  include RetrieveFederationDataPartialController
-  include IdpSelectionPartialController
-  include UserCookiesPartialController
-  include AnalyticsCookiePartialController
+  include JourneyHinting
+  include ViewableIdp
+  include RetrieveFederationData
+  include IdpSelection
+  include UserCookies
+  include AnalyticsCookie
 
   # Validate the session manually within the action, as we don't want the normal 'no session' page.
   skip_before_action :validate_session, except: :resume

--- a/app/controllers/redirect_to_country_controller.rb
+++ b/app/controllers/redirect_to_country_controller.rb
@@ -1,7 +1,5 @@
-require 'partials/eidas_validation_partial_controller'
-
 class RedirectToCountryController < ApplicationController
-  include EidasValidationPartialController
+  include EidasValidation
   before_action :ensure_session_eidas_supported
 
   def choose_a_country_submit

--- a/app/controllers/redirect_to_idp_controller.rb
+++ b/app/controllers/redirect_to_idp_controller.rb
@@ -1,9 +1,6 @@
-require 'partials/idp_selection_partial_controller'
-require 'partials/single_idp_partial_controller'
-
 class RedirectToIdpController < ApplicationController
-  include IdpSelectionPartialController
-  include SingleIdpPartialController
+  include IdpSelection
+  include SingleIdp
 
   def register
     request_form

--- a/app/controllers/redirect_to_idp_warning_controller.rb
+++ b/app/controllers/redirect_to_idp_warning_controller.rb
@@ -1,10 +1,7 @@
-require 'partials/idp_selection_partial_controller'
-require 'partials/analytics_cookie_partial_controller'
-
 class RedirectToIdpWarningController < ApplicationController
-  include IdpSelectionPartialController
-  include AnalyticsCookiePartialController
-  include ViewableIdpPartialController
+  include IdpSelection
+  include AnalyticsCookie
+  include ViewableIdp
 
   SELECTED_IDP_HISTORY_LENGTH = 5
   helper_method :user_has_no_docs_or_foreign_id_only?, :other_ways_description

--- a/app/controllers/select_documents_controller.rb
+++ b/app/controllers/select_documents_controller.rb
@@ -1,7 +1,5 @@
-require 'partials/viewable_idp_partial_controller'
-
 class SelectDocumentsController < ApplicationController
-  include ViewableIdpPartialController
+  include ViewableIdp
 
   def index
     @form = SelectDocumentsForm.new({})

--- a/app/controllers/select_phone_controller.rb
+++ b/app/controllers/select_phone_controller.rb
@@ -1,7 +1,5 @@
-require 'partials/viewable_idp_partial_controller'
-
 class SelectPhoneController < ApplicationController
-  include ViewableIdpPartialController
+  include ViewableIdp
 
   def index
     @form = SelectPhoneForm.new({})

--- a/app/controllers/sign_in_controller.rb
+++ b/app/controllers/sign_in_controller.rb
@@ -1,11 +1,7 @@
-require 'partials/idp_selection_partial_controller'
-require 'partials/viewable_idp_partial_controller'
-require 'partials/analytics_cookie_partial_controller'
-
 class SignInController < ApplicationController
-  include IdpSelectionPartialController
-  include ViewableIdpPartialController
-  include AnalyticsCookiePartialController
+  include IdpSelection
+  include ViewableIdp
+  include AnalyticsCookie
   include ActionView::Helpers::UrlHelper
 
   def index

--- a/app/controllers/single_idp_journey_controller.rb
+++ b/app/controllers/single_idp_journey_controller.rb
@@ -1,22 +1,15 @@
 # frozen_string_literal: true
 
-require 'partials/user_cookies_partial_controller'
-require 'partials/idp_selection_partial_controller'
-require 'partials/viewable_idp_partial_controller'
-require 'partials/retrieve_federation_data_partial_controller'
-require 'partials/analytics_cookie_partial_controller'
-require 'partials/single_idp_partial_controller'
-
 class SingleIdpJourneyController < ApplicationController
   before_action :do_not_cache
 
   layout 'slides', except: :rp_start_page
 
-  include IdpSelectionPartialController
-  include ViewableIdpPartialController
-  include RetrieveFederationDataPartialController
-  include AnalyticsCookiePartialController
-  include SingleIdpPartialController
+  include IdpSelection
+  include ViewableIdp
+  include RetrieveFederationData
+  include AnalyticsCookie
+  include SingleIdp
 
   skip_before_action :verify_authenticity_token, only: :redirect_from_idp
   skip_before_action :validate_session, only: %i{redirect_from_idp rp_start_page}

--- a/app/controllers/test_journey_hint_cookie_controller.rb
+++ b/app/controllers/test_journey_hint_cookie_controller.rb
@@ -1,9 +1,8 @@
-require 'partials/journey_hinting_partial_controller'
 class TestJourneyHintCookieController < ApplicationController
   skip_before_action :validate_session
   skip_before_action :set_piwik_custom_variables
   skip_after_action :store_locale_in_cookie
-  include JourneyHintingPartialController
+  include JourneyHinting
   layout 'test'
 
   def index

--- a/spec/controllers/single_idp_journey_controller_spec.rb
+++ b/spec/controllers/single_idp_journey_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 require 'controller_helper'
 require 'api_test_helper'
 require 'piwik_test_helper'
-require 'partials/user_cookies_partial_controller'
+# require 'concerns/user_cookies'
 
 describe SingleIdpJourneyController do
   VALID_TEST_RP = 'http://www.test-rp.gov.uk/SAML2/MD'.freeze

--- a/spec/controllers/single_idp_journey_controller_spec.rb
+++ b/spec/controllers/single_idp_journey_controller_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 require 'controller_helper'
 require 'api_test_helper'
 require 'piwik_test_helper'
-# require 'concerns/user_cookies'
 
 describe SingleIdpJourneyController do
   VALID_TEST_RP = 'http://www.test-rp.gov.uk/SAML2/MD'.freeze


### PR DESCRIPTION
We previously introduced some mixins that were named `PartialContoller`s to
decompose some of the behaviour defined in `ApplicationController`.
Not surprisingly, Rails has its own way do this kind of decomposition
with `ActiveSupport::Concern`. This change moves these mixins to use
`ActiveSupport::Concern`.