### PR TITLE
ZD-3731900 When your service doesn't support eIDAS but the user think…

### DIFF
--- a/app/controllers/partials/eidas_validation_partial_controller.rb
+++ b/app/controllers/partials/eidas_validation_partial_controller.rb
@@ -2,7 +2,7 @@ module EidasValidationPartialController
   def ensure_session_eidas_supported
     txn_supports_eidas = session[:transaction_supports_eidas]
     unless txn_supports_eidas
-      something_went_wrong('Transaction does not support Eidas', :forbidden)
+      something_went_wrong_warn('Transaction does not support Eidas', :forbidden)
     end
   end
 end

--- a/spec/controllers/choose_a_country_controller_spec.rb
+++ b/spec/controllers/choose_a_country_controller_spec.rb
@@ -39,7 +39,7 @@ describe ChooseACountryController do
       allow(Rails.logger).to receive(:error)
       allow(Rails.logger).to receive(:warn)
       expect(Rails.logger).not_to receive(:error)
-      expect(Rails.logger).to receive(:warn)
+      expect(Rails.logger).to receive(:warn).with('Transaction does not support Eidas')
       get :choose_a_country, params: { locale: 'en' }
     end
   end

--- a/spec/controllers/choose_a_country_controller_spec.rb
+++ b/spec/controllers/choose_a_country_controller_spec.rb
@@ -4,9 +4,9 @@ require 'api_test_helper'
 require 'piwik_test_helper'
 
 describe ChooseACountryController do
-  before(:each) do
+  before(:each) do |test|
     set_session_and_cookies_with_loa('LEVEL_2')
-    set_session_supports_eidas
+    set_session_supports_eidas unless test.metadata[:no_eidas]
     stub_countries_list
   end
 
@@ -33,6 +33,14 @@ describe ChooseACountryController do
       get :choose_a_country, params: { locale: 'en' }
       expect(stub_restart_journey_request).to have_been_made.once
       expect(session[:selected_provider]).to be_nil
+    end
+
+    it 'shows an error if eIDAS is not supported', :no_eidas do
+      allow(Rails.logger).to receive(:error)
+      allow(Rails.logger).to receive(:warn)
+      expect(Rails.logger).not_to receive(:error)
+      expect(Rails.logger).to receive(:warn)
+      get :choose_a_country, params: { locale: 'en' }
     end
   end
 end

--- a/spec/features/user_visits_redirect_to_country_spec.rb
+++ b/spec/features/user_visits_redirect_to_country_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe 'When the user visits the redirect to country page' do
 
   def given_a_session_not_supporting_eidas
     page.set_rack_session(
-      verify_session_id: no_eidas_session,
       transaction_supports_eidas: false
     )
   end


### PR DESCRIPTION
…s it should

This addresses two problems.

The first is that if a user replaces /start with /redirect-to-country on a service that doesn't support eIDAS the front end logs an error and Sentry starts showing red things.  This isn't really an error in the sense of something that is going wrong because our code isn't handling a particular set of circumstances well so should only be logged as a warning.  In the course of investigating
this, @bjgill discovered that the test that tests this was passing even though it was failing (the second problem being addressed).  The reason for this was that a specific session id was being set in the test but because the session id didn't match what had been set-up, the something went wrong page was being displayed - this was the page that was expected so the test passed anyway.  Deleting the line that sets the session id leaves the test to fail for the right reason - which was verified with the use of a temporary custom error page that could only be rendered from the place it was expected.  The temporary error page doesn't feature in this PR.

This incorporates the changes from EID-1733 which tests the controller directly whereas the feature test tests a user typing a URL in.