### PR TITLE
BAU: make single IDP tests compatible with Rails 5.1

### DIFF
--- a/spec/controllers/single_idp_journey_controller_spec.rb
+++ b/spec/controllers/single_idp_journey_controller_spec.rb
@@ -15,6 +15,7 @@ describe SingleIdpJourneyController do
     stub_request(:get, INTERNAL_PIWIK.url).with(query: hash_including({}))
     stub_transactions_for_single_idp_list
     stub_api_idp_list_for_single_idp_journey
+    allow(Rails.logger).to receive(:info)
   end
 
   context 'idp hits post providing correct parameters' do


### PR DESCRIPTION
The new rails adds some new logs that interfere with the tests that expect certain logs. The fix is just to allow and ignore all logs that are not the ones we're explictly expecting.

Note: this is only some of the fixes required for Rails 5.1