### PR TITLE
BAU: Fix unrecognised body trying to return a template

### DIFF
--- a/app/controllers/redirect_to_country_controller.rb
+++ b/app/controllers/redirect_to_country_controller.rb
@@ -20,7 +20,7 @@ class RedirectToCountryController < ApplicationController
       select_country(decorated_country)
       render json: @country_request
     else
-      render status: :bad_request
+      head :bad_request
     end
   end
 

--- a/app/controllers/redirect_to_idp_warning_controller.rb
+++ b/app/controllers/redirect_to_idp_warning_controller.rb
@@ -37,7 +37,7 @@ class RedirectToIdpWarningController < ApplicationController
       select_registration(idp)
       ajax_idp_redirection_registration_request(recommended, idp.entity_id)
     else
-      render status: :bad_request
+      head :bad_request
     end
   end
 


### PR DESCRIPTION
The error: ActionView::MissingTemplate: Missing template redirect_to_country/choose_a_country_submit_ajax
Changed render status to head, as head only returns the header whereas render status tries to return a template if body is not recognised