### PR TITLE
BAU: Fix the path for self-service talking to integration

### DIFF
--- a/app/controllers/publish_hub_config_controller.rb
+++ b/app/controllers/publish_hub_config_controller.rb
@@ -17,7 +17,7 @@ class PublishHubConfigController < ApplicationController
 
   def certificates
     do_not_cache
-    response = publish_hub_config_client.certificates(request.path.split('/hub/config/certificates/').last)
+    response = publish_hub_config_client.certificates(request.path.split('/hub/config/config/certificates/').last)
     render json: response.to_s, status: response.status
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,7 +62,7 @@ Rails.application.routes.draw do
   end
   if PUBLISH_HUB_CONFIG_ENABLED
     get 'hub/config/service-status', to: 'publish_hub_config#service_status'
-    match 'hub/config/certificates/:path', to: 'publish_hub_config#certificates', constraints: { path: /.*/ }, via: :get
+    match 'hub/config/config/certificates/:path', to: 'publish_hub_config#certificates', constraints: { path: /.*/ }, via: :get
   end
   get '/humans.txt', to: 'static#humanstxt'
 end


### PR DESCRIPTION
This path is used in integration for self-service to
get into the config service. The config service has two endpoints `/service-status` and
`/config/certificates/...`. This aligns the behaviour with the real config service.

Co-Authored-By: Olakunle Jegede <olakunle.jegede@digital.cabinet-office.gov.uk>