### PR TITLE
HUH-234 Missing tests for C-Variant

### DIFF
--- a/spec/features/user_visits_choose_a_certified_company_variant_c_page_spec.rb
+++ b/spec/features/user_visits_choose_a_certified_company_variant_c_page_spec.rb
@@ -1,0 +1,215 @@
+require 'feature_helper'
+require 'api_test_helper'
+
+describe 'When the user visits the choose a certified company page' do
+  let(:stub_idp_one) {
+    {
+        'simpleId' => 'stub-idp-one',
+        'entityId' => 'http://idcorp-one.com',
+        'levelsOfAssurance' => %w(LEVEL_1 LEVEL_2)
+    }.freeze
+  }
+
+  let(:stub_idp_two) {
+    {
+        'simpleId' => 'stub-idp-two',
+        'entityId' => 'http://idcorp-two.com',
+        'levelsOfAssurance' => %w(LEVEL_2)
+    }.freeze
+  }
+
+  let(:stub_idp_three) {
+    {
+        'simpleId' => 'stub-idp-three',
+        'entityId' => 'http://idcorp-three.com',
+        'levelsOfAssurance' => %w(LEVEL_2)
+    }.freeze
+  }
+
+  before(:each) do
+    experiment = { "short_hub_2019_q3-preview" => "short_hub_2019_q3-preview_variant_c_2_idp_short_hub" }
+    set_session_and_ab_session_cookies!(experiment)
+    stub_api_idp_list_for_loa([stub_idp_one, stub_idp_three])
+  end
+
+  context 'user has two docs and a mobile' do
+    selected_answers = {
+        device_type: { device_type_other: true },
+        documents: { has_valid_passport: true, has_driving_license: true, has_phone_can_app: true }
+    }
+    before :each do
+      page.set_rack_session(
+        page.get_rack_session.merge(
+          transaction_simple_id: 'test-rp',
+          selected_answers: selected_answers
+        )
+      )
+    end
+
+    it 'marks the unavailable IDP as unavailable' do
+      stub_api_idp_list_for_loa([{ 'simpleId' => 'stub-idp-one',
+                                   'entityId' => 'http://idcorp.com',
+                                   'levelsOfAssurance' => %w(LEVEL_2),
+                                   'temporarilyUnavailable' => true }])
+      visit '/choose-a-certified-company'
+      expect(page).to have_content t('hub.certified_companies_unavailable.title', count: 1, company: 'IDCorp')
+    end
+
+    it 'includes the appropriate feedback source' do
+      visit '/choose-a-certified-company'
+      expect_feedback_source_to_be(page, 'CHOOSE_A_CERTIFIED_COMPANY_PAGE', '/choose-a-certified-company')
+    end
+
+    it 'displays recommended IDPs' do
+      visit '/choose-a-certified-company'
+
+      expect(page).to have_current_path(choose_a_certified_company_path)
+      expect(page).to have_content t('hub_variant_c.choose_a_certified_company.idp_count')
+      within('#matching-idps') do
+        expect(page).to have_button('Choose IDCorp')
+        expect(page).to have_button('Choose Carol’s Secure ID')
+        expect(page).not_to have_button('Bob’s Identity Service')
+      end
+    end
+
+    it 'redirects to the choose a certified company about page when selecting About link' do
+      visit '/choose-a-certified-company'
+
+      click_link 'About IDCorp'
+
+      expect(page).to have_current_path(choose_a_certified_company_about_path('stub-idp-one'))
+    end
+
+    it 'displays the page in Welsh but actually the text is still English' do
+      visit '/dewis-cwmni-ardystiedig'
+
+      expect(page).to have_title t('hub_variant_c.choose_a_certified_company.title', locale: :cy)
+      expect(page).to have_css 'html[lang=cy]'
+    end
+  end
+
+  context 'user is from an LOA1 service' do
+    before(:each) do
+      stub_api_idp_list_for_loa(default_idps, 'LEVEL_1')
+      page.set_rack_session(
+        transaction_simple_id: 'test-rp',
+        requested_loa: 'LEVEL_1',
+        selected_answers: {
+          device_type: { device_type_other: true },
+          documents: { passport: true, driving_licence: true },
+          phone: { mobile_phone: true }
+        },
+      )
+    end
+
+    it 'only LEVEL_1 recommended IDPs are displayed' do
+      visit '/choose-a-certified-company'
+
+      expect(page).to have_current_path(choose_a_certified_company_path)
+
+      within('#matching-idps') do
+        expect(page).to have_button('Choose LOA1 Corp')
+      end
+    end
+
+    it 'unavailable LEVEL_1 recommended IDPs are marked as unavailable' do
+      stub_api_idp_list_for_loa([{ 'simpleId' => 'stub-idp-one',
+                                   'entityId' => 'http://idcorp.com',
+                                   'levelsOfAssurance' => %w(LEVEL_1),
+                                   'temporarilyUnavailable' => true }], 'LEVEL_1')
+      visit '/choose-a-certified-company'
+      expect(page).to have_content t('hub.certified_companies_unavailable.title', count: 1, company: 'IDCorp')
+    end
+  end
+
+  it 'redirects away if no IDP recommendations' do
+    page.set_rack_session(
+      transaction_simple_id: 'test-rp',
+      selected_answers: {
+        device_type: { device_type_other: true }
+      },
+    )
+
+    visit '/choose-a-certified-company'
+
+    expect(page).to have_current_path(select_documents_advice_path)
+  end
+
+  it 'recommends some IDPs with a recommended profile, hides non-recommended profiles, and omits non-matching profiles' do
+    page.set_rack_session(
+      transaction_simple_id: 'test-rp',
+      selected_answers: {
+        'documents' => { 'has_driving_license' => true, 'has_phone_can_app' => true, 'has_valid_passport' => true, 'has_credit_card' => true },
+        'device_type' => { 'device_type_other' => true }
+      }
+    )
+
+    visit '/choose-a-certified-company'
+
+    expect(page).to have_content t('hub_variant_c.choose_a_certified_company.idp_count')
+    within('#matching-idps') do
+      expect(page).to have_button('Choose IDCorp')
+      expect(page).to have_button('Choose Carol’s Secure ID')
+      expect(page).not_to have_button('Bob’s Identity Service')
+    end
+  end
+
+  context 'Google Analytics elements are rendered correctly' do
+    context 'when coming from an LOA2 service' do
+      before :each do
+        stub_api_idp_list_for_loa(default_idps, 'LEVEL_2')
+        page.set_rack_session(
+          transaction_simple_id: 'test-rp',
+          requested_loa: 'LEVEL_2',
+          selected_answers: {
+            device_type: { device_type_other: true },
+            documents: { has_valid_passport: true, has_driving_license: true, has_phone_can_app: true }
+          },
+          )
+      end
+
+      it 'should render GA elements on choose certified company page' do
+        visit '/choose-a-certified-company'
+
+        expect(page).to have_css "span#cross-gov-ga-tracker-id", text: "UA-XXXXX-Y"
+      end
+
+      it 'should not render GA elements on about page' do
+        visit '/choose-a-certified-company'
+
+        click_link 'About IDCorp'
+
+        expect(page).to_not have_css "span#cross-gov-ga-tracker-id", text: "UA-XXXXX-Y"
+      end
+    end
+
+    context 'when coming from an LOA1 service' do
+      before :each do
+        stub_api_idp_list_for_loa(default_idps, 'LEVEL_1')
+        page.set_rack_session(
+          transaction_simple_id: 'test-rp',
+          requested_loa: 'LEVEL_1',
+          selected_answers: {
+            device_type: { device_type_other: true },
+            documents: { passport: true, driving_licence: true },
+            phone: { mobile_phone: true }
+          },
+          )
+      end
+
+      it 'should render GA elements on choose certified company page' do
+        visit '/choose-a-certified-company'
+
+        expect(page).to have_css "span#cross-gov-ga-tracker-id", text: "UA-XXXXX-Y"
+      end
+
+      it 'should not render GA elements on about page' do
+        visit '/choose-a-certified-company'
+
+        click_link 'About IDCorp'
+
+        expect(page).to_not have_css "span#cross-gov-ga-tracker-id", text: "UA-XXXXX-Y"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Use user_visits_choose_a_certified_company_page_spec.rb as basis for variant c tests.

Mostly adapting selected_answers to new style hash hash.

Removed tests relating to protected segments as they're not relevant to this variant.

Co-authored by: Lewis Westbury <lewis.westbury@digital.cabinet-office.gov.uk>