### PR TITLE
HUH-253 Cookie Compliance - disable GA [DO NOT MERGE]

### DIFF
--- a/app/controllers/partials/analytics_partial_controller.rb
+++ b/app/controllers/partials/analytics_partial_controller.rb
@@ -8,7 +8,7 @@ module AnalyticsPartialController
   end
 
   def render_cross_gov_ga
-    @render_cross_gov_ga = true
+    @render_cross_gov_ga = false
   end
 
   def report_to_analytics(action_name)

--- a/spec/features/user_sends_authn_request_spec.rb
+++ b/spec/features/user_sends_authn_request_spec.rb
@@ -173,7 +173,8 @@ describe 'user sends authn requests' do
   end
 
   context 'and request contains cross-domain GA code' do
-    it 'will render the start page with GA elements and URL will contains _ga parameter' do
+    it 'will render the start page with GA elements and URL will contain _ga parameter' do
+      skip "Google Analytics disabled until consent mechanism in place"
       stub_session_creation
 
       visit('/test-saml?_ga=123456')
@@ -183,6 +184,20 @@ describe 'user sends authn requests' do
       expect(page).to have_current_path start_path(_ga: '123456')
       expect(page).to have_selector 'span#cross-gov-ga-tracker-id', text: 'UA-XXXXX-Y'
       expect(page).to have_selector 'span#cross-gov-ga-domain-list', text: '["www.gov.uk"]'
+    end
+  end
+
+  context 'and request does not contain cross-domain GA code' do
+    it 'will not render the start page with GA elements and URL will contain _ga parameter' do
+      stub_session_creation
+
+      visit('/test-saml?_ga=123456')
+      click_button 'saml-post'
+
+      expect(page).to have_title t('hub.start.title')
+      expect(page).to have_current_path start_path(_ga: '123456')
+      expect(page).to_not have_selector 'span#cross-gov-ga-tracker-id', text: 'UA-XXXXX-Y'
+      expect(page).to_not have_selector 'span#cross-gov-ga-domain-list', text: '["www.gov.uk"]'
     end
   end
 end

--- a/spec/features/user_visits_choose_a_certified_company_page_spec.rb
+++ b/spec/features/user_visits_choose_a_certified_company_page_spec.rb
@@ -211,6 +211,7 @@ describe 'When the user visits the choose a certified company page' do
       end
 
       it 'should render GA elements on choose certified company page' do
+        skip "Google Analytics disabled until consent mechanism in place"
         visit '/choose-a-certified-company'
 
         expect(page).to have_css "span#cross-gov-ga-tracker-id", text: "UA-XXXXX-Y"
@@ -240,9 +241,16 @@ describe 'When the user visits the choose a certified company page' do
       end
 
       it 'should render GA elements on choose certified company page' do
+        skip "Google Analytics disabled until consent mechanism in place"
         visit '/choose-a-certified-company'
 
         expect(page).to have_css "span#cross-gov-ga-tracker-id", text: "UA-XXXXX-Y"
+      end
+
+      it 'should not render GA elements on choose certified company page' do
+        visit '/choose-a-certified-company'
+
+        expect(page).to_not have_css "span#cross-gov-ga-tracker-id", text: "UA-XXXXX-Y"
       end
 
       it 'should not render GA elements on about page' do

--- a/spec/features/user_visits_choose_a_certified_company_variant_c_page_spec.rb
+++ b/spec/features/user_visits_choose_a_certified_company_variant_c_page_spec.rb
@@ -169,6 +169,7 @@ describe 'When the user visits the choose a certified company page' do
       end
 
       it 'should render GA elements on choose certified company page' do
+        skip "Google Analytics disabled until consent mechanism in place"
         visit '/choose-a-certified-company'
 
         expect(page).to have_css "span#cross-gov-ga-tracker-id", text: "UA-XXXXX-Y"
@@ -198,9 +199,16 @@ describe 'When the user visits the choose a certified company page' do
       end
 
       it 'should render GA elements on choose certified company page' do
+        skip "Google Analytics disabled until consent mechanism in place"
         visit '/choose-a-certified-company'
 
         expect(page).to have_css "span#cross-gov-ga-tracker-id", text: "UA-XXXXX-Y"
+      end
+
+      it 'should not render GA elements on choose certified company page' do
+        visit '/choose-a-certified-company'
+
+        expect(page).to_not have_css "span#cross-gov-ga-tracker-id", text: "UA-XXXXX-Y"
       end
 
       it 'should not render GA elements on about page' do


### PR DESCRIPTION
Disable GA tracking until a consent system is implemented.

Set render GA components to false.

Skip existing tests that will now fail because it has been disabled.  Deliberately have tests as skipped instead of deleting or re-purposing.

Implement tests that ensure GA doesn't get re-enabled by accident.

Co-authored by: Lewis Westbury <lewis.westbury@digital.cabinet-office.gov.uk>