### PR TITLE
OnYku8Ji: Handle unexpected headers gracefully

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -42,6 +42,7 @@ class ApplicationController < ActionController::Base
   rescue_from Api::SessionError, with: :session_error
   rescue_from Api::UpstreamError, with: :upstream_error
   rescue_from Api::SessionTimeoutError, with: :session_timeout
+  rescue_from ActionController::UnknownFormat, with: :raise_unknown_format
 
   prepend RedirectWithSeeOther
 

--- a/app/controllers/partials/user_errors_partial_controller.rb
+++ b/app/controllers/partials/user_errors_partial_controller.rb
@@ -38,6 +38,11 @@ module UserErrorsPartialController
     end
   end
 
+  def raise_unknown_format
+    logger.warn("Received a request with unexpected accept headers - #{request.headers['ACCEPT']}")
+    render plain: 'Unable to serve the requested format', status: 406
+  end
+
   # How often do we have the information needed to redirect the user back to the
   # service homepage?
   def check_whether_recoverable

--- a/spec/controllers/response_processing_controller_spec.rb
+++ b/spec/controllers/response_processing_controller_spec.rb
@@ -31,4 +31,12 @@ describe ResponseProcessingController do
     expect(subject).to receive(:something_went_wrong).with('Unknown matching response "SOMETHING"')
     get :index, params: { locale: 'en' }
   end
+
+  it 'renders error text when the request is not proccesable' do
+    request.headers['ACCEPT'] = 'image/*'
+    expect(Rails.logger).to receive(:warn).with("Received a request with unexpected accept headers - #{request.headers['ACCEPT']}")
+    get :index, params: { locale: 'en' }
+    expect(response).to have_http_status :not_acceptable
+    expect(response.body).to eq 'Unable to serve the requested format'
+  end
 end


### PR DESCRIPTION
We've seen a couple of instances where the frontend received a request with
accept headers "image/*" on various endpoints. These endpoints obviously are
not able to return such a response (i.e. image). Instead of failing with uncaught exception
we now catch the exception and render plain error.

https://govuk.zendesk.com/agent/tickets/3850666