### PR TITLE
EID-1774 Implement eIDAS escape route (exploration)

### DIFF
--- a/app/controllers/choose_a_country_controller.rb
+++ b/app/controllers/choose_a_country_controller.rb
@@ -8,6 +8,7 @@ class ChooseACountryController < ApplicationController
   def choose_a_country
     restart_journey if identity_provider_selected? && !user_journey_type?(JourneyType::EIDAS)
     @other_ways_description = current_transaction.other_ways_description
+    logger.info request.referrer ? "choose a country controller - referred by #{request.referrer}" : 'choose a country controller - no referrer'
   end
 
 private


### PR DESCRIPTION
In an ideal world we can use the referrer supplied with the request to give the user a route back to the sign-in picker they came from if their country isn't yet available as part of eidas.

Unfortunately, test-rp doesn't exactly mirror the way that the hub interacts with gov.uk so this adds some logging to enable us to see what the referrer looks like in real life.

Once the data's in, we can decide how to proceed.