### PR TITLE
BAU: log error causes

### DIFF
--- a/app/controllers/partials/user_errors_partial_controller.rb
+++ b/app/controllers/partials/user_errors_partial_controller.rb
@@ -57,12 +57,14 @@ module UserErrorsPartialController
 
   def something_went_wrong(exception, status = :internal_server_error)
     logger.error(exception)
+    logger.info("Something went wrong: #{exception.try(:message) || exception}")
     check_whether_recoverable
     render_error('something_went_wrong', status)
   end
 
   def something_went_wrong_warn(exception, status = :internal_server_error)
     logger.warn(exception)
+    logger.info("Something went wrong: #{exception.try(:message) || exception}")
     check_whether_recoverable
     render_error('something_went_wrong', status)
   end


### PR DESCRIPTION
Currently, we just log the raw exception. This makes it hard to work out what is causing the error pages to be shown. By introducing a log that includes both the name of the partial and the error message, we should then be able to do a search in the logs that will show us what is causing the errors.

This was prompted by https://github.com/alphagov/verify-frontend/pull/723#issuecomment-507752314