### PR TITLE
HUH-74: Enable journey hints from gov.uk

### DIFF
--- a/app/controllers/initiate_journey_controller.rb
+++ b/app/controllers/initiate_journey_controller.rb
@@ -39,6 +39,8 @@ private
   end
 
   def valid_journey_hint?(journey_hint)
+    return true if journey_hint&.starts_with?('idp_')
+
     [nil, 'uk_idp_start', 'registration', 'uk_idp_sign_in', 'eidas_sign_in', 'submission_confirmation'].include?(journey_hint)
   end
 

--- a/spec/controllers/initiate_journey_controller_spec.rb
+++ b/spec/controllers/initiate_journey_controller_spec.rb
@@ -24,6 +24,14 @@ describe InitiateJourneyController do
       expect(session[:journey_hint_rp]).to eq('test-rp')
     end
 
+    it 'should redirect to RP headless start page with journey hint when an IDP-specific one is used' do
+      get :index, params: { transaction_simple_id: 'test-rp', locale: 'en', journey_hint: 'idp_stub_idp' }
+
+      expect(subject).to redirect_to('http://localhost:50130/success?rp-name=test-rp&journey_hint=idp_stub_idp')
+      expect(session[:journey_hint]).to eq('idp_stub_idp')
+      expect(session[:journey_hint_rp]).to eq('test-rp')
+    end
+
     it 'should redirect to service homepage if headless startpage not defined for RP' do
       get :index, params: { transaction_simple_id: 'test-rp-noc3', locale: 'en' }
 


### PR DESCRIPTION
We're whitelisting the hint values. We're sending a new one which consists
of idp_ prefix and the name of the IDP. This will allow
to keep the hints when it begins with idp_