### PR TITLE
EID-1753 change interstitial page so that it reflects newly connected…

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -121,7 +121,7 @@ en:
       use_eidas:
         heading: Use a digital identity from another European country
         content_html: |
-          <p>If you’re part of an ID scheme in Germany or Italy you may be able to use it here.</p>
+          <p>If you’re part of an ID scheme in a participating country, you may be able to use it here.</p>
         button_text: Select your European digital identity
     start:
       title: Start


### PR DESCRIPTION
… countries

Change interstitial page so that it no longer specifically mentions Germany and Italy but instead refers to participating countries.

According to Google translate, the Welsh translation is actually the new message already which is convenient if not a little confusing.