### PR TITLE
HUB-74: Fix the hinting logic

### DIFF
--- a/app/controllers/hint_controller.rb
+++ b/app/controllers/hint_controller.rb
@@ -24,9 +24,16 @@ class HintController < ApplicationController
     set_headers
 
     entity_id = success_entity_id
+
+    return render json: { 'found': 'false' }.to_json, callback: params['callback'] if entity_id.nil?
+
+    # Ugly and temporary hack (due to time constraints)
+    # We need the list of enabled IDPs, but these lists are mapped against a transaction
+    # at this stage there's no transaction but we know this is called from PTA page
+    session[:transaction_entity_id] = 'https://prod-left.tax.service.gov.uk/SAML2/PERTAX'
     identity_providers = current_available_identity_providers_for_sign_in
 
-    if entity_id && identity_providers.any?
+    if identity_providers.any?
       idp = retrieve_decorated_singleton_idp_array_by_entity_id(
         identity_providers,
         entity_id

--- a/spec/api_test_helper.rb
+++ b/spec/api_test_helper.rb
@@ -344,6 +344,10 @@ module ApiTestHelper
     stub_request(:get, config_api_uri(idp_list_for_sign_in_endpoint(default_transaction_entity_id))).to_return(body: idps.to_json)
   end
 
+  def stub_api_idp_list_for_sign_in_without_session(idps = default_idps, transaction_entity_id = default_transaction_entity_id)
+    stub_request(:get, config_api_uri(idp_list_for_sign_in_endpoint(transaction_entity_id))).to_return(body: idps.to_json)
+  end
+
   def stub_api_idp_list_for_single_idp_journey(transaction_id = default_transaction_entity_id, idps = default_idps)
     stub_request(:get, config_api_uri(idp_list_for_single_idp_endpoint(transaction_id))).to_return(body: idps.to_json)
   end

--- a/spec/controllers/hint_controller_spec.rb
+++ b/spec/controllers/hint_controller_spec.rb
@@ -44,7 +44,8 @@ describe HintController do
 
   context '#last_successful_idp' do
     before(:each) do
-      stub_api_idp_list_for_sign_in([{ 'simpleId' => 'stub-idp-one',
+      stub_api_idp_list_for_sign_in_without_session([
+                                     { 'simpleId' => 'stub-idp-one',
                                        'entityId' => 'http://idcorp.com',
                                        'levelsOfAssurance' => %w(LEVEL_1) },
                                      { 'simpleId' => 'stub-idp-two',
@@ -53,8 +54,9 @@ describe HintController do
                                      { 'simpleId' => 'stub-idp-broken',
                                        'entityId' => 'http://idcorp-broken.com',
                                        'levelsOfAssurance' => %w(LEVEL_1),
-                                       'temporarilyUnavailable' => true }])
-      set_session_and_cookies_with_loa('LEVEL_1')
+                                       'temporarilyUnavailable' => true }
+                                     ],
+                                     'https://prod-left.tax.service.gov.uk/SAML2/PERTAX')
     end
 
     context 'user has previously succesfully signed in' do
@@ -91,7 +93,7 @@ describe HintController do
 
     context 'list of available identity providers is empty' do
       it 'json object should contain empty strings for simpleId and displayName' do
-        stub_api_idp_list_for_sign_in([])
+        stub_api_idp_list_for_sign_in_without_session([], 'https://prod-left.tax.service.gov.uk/SAML2/PERTAX')
         cookies.encrypted[CookieNames::VERIFY_FRONT_JOURNEY_HINT] = {
           'SUCCESS' => 'http://idcorp-two.com',
         }.to_json


### PR DESCRIPTION
On the hint endpoint, we need to call the config to obtain
the available IDPs. However, these calls require a transaction entity ID.
For the test we're hardcoding the transaction ID, otherwise we
would have to make another release in the JavaScript code deployed to GOV.UK