### PR TITLE
XFY6yswN: Change the Start again link on timeout page

### DIFF
--- a/app/controllers/partials/user_errors_partial_controller.rb
+++ b/app/controllers/partials/user_errors_partial_controller.rb
@@ -17,6 +17,11 @@ module UserErrorsPartialController
 
   def session_timeout(exception)
     logger.info(exception)
+    @redirect_to_destination = if CONTINUE_ON_FAILED_REGISTRATION_RPS.include?(current_transaction_simple_id)
+                                 '/redirect-to-service/error'
+                               else
+                                 session[:transaction_homepage]
+                               end
     render_error('session_timeout', :forbidden)
   end
 

--- a/app/views/errors/session_timeout.html.erb
+++ b/app/views/errors/session_timeout.html.erb
@@ -6,7 +6,7 @@
   <div class="column-two-thirds">
     <h1 class="heading-large"><%= t 'errors.session_timeout.title' %></h1>
     <h2 class="heading-medium"><%= t 'errors.session_timeout.return_to_service' %></h2>
-    <p><%= link_to t('errors.session_timeout.start_again'), '/redirect-to-service/error', class: 'button' %></p>
+    <p><%= link_to t('errors.session_timeout.start_again'), @redirect_to_destination, class: 'button' %></p>
     <p><%= raw t('errors.session_timeout.feedback_message', feedback_link: link_to(t('errors.session_timeout.feedback'), feedback_path('feedback-source': feedback_source))) %></p>
   </div>
 </div>

--- a/spec/features/user_gets_soft_session_timeout_page_spec.rb
+++ b/spec/features/user_gets_soft_session_timeout_page_spec.rb
@@ -7,7 +7,14 @@ RSpec.describe 'When the user visits a page that triggers an API call when the s
     stub_api_idp_list_for_loa
   end
 
-  it 'should render the soft session timeout page when SESSION_TIMEOUT received from the API' do
+  it 'should render the soft session timeout page when SESSION_TIMEOUT received from the API and have a correct link' do
+    stub_api_returns_error('SESSION_TIMEOUT')
+    visit redirect_to_idp_register_path
+    expect(page).to have_link(href: 'http://www.test-rp.gov.uk/', class: 'button')
+  end
+
+  it 'should render the soft session timeout page when SESSION_TIMEOUT received from the API when continue on failed is enabled and have a correct link' do
+    set_session!(transaction_simple_id: 'test-rp-with-continue-on-fail')
     stub_api_returns_error('SESSION_TIMEOUT')
     visit redirect_to_idp_register_path
     expect(page).to have_link(href: '/redirect-to-service/error', class: 'button')


### PR DESCRIPTION
We're inconsistent on when we send users back to the RP. There's a flag which
controls that (CONTINUE_ON_FAILED_REGISTRATION). However, it's not used on the timeout page and the user
gets sent to the RP with error regardless.
This is to make sure users gets sent on non-success scenarios to RPs only if the flag
is enabled.