### PR TITLE
HUH-248: Show last successful IDP on the interstitial page if successful IDP hint set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,10 +11,12 @@
 /log/*
 !/log/.keep
 /tmp
+.byebug_history
 .gems
 .idea
 *.swp
 local.env
+
 
 verify-frontend.iml
 

--- a/app/controllers/authn_request_controller.rb
+++ b/app/controllers/authn_request_controller.rb
@@ -100,6 +100,9 @@ private
         do_eidas_sign_in_redirect(redirect_params)
       when 'submission_confirmation'
         redirect_to confirm_your_identity_path(redirect_params)
+      when successful_idp_hint?
+        flash[:journey_hint] = hint
+        redirect_to redirect_to_idp_sign_in_with_last_successful_idp_path(redirect_params)
       else
         logger.info "Unrecognised journey_hint value: #{hint}" unless hint.nil? || hint.eql?('unspecified')
         do_default_redirect(redirect_params)
@@ -127,5 +130,9 @@ private
 
   def raise_error_if_params_invalid
     something_went_wrong_warn("Missing/empty SAML message from #{request.referer}", :bad_request) if params['SAMLRequest'].blank?
+  end
+
+  def successful_idp_hint?
+    ->(hint) { hint && hint.start_with?('idp_') }
   end
 end

--- a/app/controllers/partials/viewable_idp_partial_controller.rb
+++ b/app/controllers/partials/viewable_idp_partial_controller.rb
@@ -6,13 +6,6 @@ module ViewableIdpPartialController
     end
   end
 
-  def select_viewable_idp_for_sign_in_by_simple_id(simple_id)
-    for_viewable_idp_from_simple_id(simple_id, current_available_identity_providers_for_sign_in) do |decorated_idp|
-      store_selected_idp_for_session(decorated_idp.identity_provider)
-      yield decorated_idp
-    end
-  end
-
   def select_viewable_idp_for_loa(entity_id)
     for_viewable_idp(entity_id, current_identity_providers_for_loa) do |decorated_idp|
       store_selected_idp_for_session(decorated_idp.identity_provider)
@@ -36,16 +29,6 @@ module ViewableIdpPartialController
       simple_id = matching_idp.nil? ? nil : matching_idp.simple_id
       logger.error "Viewable IdP not found for entity ID #{entity_id} with simple ID #{simple_id}"
       render_not_found
-    end
-  end
-
-  def for_viewable_idp_from_simple_id(simple_id, identity_provider_list)
-    matching_idp = identity_provider_list.detect { |idp| idp.simple_id == simple_id }
-    idp = IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate(matching_idp)
-    if idp.viewable?
-      yield idp
-    else
-      raise StandardError.new "Viewable IdP not found for simple ID #{simple_id}"
     end
   end
 

--- a/app/controllers/redirect_to_idp_controller.rb
+++ b/app/controllers/redirect_to_idp_controller.rb
@@ -30,6 +30,7 @@ class RedirectToIdpController < ApplicationController
   end
 
   def sign_in_with_last_successful_idp
+    session[:journey_type] = 'sign-in-last-sucessful-idp'
     simple_id = flash[:journey_hint]
     return render_not_found unless simple_id
 

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -43,6 +43,7 @@ cy:
     forgot_company: wedi-anghofio-cwmni
     response_processing: prosesu-ymateb
     redirect_to_idp_sign_in: ailgyfeirio-i-idp/mewngofnodi
+    redirect_to_idp_sign_in_with_last_successful_idp: redirect-to-idp-sign-in-with-last-successful-idp-cy
     redirect_to_idp_register: ailgyfeirio-i-idp/cofrestru
     redirect_to_idp_resume: ailgyfeirio-i-idp/ailddechrau
     redirect_to_service_signing_in: ailgyfeirio-i-gwasanaeth/mewngofnodi

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -43,6 +43,7 @@ en:
     forgot_company: forgot-company
     response_processing: response-processing
     redirect_to_idp_sign_in: redirect-to-idp/sign-in
+    redirect_to_idp_sign_in_with_last_successful_idp: redirect-to-idp-sign-in-with-last-successful-idp
     redirect_to_idp_register: redirect-to-idp/register
     redirect_to_idp_resume: redirect-to-idp/resume
     redirect_to_service_signing_in: redirect-to-service/signing-in

--- a/config/main_routes.rb
+++ b/config/main_routes.rb
@@ -83,6 +83,7 @@ get 'forgot_company', to: 'static#forgot_company', as: :forgot_company
 get 'response_processing', to: 'response_processing#index', as: :response_processing
 get 'redirect_to_idp_register', to: 'redirect_to_idp#register', as: :redirect_to_idp_register
 get 'redirect_to_idp_sign_in', to: 'redirect_to_idp#sign_in', as: :redirect_to_idp_sign_in
+get 'redirect_to_idp_sign_in_with_last_successful_idp', to: 'redirect_to_idp#sign_in_with_last_successful_idp', as: :redirect_to_idp_sign_in_with_last_successful_idp
 get 'redirect_to_idp_resume', to: 'redirect_to_idp#resume', as: :redirect_to_idp_resume
 get 'redirect_to_service_signing_in' => 'redirect_to_service#signing_in', as: :redirect_to_service_signing_in
 get 'redirect_to_service_start_again' => 'redirect_to_service#start_again', as: :redirect_to_service_start_again

--- a/spec/controllers/authn_request_controller_spec.rb
+++ b/spec/controllers/authn_request_controller_spec.rb
@@ -39,4 +39,10 @@ describe AuthnRequestController do
     post :rp_request, params: { 'SAMLRequest' => nil, 'RelayState' => 'my-relay-state' }
     expect(response).to have_http_status :bad_request
   end
+
+  it 'will set hint in flash and redirect to redirect_to_idp_sign_in_with_last_successful_idp_path if idp hint' do
+    post :rp_request, params: { '_ga' => :ga_id, 'journey_hint' => 'idp_simple_id', 'SAMLRequest' => 'my-saml-request', 'RelayState' => 'my-relay-state' }
+    expect(response).to redirect_to redirect_to_idp_sign_in_with_last_successful_idp_path(_ga: :ga_id)
+    expect(flash[:journey_hint]).to eq('idp_simple_id')
+  end
 end

--- a/spec/controllers/redirect_to_idp_controller_spec.rb
+++ b/spec/controllers/redirect_to_idp_controller_spec.rb
@@ -272,7 +272,7 @@ describe RedirectToIdpController do
                                     'LEVEL_1',
                                     false,
                                     nil,
-                                    nil
+                                    'sign-in-last-sucessful-idp'
                                   )
 
         subject

--- a/spec/features/redirects_with_journey_hint_authn_request_spec.rb
+++ b/spec/features/redirects_with_journey_hint_authn_request_spec.rb
@@ -38,6 +38,12 @@ describe 'pages redirect with journey hint parameter', type: :request do
       post '/SAML2/SSO', params: { 'SAMLRequest' => 'my-saml-request', 'RelayState' => 'my-relay-state' }
       expect(response).to redirect_to start_path
     end
+
+    it 'will redirect the user to IDP sign in when journey hint parameter is set to idp_simple_id' do
+      stub_session_creation
+      post '/SAML2/SSO', params: { 'SAMLRequest' => 'my-saml-request', 'RelayState' => 'my-relay-state', 'journey_hint' => 'idp_something' }
+      expect(response).to redirect_to redirect_to_idp_sign_in_with_last_successful_idp_path
+    end
   end
 
   context 'when transaction is Eidas enabled' do


### PR DESCRIPTION
We're testing a new flow where a journey hint is set on the interstitial
page if it is determined the user has previously signed in successfully.
The hint is the simple_id of the IDP, prefixed with `idp_`.

These changes allow that hint to be picked up, and the idp selected,
before redirecting the user to the idp.