### PR TITLE
HUH-74 Add last_successful_idp endpoint to HintController

### DIFF
--- a/app/controllers/hint_controller.rb
+++ b/app/controllers/hint_controller.rb
@@ -1,7 +1,11 @@
 require 'partials/journey_hinting_partial_controller'
+require 'partials/retrieve_federation_data_partial_controller'
+require 'partials/viewable_idp_partial_controller'
 
 class HintController < ApplicationController
   include JourneyHintingPartialController
+  include RetrieveFederationDataPartialController
+  include ViewableIdpPartialController
   skip_before_action :validate_session
   skip_before_action :set_piwik_custom_variables
   skip_before_action :verify_authenticity_token
@@ -12,6 +16,30 @@ class HintController < ApplicationController
     entity_id = attempted_entity_id
 
     json_object = { 'status': 'OK', 'value': !entity_id.nil? }
+
+    render json: json_object.to_json, callback: params['callback']
+  end
+
+  def last_successful_idp
+    set_headers
+
+    entity_id = success_entity_id
+    identity_providers = current_available_identity_providers_for_sign_in
+
+    if entity_id && identity_providers.any?
+      idp = retrieve_decorated_singleton_idp_array_by_entity_id(
+        identity_providers,
+        entity_id
+      ).first
+
+      json_object = {
+        'found': 'true',
+        'simpleId': idp.simple_id,
+        'displayName': idp.display_name
+      }
+    else
+      json_object = { 'found': 'false' }
+    end
 
     render json: json_object.to_json, callback: params['callback']
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,6 +52,7 @@ Rails.application.routes.draw do
   get 'redirect-to-rp/:transaction_simple_id', to: 'redirect_to_rp#redirect_to_rp'
   get 'service-status', to: 'service_status#index', as: :service_status
   get 'hint', to: 'hint#ajax_request'
+  get 'successful-idp', to: 'hint#last_successful_idp'
   get '/SAML2/metadata/sp', to: 'metadata#service_providers', as: :service_provider_metadata
   get '/SAML2/metadata/idp', to: 'metadata#identity_providers', as: :identity_provider_metadata
   if SINGLE_IDP_FEATURE

--- a/spec/controllers/hint_controller_spec.rb
+++ b/spec/controllers/hint_controller_spec.rb
@@ -5,37 +5,105 @@ require 'api_test_helper'
 
 describe HintController do
   subject { get :ajax_request, params: { locale: 'en' } }
+  let(:successful_idp) { get :last_successful_idp, params: { locale: 'en' } }
 
-  context 'user has a journey hint present' do
-    it 'json object should return true' do
-      cookies.encrypted[CookieNames::VERIFY_FRONT_JOURNEY_HINT] = {
-        'ATTEMPT' => 'http://idcorp.com',
-      }.to_json
+  context '#hint' do
+    context 'user has a journey hint present' do
+      it 'json object should return true' do
+        cookies.encrypted[CookieNames::VERIFY_FRONT_JOURNEY_HINT] = {
+          'ATTEMPT' => 'http://idcorp.com',
+        }.to_json
 
-      body = JSON.parse(subject.body)
-      expect(body["value"]).to eq(true)
-      expect(subject.content_type).to eq("application/json")
-      expect(subject).to have_http_status(200)
+        body = JSON.parse(subject.body)
+        expect(body["value"]).to eq(true)
+        expect(subject.content_type).to eq("application/json")
+        expect(subject).to have_http_status(200)
+      end
+
+      it 'json object should return true even if the value is not set' do
+        cookies.encrypted[CookieNames::VERIFY_FRONT_JOURNEY_HINT] = {
+          'ATTEMPT' => '',
+        }.to_json
+
+        body = JSON.parse(subject.body)
+        expect(body["value"]).to eq(true)
+        expect(subject.content_type).to eq("application/json")
+        expect(subject).to have_http_status(200)
+      end
     end
 
-    it 'json object should return true even if the value is not set' do
-      cookies.encrypted[CookieNames::VERIFY_FRONT_JOURNEY_HINT] = {
-        'ATTEMPT' => '',
-      }.to_json
-
-      body = JSON.parse(subject.body)
-      expect(body["value"]).to eq(true)
-      expect(subject.content_type).to eq("application/json")
-      expect(subject).to have_http_status(200)
+    context 'user does not have a journey hint present' do
+      it 'json object should return false' do
+        body = JSON.parse(subject.body)
+        expect(body["value"]).to eq(false)
+        expect(subject.content_type).to eq("application/json")
+        expect(subject).to have_http_status(200)
+      end
     end
   end
 
-  context 'user does not have a journey hint present' do
-    it 'json object should return false' do
-      body = JSON.parse(subject.body)
-      expect(body["value"]).to eq(false)
-      expect(subject.content_type).to eq("application/json")
-      expect(subject).to have_http_status(200)
+  context '#last_successful_idp' do
+    before(:each) do
+      stub_api_idp_list_for_sign_in([{ 'simpleId' => 'stub-idp-one',
+                                       'entityId' => 'http://idcorp.com',
+                                       'levelsOfAssurance' => %w(LEVEL_1) },
+                                     { 'simpleId' => 'stub-idp-two',
+                                       'entityId' => 'http://idcorp-two.com',
+                                       'levelsOfAssurance' => %w(LEVEL_1) },
+                                     { 'simpleId' => 'stub-idp-broken',
+                                       'entityId' => 'http://idcorp-broken.com',
+                                       'levelsOfAssurance' => %w(LEVEL_1),
+                                       'temporarilyUnavailable' => true }])
+      set_session_and_cookies_with_loa('LEVEL_1')
+    end
+
+    context 'user has previously succesfully signed in' do
+      it 'json object should include simpleId and displayName' do
+        cookies.encrypted[CookieNames::VERIFY_FRONT_JOURNEY_HINT] = {
+          'SUCCESS' => 'http://idcorp-two.com',
+        }.to_json
+
+        body = JSON.parse(successful_idp.body)
+
+        expect(body['found']).to eq('true')
+        expect(body['simpleId']).to eq('stub-idp-two')
+        expect(body['displayName']).to eq('Bob’s Identity Service')
+        expect(successful_idp.content_type).to eq("application/json")
+        expect(successful_idp).to have_http_status(200)
+      end
+    end
+
+    context 'user has not previously successfully signed in' do
+      it 'json object should contain empty strings for simpleId and displayName' do
+        cookies.encrypted[CookieNames::VERIFY_FRONT_JOURNEY_HINT] = {
+          'ATTEMPT' => 'http://idcorp-two.com',
+        }.to_json
+
+        body = JSON.parse(successful_idp.body)
+
+        expect(body['found']).to eq('false')
+        expect(body.keys).not_to include('simpleId')
+        expect(body.keys).not_to include('displayName')
+        expect(successful_idp.content_type).to eq("application/json")
+        expect(successful_idp).to have_http_status(200)
+      end
+    end
+
+    context 'list of available identity providers is empty' do
+      it 'json object should contain empty strings for simpleId and displayName' do
+        stub_api_idp_list_for_sign_in([])
+        cookies.encrypted[CookieNames::VERIFY_FRONT_JOURNEY_HINT] = {
+          'SUCCESS' => 'http://idcorp-two.com',
+        }.to_json
+
+        body = JSON.parse(successful_idp.body)
+
+        expect(body['found']).to eq('false')
+        expect(body.keys).not_to include('simpleId')
+        expect(body.keys).not_to include('displayName')
+        expect(successful_idp.content_type).to eq("application/json")
+        expect(successful_idp).to have_http_status(200)
+      end
     end
   end
 end


### PR DESCRIPTION
We want to run a test where users are shown a direct link to log in with
the supplier they were last successful with. This is derived from their
cookie. Some JS is being written that will call this endpoint to find
out which IDP that was, and return some information which will be
useful.