### PR TITLE
Updated 'Cookies and analytics' section

### DIFF
--- a/app/views/static/privacy_notice.en.html.erb
+++ b/app/views/static/privacy_notice.en.html.erb
@@ -197,7 +197,7 @@ end %>
 <p>
 <b>Cabinet Office Data Protection Officer</b>
 <br>
-<a href="mailto:DPO@cabinetoffice.gov.uk">DPO@cabinetoffice.gov.uk>
+<a href="mailto:DPO@cabinetoffice.gov.uk">DPO@cabinetoffice.gov.uk</a>
 <br>
 </p>
 

--- a/app/views/static/privacy_notice.en.html.erb
+++ b/app/views/static/privacy_notice.en.html.erb
@@ -9,150 +9,213 @@ end %>
 <div class="grid-row">
   <div class="column-two-thirds">
     <h1 class="heading-xlarge">Privacy notice</h1>
-    <p>Last updated: 18 June 2019</p>
-    <h2 class="heading-large" id="who-we-are">Who we are</h2>
-    <p>GOV.UK Verify is built and run by the Government Digital Service (GDS), which is part of the Cabinet Office.</p>
-    <p>GOV.UK Verify allows you to prove your identity when using digital government services, like the service you use to <a href="https://www.gov.uk/log-in-file-self-assessment-tax-return">sign in and file your Self Assessment tax return</a>.</p>
-    <p>GOV.UK Verify has now been extended to comply with the eIDAS regulation, which lets users with digital identities from some EU countries access government services in the UK. It also lets users who have proved their identity with GOV.UK Verify access services in some EU countries.</p>
-    <p>This privacy notice explains what data we might collect, how it’s used and how it’s protected.</p>
+    <p>Last updated: 20 September 2019</p>
+ <h2 class="heading-large" id="who-we-are">Who we are</h2>
 
-    <h2 class="heading-large" id="what-data-we-collect">What data we collect</h2>
-    <p>We process information about you when you use GOV.UK Verify. This may include any of the following.</p>
+<p>GOV.UK Verify is built and run by the Government Digital Service (GDS), which is part of the Cabinet Office.</p>
+ 
+<p>GOV.UK Verify allows you to prove your identity when using digital government services, like the service you use to <a href="https://www.gov.uk/log-in-file-self-assessment-tax-return">file your Self Assessment tax return</a>.</p>
 
-    <h3 class="heading-medium" id="how-personal-data-is-used-when-signing-in-with-gov.uk-verify">How personal data is used when signing in with GOV.UK Verify</h3>
-    <p>GOV.UK Verify provides a ‘hub’ between services and companies which verify users’ identities on behalf of the government. These are known as ‘certified companies’. They have met government and industry standards to provide identity assurance services as part of GOV.UK Verify.</p>
-    <p>After you’ve been verified by a company, they will send your personal data to the hub. The hub will then send it to the government service that you want to use.</p>
-    <p>This personal data might include your:</p>
-    <ol class="list-bullet list">
-      <li>name (including previous names)</li>
-      <li>address (which may include previous addresses)</li>
-      <li>date of birth</li>
-      <li>age (range)</li>
-      <li>gender (optional)</li>
-      <li>IP address</li>
-      <li>personal identifier (PID)</li>
-    </ol>
+<p>GOV.UK Verify also meets the eIDAS regulation, which lets users with digital identities from some EU countries access government services in the UK. It also lets users who have proved their identity with GOV.UK Verify access services in some EU countries.</p>
 
-    <h3 class="heading-medium" id="how-personal-data-is-used-when-signing-in-with-a-digital-identity-from-another-eu-country">How personal data is used when signing in with a digital identity from another EU country</h3>
-    <p>After your digital identity from another EU country has been authenticated, we’ll collect your personal data and pass it on to the government service that you want to use. We do this to help you to transact securely with government services.</p>
-    <p>This personal data might include your:</p>
-    <ol class="list-bullet list">
-      <li>family name</li>
-      <li>first name</li>
-      <li>date of birth</li>
-      <li>personal identifier (PID)</li>
-    </ol>
+<p>GOV.UK Verify has been designed to meet the <a href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/361496/PCAG_IDA_Principles_3.1__4_.pdf">Identity Assurance Principles</a>, written by the Cabinet Office <a href="https://www.gov.uk/government/groups/privacy-and-consumer-advisory-group">Privacy and Consumer Advisory Group</a>.</p>
 
-    <h3 class="heading-medium" id="how-personal-data-is-used-when-signing-in-with-gov.uk-verify-to-access-services-across-eu-member-states">How personal data is used when signing in with GOV.UK Verify to access services across EU Member States</h3>
-    <p>After your digital identity from GOV.UK Verify has been authenticated, we’ll send your personal data to the services across the EU Member States that you want to use.</p>
-    <p>This personal data might include your:</p>
-    <ol class="list-bullet list">
-      <li>family name</li>
-      <li>first name</li>
-      <li>date of birth</li>
-      <li>personal identifier (PID)</li>
-    </ol>
+<p>You can find more detailed information about GOV.UK Verify on the <a href="https://gds.blog.gov.uk/category/id-assurance/">GOV.UK Verify blog</a>.</p>
 
-    <h3 class="heading-medium" id="user-support-questions-and-feedback">User support questions and feedback</h3>
-    <p>We process questions or feedback you send to user support, including your name and email address, details of your query, and what we’ve done to help.</p>
+<p>This privacy notice explains what data we might collect, how it's used and how it's protected.</p>
 
-    <h3 class="heading-medium" id="technical-information">Technical information</h3>
-    <p>We might automatically collect other non-personal information like:</p>
-    <ol class="list-bullet list">
-      <li>your IP address (this could be a static or dynamic IP address and will sometimes point to a specific computer or device)</li>
-      <li>which browser and operating system you’re using</li>
-      <li>how long you’ve spent on a particular page</li>
-      <li>which website you came from</li>
-      <li>which website you went to next</li>
-    </ol>
-    <p>This information helps us understand how you use GOV.UK Verify. We use it to find out ways we can improve GOV.UK Verify to make sure it works for the people who need it.</p>
+<h2 class="heading-large" id="what-data-we-collect">What data we collect</h2>
 
-    <h2 class="heading-large" id="cookies-and-analytics">Cookies and analytics</h2>
-    <p>You can read our full <a href="https://www.signin.service.gov.uk/cookies">cookie notice</a> to find out how we use cookies.</p>
+<p>We collect personal data from you when you:</p>
+<ol class="list-bullet list">
+  <li>sign in to a service with GOV.UK Verify</li>
+  <li>sign in to a service with a digital identity from an EU country</li>
+  <li>send us questions or feedback</li>
+</ol>
 
-    <h2 class="heading-large" id="what-we-do-with-your-data">What we do with your data</h2>
-    <p>We might share the data we collect with:</p>
-    <ol class="list-bullet list">
-      <li>other government departments and agencies</li>
-      <li>the company who verified your identity</li>
-      <li>other public bodies</li>
-    </ol>
-    <p>We process some personal data to help prevent fraud in government services. We do this to make sure GOV.UK Verify meets the UK government’s identity standards.</p>
-    <p>We will not:</p>
-    <ol class="list-bullet list">
-      <li>sell or rent your data to third parties</li>
-      <li>share your data with third parties for marketing purposes</li>
-    </ol>
-    <p>We will share your data if we’re required to do so by law, for example by court order, or to prevent fraud or other crime.</p>
+<h3 class="heading-large" id="when-you-sign-in-with-govuk-verify">When you sign in with GOV.UK Verify</h3>
 
-    <h2 class="heading-large" id="how-long-we-keep-your-data-for">How long we keep your data for</h2>
-    <p>We will only retain your personal data for as long as:</p>
-    <ol class="list-bullet list">
-      <li>the law requires us to</li>
-      <li>we need to provide this service</li>
-    </ol>
+<p>GOV.UK Verify provides a 'hub' between services and companies that prove users' identities on behalf of the government. These companies have met government and industry standards to check and prove users' identities as part of GOV.UK Verify.</p>
 
-    <h2 class="heading-large" id="certified-companies-digital-id-schemes-in-other-european-countries-and-government-organisations">Certified companies, digital identity schemes in other European countries and government organisations</h2>
-    <p>Cabinet Office is the data controller for the data processed by GOV.UK Verify. Where these pages link out to services provided by other government organisations, digital identity schemes in other EU countries and companies that we partner with, their own privacy policies will apply. These are managed by each service provider and they are the data controllers for the data they collect. These purposes are not described in this privacy notice. Read their privacy policies to find out how they process your data and how to exercise your rights around how they do it.</p>
-    <p>A data controller determines how and why personal data is processed. For more information, read the Cabinet Office’s entry in the <a href="https://ico.org.uk/ESDWebPages/Entry/Z7414053">Data Protection Public Register</a>.</p>
+<p>After the company proves your identity, they send limited personal data they collect to the hub. The hub will then send it to the service you want to use.</p>
 
-    <h2 class="heading-large" id="where-your-data-is-stored">Where your data is stored</h2>
-    <p>GOV.UK Verify processes your personal data in the European Economic Area (EEA)</p>
+<p>This personal data might include your:</p>
+<ol class="list-bullet list">
+  <li>name (including any previous names)</li>
+  <li>address (including any previous addresses)</li>
+  <li>date of birth</li>
+  <li>age range</li>
+  <li>gender (this is usually optional)</li>
+  <li>IP address</li>
+  <li>persistent identifier (PID) - this is given to you by the company that proved your identity</li>
+</ol>
 
-    <h2 class="heading-large" id="your-rights">Your rights</h2>
-    <p>You have the right to request:</p>
-    <ol class="list-bullet list">
-      <li>information about how your personal data is processed and to request a copy of the personal data you’ve given to us</li>
-      <li>that any inaccuracies about your personal data be corrected without delay</li>
-      <li>that any incomplete personal data is completed, including by means of a supplementary statement</li>
-      <li>that your personal data is erased if there is no longer a justification for us to hold it</li>
-      <li>that the processing of your personal data is restricted in certain circumstances, for example when accuracy is contested</li>
-    </ol>
-    <p>If your personal data is processed on the basis of consent, then you have the right to withdraw your consent at any time.</p>
+<p>If you use GOV.UK Verify to sign in to a service in an EU country, the hub will send any personal data it collects to the service you want to use.</p>
 
-    <h2 class="heading-large" id="links-to-other-websites">Links to other websites</h2>
-    <p>GOV.UK Verify is one of the services on GOV.UK and has links to other websites.</p>
-    <p>This privacy notice only applies to <a href="https://www.gov.uk/government/publications/introducing-govuk-verify">GOV.UK Verify</a> and doesn’t cover other government services and transactions that we link to.</p>
+<p>This personal data might include your:</p>
+<ol class="list-bullet list">
+  <li>family name</li>
+  <li>first name</li>
+  <li>date of birth</li>
+  <li>PID</li>
+</ol>
 
-    <h2 class="heading-large" id="identity-assurance-principles-when-signing-in-with-gov-uk-verify">Identity Assurance Principles when signing in with GOV.UK Verify</h2>
-    <p>GOV.UK Verify has been designed to comply with the <a href="https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/361496/PCAG_IDA_Principles_3.1__4_.pdf">Identity Assurance Principles</a> prepared by the Cabinet Office <a href="https://www.gov.uk/government/groups/privacy-and-consumer-advisory-group">Privacy and Consumer Advisory Group</a>.</p>
-    <p>You can also find more detailed information about the service on the <a href="https://identityassurance.blog.gov.uk/">GOV.UK Verify blog</a>.</p>
+<h3 class="heading-large" id="when-you-sign-in-with-a-digital-identity-from-an-eu-country">When you sign in with a digital identity from an EU country</h3>
 
-    <h2 class="heading-large" id="childrens-privacy-protection">Children’s privacy protection</h2>
-    <p>We understand the importance of protecting children’s privacy online. GOV.UK Verify is not designed for, or intentionally targeted at, children that are 13 years of age or younger. It is not our policy to intentionally collect or maintain data about anyone under the age of 13.</p>
+<p>After you've signed in, we'll collect your personal data and send it to the government service that you want to use. We do this to help protect your identity when you use government services.</p>
 
-    <h2 class="heading-large" id="how-we-protect-your-data-and-keep-it-secure">How we protect your data and keep it secure</h2>
-    <p>We’re committed to doing all that we can to keep your data secure. To prevent unauthorised access or disclosure we have put in place technical and organisational procedures to secure the data we collect about you. For example, we protect your data using varying levels of encryption.</p>
-    <p>We also make sure that any third parties that we deal with have an obligation to keep all personal data they process on our behalf secure.</p>
+<p>This personal data might include your:</p>
+<ol class="list-bullet list">
+  <li>family name</li>
+  <li>first name</li>
+  <li>date of birth</li>
+  <li>PID</li>
+</ol>
 
-    <h2 class="heading-large" id="changes-to-this-notice">Changes to this notice</h2>
-    <p>We may change this privacy notice. In that case, the ‘last updated’ date at the bottom of this page will change. Any changes to this privacy notice will apply to you and your data as of that date.</p>
-    <p>We encourage you to review this privacy notice regularly to stay informed about how we are protecting your data.</p>
+<h3 class="heading-large" id="when-you-send-us-a-question-or-feedback">When you send us a question or feedback</h3>
 
-    <h2 class="heading-medium" id="how-to-contact-us-or-make-a-complaint">How to contact us or make a complaint</h2>
-    <p>You can contact the Verify Privacy Team at <a href="mailto:verify-privacy@digital.cabinet-office.gov.uk">verify-privacy@digital.cabinet-office.gov.uk</a> if you:</p>
-    <ol class="list-bullet list">
-      <li>have a question about anything in the privacy notice</li>
-      <li>think that your personal data has been misused or mishandled</li>
-    </ol>
-    <p>You can also contact the Cabinet Office Data Protection Officer (DPO) at <a href="mailto:DPO@cabinetoffice.gov.uk">DPO@cabinetoffice.gov.uk</a>.</p>
-    <p>Or by post at:</p>
-    <p>
-    <address>
-      Data Protection Officer
-      <br>
-      Cabinet Office
-      <br>
-      70 Whitehall
-      <br>
-      London SW1A 2AS
-    </address>
-    </p>
-    <p>The DPO provides independent advice and monitoring of our use of personal information.</p>
+<p>We keep any questions or feedback you send about GOV.UK Verify, as well as details about what we've done to help. We'll also keep some personal data, such as your name and email address.</p>
 
-    <p>You can make a complaint to the Information Commissioner’s Office (ICO), who is an independent regulator.</p>
+<h2 class="heading-large" id="cookies-and-analytics">Cookies and analytics</h2>
 
-    <p>
+<p>We use Matomo to collect information about how you use GOV.UK Verify.</p>
+
+<p>Matomo stores information about:</p>
+<ol class="list-bullet list">
+  <li>which pages you visit</li>
+  <li>how long you spend on each page</li>
+  <li>how you got to the site</li>
+  <li>what you click on while you're visiting the site</li>
+</ol>
+
+<p>We do not store any of your personal data on our analytics system.</p>
+
+<p>GOV.UK Verify puts small files (known as 'cookies') onto your computer. Read our full <a href="https://www.signin.service.gov.uk/cookies">cookie notice</a> to find out how we use cookies.</p>
+
+<p>To protect GOV.UK Verify from crime and fraud, we might sometimes share your personal data with:</p>
+<ol class="list-bullet list">
+  <li>law enforcement agencies</li>
+  <li>public sector organisations, for example the Cabinet Office, Home Office and others</li>
+  <li>relevant private sector organisations</li>
+</ol>
+
+<p>This personal data might include your:</p>
+<ol class="list-bullet list">
+  <li>family name</li>
+  <li>first name</li>
+  <li>date of birth</li>
+  <li>PID</li>
+  <li>phone number</li>
+  <li>biometric information</li>
+  <li>email addresses</li>
+  <li>address</li>
+</ol>
+
+<h2 class="heading-large" id="what-we-do-with-your-data">What we do with your data</h2>
+
+<p>We might share the data we collect with:</p>
+<ol class="list-bullet list">
+  <li>other government departments and agencies</li>
+  <li>the company who verified your identity</li>
+  <li>other public bodies</li>
+</ol>
+
+<p>We will not:</p>
+<ol class="list-bullet list">
+  <li>sell your data to third parties</li>
+  <li>share your data with third parties for marketing purposes</li>
+</ol>
+
+<h2 class="heading-large" id="legal-basis-for-using-your-data">Legal basis for using your data</h2>
+
+<p>The legal basis for processing your personal data is that it's necessary to perform a task in the public interest.</p>
+
+<p>Sometimes, you will need to give your consent before any personal data is processed. In that case, you have the right to withdraw your consent at any time.</p>
+
+<h2 class="heading-large" id="how-long-we-keep-your-data-for">How long we keep your data for</h2>
+
+<p>We will only keep your personal data for as long as:</p>
+<ol class="list-bullet list">
+<li>it's needed for the purposes set out in this privacy notice</li>
+<li>the law requires us to</li>
+</ol>
+
+<h2 class="heading-large" id="who-controls-your-data">Who controls your data</h2>
+
+<p>Cabinet Office is the data controller for the data processed by GOV.UK Verify. A data controller determines how and why personal data is processed. For more information, read the Cabinet Office's entry in the <a href="https://ico.org.uk/ESDWebPages/Entry/Z7414053">Data Protection Public Register</a>.</p>
+
+<h2 class="heading-large" id="where-your-data-is-stored">Where your data is stored</h2>
+
+<p>GOV.UK Verify stores your personal data in the European Economic Area (EEA).</p>
+
+<h2 class="heading-large" id="your-rights">Your rights</h2>
+
+<p>You have the right to request:</p>
+<ol class="list-bullet list">
+  <li>information about how your personal data is processed</li>
+  <li>a copy of any personal data you've given to us</li>
+  <li>that anything inaccurate in your personal data is corrected immediately</li>
+  <li>that any incomplete personal data is completed - you can do this by sending us a 'supplementary statement' that explains what's wrong with the data we've collected</li>
+  <li>that your personal data is deleted if there's no longer a reason for us to hold it</li>
+  <li>that the processing of your personal data is restricted in certain circumstances, for example if we've collected inaccurate information</li>
+</ol>
+
+<h2 class="heading-large" id="links-to-other-websites">Links to other websites</h2>
+
+<p>GOV.UK Verify is one of the services on GOV.UK and has links to other websites.</p>
+
+<p>This privacy notice only applies to <a href="https://www.gov.uk/government/publications/introducing-govuk-verify/introducing-govuk-verify">GOV.UK Verify</a> and doesn't cover other government services, companies or digital identity schemes that we link to. Read their own terms and conditions, privacy policies and data controllers if you want to find out how they process your personal data.</p>
+
+<h2 class="heading-large" id="childrens-privacy-protection">Children's privacy protection</h2>
+
+<p>We understand the importance of protecting children's privacy online. GOV.UK Verify is not designed for or intentionally targeted at children that are 13 or younger. We will not intentionally collect or keep data about anyone under the age of 13.</p>
+
+<h2 class="heading-large" id="how-we-protect-your-data-and-keep-it-secure">How we protect your data and keep it secure</h2>
+
+<p>We're committed to doing all that we can to keep your data secure. We have set up systems and processes to prevent unauthorised access or disclosure of your data. For example, we protect your data using varying levels of encryption.</p>
+ 
+<p>We also make sure that any third parties that we deal with have an obligation to keep all personal data they process on our behalf secure.</p>
+
+<h2 class="heading-large" id="changes-to-this-notice">Changes to this notice</h2>
+
+<p>We may change this privacy notice. In that case, the 'last updated' date at the bottom of this page will change. Any changes to this privacy notice will apply to you and your data as of that date.</p>
+
+<p>We encourage you to review this privacy notice regularly to find out how we are protecting your data.</p>
+
+<h2 class="heading-large" id="contact-us-or-make-a-complaint">Contact us or make a complaint</h2>
+
+<p>You can contact the GOV.UK Verify Privacy Team at <a href="mailto:verify-privacy@digital.cabinet-office.gov.uk">verify-privacy@digital.cabinet-office.gov.uk</a> if you:</p>
+<ol class="list-bullet list">
+  <li>have a question about anything in the privacy notice</li>
+  <li>think that your personal data has been misused or mishandled</li>
+</ol>
+
+<h2 class="heading-large" id="contact-an-independent-body">Contact an independent body</h2>
+
+<p>You can contact the Cabinet Office Data Protection Officer (DPO), which provides independent advice and monitoring of our use of personal data.</p>
+
+<p>
+<b>Cabinet Office Data Protection Officer</b>
+<br>
+<a href="mailto:DPO@cabinetoffice.gov.uk">DPO@cabinetoffice.gov.uk>
+<br>
+</p>
+
+<p>
+<address>
+Data Protection Officer
+<br>
+Cabinet Office
+<br>
+70 Whitehall
+<br>
+London SW1A 2AS
+</address>
+</p>
+
+<p>You can also make a complaint to the Information Commissioner's Office (ICO), who is an independent regulator.</p>
+
+   <p>
       ICO<br>
       <a href="mailto:casework@ico.org.uk">casework@ico.org.uk</a><br>
       Telephone: 0303 123 1113<br>
@@ -160,9 +223,9 @@ end %>
       Monday to Friday, from 9 am to 4:30 pm<br>
     </p>
 
-    <p><a href="https://www.gov.uk/call-charges">Find out about call charges</a>.</p>
+<p><a href="https://www.gov.uk/call-charges">Find out about call charges</a>.</p>
 
-    <p>
+ <p>
     <address>
       Information Commissioner’s Office
       <br>
@@ -175,8 +238,9 @@ end %>
       Cheshire SK9 5AF
     </address>
     </p>
+
     <div class="meta-data group">
-      <p class="modified-date">Last updated: 18 June 2019</p>
+      <p class="modified-date">Last updated: 20 September 2019</p>
     </div>
   </div>
 </div>

--- a/app/views/static/privacy_notice.en.html.erb
+++ b/app/views/static/privacy_notice.en.html.erb
@@ -50,7 +50,7 @@ end %>
   <li>persistent identifier (PID) - this is given to you by the company that proved your identity</li>
 </ol>
 
-<p>If you use GOV.UK Verify to sign in to a service in an EU country, the hub will send any personal data it collects to the service you want to use.</p>
+<p>If you use GOV.UK Verify to sign in to a service in an EU country, the hub will send limited personal data it collects to the service you want to use.</p>
 
 <p>This personal data might include your:</p>
 <ol class="list-bullet list">
@@ -216,11 +216,11 @@ London SW1A 2AS
 <p>You can also make a complaint to the Information Commissioner's Office (ICO), who is an independent regulator.</p>
 
    <p>
-      ICO<br>
+     <b>ICO</b><br>
       <a href="mailto:casework@ico.org.uk">casework@ico.org.uk</a><br>
       Telephone: 0303 123 1113<br>
       Textphone: 01625 545 860<br>
-      Monday to Friday, from 9 am to 4:30 pm<br>
+      Monday to Friday, from 9am to 4:30pm<br>
     </p>
 
 <p><a href="https://www.gov.uk/call-charges">Find out about call charges</a>.</p>

--- a/app/views/static/privacy_notice.en.html.erb
+++ b/app/views/static/privacy_notice.en.html.erb
@@ -10,234 +10,194 @@ end %>
   <div class="column-two-thirds">
     <h1 class="heading-xlarge">Privacy notice</h1>
     <p>Last updated: 20 September 2019</p>
- <h2 class="heading-large" id="who-we-are">Who we are</h2>
+    <h2 class="heading-large" id="who-we-are">Who we are</h2>
+    <p>GOV.UK Verify is built and run by the Government Digital Service (GDS), which is part of the Cabinet Office.</p>
+    <p>GOV.UK Verify allows you to prove your identity when using digital government services, like the service you use to <a href="https://www.gov.uk/log-in-file-self-assessment-tax-return">file your Self Assessment tax return</a>.</p>
+    <p>GOV.UK Verify also meets the eIDAS regulation, which lets users with digital identities from some EU countries access government services in the UK. It also lets users who have proved their identity with GOV.UK Verify access services in some EU countries.</p>
+    <p>GOV.UK Verify has been designed to meet the <a href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/361496/PCAG_IDA_Principles_3.1__4_.pdf">Identity Assurance Principles</a>, written by the Cabinet Office <a href="https://www.gov.uk/government/groups/privacy-and-consumer-advisory-group">Privacy and Consumer Advisory Group</a>.</p>
+    <p>You can find more detailed information about GOV.UK Verify on the <a href="https://gds.blog.gov.uk/category/id-assurance/">GOV.UK Verify blog</a>.</p>
+    <p>This privacy notice explains what data we might collect, how it's used and how it's protected.</p>
 
-<p>GOV.UK Verify is built and run by the Government Digital Service (GDS), which is part of the Cabinet Office.</p>
- 
-<p>GOV.UK Verify allows you to prove your identity when using digital government services, like the service you use to <a href="https://www.gov.uk/log-in-file-self-assessment-tax-return">file your Self Assessment tax return</a>.</p>
+    <h2 class="heading-large" id="what-data-we-collect">What data we collect</h2>
+    <p>We collect personal data from you when you:</p>
+    <ol class="list-bullet list">
+      <li>sign in to a service with GOV.UK Verify</li>
+      <li>sign in to a service with a digital identity from an EU country</li>
+      <li>send us questions or feedback</li>
+    </ol>
 
-<p>GOV.UK Verify also meets the eIDAS regulation, which lets users with digital identities from some EU countries access government services in the UK. It also lets users who have proved their identity with GOV.UK Verify access services in some EU countries.</p>
+    <h3 class="heading-large" id="when-you-sign-in-with-govuk-verify">When you sign in with GOV.UK Verify</h3>
+    <p>GOV.UK Verify provides a 'hub' between services and companies that prove users' identities on behalf of the government. These companies have met government and industry standards to check and prove users' identities as part of GOV.UK Verify.</p>
+    <p>After the company proves your identity, they send limited personal data they collect to the hub. The hub will then send it to the service you want to use.</p>
+    <p>This personal data might include your:</p>
+    <ol class="list-bullet list">
+      <li>name (including any previous names)</li>
+      <li>address (including any previous addresses)</li>
+      <li>date of birth</li>
+      <li>age range</li>
+      <li>gender (this is usually optional)</li>
+      <li>IP address</li>
+      <li>persistent identifier (PID) - this is given to you by the company that proved your identity</li>
+    </ol>
+    <p>If you use GOV.UK Verify to sign in to a service in an EU country, the hub will send limited personal data it collects to the service you want to use.</p>
+    <p>This personal data might include your:</p>
+    <ol class="list-bullet list">
+      <li>family name</li>
+      <li>first name</li>
+      <li>date of birth</li>
+      <li>PID</li>
+    </ol>
 
-<p>GOV.UK Verify has been designed to meet the <a href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/361496/PCAG_IDA_Principles_3.1__4_.pdf">Identity Assurance Principles</a>, written by the Cabinet Office <a href="https://www.gov.uk/government/groups/privacy-and-consumer-advisory-group">Privacy and Consumer Advisory Group</a>.</p>
+    <h3 class="heading-large" id="when-you-sign-in-with-a-digital-identity-from-an-eu-country">When you sign in with a digital identity from an EU country</h3>
+    <p>After you've signed in, we'll collect your personal data and send it to the government service that you want to use. We do this to help protect your identity when you use government services.</p>
+    <p>This personal data might include your:</p>
+    <ol class="list-bullet list">
+      <li>family name</li>
+      <li>first name</li>
+      <li>date of birth</li>
+      <li>PID</li>
+    </ol>
 
-<p>You can find more detailed information about GOV.UK Verify on the <a href="https://gds.blog.gov.uk/category/id-assurance/">GOV.UK Verify blog</a>.</p>
+    <h3 class="heading-large" id="when-you-send-us-a-question-or-feedback">When you send us a question or feedback</h3>
+    <p>We keep any questions or feedback you send about GOV.UK Verify, as well as details about what we've done to help. We'll also keep some personal data, such as your name and email address.</p>
 
-<p>This privacy notice explains what data we might collect, how it's used and how it's protected.</p>
+    <h2 class="heading-large" id="cookies-and-analytics">Cookies and analytics</h2>
+    <p>We use Matomo to collect information about how you use GOV.UK Verify.</p>
+    <p>Matomo stores information about:</p>
+    <ol class="list-bullet list">
+      <li>which pages you visit</li>
+      <li>how long you spend on each page</li>
+      <li>how you got to the site</li>
+      <li>what you click on while you're visiting the site</li>
+    </ol>
+    <p>We do not store any of your personal data on our analytics system.</p>
+    <p>GOV.UK Verify puts small files (known as 'cookies') onto your computer. Read our full <a href="https://www.signin.service.gov.uk/cookies">cookie notice</a> to find out how we use cookies.</p>
+    <p>To protect GOV.UK Verify from crime and fraud, we might sometimes share your personal data with:</p>
+    <ol class="list-bullet list">
+      <li>law enforcement agencies</li>
+      <li>public sector organisations, for example the Cabinet Office, Home Office and others</li>
+      <li>relevant private sector organisations</li>
+    </ol>
+    <p>This personal data might include your:</p>
+    <ol class="list-bullet list">
+      <li>family name</li>
+      <li>first name</li>
+      <li>date of birth</li>
+      <li>PID</li>
+      <li>phone number</li>
+      <li>biometric information</li>
+      <li>email addresses</li>
+      <li>address</li>
+    </ol>
 
-<h2 class="heading-large" id="what-data-we-collect">What data we collect</h2>
+    <h2 class="heading-large" id="what-we-do-with-your-data">What we do with your data</h2>
+    <p>We might share the data we collect with:</p>
+    <ol class="list-bullet list">
+      <li>other government departments and agencies</li>
+      <li>the company who verified your identity</li>
+      <li>other public bodies</li>
+    </ol>
+    <p>We will not:</p>
+    <ol class="list-bullet list">
+      <li>sell your data to third parties</li>
+      <li>share your data with third parties for marketing purposes</li>
+    </ol>
 
-<p>We collect personal data from you when you:</p>
-<ol class="list-bullet list">
-  <li>sign in to a service with GOV.UK Verify</li>
-  <li>sign in to a service with a digital identity from an EU country</li>
-  <li>send us questions or feedback</li>
-</ol>
+    <h2 class="heading-large" id="legal-basis-for-using-your-data">Legal basis for using your data</h2>
+    <p>The legal basis for processing your personal data is that it's necessary to perform a task in the public interest.</p>
+    <p>Sometimes, you will need to give your consent before any personal data is processed. In that case, you have the right to withdraw your consent at any time.</p>
 
-<h3 class="heading-large" id="when-you-sign-in-with-govuk-verify">When you sign in with GOV.UK Verify</h3>
+    <h2 class="heading-large" id="how-long-we-keep-your-data-for">How long we keep your data for</h2>
+    <p>We will only keep your personal data for as long as:</p>
+    <ol class="list-bullet list">
+      <li>it's needed for the purposes set out in this privacy notice</li>
+      <li>the law requires us to</li>
+    </ol>
 
-<p>GOV.UK Verify provides a 'hub' between services and companies that prove users' identities on behalf of the government. These companies have met government and industry standards to check and prove users' identities as part of GOV.UK Verify.</p>
+    <h2 class="heading-large" id="who-controls-your-data">Who controls your data</h2>
+    <p>Cabinet Office is the data controller for the data processed by GOV.UK Verify. A data controller determines how and why personal data is processed. For more information, read the Cabinet Office's entry in the <a href="https://ico.org.uk/ESDWebPages/Entry/Z7414053">Data Protection Public Register</a>.</p>
 
-<p>After the company proves your identity, they send limited personal data they collect to the hub. The hub will then send it to the service you want to use.</p>
+    <h2 class="heading-large" id="where-your-data-is-stored">Where your data is stored</h2>
+    <p>GOV.UK Verify stores your personal data in the European Economic Area (EEA).</p>
 
-<p>This personal data might include your:</p>
-<ol class="list-bullet list">
-  <li>name (including any previous names)</li>
-  <li>address (including any previous addresses)</li>
-  <li>date of birth</li>
-  <li>age range</li>
-  <li>gender (this is usually optional)</li>
-  <li>IP address</li>
-  <li>persistent identifier (PID) - this is given to you by the company that proved your identity</li>
-</ol>
+    <h2 class="heading-large" id="your-rights">Your rights</h2>
+    <p>You have the right to request:</p>
+    <ol class="list-bullet list">
+      <li>information about how your personal data is processed</li>
+      <li>a copy of any personal data you've given to us</li>
+      <li>that anything inaccurate in your personal data is corrected immediately</li>
+      <li>that any incomplete personal data is completed - you can do this by sending us a 'supplementary statement' that explains what's wrong with the data we've collected</li>
+      <li>that your personal data is deleted if there's no longer a reason for us to hold it</li>
+      <li>that the processing of your personal data is restricted in certain circumstances, for example if we've collected inaccurate information</li>
+    </ol>
 
-<p>If you use GOV.UK Verify to sign in to a service in an EU country, the hub will send limited personal data it collects to the service you want to use.</p>
+    <h2 class="heading-large" id="links-to-other-websites">Links to other websites</h2>
+    <p>GOV.UK Verify is one of the services on GOV.UK and has links to other websites.</p>
+    <p>This privacy notice only applies to <a href="https://www.gov.uk/government/publications/introducing-govuk-verify/introducing-govuk-verify">GOV.UK Verify</a> and doesn't cover other government services, companies or digital identity schemes that we link to. Read their own terms and conditions, privacy policies and data controllers if you want to find out how they process your personal data.</p>
 
-<p>This personal data might include your:</p>
-<ol class="list-bullet list">
-  <li>family name</li>
-  <li>first name</li>
-  <li>date of birth</li>
-  <li>PID</li>
-</ol>
+    <h2 class="heading-large" id="childrens-privacy-protection">Children's privacy protection</h2>
+    <p>We understand the importance of protecting children's privacy online. GOV.UK Verify is not designed for or intentionally targeted at children that are 13 or younger. We will not intentionally collect or keep data about anyone under the age of 13.</p>
 
-<h3 class="heading-large" id="when-you-sign-in-with-a-digital-identity-from-an-eu-country">When you sign in with a digital identity from an EU country</h3>
+    <h2 class="heading-large" id="how-we-protect-your-data-and-keep-it-secure">How we protect your data and keep it secure</h2>
+    <p>We're committed to doing all that we can to keep your data secure. We have set up systems and processes to prevent unauthorised access or disclosure of your data. For example, we protect your data using varying levels of encryption.</p>
+    <p>We also make sure that any third parties that we deal with have an obligation to keep all personal data they process on our behalf secure.</p>
 
-<p>After you've signed in, we'll collect your personal data and send it to the government service that you want to use. We do this to help protect your identity when you use government services.</p>
+    <h2 class="heading-large" id="changes-to-this-notice">Changes to this notice</h2>
+    <p>We may change this privacy notice. In that case, the 'last updated' date at the bottom of this page will change. Any changes to this privacy notice will apply to you and your data as of that date.</p>
+    <p>We encourage you to review this privacy notice regularly to find out how we are protecting your data.</p>
 
-<p>This personal data might include your:</p>
-<ol class="list-bullet list">
-  <li>family name</li>
-  <li>first name</li>
-  <li>date of birth</li>
-  <li>PID</li>
-</ol>
+    <h2 class="heading-large" id="contact-us-or-make-a-complaint">Contact us or make a complaint</h2>
+    <p>You can contact the GOV.UK Verify Privacy Team at <a href="mailto:verify-privacy@digital.cabinet-office.gov.uk">verify-privacy@digital.cabinet-office.gov.uk</a> if you:</p>
+    <ol class="list-bullet list">
+      <li>have a question about anything in the privacy notice</li>
+      <li>think that your personal data has been misused or mishandled</li>
+    </ol>
 
-<h3 class="heading-large" id="when-you-send-us-a-question-or-feedback">When you send us a question or feedback</h3>
+    <h2 class="heading-large" id="contact-an-independent-body">Contact an independent body</h2>
+    <p>You can contact the Cabinet Office Data Protection Officer (DPO), which provides independent advice and monitoring of our use of personal data.</p>
+    <p>
+      <b>Cabinet Office Data Protection Officer</b>
+      <br>
+      <a href="mailto:DPO@cabinetoffice.gov.uk">DPO@cabinetoffice.gov.uk</a>
+      <br>
+    </p>
+    <p>
+      <address>
+      Data Protection Officer
+      <br>
+      Cabinet Office
+      <br>
+      70 Whitehall
+      <br>
+      London SW1A 2AS
+      </address>
+    </p>
 
-<p>We keep any questions or feedback you send about GOV.UK Verify, as well as details about what we've done to help. We'll also keep some personal data, such as your name and email address.</p>
+    <p>You can also make a complaint to the Information Commissioner's Office (ICO), who is an independent regulator.</p>
 
-<h2 class="heading-large" id="cookies-and-analytics">Cookies and analytics</h2>
-
-<p>We use Matomo to collect information about how you use GOV.UK Verify.</p>
-
-<p>Matomo stores information about:</p>
-<ol class="list-bullet list">
-  <li>which pages you visit</li>
-  <li>how long you spend on each page</li>
-  <li>how you got to the site</li>
-  <li>what you click on while you're visiting the site</li>
-</ol>
-
-<p>We do not store any of your personal data on our analytics system.</p>
-
-<p>GOV.UK Verify puts small files (known as 'cookies') onto your computer. Read our full <a href="https://www.signin.service.gov.uk/cookies">cookie notice</a> to find out how we use cookies.</p>
-
-<p>To protect GOV.UK Verify from crime and fraud, we might sometimes share your personal data with:</p>
-<ol class="list-bullet list">
-  <li>law enforcement agencies</li>
-  <li>public sector organisations, for example the Cabinet Office, Home Office and others</li>
-  <li>relevant private sector organisations</li>
-</ol>
-
-<p>This personal data might include your:</p>
-<ol class="list-bullet list">
-  <li>family name</li>
-  <li>first name</li>
-  <li>date of birth</li>
-  <li>PID</li>
-  <li>phone number</li>
-  <li>biometric information</li>
-  <li>email addresses</li>
-  <li>address</li>
-</ol>
-
-<h2 class="heading-large" id="what-we-do-with-your-data">What we do with your data</h2>
-
-<p>We might share the data we collect with:</p>
-<ol class="list-bullet list">
-  <li>other government departments and agencies</li>
-  <li>the company who verified your identity</li>
-  <li>other public bodies</li>
-</ol>
-
-<p>We will not:</p>
-<ol class="list-bullet list">
-  <li>sell your data to third parties</li>
-  <li>share your data with third parties for marketing purposes</li>
-</ol>
-
-<h2 class="heading-large" id="legal-basis-for-using-your-data">Legal basis for using your data</h2>
-
-<p>The legal basis for processing your personal data is that it's necessary to perform a task in the public interest.</p>
-
-<p>Sometimes, you will need to give your consent before any personal data is processed. In that case, you have the right to withdraw your consent at any time.</p>
-
-<h2 class="heading-large" id="how-long-we-keep-your-data-for">How long we keep your data for</h2>
-
-<p>We will only keep your personal data for as long as:</p>
-<ol class="list-bullet list">
-<li>it's needed for the purposes set out in this privacy notice</li>
-<li>the law requires us to</li>
-</ol>
-
-<h2 class="heading-large" id="who-controls-your-data">Who controls your data</h2>
-
-<p>Cabinet Office is the data controller for the data processed by GOV.UK Verify. A data controller determines how and why personal data is processed. For more information, read the Cabinet Office's entry in the <a href="https://ico.org.uk/ESDWebPages/Entry/Z7414053">Data Protection Public Register</a>.</p>
-
-<h2 class="heading-large" id="where-your-data-is-stored">Where your data is stored</h2>
-
-<p>GOV.UK Verify stores your personal data in the European Economic Area (EEA).</p>
-
-<h2 class="heading-large" id="your-rights">Your rights</h2>
-
-<p>You have the right to request:</p>
-<ol class="list-bullet list">
-  <li>information about how your personal data is processed</li>
-  <li>a copy of any personal data you've given to us</li>
-  <li>that anything inaccurate in your personal data is corrected immediately</li>
-  <li>that any incomplete personal data is completed - you can do this by sending us a 'supplementary statement' that explains what's wrong with the data we've collected</li>
-  <li>that your personal data is deleted if there's no longer a reason for us to hold it</li>
-  <li>that the processing of your personal data is restricted in certain circumstances, for example if we've collected inaccurate information</li>
-</ol>
-
-<h2 class="heading-large" id="links-to-other-websites">Links to other websites</h2>
-
-<p>GOV.UK Verify is one of the services on GOV.UK and has links to other websites.</p>
-
-<p>This privacy notice only applies to <a href="https://www.gov.uk/government/publications/introducing-govuk-verify/introducing-govuk-verify">GOV.UK Verify</a> and doesn't cover other government services, companies or digital identity schemes that we link to. Read their own terms and conditions, privacy policies and data controllers if you want to find out how they process your personal data.</p>
-
-<h2 class="heading-large" id="childrens-privacy-protection">Children's privacy protection</h2>
-
-<p>We understand the importance of protecting children's privacy online. GOV.UK Verify is not designed for or intentionally targeted at children that are 13 or younger. We will not intentionally collect or keep data about anyone under the age of 13.</p>
-
-<h2 class="heading-large" id="how-we-protect-your-data-and-keep-it-secure">How we protect your data and keep it secure</h2>
-
-<p>We're committed to doing all that we can to keep your data secure. We have set up systems and processes to prevent unauthorised access or disclosure of your data. For example, we protect your data using varying levels of encryption.</p>
- 
-<p>We also make sure that any third parties that we deal with have an obligation to keep all personal data they process on our behalf secure.</p>
-
-<h2 class="heading-large" id="changes-to-this-notice">Changes to this notice</h2>
-
-<p>We may change this privacy notice. In that case, the 'last updated' date at the bottom of this page will change. Any changes to this privacy notice will apply to you and your data as of that date.</p>
-
-<p>We encourage you to review this privacy notice regularly to find out how we are protecting your data.</p>
-
-<h2 class="heading-large" id="contact-us-or-make-a-complaint">Contact us or make a complaint</h2>
-
-<p>You can contact the GOV.UK Verify Privacy Team at <a href="mailto:verify-privacy@digital.cabinet-office.gov.uk">verify-privacy@digital.cabinet-office.gov.uk</a> if you:</p>
-<ol class="list-bullet list">
-  <li>have a question about anything in the privacy notice</li>
-  <li>think that your personal data has been misused or mishandled</li>
-</ol>
-
-<h2 class="heading-large" id="contact-an-independent-body">Contact an independent body</h2>
-
-<p>You can contact the Cabinet Office Data Protection Officer (DPO), which provides independent advice and monitoring of our use of personal data.</p>
-
-<p>
-<b>Cabinet Office Data Protection Officer</b>
-<br>
-<a href="mailto:DPO@cabinetoffice.gov.uk">DPO@cabinetoffice.gov.uk</a>
-<br>
-</p>
-
-<p>
-<address>
-Data Protection Officer
-<br>
-Cabinet Office
-<br>
-70 Whitehall
-<br>
-London SW1A 2AS
-</address>
-</p>
-
-<p>You can also make a complaint to the Information Commissioner's Office (ICO), who is an independent regulator.</p>
-
-   <p>
-     <b>ICO</b><br>
+    <p>
+      <b>ICO</b><br>
       <a href="mailto:casework@ico.org.uk">casework@ico.org.uk</a><br>
       Telephone: 0303 123 1113<br>
       Textphone: 01625 545 860<br>
       Monday to Friday, from 9am to 4:30pm<br>
     </p>
 
-<p><a href="https://www.gov.uk/call-charges">Find out about call charges</a>.</p>
+    <p><a href="https://www.gov.uk/call-charges">Find out about call charges</a></p>
 
- <p>
-    <address>
-      Information Commissioner’s Office
-      <br>
-      Wycliffe House
-      <br>
-      Water Lane
-      <br>
-      Wilmslow
-      <br>
-      Cheshire SK9 5AF
-    </address>
-    </p>
+    <p>
+      <address>
+        Information Commissioner’s Office
+        <br>
+        Wycliffe House
+        <br>
+        Water Lane
+        <br>
+        Wilmslow
+        <br>
+        Cheshire SK9 5AF
+      </address>
+   </p>
 
     <div class="meta-data group">
       <p class="modified-date">Last updated: 20 September 2019</p>

--- a/app/views/static/privacy_notice.en.html.erb
+++ b/app/views/static/privacy_notice.en.html.erb
@@ -9,7 +9,7 @@ end %>
 <div class="grid-row">
   <div class="column-two-thirds">
     <h1 class="heading-xlarge">Privacy notice</h1>
-    <p>Last updated: 20 September 2019</p>
+    <p>Last updated: 23 September 2019</p>
     <h2 class="heading-large" id="who-we-are">Who we are</h2>
     <p>GOV.UK Verify is built and run by the Government Digital Service (GDS), which is part of the Cabinet Office.</p>
     <p>GOV.UK Verify allows you to prove your identity when using digital government services, like the service you use to <a href="https://www.gov.uk/log-in-file-self-assessment-tax-return">file your Self Assessment tax return</a>.</p>
@@ -200,7 +200,7 @@ end %>
    </p>
 
     <div class="meta-data group">
-      <p class="modified-date">Last updated: 20 September 2019</p>
+      <p class="modified-date">Last updated: 23 September 2019</p>
     </div>
   </div>
 </div>

--- a/spec/features/user_visits_privacy_notice_page_spec.rb
+++ b/spec/features/user_visits_privacy_notice_page_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'When the user visits the privacy notice page' do
   it 'displays the page in English' do
     visit '/privacy-notice'
     expect(page).to have_title t('hub.privacy_notice.title')
-    expect(page).to have_content 'We process information about you when you use GOV.UK Verify. This may include any of the following.'
+    expect(page).to have_content 'This privacy notice explains what data we might collect, how it\'s used and how it\'s protected.'
     expect(page).to have_link 'DPO@cabinetoffice.gov.uk', href: 'mailto:DPO@cabinetoffice.gov.uk'
     expect(page).to have_content 'Cabinet Office is the data controller for the data processed by GOV.UK Verify.'
   end


### PR DESCRIPTION
I've added some new information about sharing data for fraud and threat intelligence reasons to the 'Cookies and analytics' section.

I've also rewritten the rest of the GOV.UK Verify privacy notice to make sure it meets GDS style.