### PR TITLE
BAU: Try not to present users with a list of all services

### DIFF
--- a/app/views/errors/something_went_wrong.html.erb
+++ b/app/views/errors/something_went_wrong.html.erb
@@ -6,10 +6,10 @@
   <div class="column-two-thirds">
     <h1 class="heading-large"><%= t 'errors.something_went_wrong.heading' %></h1>
     <p><%= t 'errors.something_went_wrong.error_message' %></p>
-    <p><%= t 'errors.something_went_wrong.start_again' %></p>
+    <p><%= t 'errors.something_went_wrong.start_again_text' %></p>
 
     <% if local_assigns[:transaction_homepage] %>
-      <p><%= link_to t('errors.session_timeout.start_again'), transaction_homepage, class: 'button' %></p>
+      <p><%= link_to t('errors.something_went_wrong.start_again_link'), transaction_homepage, class: 'button' %></p>
 
       <% if local_assigns[:other_ways_text] && local_assigns[:other_ways_description] %>
         <%= render partial: 'shared/other_ways', locals: {other_ways_text: other_ways_text, other_ways_description: other_ways_description} %>

--- a/app/views/errors/something_went_wrong.html.erb
+++ b/app/views/errors/something_went_wrong.html.erb
@@ -7,7 +7,14 @@
     <h1 class="heading-large"><%= t 'errors.something_went_wrong.heading' %></h1>
     <p><%= t 'errors.something_went_wrong.error_message' %></p>
     <p><%= t 'errors.something_went_wrong.start_again' %></p>
-    <% if transaction_taxon_list.any? %>
+
+    <% if local_assigns[:transaction_homepage] %>
+      <p><%= link_to t('errors.session_timeout.start_again'), transaction_homepage, class: 'button' %></p>
+
+      <% if local_assigns[:other_ways_text] && local_assigns[:other_ways_description] %>
+        <%= render partial: 'shared/other_ways', locals: {other_ways_text: other_ways_text, other_ways_description: other_ways_description} %>
+      <% end %>
+    <% elsif transaction_taxon_list.any? %>
       <h2 class="heading-medium"><%= t 'hub.transaction_list.title' %></h2>
       <%= render partial: 'shared/transaction_list' %>
     <% end %>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -662,7 +662,8 @@ cy:
       title: Mae rhywbeth wedi mynd o’i le
       heading: Mae’n ddrwg gennym, mae rhywbeth wedi mynd o’i le
       error_message: Gall hyn fod oherwydd bod eich sesiwn wedi’i amseru allan neu roedd gwall yn y system.
-      start_again: Oherwydd bod hwn yn wasanaeth diogel, bydd angen i chi ddechrau eto.
+      start_again_text: Oherwydd bod hwn yn wasanaeth diogel, bydd angen i chi ddechrau eto.
+      start_again_link: Dechrau eto
     proxy_node_error:
       start_again: Gan eich bod yn defnyddio gwasanaeth diogel o wlad Ewropeaidd arall, bydd angen i chi fynd yn ôl i'r dudalen lle dechreuoch  ddefnyddio'r gwasanaeth hwnnw.
     page_not_found:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -661,7 +661,8 @@ en:
       title: Something went wrong
       heading: Sorry, something went wrong
       error_message: This may be because your session timed out or there was a system error.
-      start_again: Because this is a secure service, you’ll need to start again.
+      start_again_text: Because this is a secure service, you’ll need to start again.
+      start_again_link: Start again
     proxy_node_error:
       start_again: Because you were using a secure service from another European country, you’ll need to go back to the page where you started using that service.
     page_not_found:

--- a/spec/feature_helper.rb
+++ b/spec/feature_helper.rb
@@ -72,6 +72,10 @@ module FeatureHelper
     'my-session-id-cookie'
   end
 
+  def default_transaction_homepage
+    'http://www.test-rp.gov.uk/'
+  end
+
   def create_cookie_hash
     {
         CookieNames::SESSION_COOKIE_NAME => 'my-session-cookie',
@@ -177,7 +181,7 @@ private
       verify_session_id: default_session_id,
       requested_loa: 'LEVEL_2',
       transaction_entity_id: 'http://www.test-rp.gov.uk/SAML2/MD',
-      transaction_homepage: 'http://www.test-rp.gov.uk/',
+      transaction_homepage: default_transaction_homepage,
       selected_answers: { device_type: { device_type_other: true } },
     }
   end
@@ -189,7 +193,7 @@ private
         verify_session_id: default_session_id,
         requested_loa: 'LEVEL_2',
         transaction_entity_id: 'http://www.test-rp.gov.uk/SAML2/MD',
-        transaction_homepage: 'http://www.test-rp.gov.uk/',
+        transaction_homepage: default_transaction_homepage,
         selected_answers: { documents: { driving_licence: false }, device_type: { device_type_other: true } },
     }
   end

--- a/spec/features/user_encounters_error_page_spec.rb
+++ b/spec/features/user_encounters_error_page_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe 'user encounters error page' do
     expect(page).to have_content t('errors.something_went_wrong.heading')
     expect(page).to have_css "#piwik-custom-url", text: "errors/generic-error"
     expect(page).to have_link "test GOV.UK Verify user journeys", href: "http://localhost:50130/test-rp"
+    expect(page).to_not have_link t('errors.session_timeout.start_again')
   end
 
   it 'will present the user with no list of transactions if we cant read the errors' do
@@ -118,7 +119,8 @@ RSpec.describe 'user encounters error page' do
         visit sign_in_path
         click_button 'IDCorp'
         expect(page).to have_content t('errors.something_went_wrong.heading')
-        expect(page).to have_link "test GOV.UK Verify user journeys", href: "http://localhost:50130/test-rp"
+        expect(page).to have_link t('errors.session_timeout.start_again'), href: default_transaction_homepage
+        expect(page).to have_content t('hub.other_ways_heading', other_ways_description: t('rps.test-rp.name'))
         expect(page).to have_css "#piwik-custom-url", text: "errors/generic-error"
         expect(page.status_code).to eq(500)
       end

--- a/spec/features/user_encounters_error_page_spec.rb
+++ b/spec/features/user_encounters_error_page_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'user encounters error page' do
     expect(page).to have_content t('errors.something_went_wrong.heading')
     expect(page).to have_css "#piwik-custom-url", text: "errors/generic-error"
     expect(page).to have_link "test GOV.UK Verify user journeys", href: "http://localhost:50130/test-rp"
-    expect(page).to_not have_link t('errors.session_timeout.start_again')
+    expect(page).to_not have_link t('errors.something_went_wrong.start_again_link')
   end
 
   it 'will present the user with no list of transactions if we cant read the errors' do
@@ -119,7 +119,7 @@ RSpec.describe 'user encounters error page' do
         visit sign_in_path
         click_button 'IDCorp'
         expect(page).to have_content t('errors.something_went_wrong.heading')
-        expect(page).to have_link t('errors.session_timeout.start_again'), href: default_transaction_homepage
+        expect(page).to have_link t('errors.something_went_wrong.start_again_link'), href: default_transaction_homepage
         expect(page).to have_content t('hub.other_ways_heading', other_ways_description: t('rps.test-rp.name'))
         expect(page).to have_css "#piwik-custom-url", text: "errors/generic-error"
         expect(page.status_code).to eq(500)


### PR DESCRIPTION
When a user hits the 'something has gone wrong' page, we used to expect them to choose their service from a list of all the services. This change sees whether we know the service the user came from. If so, we give the user a simple link to click to go back to the start. Additionally, present the user with information on other ways to acieve their goal, in case Verify is repeatedly failing for them.

I intend to merge this tomorrow, after #722 has had some time in production, so I can be sure that this will help some meaningful number of users.