### PR TITLE
EID-1733: warn instead of error on choose a country (non-eIDAS)

### DIFF
--- a/app/controllers/partials/eidas_validation_partial_controller.rb
+++ b/app/controllers/partials/eidas_validation_partial_controller.rb
@@ -2,7 +2,7 @@ module EidasValidationPartialController
   def ensure_session_eidas_supported
     txn_supports_eidas = session[:transaction_supports_eidas]
     unless txn_supports_eidas
-      something_went_wrong('Transaction does not support Eidas', :forbidden)
+      something_went_wrong_warn('Transaction does not support Eidas', :forbidden)
     end
   end
 end

--- a/spec/controllers/choose_a_country_controller_spec.rb
+++ b/spec/controllers/choose_a_country_controller_spec.rb
@@ -4,9 +4,9 @@ require 'api_test_helper'
 require 'piwik_test_helper'
 
 describe ChooseACountryController do
-  before(:each) do
+  before(:each) do |test|
     set_session_and_cookies_with_loa('LEVEL_2')
-    set_session_supports_eidas
+    set_session_supports_eidas unless test.metadata[:no_eidas]
     stub_countries_list
   end
 
@@ -33,6 +33,14 @@ describe ChooseACountryController do
       get :choose_a_country, params: { locale: 'en' }
       expect(stub_restart_journey_request).to have_been_made.once
       expect(session[:selected_provider]).to be_nil
+    end
+
+    it 'shows an error if eIDAS is not supported', :no_eidas do
+      allow(Rails.logger).to receive(:error)
+      allow(Rails.logger).to receive(:warn)
+      expect(Rails.logger).not_to receive(:error)
+      expect(Rails.logger).to receive(:warn)
+      get :choose_a_country, params: { locale: 'en' }
     end
   end
 end


### PR DESCRIPTION
We expect this error only to occur if the user goes to the country controller by mistake, by manually entering the URI, or by having multiple Verify sessions running at the same time (ie from different transaction one of which does not support eIDAS).

> Not sure if we want to land this – see discussion on ticket.

https://govukverify.atlassian.net/browse/EID-1733