### PR TITLE
Do not raise error on 502/504 html error responses

### DIFF
--- a/lib/api/hub_response_handler.rb
+++ b/lib/api/hub_response_handler.rb
@@ -47,7 +47,11 @@ module Api
       begin
         MultiJson.load(body)
       rescue MultiJson::ParseError
-        raise Error, "Received #{status}, but unable to parse JSON"
+        case status
+        when HTTP::Response::Status[502], HTTP::Response::Status[504] then return nil
+        else
+          raise Error, "Received #{status}, but unable to parse JSON"
+        end
       end
     end
   end

--- a/spec/lib/api/hub_response_handler_spec.rb
+++ b/spec/lib/api/hub_response_handler_spec.rb
@@ -21,6 +21,24 @@ module Api
         }.to raise_error Error, /Received 500 with error message: 'NONE', type: 'NONE' and id: 'NONE'/
       end
 
+      it 'raises an error when API response status is 502 and message is not JSON' do
+        expect {
+          response_handler.handle_response(HTTP::Response::Status[502], '<html><head><title>502 Bad Gateway</title></head><body>Bad Gateway</body></html>')
+        }.to raise_error Error, /Received 502 with error message: 'NONE', type: 'NONE' and id: 'NONE'/
+      end
+
+      it 'raises an error when API response status is 504 and message is not JSON' do
+        expect {
+          response_handler.handle_response(HTTP::Response::Status[504], '<html><head><title>504 Gateway Timeout</title></head><body>Gateway Timeout</body></html>')
+        }.to raise_error Error, /Received 504 with error message: 'NONE', type: 'NONE' and id: 'NONE'/
+      end
+
+      it 'raises an error when API response status is 500 and message is not JSON' do
+        expect {
+          response_handler.handle_response(HTTP::Response::Status[500], '<html><head><title>500 Server Error</title></head><body>Server Error</body></html>')
+        }.to raise_error Error, /Received 500, but unable to parse JSON/
+      end
+
       it 'raises a session error when type is set to SESSION_ERROR' do
         error_body = { clientMessage: 'Failure', errorId: '0', exceptionType: 'EXPECTED_SESSION_STARTED_STATE_ACTUAL_IDP_SELECTED_STATE' }
         expect {


### PR DESCRIPTION
### What
In the case of 502 and 504 error responses with an html error messsage, do not raise an error.

The error status will still be propagated, but with no error message.

### Why
Due to an issue with nginx and policy, the `HubResponseHandler` in frontend is receiving many **html** error responses, when expecting json error responses.

i.e.
````
HTTP/2.0 504 Gateway Timeout Error

<html>
<head><title>504 Gateway Time-out</title></head>
<body bgcolor="white">
<center><h1>504 Gateway Time-out</h1></center>
</body>
</html>
````

These errors are surfacing as frontend sentry alerts, when we are already getting backend alerts for the same issue.