### PR TITLE
BUGFIX for missing styles on failed registration

### DIFF
--- a/app/views/failed_registration/_continue_rp.html.erb
+++ b/app/views/failed_registration/_continue_rp.html.erb
@@ -1,17 +1,17 @@
 <h1 class="govuk-heading-l"><%= t('hub.failed_registration.continue_heading', transaction_name: transaction.name) %></h1>
 
-<p>
+<p class="govuk-body">
   <%= t 'hub.failed_registration.continue_idp_text', idp_name: idp.display_name %>
   <%= raw transaction.other_ways_text %>
 </p>
 
-<p><%= t 'hub.failed_registration.continue_text', rp_name: transaction.rp_name %></p>
+<p class="govuk-body"><%= t 'hub.failed_registration.continue_text', rp_name: transaction.rp_name %></p>
 
 <%= button_link_to t('navigation.continue'), redirect_to_service_error_path, class: 'govuk-button' %>
 
 <h2 class="govuk-heading-m"><%= t 'hub.failed_registration.try_another_summary' %></h2>
 <div>
-  <p><%= t 'hub.failed_registration.try_another_text', idp_name: @idp.display_name %></p>
+  <p class="govuk-body"><%= t 'hub.failed_registration.try_another_text', idp_name: @idp.display_name %></p>
   <%= link_to t('hub.failed_registration.try_another_company'), try_another_company_path %>
 </div>
 

--- a/app/views/failed_registration/_custom_failed_registration.html.erb
+++ b/app/views/failed_registration/_custom_failed_registration.html.erb
@@ -1,6 +1,6 @@
 <h1 class="govuk-heading-l"><%= raw transaction.custom_fail_heading  %></h1>
 
-<p><%= raw(transaction.custom_fail_what_next_content % { idp_name: idp.display_name }) %></p>
+<p class="govuk-body"><%= raw(transaction.custom_fail_what_next_content % { idp_name: idp.display_name }) %></p>
 
 <h2 class="govuk-heading-m">
   <%= raw transaction.custom_fail_other_options %>


### PR DESCRIPTION
@jakubmiarka reported the following bug in the verify frontend.  This should hopefully fix the issue:

![image](https://user-images.githubusercontent.com/29251905/74429975-d6219a80-4e53-11ea-8443-4595d7975e74.png)
