### PR TITLE
EID-1774 add a new other ways view for users who leave eIDAS

### DIFF
--- a/app/controllers/other_ways_to_access_service_controller.rb
+++ b/app/controllers/other_ways_to_access_service_controller.rb
@@ -3,4 +3,9 @@ class OtherWaysToAccessServiceController < ApplicationController
     @other_ways_description = current_transaction.other_ways_description
     @other_ways_text = current_transaction.other_ways_text
   end
+
+  def after_eidas
+    @other_ways_description = current_transaction.other_ways_description
+    @other_ways_text = current_transaction.other_ways_text
+  end
 end

--- a/app/views/choose_a_country/choose_a_country.html.erb
+++ b/app/views/choose_a_country/choose_a_country.html.erb
@@ -47,7 +47,7 @@
 
   <div class="column-two-thirds">
     <h3 class="heading-small"><%= t 'hub.choose_a_country.country_not_listed_heading' %></h3>
-    <p><%= t 'hub.choose_a_country.country_not_listed_description' %><%= link_to t('hub.choose_a_country.country_not_listed_link', other_ways_description: @other_ways_description), other_ways_to_access_service_path %></p>
+    <p><%= t 'hub.choose_a_country.country_not_listed_description' %><%= link_to t('hub.choose_a_country.country_not_listed_link', other_ways_description: @other_ways_description), other_ways_after_eidas_path %></p>
   </div>
 
   <%= form_tag({}, {id: 'post-to-country', class: 'hidden', authenticity_token: false, enforce_utf8: false}) do %>

--- a/app/views/other_ways_to_access_service/after_eidas.erb
+++ b/app/views/other_ways_to_access_service/after_eidas.erb
@@ -1,0 +1,25 @@
+<%= page_title 'hub.other_ways_after_eidas.title' %>
+<% content_for :feedback_source, 'OTHER_WAYS_AFTER_EIDAS_PAGE' %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    
+    <h1 class="heading-large"><%= t 'hub.other_ways_after_eidas.heading', other_ways_description: @other_ways_description %></h1>
+    <div class="other-ways-to-complete-transaction">
+      <%= t 'hub.other_ways_after_eidas.explanation', other_ways_description: @other_ways_description %>
+    </div>
+
+    <h2 class="heading-medium"><%= t 'hub.other_ways_after_eidas.verify.heading' %></h2>
+    <div class="other-ways-to-complete-transaction">
+      <%= t 'hub.other_ways_after_eidas.verify.explanation_html' %>
+    </div>
+
+    <%= button_link_to t('hub.other_ways_after_eidas.verify.button'), start_path, id: 'next-button' %>
+
+    <h2 class="heading-medium"><%= t 'hub.other_ways_heading', other_ways_description: @other_ways_description %></h2>
+    <div class="other-ways-to-complete-transaction">
+      <%= raw @other_ways_text %>
+    </div>
+
+  </div>
+</div>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -40,6 +40,7 @@ cy:
     failed_country_sign_in: methu-mewngofnodi-gwlad
     failed_uplift: methwyd-yr-ymgodiad
     other_ways_to_access_service: ffyrdd-eraill-i-gael-mynediad-i'r-gwasanaeth
+    other_ways_after_eidas: country-not-listed-cy
     forgot_company: wedi-anghofio-cwmni
     response_processing: prosesu-ymateb
     redirect_to_idp_sign_in: ailgyfeirio-i-idp/mewngofnodi
@@ -271,6 +272,21 @@ cy:
   hub:
     other_ways_title: Ffyrdd eraill i gael mynediad i’r gwasanaeth
     other_ways_heading: Ffyrdd eraill i %{other_ways_description}
+    other_ways_after_eidas:
+      title: Country not listed
+      heading: Other ways to %{other_ways_description}
+      explanation: If your digital identity scheme is not available yet, you can prove who you are another way to %{other_ways_description}.
+      verify:
+        heading: "Use GOV.UK Verify"
+        explanation_html: |
+          <p>To create an account, you must choose a company to verify your identity. The company will check your personal details and identity documents.</p>
+          <p>GOV.UK Verify works best if you:</p>
+          <ul>
+          <li>have a UK address</li>
+          <li>are over 20</li>
+          <li>have at least one photo identity document, from any country</li>
+          </ul>
+        button: "Use GOV.UK Verify"
     choose_a_country:
       title: Dewiswch wlad
       heading: Defnyddio hunaniaeth digidol o wlad Ewropeaidd arall

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,6 +40,7 @@ en:
     failed_country_sign_in: failed-country-sign-in
     failed_uplift: failed-uplift
     other_ways_to_access_service: other-ways-to-access-service
+    other_ways_after_eidas: country-not-listed
     forgot_company: forgot-company
     response_processing: response-processing
     redirect_to_idp_sign_in: redirect-to-idp/sign-in
@@ -268,13 +269,28 @@ en:
   hub:
     other_ways_title: Other ways to access the service
     other_ways_heading: Other ways to %{other_ways_description}
+    other_ways_after_eidas:
+      title: Country not listed
+      heading: Other ways to %{other_ways_description}
+      explanation: If your digital identity scheme is not available yet, you can prove who you are another way to %{other_ways_description}.
+      verify:
+        heading: "Use GOV.UK Verify"
+        explanation_html: |
+          <p>To create an account, you must choose a company to verify your identity. The company will check your personal details and identity documents.</p>
+          <p>GOV.UK Verify works best if you:</p>
+          <ul>
+          <li>have a UK address</li>
+          <li>are over 20</li>
+          <li>have at least one photo identity document, from any country</li>
+          </ul>
+        button: "Use GOV.UK Verify"
     choose_a_country:
       title: Choose a country
       heading: Use a digital identity from another European country
       description: You can use a digital identity from another European country to access services on GOV.UK.
       country_not_listed_heading: My country isn't listed
-      country_not_listed_description: "If your country hasn't joined yet, there are "
-      country_not_listed_link: other ways to %{other_ways_description}.
+      country_not_listed_description: "If your country's digital identity scheme isn't available yet, see how else you can "
+      country_not_listed_link: "%{other_ways_description}."
       select_label: "Select %{scheme_name}"
     redirect_to_country:
       title: Redirect to country

--- a/config/main_routes.rb
+++ b/config/main_routes.rb
@@ -91,7 +91,10 @@ post 'redirect_to_country', to: 'redirect_to_country#choose_a_country_submit', a
 get 'failed_uplift', to: 'failed_uplift#index', as: :failed_uplift
 get 'failed_sign_in', to: 'failed_sign_in#idp', as: :failed_sign_in
 get 'failed_country_sign_in', to: 'failed_sign_in#country', as: :failed_country_sign_in
+
 get 'other_ways_to_access_service', to: 'other_ways_to_access_service#index', as: :other_ways_to_access_service
+get 'other_ways_after_eidas', to: 'other_ways_to_access_service#after_eidas', as: :other_ways_after_eidas
+
 get 'forgot_company', to: 'static#forgot_company', as: :forgot_company
 get 'response_processing', to: 'response_processing#index', as: :response_processing
 get 'redirect_to_idp_register', to: 'redirect_to_idp#register', as: :redirect_to_idp_register

--- a/spec/features/user_visits_choose_a_country_page_spec.rb
+++ b/spec/features/user_visits_choose_a_country_page_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe 'When the user visits the choose a country page' do
     visit '/choose-a-country'
     click_on t('hub.choose_a_country.country_not_listed_link', other_ways_description: 'test GOV.UK Verify user journeys')
 
-    expect(page).to have_current_path('/other-ways-to-access-service')
+    expect(page).to have_current_path('/country-not-listed')
   end
 
   it 'includes the appropriate feedback source' do


### PR DESCRIPTION
Users may choose to leave the eIDAS `choose-a-country` view because their country is not listed.

We have designed a new _other ways_ page for them which provides slightly more relevant information, as some users may still be able to use Verify.

* Adds a new `after_eidas` action for the `OtherWaysToAccessServiceController`
* Adds a new route: `other_ways_after_eidas`
* Allows the user to enter a Verify journey directly from `other_ways_after_eidas`
* Adds local resource to define the new route, and new text for `other_ways_after_eidas`
* Pending Welsh wording for the new resources - so currently provides English wording in both `en.yml` and `cy.yml`

**Not worth reviewing until the Wesh text is also available.** This PR does allow us to test using Heroku though.