### PR TITLE
BUG: Missing feedback source for paused-registration page

### DIFF
--- a/app/models/feedback_source_mapper.rb
+++ b/app/models/feedback_source_mapper.rb
@@ -49,6 +49,7 @@ class FeedbackSourceMapper
       'PROVE_IDENTITY_PAGE' => 'prove_identity',
       'CONTINUE_TO_YOUR_IDP_PAGE' => 'continue_to_your_idp',
       'RESUME_PAGE' => 'resume_registration',
+      'PAUSED_REGISTRATION_PAGE' => 'paused_registration',
       'TIMEOUT_PAGE' => 'further_information_timeout',
       'ACCESSIBILITY_PAGE' => 'accessibility',
   }.freeze


### PR DESCRIPTION
If user tries to provide a feedback from the paused registration page
they are presented with 404 Page not found.
This is due to a missing feedback source.

This can be reproduced by trying to visit https://www.signin.service.gov.uk/feedback?feedback-source=PAUSED_REGISTRATION_PAGE (with a valid session)