### PR TITLE
HUH-74 Fix bug if last successful IDP not available

### DIFF
--- a/app/controllers/hint_controller.rb
+++ b/app/controllers/hint_controller.rb
@@ -39,11 +39,16 @@ class HintController < ApplicationController
         entity_id
       ).first
 
-      json_object = {
-        'found': 'true',
-        'simpleId': idp.simple_id,
-        'displayName': idp.display_name
-      }
+      if idp.nil?
+        logger.info "No IDP found for entity ID #{entity_id} and identity providers #{identity_providers}"
+        json_object = { 'found': 'false' }
+      else
+        json_object = {
+          'found': 'true',
+          'simpleId': idp.simple_id,
+          'displayName': idp.display_name
+        }
+      end
     else
       json_object = { 'found': 'false' }
     end

--- a/spec/controllers/hint_controller_spec.rb
+++ b/spec/controllers/hint_controller_spec.rb
@@ -73,10 +73,24 @@ describe HintController do
         expect(successful_idp.content_type).to eq("application/json")
         expect(successful_idp).to have_http_status(200)
       end
+
+      it 'should return not found if last succesful entity ID not in available providers' do
+        cookies.encrypted[CookieNames::VERIFY_FRONT_JOURNEY_HINT] = {
+          'SUCCESS' => 'http://not-available.com',
+        }.to_json
+
+        body = JSON.parse(successful_idp.body)
+
+        expect(body['found']).to eq('false')
+        expect(body.keys).not_to include('simpleId')
+        expect(body.keys).not_to include('displayName')
+        expect(successful_idp.content_type).to eq("application/json")
+        expect(successful_idp).to have_http_status(200)
+      end
     end
 
     context 'user has not previously successfully signed in' do
-      it 'json object should contain empty strings for simpleId and displayName' do
+      it 'json object should not contain simpleId and displayName' do
         cookies.encrypted[CookieNames::VERIFY_FRONT_JOURNEY_HINT] = {
           'ATTEMPT' => 'http://idcorp-two.com',
         }.to_json
@@ -92,7 +106,7 @@ describe HintController do
     end
 
     context 'list of available identity providers is empty' do
-      it 'json object should contain empty strings for simpleId and displayName' do
+      it 'json object should not contain simpleId and displayName' do
         stub_api_idp_list_for_sign_in_without_session([], 'https://prod-left.tax.service.gov.uk/SAML2/PERTAX')
         cookies.encrypted[CookieNames::VERIFY_FRONT_JOURNEY_HINT] = {
           'SUCCESS' => 'http://idcorp-two.com',


### PR DESCRIPTION
We've [seen a few errors in Sentry](https://sentry.tools.signin.service.gov.uk/verify/prod-frontend/issues/3791/events/277199/) where the last successful IDP wasn't found in
the list of available IDPs. This will prevent an error being thrown and
log so we can investigate, whilst being invisible to the user.