### PR TITLE
HUH-74: Change the hint check from attempted to success

### DIFF
--- a/app/controllers/hint_controller.rb
+++ b/app/controllers/hint_controller.rb
@@ -13,7 +13,7 @@ class HintController < ApplicationController
   def ajax_request
     set_headers
 
-    entity_id = attempted_entity_id
+    entity_id = success_entity_id
 
     json_object = { 'status': 'OK', 'value': !entity_id.nil? }
 

--- a/spec/controllers/hint_controller_spec.rb
+++ b/spec/controllers/hint_controller_spec.rb
@@ -11,7 +11,7 @@ describe HintController do
     context 'user has a journey hint present' do
       it 'json object should return true' do
         cookies.encrypted[CookieNames::VERIFY_FRONT_JOURNEY_HINT] = {
-          'ATTEMPT' => 'http://idcorp.com',
+          'SUCCESS' => 'http://idcorp.com',
         }.to_json
 
         body = JSON.parse(subject.body)
@@ -22,7 +22,7 @@ describe HintController do
 
       it 'json object should return true even if the value is not set' do
         cookies.encrypted[CookieNames::VERIFY_FRONT_JOURNEY_HINT] = {
-          'ATTEMPT' => '',
+          'SUCCESS' => '',
         }.to_json
 
         body = JSON.parse(subject.body)


### PR DESCRIPTION
We're showing a hint on GOV.UK if the user has *successfully* verified, but we're currently
reporting if they even *attempted* to verified. This changes the logic to
return true if they successfully verify
so we can use the same tracking.