### PR TITLE
Revert "Do not raise error on 502/504 html error responses"

### DIFF
--- a/lib/api/hub_response_handler.rb
+++ b/lib/api/hub_response_handler.rb
@@ -47,11 +47,7 @@ module Api
       begin
         MultiJson.load(body)
       rescue MultiJson::ParseError
-        case status
-        when HTTP::Response::Status[502], HTTP::Response::Status[504] then return nil
-        else
-          raise Error, "Received #{status}, but unable to parse JSON"
-        end
+        raise Error, "Received #{status}, but unable to parse JSON"
       end
     end
   end

--- a/spec/lib/api/hub_response_handler_spec.rb
+++ b/spec/lib/api/hub_response_handler_spec.rb
@@ -21,24 +21,6 @@ module Api
         }.to raise_error Error, /Received 500 with error message: 'NONE', type: 'NONE' and id: 'NONE'/
       end
 
-      it 'raises an error when API response status is 502 and message is not JSON' do
-        expect {
-          response_handler.handle_response(HTTP::Response::Status[502], '<html><head><title>502 Bad Gateway</title></head><body>Bad Gateway</body></html>')
-        }.to raise_error Error, /Received 502 with error message: 'NONE', type: 'NONE' and id: 'NONE'/
-      end
-
-      it 'raises an error when API response status is 504 and message is not JSON' do
-        expect {
-          response_handler.handle_response(HTTP::Response::Status[504], '<html><head><title>504 Gateway Timeout</title></head><body>Gateway Timeout</body></html>')
-        }.to raise_error Error, /Received 504 with error message: 'NONE', type: 'NONE' and id: 'NONE'/
-      end
-
-      it 'raises an error when API response status is 500 and message is not JSON' do
-        expect {
-          response_handler.handle_response(HTTP::Response::Status[500], '<html><head><title>500 Server Error</title></head><body>Server Error</body></html>')
-        }.to raise_error Error, /Received 500, but unable to parse JSON/
-      end
-
       it 'raises a session error when type is set to SESSION_ERROR' do
         error_body = { clientMessage: 'Failure', errorId: '0', exceptionType: 'EXPECTED_SESSION_STARTED_STATE_ACTUAL_IDP_SELECTED_STATE' }
         expect {


### PR DESCRIPTION
Reverts alphagov/verify-frontend#750

Catching these 502 and 504 errors here just meant they were propagated further and still surfaced in frontend logs, continuing to cause sentry events, 😱. 

The actual fix was via https://github.com/alphagov/verify-hub/pull/404, which stopped the 502s and 504s.