### PR TITLE
BAU: Track requests for hint

### DIFF
--- a/app/controllers/hint_controller.rb
+++ b/app/controllers/hint_controller.rb
@@ -15,6 +15,8 @@ class HintController < ApplicationController
 
     entity_id = success_entity_id
 
+    FEDERATION_REPORTER.report_hint_present(request, !entity_id.nil?)
+
     json_object = { 'status': 'OK', 'value': !entity_id.nil? }
 
     render json: json_object.to_json, callback: params['callback']

--- a/app/models/analytics/federation_reporter.rb
+++ b/app/models/analytics/federation_reporter.rb
@@ -197,6 +197,15 @@ module Analytics
       )
     end
 
+    def report_hint_present(request, hint_present)
+      report_event_without_current_transaction(
+        request,
+        'Engagement',
+        'Journey hint present',
+        hint_present ? 'yes' : 'no'
+      )
+    end
+
     def report_action(current_transaction, request, action, extra_custom_vars = {})
       begin
         @analytics_reporter.report_action(
@@ -229,6 +238,16 @@ module Analytics
       rescue Display::FederationTranslator::TranslationError => e
         Rails.logger.warn e
       end
+    end
+
+    def report_event_without_current_transaction(request, event_category, event_name, event_action)
+      @analytics_reporter.report_event(
+        request,
+        '',
+        event_category,
+        event_name,
+        event_action
+      )
     end
 
   private

--- a/spec/controllers/hint_controller_spec.rb
+++ b/spec/controllers/hint_controller_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 require 'controller_helper'
 require 'spec_helper'
 require 'api_test_helper'
+require 'piwik_test_helper'
 
 describe HintController do
   subject { get :ajax_request, params: { locale: 'en' } }
@@ -14,10 +15,13 @@ describe HintController do
           'SUCCESS' => 'http://idcorp.com',
         }.to_json
 
+        stub_piwik_request = stub_piwik_report_journey_hint_present('yes')
+
         body = JSON.parse(subject.body)
         expect(body["value"]).to eq(true)
         expect(subject.content_type).to eq("application/json")
         expect(subject).to have_http_status(200)
+        expect(stub_piwik_request).to have_been_made.once
       end
 
       it 'json object should return true even if the value is not set' do
@@ -25,19 +29,24 @@ describe HintController do
           'SUCCESS' => '',
         }.to_json
 
+        stub_piwik_request = stub_piwik_report_journey_hint_present('yes')
+
         body = JSON.parse(subject.body)
         expect(body["value"]).to eq(true)
         expect(subject.content_type).to eq("application/json")
         expect(subject).to have_http_status(200)
+        expect(stub_piwik_request).to have_been_made.once
       end
     end
 
     context 'user does not have a journey hint present' do
       it 'json object should return false' do
+        stub_piwik_request = stub_piwik_report_journey_hint_present('no')
         body = JSON.parse(subject.body)
         expect(body["value"]).to eq(false)
         expect(subject.content_type).to eq("application/json")
         expect(subject).to have_http_status(200)
+        expect(stub_piwik_request).to have_been_made.once
       end
     end
   end

--- a/spec/piwik_test_helper.rb
+++ b/spec/piwik_test_helper.rb
@@ -35,6 +35,22 @@ def stub_piwik_request_no_session(extra_parameters = {}, extra_headers = {}, ext
       .with(headers: piwik_headers.update(extra_headers), query: hash_including(piwik_request.update(extra_parameters)))
 end
 
+def stub_piwik_request_no_session_no_cvar(extra_parameters = {}, extra_headers = {})
+  piwik_request = {
+      'rec' => '1',
+      'apiv' => '1',
+      'idsite' => INTERNAL_PIWIK.site_id.to_s,
+      'cookie' => 'false'
+  }
+  piwik_headers = {
+      'Connection' => 'Keep-Alive',
+      'Host' => 'localhost:4242',
+      'User-Agent' => 'Rails Testing'
+  }
+  stub_request(:get, INTERNAL_PIWIK.url)
+      .with(headers: piwik_headers.update(extra_headers), query: hash_including(piwik_request.update(extra_parameters)))
+end
+
 def create_extra_custom_variables_only(extra_custom_variables)
   '{' + extra_custom_variables.join(',') + '}'
 end
@@ -93,6 +109,16 @@ def stub_piwik_report_number_of_recommended_idps(number_of_recommended_idps, loa
     e_a: number_of_recommended_idps.to_s
   }
   stub_piwik_request(piwik_request, {}, loa, [], transaction_analytics_description)
+end
+
+def stub_piwik_report_journey_hint_present(hint_present)
+  piwik_request = {
+    e_c: 'Engagement',
+    action_name: 'trackEvent',
+    e_n: 'Journey hint present',
+    e_a: hint_present
+  }
+  stub_piwik_request_no_session_no_cvar(piwik_request)
 end
 
 def stub_piwik_report_single_idp_success(service_id, uuid)


### PR DESCRIPTION
This adds Matomo tracking for ajax calls made from GOV.UK.
It will allow us to see the responses whether users have the cookie or not.