### PR TITLE
HUH-253 Disable Piwik (Matomo) cookies [DO NOT MERGE]

### DIFF
--- a/app/assets/javascripts/analytics.js
+++ b/app/assets/javascripts/analytics.js
@@ -26,7 +26,6 @@
 
     var piwikAnalyticsQueue = [
       ["appendToTrackingUrl", "new_visit=" + newVisit],
-      ["setUserId", getPiwikVisitorIdCookie()],
       ["setDocumentTitle", enTitle],
       ["trackPageView"],
       ["enableLinkTracking"],

--- a/app/assets/javascripts/piwik_event_tracking.js
+++ b/app/assets/javascripts/piwik_event_tracking.js
@@ -26,6 +26,8 @@
 
     global.GOVUK.piwikEventsTracking = {
         init: function() {
+            _paq.push(['disableCookies']);
+
             var piwikEvents = {
                 evidence_example: getEvidenceEvent('example'),
                 journey_user_type: getUserTypeEvent()

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,7 +18,6 @@ class ApplicationController < ActionController::Base
   include AnalyticsPartialController
 
   before_action :validate_session
-  before_action :set_visitor_cookie
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception

--- a/spec/features/user_sends_authn_request_spec.rb
+++ b/spec/features/user_sends_authn_request_spec.rb
@@ -27,7 +27,7 @@ describe 'user sends authn requests' do
 
       cookies = Capybara.current_session.driver.browser.rack_mock_session.cookie_jar
       expected_cookies = CookieNames.session_cookies + [
-        CookieNames::VERIFY_LOCALE, CookieNames::AB_TEST, CookieNames::PIWIK_USER_ID
+        CookieNames::VERIFY_LOCALE, CookieNames::AB_TEST
       ]
 
       expect(cookies.to_hash.keys.to_set).to eql expected_cookies.to_set

--- a/spec/javascripts/piwik_event_tracking_spec.js
+++ b/spec/javascripts/piwik_event_tracking_spec.js
@@ -28,21 +28,21 @@ describe('Analytics', function () {
             $('input[piwik_event_tracking="journey_user_type"][value="false"]').prop('checked', true).change();
             $('input[piwik_event_tracking="journey_user_type"][value="true"]').prop('checked', true).change();
 
-            expect(_paq.push.calls.count()).toBe(1);
+            expect(_paq.push.calls.count()).toBe(2);
             expectLatestEntryInPiwikQueueToMatch('Journey', 'Change to First Time', 'user_type');
         });
 
         it('should report to Piwik when evidence is selected', function () {
             $('input[piwik_event_tracking="evidence_example"]').prop('checked', true).change();
 
-            expect(_paq.push.calls.count()).toBe(1);
+            expect(_paq.push.calls.count()).toBe(2);
             expectLatestEntryInPiwikQueueToMatch('Evidence', 'yes', 'example');
         });
 
         it('should not report to Piwik when an input without the markup is changed', function () {
             $('#some-other-checkbox').prop('checked', true).change();
 
-            expect(_paq.push).not.toHaveBeenCalled();
+            expect(_paq.push.calls.count()).toBe(1);
         });
     });
     describe('on a page with the user_type already selected', function() {
@@ -58,7 +58,7 @@ describe('Analytics', function () {
         it('should report to Piwik when the user type input is changed from an initial value', function () {
             $('input[piwik_event_tracking="journey_user_type"][value="true"]').prop('checked', true).change();
 
-            expect(_paq.push.calls.count()).toBe(1);
+            expect(_paq.push.calls.count()).toBe(2);
             expectLatestEntryInPiwikQueueToMatch('Journey', 'Change to First Time', 'user_type');
         });
     });


### PR DESCRIPTION
Temporary measures to suspend Matomo cookie activity whilst a consent mechanism is put into place.

Push value on to piwikAnalyticsQueue to disable cookies.

Remove code that deposits cookies.  Amend tests so that they aren't broken.