### PR TITLE
BAU: Fix checking for CSRF token

### DIFF
--- a/app/controllers/single_idp_journey_controller.rb
+++ b/app/controllers/single_idp_journey_controller.rb
@@ -18,7 +18,7 @@ class SingleIdpJourneyController < ApplicationController
   include AnalyticsCookiePartialController
   include SingleIdpPartialController
 
-  protect_from_forgery except: :redirect_from_idp
+  skip_before_action :verify_authenticity_token, only: :redirect_from_idp
   skip_before_action :validate_session, only: %i{redirect_from_idp rp_start_page}
   skip_before_action :set_piwik_custom_variables, only: %i{redirect_from_idp rp_start_page}
 


### PR DESCRIPTION
We've been seeing exception in the logs where the users get `TypeError: no implicit conversion of nil into String`.
This is caused by invalid session in combination with missing authenticity token (CSRF).
The current protect_from_forgery on the controller is not raising exception and therefore
keeps processing the request and failing further down. We have turned the logic around
(swapped `except` for `only`) so that the controller inherits the forgery protection
from the ApplicationController instead and we only overwrite the single method with skip.

Co-Authored-By: Phil Miller <phillip.miller@digital.cabinet-office.gov.uk>

https://sentry.tools.signin.service.gov.uk/verify/prod-frontend/issues/1147