### PR TITLE
HUB-422: Fix backend validation models

### DIFF
--- a/app/assets/stylesheets/pages/_slides.scss
+++ b/app/assets/stylesheets/pages/_slides.scss
@@ -129,6 +129,19 @@
   .govuk-details__text {
     border-left: 5px solid govuk-colour("white");
   }
+
+  .govuk-error-summary {
+    border: 5px solid govuk-colour("white");
+    color: govuk-colour("white");
+  }
+
+  .govuk-error-message {
+    color: govuk-colour("white");
+  }
+
+  .govuk-error-summary__list a {
+    color: govuk-colour("white");
+  }
 }
 
 .hide-mobile {

--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -24,7 +24,7 @@ class FeedbackController < ApplicationController
         render :index
       end
     else
-      flash.now[:errors] = @form.errors[:base].first
+      flash.now[:errors] = @form.errors.full_messages.join(', ')
       render :index
     end
   end

--- a/app/controllers/further_information_controller.rb
+++ b/app/controllers/further_information_controller.rb
@@ -22,6 +22,7 @@ class FurtherInformationController < ApplicationController
     else
       @seconds_to_timeout = get_seconds_to_timeout
       @transaction_name = current_transaction.name
+      flash.now[:errors] = @cycle_three_attribute.errors.full_messages.join(', ')
       render 'index'
     end
   end

--- a/app/models/cycle_three/cycle_three_attribute.rb
+++ b/app/models/cycle_three/cycle_three_attribute.rb
@@ -48,7 +48,7 @@ module CycleThree
 
     def matches_regex
       unless pattern.match?(@cycle_three_data)
-        errors.add(:cycle_three_data, format(I18n.t('hub.further_information.attribute_validation_message'), cycle_three_name: name))
+        errors.add(:cycle_three_data, I18n.t('hub.further_information.attribute_validation_message', cycle_three_name: name))
       end
     end
   end

--- a/app/models/cycle_three/cycle_three_attribute.rb
+++ b/app/models/cycle_three/cycle_three_attribute.rb
@@ -48,10 +48,7 @@ module CycleThree
 
     def matches_regex
       unless pattern.match?(@cycle_three_data)
-        errors.add(
-          :cycle_three_data,
-          'hub.further_information.attribute_validation_message'
-        )
+        errors.add(:cycle_three_data, format(I18n.t('hub.further_information.attribute_validation_message'), cycle_three_name: name))
       end
     end
   end

--- a/app/models/feedback_form.rb
+++ b/app/models/feedback_form.rb
@@ -2,8 +2,7 @@ class FeedbackForm
   include ActiveModel::Model
 
   attr_reader :what, :details, :reply, :name, :email, :referer, :user_agent, :js_disabled
-  validate :mandatory_fields_present, :name_should_be_present,
-           :what_should_be_present, :details_should_be_present, :reply_should_be_present,
+  validate :name_should_be_present, :what_should_be_present, :details_should_be_present, :reply_should_be_present,
            :email_format_should_be_valid
 
   validate :length_of_what, :length_of_details, :length_of_name, :length_of_email
@@ -50,15 +49,9 @@ class FeedbackForm
 
 private
 
-  def mandatory_fields_present
-    if what_missing? || details_missing? || @reply.blank?
-      errors.add(:base, I18n.t('hub.feedback.errors.no_selection')) unless errors.include?(:base)
-    end
-  end
-
   def reply_should_be_present
     if @reply.blank?
-      errors.add(:reply, I18n.t('hub.feedback.errors.reply'))
+      errors.add(:reply_true, I18n.t('hub.feedback.errors.reply'))
     end
   end
 
@@ -76,14 +69,12 @@ private
 
   def name_should_be_present
     if reply_required? && name_missing?
-      errors.add(:base, I18n.t('hub.feedback.errors.no_selection')) unless errors.include?(:base)
       errors.add(:name, I18n.t('hub.feedback.errors.name'))
     end
   end
 
   def email_format_should_be_valid
     if reply_required? && (email_missing? || !EmailValidator.valid?(email, strict_mode: true))
-      errors.add(:base, I18n.t('hub.feedback.errors.no_selection')) unless errors.include?(:base)
       errors.add(:email, I18n.t('hub.feedback.errors.email'))
     end
   end

--- a/app/models/interstitial_question_form.rb
+++ b/app/models/interstitial_question_form.rb
@@ -24,7 +24,7 @@ private
 
   def answer_required
     if @interstitial_question_result.blank?
-      errors.add(:base, [I18n.t('hub.redirect_to_idp_question.validation_message')])
+      errors.add(:interstitial_question_result_true, I18n.t('hub.redirect_to_idp_question.validation_message'))
     end
   end
 end

--- a/app/models/other_identity_documents_form.rb
+++ b/app/models/other_identity_documents_form.rb
@@ -15,8 +15,8 @@ class OtherIdentityDocumentsForm
 private
 
   def one_must_be_present
-    if !%w(true false).include?(@non_uk_id_document)
-      errors.add(:base, I18n.t('hub.select_documents.errors.no_selection'))
+    unless %w(true false).include?(@non_uk_id_document)
+      errors.add(:non_uk_id_document_true, I18n.t('hub.select_documents.errors.no_selection'))
     end
   end
 end

--- a/app/models/other_identity_documents_form.rb
+++ b/app/models/other_identity_documents_form.rb
@@ -16,7 +16,7 @@ private
 
   def one_must_be_present
     unless %w(true false).include?(@non_uk_id_document)
-      errors.add(:non_uk_id_document_true, I18n.t('hub.select_documents.errors.no_selection'))
+      errors.add(:non_uk_id_document_true, I18n.t('hub.other_documents.errors.non_uk_docs'))
     end
   end
 end

--- a/app/models/select_documents_form.rb
+++ b/app/models/select_documents_form.rb
@@ -2,7 +2,7 @@ class SelectDocumentsForm
   include ActiveModel::Model
 
   attr_reader :driving_licence, :ni_driving_licence, :passport, :any_driving_licence
-  validate :any_driving_licence_and_passport_must_be_present
+  validate :any_driving_license_must_be_present, :passport_must_be_present
   validate :driving_licence_details_present
 
   def initialize(hash)
@@ -36,23 +36,19 @@ class SelectDocumentsForm
 
 private
 
-  def any_driving_licence_and_passport_must_be_present
-    unless any_driving_licence && passport
-      add_documents_error
-    end
+  def any_driving_license_must_be_present
+    errors.add(:any_driving_licence_true, I18n.t('hub.select_documents.errors.no_driving_license_selection')) unless any_driving_licence
+  end
+
+  def passport_must_be_present
+    errors.add(:passport_true, I18n.t('hub.select_documents.errors.no_passport_selection')) unless passport
   end
 
   def driving_licence_details_present
-    if any_driving_licence == 'true' && no_driving_licence_details?
-      add_documents_error
-    end
+    errors.add(:driving_licence_great_britain, I18n.t('hub.select_documents.errors.no_driving_licence_issuer_selection')) if any_driving_licence == 'true' && no_driving_licence_details?
   end
 
   def no_driving_licence_details?
     !(driving_licence == 'great_britain' || driving_licence == 'northern_ireland')
-  end
-
-  def add_documents_error
-    errors.add(:base, I18n.t('hub.select_documents.errors.no_selection'))
   end
 end

--- a/app/models/select_documents_variant_c_form.rb
+++ b/app/models/select_documents_variant_c_form.rb
@@ -47,6 +47,6 @@ private
   end
 
   def add_documents_error
-    errors.add(:base, I18n.t('hub_variant_c.select_documents.errors.no_selection'))
+    errors.add(:has_valid_passport, I18n.t('hub_variant_c.select_documents.errors.no_selection'))
   end
 end

--- a/app/models/select_phone_form.rb
+++ b/app/models/select_phone_form.rb
@@ -3,7 +3,7 @@ class SelectPhoneForm
 
   attr_reader :mobile_phone, :smart_phone
 
-  validate :smart_phone_not_specified_when_required
+  validate :mobile_phone_must_be_present_when_required, :smart_phone_not_specified_when_required
   validate :invalid_selection
 
   def initialize(params)
@@ -24,24 +24,31 @@ class SelectPhoneForm
 
 private
 
+  def mobile_phone_must_be_present_when_required
+    if mobile_phone.nil? && smart_phone_not_specified?
+      errors.add(:mobile_phone_true, I18n.t('hub.select_phone.errors.mobile_phone'))
+    end
+  end
+
   def smart_phone_not_specified_when_required
-    if mobile_phone != 'false' && smart_phone_not_specified?
-      add_no_selection_error
+    if has_mobile_phone? && smart_phone_not_specified?
+      errors.add(:smart_phone_true, I18n.t('hub.select_phone.errors.smart_phone'))
     end
   end
 
   def invalid_selection
     if has_no_mobile_phone? && has_smart_phone?
-      errors.add(:base, I18n.t('hub.select_phone.errors.invalid_selection'))
+      errors.add(:mobile_phone_true, I18n.t('hub.select_phone.errors.invalid_selection'))
+      errors.add(:smart_phone_true, I18n.t('hub.select_phone.errors.invalid_selection'))
     end
-  end
-
-  def add_no_selection_error
-    errors.add(:base, I18n.t('hub.select_phone.errors.no_selection'))
   end
 
   def has_smart_phone?
     smart_phone == 'true'
+  end
+
+  def has_mobile_phone?
+    mobile_phone == 'true'
   end
 
   def has_no_mobile_phone?

--- a/app/models/start_form.rb
+++ b/app/models/start_form.rb
@@ -16,7 +16,7 @@ private
 
   def answer_required
     if @selection.blank?
-      errors.add(:base, [I18n.t('hub.start.error_message')])
+      errors.add(:selection_true, I18n.t('hub.start.error_message'))
     end
   end
 end

--- a/app/models/will_it_work_for_me_form.rb
+++ b/app/models/will_it_work_for_me_form.rb
@@ -27,22 +27,19 @@ private
 
   def residency_questions_answered
     if resident_last_12_months.blank?
-      no_selection_error
+      errors.add(:resident_last_12_months_true, I18n.t('hub.will_it_work_for_me.question.errors.resident_12_months'))
     end
 
-    if !resident_last_12_months? && not_resident_reason.blank?
-      no_selection_error
+    if not_resident_missing?
+      errors.add(:not_resident_reason_moved_recently, I18n.t('hub.will_it_work_for_me.question.errors.not_resident_reason'))
     end
   end
 
   def age_threshold_question_answered
-    if above_age_threshold.blank?
-      no_selection_error
-    end
+    errors.add(:above_age_threshold_true, I18n.t('hub.will_it_work_for_me.question.errors.age_threshold')) if above_age_threshold.blank?
   end
 
-  def no_selection_error
-    errors.add(:base, I18n.t('hub.will_it_work_for_me.question.errors.no_selection'))
-    throw(:abort)
+  def not_resident_missing?
+    resident_last_12_months == 'false' && not_resident_reason.blank?
   end
 end

--- a/app/views/feedback/index.html.erb
+++ b/app/views/feedback/index.html.erb
@@ -2,10 +2,11 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l"><%= t 'hub.feedback.heading' %></h1>
 
     <%= render 'shared/form-errors', errors: flash[:errors], form: @form %>
 
+    <h1 class="govuk-heading-l"><%= t 'hub.feedback.heading' %></h1>
+    
     <%= t 'hub.feedback.introduction_html' %>
 
     <% if @has_email_sending_error %>
@@ -61,17 +62,17 @@
           </div>
         </fieldset>
 
-          <div class="govuk-form-group <% if @form.errors.include?(:reply) %>govuk-form-group--error<% end %>">
+          <div class="govuk-form-group <% if @form.errors.include?(:reply_true) %>govuk-form-group--error<% end %>">
             <fieldset class="govuk-fieldset" aria-describedby="reply-conditional-hint">
               <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
                   <%= t 'hub.feedback.questions.reply' %>
-                <% if @form.errors.include?(:reply) %>
-                  <span class="govuk-error-message"><%= @form.errors[:reply].first %></span>
+                <% if @form.errors.include?(:reply_true) %>
+                  <span class="govuk-error-message"><%= @form.errors[:reply_true].first %></span>
                 <% end %>
               </legend>
               <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">
                 <div class="govuk-radios__item">
-                  <%= f.radio_button :reply, true, {required: true, class: "govuk-radios__input", 'data-aria-controls': "conditional-reply_true", data: { msg: t('hub.feedback.errors.reply')}}%>
+                  <%= f.radio_button :reply, true, {required: true, class: "govuk-radios__input", id: "feedback_form_reply_true", 'data-aria-controls': "conditional-reply_true", data: { msg: t('hub.feedback.errors.reply')} }%>
                   <%= f.label :reply_true,  t('hub.feedback.questions.reply_option_yes'), class: "govuk-label govuk-radios__label"%>
                 </div>
                 <div class="govuk-radios__conditional govuk-radios__conditional--hidden"

--- a/app/views/further_information/index.html.erb
+++ b/app/views/further_information/index.html.erb
@@ -7,6 +7,8 @@
       <%= render partial: 'further_information/modal_dialog'%>
     <% end %>
 
+    <%= render 'shared/form-errors', errors: flash[:errors], form: @cycle_three_attribute %>
+
     <h1 class="govuk-heading-l"><%= @transaction_name.slice(0,1).upcase + @transaction_name.slice(1..-1)%></h1>
     <% if @cycle_three_attribute.intro_html %>
       <%= raw @cycle_three_attribute.intro_html %>
@@ -18,13 +20,13 @@
                   html: { novalidate: true,
                           id: 'further-information' } do |f| %>
       <fieldset class="govuk-fieldset">
-        <div class="govuk-form-group <%= 'error' if @cycle_three_attribute.errors[:cycle_three_data].any? %>">
+        <div class="govuk-form-group <%= 'govuk-form-group--error' if @cycle_three_attribute.errors[:cycle_three_data].any? %>">
           <%= f.label :cycle_three_data, class: 'govuk-label govuk-!-font-weight-bold' do %>
             <%= @cycle_three_attribute.field_name %><% end %>
             <span class="govuk-hint"><%= t('hub.further_information.example_text', example: @cycle_three_attribute.example) %></span>
             <% if @cycle_three_attribute.errors.include?(:cycle_three_data) %>
-              <span class="error-message">
-                <%= t(@cycle_three_attribute.errors[:cycle_three_data].first, cycle_three_name: @cycle_three_attribute.name) %>
+              <span class="govuk-error-message">
+                <%= @cycle_three_attribute.errors[:cycle_three_data].first %>
               </span>
             <% end %>
           

--- a/app/views/other_identity_documents/index.html.erb
+++ b/app/views/other_identity_documents/index.html.erb
@@ -5,6 +5,9 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+
+    <%= render 'shared/form-errors', errors: flash[:errors], form: @form %>
+
     <h1 class="govuk-heading-l"><%= t 'hub.other_documents.title_other_identity_documents' %></h1>
     <p><%= t 'hub.select_documents.documents_from_other_countries' %></p>
 
@@ -12,27 +15,22 @@
       <%= t 'hub.select_documents.highlight' %>
     </div>
 
-    <% if flash[:errors] %>
-      <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
-        <div class="govuk-error-summary__body">
-          <ul class="govuk-list govuk-error-summary__list">
-            <li><a href="#validate-other-documents"><%= flash[:errors] %></a></li>
-          </ul>
-        </div>
-      </div>
-    <% end %>
-
     <%= form_for @form, url: other_identity_documents_submit_path, html: {id: 'validate-other-documents', class: 'select-documents-form', novalidate: 'novalidate', 'data-msg': t('hub.select_documents.errors.no_selection')} do |f| %>
-        <div class="govuk-form-group">
+        <div class="govuk-form-group<% if @form.errors.include?(:non_uk_id_document_true) %> govuk-form-group--error<% end %>">
           <fieldset class="govuk-fieldset">
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
-              <h1 class="govuk-fieldset__heading">
+              <h2 class="govuk-fieldset__heading">
                 <%= t 'hub.other_documents.non_uk_id_document' %>
-              </h1>
+              </h2>
             </legend>
+            <% if @form.errors.include?(:non_uk_id_document_true) %>
+              <span class="govuk-error-message">
+                <%= @form.errors[:non_uk_id_document_true].first %>
+              </span>
+            <% end %>
             <div class="govuk-radios">
               <div class="govuk-radios__item">
-                <%= f.radio_button :non_uk_id_document, true, {class: "govuk-radios__input"}%>
+                <%= f.radio_button :non_uk_id_document, true, {class: "govuk-radios__input", id: "other_identity_documents_form_non_uk_id_document_true"}%>
                 <%= f.label :non_uk_id_document_true, t('hub.select_documents.documents_option_yes'), class: "govuk-label govuk-radios__label"%>
               </div>
               <div class="govuk-radios__item">

--- a/app/views/redirect_to_idp_question/redirect_to_idp_question_LOA1.html.erb
+++ b/app/views/redirect_to_idp_question/redirect_to_idp_question_LOA1.html.erb
@@ -3,18 +3,24 @@
 
 <div class="govuk-grid-row js-continue-to-idp" data-location="<%= url_for(controller: 'redirect_to_idp_warning', action: 'continue_ajax', locale: I18n.locale)  %>">
   <div class="govuk-grid-column-two-thirds">
+
+    <%= render 'shared/form-errors', errors: flash[:errors], form: @form %>
+
     <h1 class="govuk-heading-l"><%= t 'hub.redirect_to_idp_question.loa1_heading', display_name: @idp.display_name %></h1>
     <%= raw @idp.interstitial_question %>
 
-    <%= render 'shared/form-errors', errors: flash[:errors], form_name: 'interstitial-question-form' %>
-    
     <%= form_for @form, url: redirect_to_idp_question_submit_path, html: {id: 'interstitial-question-form', class: 'js-validate', novalidate: 'novalidate'} do |f| %>
         <%= content_tag :div, class: form_question_class do %>
-        <div class="govuk-form-group">
+        <div class="govuk-form-group <% if @form.errors.include?(:interstitial_question_result_true) %>govuk-form-group--error<% end %>">
           <fieldset class="govuk-fieldset">
             <div class="govuk-radios">
+              <% if @form.errors.include?(:interstitial_question_result_true) %>
+                <span class="govuk-error-message">
+                  <%= @form.errors[:interstitial_question_result_true].first %>
+                </span>
+              <% end %>
               <div class="govuk-radios__item">
-                <%= f.radio_button :interstitial_question_result, true, {required: true, data: { msg: t('hub.redirect_to_idp_question.validation_message')}, class: "govuk-radios__input"}%>
+                <%= f.radio_button :interstitial_question_result, true, {required: true, data: { msg: t('hub.redirect_to_idp_question.validation_message')}, class: "govuk-radios__input", id: "interstitial_question_form_interstitial_question_result_true"}%>
                 <%= f.label :interstitial_question_result_true, t('hub.redirect_to_idp_question.answer_yes'), class: "govuk-label govuk-radios__label"%>
               </div>
               <div class="govuk-radios__item">

--- a/app/views/redirect_to_idp_question/redirect_to_idp_question_LOA2.html.erb
+++ b/app/views/redirect_to_idp_question/redirect_to_idp_question_LOA2.html.erb
@@ -3,17 +3,23 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds js-continue-to-idp" data-location="<%= url_for(controller: 'redirect_to_idp_warning', action: 'continue_ajax', locale: I18n.locale)  %>">
+
+    <%= render 'shared/form-errors', errors: flash[:errors], form: @form %>
+
     <h1 class="govuk-heading-l"><%= t 'hub.redirect_to_idp_question.heading', display_name: @idp.display_name %></h1>
     <%= raw @idp.interstitial_question %>
 
-    <%= render 'shared/form-errors', errors: flash[:errors], form_name: "interstitial-question-form" %>
-
     <%= form_for @form, url: redirect_to_idp_question_submit_path, html: {id: 'interstitial-question-form', class: 'js-validate', novalidate: 'novalidate'} do |f| %>
-        <div class="govuk-form-group">
+        <div class="govuk-form-group<% if @form.errors.include?(:interstitial_question_result_true) %>govuk-form-group--error<% end %>">
           <fieldset class="govuk-fieldset">
             <div class="govuk-radios">
+              <% if @form.errors.include?(:interstitial_question_result_true) %>
+                <span class="govuk-error-message">
+                  <%= @form.errors[:interstitial_question_result_true].first %>
+                </span>
+              <% end %>
               <div class="govuk-radios__item">
-                <%= f.radio_button :interstitial_question_result, true, {required: true, data: { msg: t('hub.redirect_to_idp_question.validation_message')}, class: "govuk-radios__input" }%>
+                <%= f.radio_button :interstitial_question_result, true, {required: true, data: { msg: t('hub.redirect_to_idp_question.validation_message')}, class: "govuk-radios__input", id: "interstitial_question_form_interstitial_question_result_true"}%>
                 <%= f.label :interstitial_question_result_true, t('hub.redirect_to_idp_question.answer_yes'), class: "govuk-label govuk-radios__label"%>
               </div>
               <div class="govuk-radios__item">

--- a/app/views/select_documents/index.html.erb
+++ b/app/views/select_documents/index.html.erb
@@ -5,45 +5,47 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+
+    <%= render 'shared/form-errors', errors: flash[:errors], form: @form %>
+
     <h1 class="govuk-heading-l"><%= t 'hub.select_documents.title_photo_documents' %></h1>
     <div class="govuk-inset-text">
       <%= t 'hub.select_documents.highlight' %>
     </div>
-    
-    <% if flash[:errors] %>
-      <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
-        <div class="govuk-error-summary__body">
-          <ul class="govuk-list govuk-error-summary__list">
-            <li><a href="#validate-select-documents"><%= flash[:errors] %></a></li>
-          </ul>
-        </div>
-      </div>
-    <% end %>
-    
+
     <%= form_for @form, url: select_documents_submit_path, html: {id: 'validate-select-documents', class: 'select-documents-form', novalidate: 'novalidate', 'data-msg': t('hub.select_documents.errors.no_selection')} do |f| %>
-      <div class="govuk-form-group <% if @form.errors.include?(:base) %>govuk-form-group--error<% end %>">
+      <div class="govuk-form-group <% if @form.errors.include?(:any_driving_licence_true) %>govuk-form-group--error<% end %>">
         <fieldset class="govuk-fieldset" aria-describedby="how-contacted-conditional-hint">
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
             <h2 class="govuk-heading-m">
               <%= t 'hub.select_documents.valid_UK_driving_licence' %>
             </h2>
           </legend>
+          <% if @form.errors.include?(:any_driving_licence_true) %>
+            <span class="govuk-error-message">
+              <%= @form.errors[:any_driving_licence_true].first %>
+            </span>
+          <% end %>
           <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">
             <div class="govuk-radios__item">
-              <%= f.radio_button :any_driving_licence, true, {class: "govuk-radios__input", 'data-aria-controls': "conditional-any_driving_licence_true"}%>
+              <%= f.radio_button :any_driving_licence, true, {class: "govuk-radios__input", id: "select_documents_form_any_driving_licence_true", 'data-aria-controls': "conditional-any_driving_licence_true"}%>
               <%= f.label :any_driving_licence_true, t('hub.select_documents.documents_option_yes'), class: "govuk-label govuk-radios__label"%>
             </div>
-            <div class="govuk-radios__conditional govuk-radios__conditional--hidden"
-              id="conditional-any_driving_licence_true">
-              <div class="govuk-form-group">
+            <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-any_driving_licence_true">
+              <div class="govuk-form-group<% if @form.errors.include?(:driving_licence_great_britain) %> govuk-form-group--error<% end %>">
                 <fieldset class="govuk-fieldset">
                   <fieldset class="govuk-fieldset">
                     <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
                       <h2 class="govuk-heading-s"><%= t 'hub.select_documents.where_driving_licence_issued' %></h2>
                     </legend>
+                    <% if @form.errors.include?(:driving_licence_great_britain) %>
+                      <span class="govuk-error-message">
+                        <%= @form.errors[:driving_licence_great_britain].first %>
+                      </span>
+                    <% end %>
                     <div class="govuk-radios">
                       <div class="govuk-radios__item">
-                        <%= f.radio_button :driving_licence, 'great_britain', {class: "govuk-radios__input"}%>
+                        <%= f.radio_button :driving_licence, 'great_britain', {class: "govuk-radios__input", id: "select_documents_form_driving_licence_great_britain"}%>
                         <%= f.label :driving_licence_great_britain, t('hub.select_documents.driving_licence_details.great_britain'), class: "govuk-label govuk-radios__label"%>
                       </div>
                       <div class="govuk-radios__item">
@@ -52,6 +54,7 @@
                       </div>
                     </div>
                   </fieldset>
+                </fieldset>
               </div>
             </div>
             <div class="govuk-radios__item">
@@ -62,14 +65,19 @@
         </fieldset>
       </div>
       
-      <div class="govuk-form-group <% if @form.errors.include?(:base) %>govuk-form-group--error<% end %>">
+      <div class="govuk-form-group <% if @form.errors.include?(:passport_true) %>govuk-form-group--error<% end %>">
         <fieldset class="govuk-fieldset">
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
             <h2 class="govuk-heading-m"><%= t 'hub.select_documents.uk_passport' %></h2>
           </legend>
+          <% if @form.errors.include?(:passport_true) %>
+            <span class="govuk-error-message">
+              <%= @form.errors[:passport_true].first %>
+            </span>
+          <% end %>
           <div class="govuk-radios">
-            <div class="govuk-radios__item">
-              <%= f.radio_button :passport, true, {class: "govuk-radios__input"}%>
+            <div class="govuk-radios__item" >
+              <%= f.radio_button :passport, true, {class: "govuk-radios__input", id: "select_documents_form_passport_true"}%>
               <%= f.label :passport_true, t('hub.select_documents.documents_option_yes'), class: "govuk-label govuk-radios__label"%>
             </div>
             <div class="govuk-radios__item">

--- a/app/views/select_documents_variant_c/index.html.erb
+++ b/app/views/select_documents_variant_c/index.html.erb
@@ -3,49 +3,49 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <div class="govuk-form-group <% if flash[:errors] %>govuk-form-group--error<% end %>">
-      <%= form_for @form, url: select_documents_submit_path, html: {id: 'validate-select-documents', novalidate: 'novalidate', 'data-msg': t('hub_variant_c.select_documents.errors.no_selection')} do |f| %>
-          <fieldset class="govuk-fieldset">
-            <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-              <h1 class="govuk-fieldset__heading"><%= t 'hub_variant_c.select_documents.heading' %></h1>
-            </legend>
-            <p><%= t 'hub_variant_c.select_documents.explanation' %></p>
 
-            <p><%= t 'hub_variant_c.select_documents.select_all_that_apply' %></p>
+    <%= render 'shared/form-errors', errors: flash[:errors], form: @form %>
 
-            <% if flash[:errors] %>
-              <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
-                <div class="govuk-error-summary__body">
-                  <ul class="govuk-list govuk-error-summary__list">
-                    <li><a href="#checkboxes"><%= flash[:errors] %></a></li>
-                  </ul>
-                </div>
-              </div>
-            <% end %>
-            <div id="checkboxes" class="govuk-checkboxes">
-              <div class="govuk-checkboxes__item">
-                <%= f.check_box :has_valid_passport,{class: "govuk-checkboxes__input" }, "t", "f" %>
-                <%= f.label :has_valid_passport,  t('hub_variant_c.select_documents.documents_option_valid_passport'), class: "govuk-label govuk-checkboxes__label"%>
-              </div>
-              <div class="govuk-checkboxes__item">
-                <%= f.check_box :has_driving_license,{class: "govuk-checkboxes__input" }, "t", "f" %>
-                <%= f.label :has_driving_license,  t('hub_variant_c.select_documents.documents_option_driving_license'), class: "govuk-label govuk-checkboxes__label"%>
-              </div>
-              <div class="govuk-checkboxes__item">
-                <%= f.check_box :has_phone_can_app,{class: "govuk-checkboxes__input" }, "t", "f" %>
-                <%= f.label :has_phone_can_app,  t('hub_variant_c.select_documents.documents_option_phone_can_app'), class: "govuk-label govuk-checkboxes__label"%>
-              </div>
-              <div class="govuk-checkboxes__item">
-                <%= f.check_box :has_credit_card,{class: "govuk-checkboxes__input" }, "t", "f" %>
-                <%= f.label :has_credit_card,  t('hub_variant_c.select_documents.documents_option_credit_card'), class: "govuk-label govuk-checkboxes__label"%>
-              </div>
-              <div class="govuk-radios__divider">or</div>
-              <div class="govuk-checkboxes__item">
-                <%= f.check_box :has_nothing,{class: "govuk-checkboxes__input" }, "t", "f" %>
-                <%= f.label :has_nothing,  t('hub_variant_c.select_documents.documents_option_nothing'), class: "govuk-label govuk-checkboxes__label"%>
-              </div>
+    <%= form_for @form, url: select_documents_submit_path, html: {id: 'validate-select-documents', novalidate: 'novalidate', 'data-msg': t('hub_variant_c.select_documents.errors.no_selection')} do |f| %>
+      <div class="govuk-form-group<% if @form.errors.include?(:has_valid_passport) %> govuk-form-group--error<% end %>">
+        <fieldset class="govuk-fieldset">
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+            <h1 class="govuk-fieldset__heading"><%= t 'hub_variant_c.select_documents.heading' %></h1>
+          </legend>
+          <p><%= t 'hub_variant_c.select_documents.explanation' %></p>
+
+          <p><%= t 'hub_variant_c.select_documents.select_all_that_apply' %></p>
+
+          <% if @form.errors.include?(:has_valid_passport) %>
+            <span class="govuk-error-message">
+              <%= @form.errors[:has_valid_passport].first %>
+            </span>
+          <% end %>
+
+          <div id="checkboxes" class="govuk-checkboxes">
+            <div class="govuk-checkboxes__item">
+              <%= f.check_box :has_valid_passport,{class: "govuk-checkboxes__input", id: "select_documents_variant_c_form_has_valid_passport" }, "t", "f" %>
+              <%= f.label :has_valid_passport,  t('hub_variant_c.select_documents.documents_option_valid_passport'), class: "govuk-label govuk-checkboxes__label"%>
             </div>
-          </fieldset>
+            <div class="govuk-checkboxes__item">
+              <%= f.check_box :has_driving_license,{class: "govuk-checkboxes__input" }, "t", "f" %>
+              <%= f.label :has_driving_license,  t('hub_variant_c.select_documents.documents_option_driving_license'), class: "govuk-label govuk-checkboxes__label"%>
+            </div>
+            <div class="govuk-checkboxes__item">
+              <%= f.check_box :has_phone_can_app,{class: "govuk-checkboxes__input" }, "t", "f" %>
+              <%= f.label :has_phone_can_app,  t('hub_variant_c.select_documents.documents_option_phone_can_app'), class: "govuk-label govuk-checkboxes__label"%>
+            </div>
+            <div class="govuk-checkboxes__item">
+              <%= f.check_box :has_credit_card,{class: "govuk-checkboxes__input" }, "t", "f" %>
+              <%= f.label :has_credit_card,  t('hub_variant_c.select_documents.documents_option_credit_card'), class: "govuk-label govuk-checkboxes__label"%>
+            </div>
+            <div class="govuk-radios__divider">or</div>
+            <div class="govuk-checkboxes__item">
+              <%= f.check_box :has_nothing,{class: "govuk-checkboxes__input" }, "t", "f" %>
+              <%= f.label :has_nothing,  t('hub_variant_c.select_documents.documents_option_nothing'), class: "govuk-label govuk-checkboxes__label"%>
+            </div>
+          </div>
+        </fieldset>
 
         <details class="govuk-details govuk-!-padding-top-6" data-module="govuk-details">
           <summary class="govuk-details__summary">
@@ -57,7 +57,7 @@
         </details>
 
         <%= f.submit t('navigation.continue'), class: 'govuk-button', id: 'next-button' %>
-      <% end %>
-    </div>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/app/views/select_phone/index.html.erb
+++ b/app/views/select_phone/index.html.erb
@@ -3,35 +3,46 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+
+    <%= render 'shared/form-errors', errors: flash[:errors], form: @form %>
+
     <h1 class="govuk-heading-l"><%= t 'hub.select_phone.title' %></h1>
     <p><%= t 'hub.select_phone.explanation' %></p>
 
-    <%= render 'shared/form-errors', errors: flash[:errors], form_name: 'validate-phone' %>
-
     <%= form_for @form, url: select_phone_path, html: { id: 'validate-phone', class: 'select-phone-form', novalidate: 'novalidate', 'data-msg': t('hub.select_phone.errors.no_selection')} do |f| %>
-        <div class="govuk-form-group <% if @form.errors.include?(:base) %>govuk-form-group--error<% end %>">
+        <div class="govuk-form-group <% if @form.errors.include?(:mobile_phone_true) %>govuk-form-group--error<% end %>">
           <fieldset class="govuk-fieldset" aria-describedby="how-contacted-conditional-hint">
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
               <h2 class="govuk-heading-m govuk-visually-hidden">
                 <%= t 'hub.select_phone.question.mobile_phone' %>
               </h2>
             </legend>
+            <% if @form.errors.include?(:mobile_phone_true) %>
+              <span class="govuk-error-message">
+                <%= @form.errors[:mobile_phone_true].first %>
+              </span>
+            <% end %>
             <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">
               <div class="govuk-radios__item">
-                <%= f.radio_button :mobile_phone, true, {class: "govuk-radios__input", 'data-aria-controls': "conditional-mobile_phone_true"}%>
+                <%= f.radio_button :mobile_phone, true, {class: "govuk-radios__input", id: "select_phone_form_mobile_phone_true", 'data-aria-controls': "conditional-mobile_phone_true"}%>
                 <%= f.label :mobile_phone_true, t('hub.select_phone.question.mobile_phone_option_yes'), class: "govuk-label govuk-radios__label"%>
               </div>
               <div class="govuk-radios__conditional govuk-radios__conditional--hidden"
                 id="conditional-mobile_phone_true">
-                <div class="govuk-form-group">
+                <div class="govuk-form-group<% if @form.errors.include?(:smart_phone_true) %> govuk-form-group--error<% end %>">
                   <fieldset class="govuk-fieldset">
                     <fieldset class="govuk-fieldset">
                       <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
                         <h2 class="govuk-heading-s"><%= t 'hub.select_phone.question.smart_phone' %></h2>
                       </legend>
+                      <% if @form.errors.include?(:smart_phone_true) %>
+                        <span class="govuk-error-message">
+                          <%= @form.errors[:smart_phone_true].first %>
+                        </span>
+                      <% end %>
                       <div class="govuk-radios">
                         <div class="govuk-radios__item">
-                          <%= f.radio_button :smart_phone, true, {class: "govuk-radios__input"}%>
+                          <%= f.radio_button :smart_phone, true, {class: "govuk-radios__input", id: "select_phone_form_smart_phone_true"}%>
                           <%= f.label :smart_phone_true, t('hub.select_phone.question.smart_phone_option_yes'), class: "govuk-label govuk-radios__label"%>
                         </div>
                         <div class="govuk-radios__item">
@@ -44,6 +55,7 @@
                         </div>
                       </div>
                     </fieldset>
+                  </fieldset>
                 </div>
               </div>
               <div class="govuk-radios__item">

--- a/app/views/shared/_form-errors.html.erb
+++ b/app/views/shared/_form-errors.html.erb
@@ -1,5 +1,8 @@
 <% if errors %>
   <div  class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
+    <h2 class="govuk-error-summary__title" id="error-summary-title">
+      There is a problem
+    </h2>
     <div class="govuk-error-summary__body">
       <ul class="govuk-list govuk-error-summary__list">
         

--- a/app/views/shared/_form-errors.html.erb
+++ b/app/views/shared/_form-errors.html.erb
@@ -1,7 +1,7 @@
 <% if errors %>
   <div  class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
     <h2 class="govuk-error-summary__title" id="error-summary-title">
-      There is a problem
+      <%= t 'errors.form.there_is_a_problem' %>
     </h2>
     <div class="govuk-error-summary__body">
       <ul class="govuk-list govuk-error-summary__list">

--- a/app/views/start/start.html.erb
+++ b/app/views/start/start.html.erb
@@ -3,16 +3,21 @@
 <% content_for :feedback_source, 'START_PAGE' %>
 <% # Uses slide layout %>
 
-  <h1 class="govuk-heading-l"><%= t 'hub.start.heading' %></h1>
+  <%= render 'shared/form-errors', errors: flash[:errors], form: @form %>
 
-  <%= render 'shared/form-errors', errors: flash[:errors], form_name: "start-page-form" %>
+  <h1 class="govuk-heading-l"><%= t 'hub.start.heading' %></h1>
 
   <%= form_for @form, url: start_path, html: {id: 'start-page-form', class: 'js-validate', novalidate: 'novalidate'} do |f| %>
     <%= content_tag :div, class: form_question_class do %>
       <fieldset class="govuk-fieldset">
+        <% if @form.errors.include?(:selection_true) %>
+            <span class="govuk-error-message">
+              <%= @form.errors[:selection_true].first %>
+            </span>
+        <% end %>
         <div class="govuk-radios">
           <div class="govuk-radios__item">
-            <%= f.radio_button :selection, true, {required: true, data: { msg: t('hub.start.error_message')}, piwik_event_tracking: 'journey_user_type', class: "govuk-radios__input"}%>
+            <%= f.radio_button :selection, true, {required: true, data: { msg: t('hub.start.error_message')}, piwik_event_tracking: 'journey_user_type', class: "govuk-radios__input", id: "start_form_selection_true"}%>
             <%= f.label :selection_true, t('hub.start.answer_yes'), class: "govuk-label govuk-radios__label"%>
           </div>
           <div class="govuk-radios__item">

--- a/app/views/will_it_work_for_me/index.html.erb
+++ b/app/views/will_it_work_for_me/index.html.erb
@@ -3,21 +3,27 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+
+    <%= render 'shared/form-errors', errors: flash[:errors], form: @form %>
+
     <h1 class="govuk-heading-l"><%= t 'hub.will_it_work_for_me.heading' %></h1>
 
-    <%= render 'shared/form-errors', errors: flash[:errors], form_name: 'validate-will-it-work-for-me' %>  
-
     <%= form_for @form, url: will_it_work_for_me_path, html: { id: 'validate-will-it-work-for-me', class: 'will-it-work-for-me-form heading-banner-top-margin', novalidate: 'novalidate', 'data-msg': t('hub.will_it_work_for_me.question.errors.no_selection')} do |f| %>
-        <div class="govuk-form-group">
+        <div class="govuk-form-group <% if @form.errors.include?(:above_age_threshold_true) %>govuk-form-group--error<% end %>">
           <fieldset class="govuk-fieldset" aria-describedby="changed-name-hint">
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
               <h2 class="govuk-fieldset__heading">
                 <%= t 'hub.will_it_work_for_me.question.above_age_threshold' %>
               </h2>
             </legend>
+            <% if @form.errors.include?(:above_age_threshold_true) %>
+              <span class="govuk-error-message">
+                <%= @form.errors[:above_age_threshold_true].first %>
+              </span>
+            <% end %>
             <div class="govuk-radios">
               <div class="govuk-radios__item">
-                <%= f.radio_button :above_age_threshold, true, {class: "govuk-radios__input"}%>
+              <%= f.radio_button :above_age_threshold, true, {class: "govuk-radios__input", id: "will_it_work_for_me_form_above_age_threshold_true"}%>
                 <%= f.label :above_age_threshold_true, t('hub.will_it_work_for_me.question.option_yes'), class: "govuk-label govuk-radios__label"%>
               </div>
               <div class="govuk-radios__item">
@@ -28,16 +34,21 @@
           </fieldset>
         </div>
 
-        <div class="govuk-form-group">
+        <div class="govuk-form-group <% if @form.errors.include?(:resident_last_12_months_true) %>govuk-form-group--error<% end %>">
           <fieldset class="govuk-fieldset" aria-describedby="how-contacted-conditional-hint">
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
               <h2 class="govuk-fieldset__heading">
                 <%= t 'hub.will_it_work_for_me.question.resident_last_12_months' %>
               </h2>
             </legend>
+            <% if @form.errors.include?(:resident_last_12_months_true) %>
+              <span class="govuk-error-message">
+                <%= @form.errors[:resident_last_12_months_true].first %>
+              </span>
+            <% end %>
             <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">
               <div class="govuk-radios__item">
-                <%= f.radio_button :resident_last_12_months, true, {class: "govuk-radios__input"}%>
+                <%= f.radio_button :resident_last_12_months, true, {class: "govuk-radios__input", id: "will_it_work_for_me_form_resident_last_12_months_true"}%>
                 <%= f.label :resident_last_12_months_true, t('hub.will_it_work_for_me.question.option_yes'), class: "govuk-label govuk-radios__label"%>
               </div>
               <div class="govuk-radios__item">
@@ -46,16 +57,21 @@
               </div>
               <div class="govuk-radios__conditional govuk-radios__conditional--hidden"
                 id="conditional-will_it_work_for_me_form_resident_last_12_months_false">
-                <div class="govuk-form-group">
+                <div class="govuk-form-group <% if @form.errors.include?(:not_resident_reason_moved_recently) %>govuk-form-group--error<% end %>">
                   <fieldset class="govuk-fieldset">
                     <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
                       <h2 class="govuk-heading-s">
                         <%= t 'hub.will_it_work_for_me.question.not_resident_reason.title' %>
                       </h2>
                     </legend>
+                    <% if @form.errors.include?(:not_resident_reason_moved_recently) %>
+                      <span class="govuk-error-message">
+                        <%= @form.errors[:not_resident_reason_moved_recently].first %>
+                      </span>
+                    <% end %>
                     <div class="govuk-radios">
                       <div class="govuk-radios__item">
-                        <%= f.radio_button :not_resident_reason, 'MovedRecently', {class: "govuk-radios__input"}%>
+                        <%= f.radio_button :not_resident_reason, 'MovedRecently', {class: "govuk-radios__input", id: "will_it_work_for_me_form_not_resident_reason_moved_recently"}%>
                         <%= f.label :not_resident_reason_moved_recently, t('hub.will_it_work_for_me.question.not_resident_reason.recently'), class: "govuk-label govuk-radios__label"%>
                       </div>
                       <div class="govuk-radios__item">

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -472,7 +472,7 @@ cy:
           no_selection: Dylech ateb pob cwestiwn
           age_threshold: Please tell us if you are 20 or over
           resident_12_months: Please tell us if you lived in the UK for the last 12 months
-          not_resident_reason: Please tell us why you haven't lived in the UK for the last 12 months
+          not_resident_reason: Dewiswch opsiwn
     idp_wont_work_for_you_one_doc:
       title: Ni all %{idp_name} cadarnhau pwy ydych chi
       heading: Ni all %{idp_name} cadarnhau pwy ydych chi

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -466,6 +466,9 @@ cy:
           no_address: Nid oes gennyf gyfeiriad yn y DU
         errors:
           no_selection: Dylech ateb pob cwestiwn
+          age_threshold: Please tell us if you are 20 or over
+          resident_12_months: Please tell us if you lived in the UK for the last 12 months
+          not_resident_reason: Please tell us why you haven't lived in the UK for the last 12 months
     idp_wont_work_for_you_one_doc:
       title: Ni all %{idp_name} cadarnhau pwy ydych chi
       heading: Ni all %{idp_name} cadarnhau pwy ydych chi

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -452,6 +452,8 @@ cy:
       errors:
         no_selection: Dylech ateb pob cwestiwn
         invalid_selection: Dylech edrych dros eich dewis
+        mobile_phone: Please tell us if you have a mobile phone or tablet
+        smart_phone: Please tell us if you can install apps
     will_it_work_for_me:
       title: Allai i gael fy nilysu?
       heading: Amdanoch chi

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -428,8 +428,9 @@ cy:
         no_documents: Nid oes gennyf y dogfennau hyn gyda mi
       errors:
         no_selection: Dewiswch y dogfennau sydd gennych
-        invalid_selection: Edrychwch dros eich dewis
-        no_driving_licence_selection: Dewiswch y drwydded yrru sydd gennych
+        no_driving_license_selection: Please select if you have a driving license
+        no_passport_selection: Please select if you have a passport
+        no_driving_licence_issuer_selection: Please select the issuer of your driving license
       neither_documents: Nid yw'r un o'r dogfennau hyn gennyf
       where_driving_licence_issued: Ble cyhoeddwyd eich trwydded yrru?
       driving_licence_details:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -439,6 +439,8 @@ cy:
     other_documents:
       title_other_identity_documents: Dogfennau hunaniaeth eraill
       non_uk_id_document: Oes gennych chi pasbort sydd ddim yn un o'r DU, cerdyn ID neu drwydded yrru?
+      errors:
+        non_uk_docs: Tell us if you have a non-UK passport, ID card or driving licence
     select_phone:
       title: Oes gennych ffôn symudol neu lechen?
       explanation: Gall cwmnïau ardystiedig anfon codau diogelwch i’ch ffôn symudol.
@@ -579,7 +581,7 @@ cy:
       choose_another_certified_company_link: dewis cwmni ardystiedig arall
       identity_documents: Rydych angen eich dogfennau hunaniaeth gyda chi oherwydd bydd yn rhaid i chi ychwanegu eu manylion.
       or_html: neu %{choose_another_company_link}
-      validation_message: Dylech ateb y cwestiwn
+      validation_message: Dewiswch opsiwn
     confirm_your_identity:
       title: Cadarnhau eich hunaniaeth
       use_other_idp: Os nad hwn yw’r cwmni a wnaeth eich dilysu, %{sign_in_link}.

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -877,3 +877,5 @@ cy:
       other_ways: "Ceisiwch eto yn nes ymlaen neu ddewis ffordd arall i "
       other_ways_link: "profi eich hunaniaeth ar-lein"
     no_selection: Dylech ateb y cwestiynau
+    form:
+      there_is_a_problem: There is a problem

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -695,7 +695,6 @@ cy:
         email_hint: Byddwn ond yn ei ddefnyddio i ateb eich neges.
       errors:
         heading: Roedd problem wrth anfon y ffurflen
-        no_selection: Dylech ateb y cwestiynau
         details: Dylech roi manylion
         too_long: Gall y maes hwn fod hyd at %{max_length} nod  #TODO TT-1461: confirm text
         name: Dylech roi enw

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -481,7 +481,7 @@ en:
           no_selection: Please answer all the questions
           age_threshold: Tell us if you're 20 or over
           resident_12_months: Tell us if you've lived in the UK for the last 12 months
-          not_resident_reason: Tell us why you have not lived in the UK for the last 12 months
+          not_resident_reason: Select an option
     idp_wont_work_for_you_one_doc:
       title: "%{idp_name} cannot verify your identity"
       heading: "%{idp_name} cannot verify your identity"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -436,8 +436,9 @@ en:
         no_documents: I don’t have any of these documents with me
       errors:
         no_selection: Please select the documents you have
-        invalid_selection: Please check your selection
-        no_driving_licence_selection: Please select the driving licence you have
+        no_driving_license_selection: Please select if you have a driving license
+        no_passport_selection: Please select if you have a passport
+        no_driving_licence_issuer_selection: Please select the issuer of your driving license
       neither_documents: I don't have either of these documents
       where_driving_licence_issued: Where was your driving licence issued?
       driving_licence_details:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -698,10 +698,8 @@ en:
         email_hint: We’ll only use this to reply to your message.
       errors:
         heading: There was a problem submitting the form
-        no_selection: Please answer the questions
         what: Please tell us what were you trying to do?
         details: Please provide further details of your question, problem or feedback?
-        reply: Please tell us who you are for a reply?
         too_long: This field can be up to %{max_length} characters  #TODO TT-1461: confirm text
         name: Please enter a name
         email: Please enter a valid email address

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -475,6 +475,9 @@ en:
           no_address: I don’t have a UK address
         errors:
           no_selection: Please answer all the questions
+          age_threshold: Please tell us if you are 20 or over
+          resident_12_months: Please tell us if you lived in the UK for the last 12 months
+          not_resident_reason: Please tell us why you haven't lived in the UK for the last 12 months
     idp_wont_work_for_you_one_doc:
       title: "%{idp_name} cannot verify your identity"
       heading: "%{idp_name} cannot verify your identity"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -461,6 +461,8 @@ en:
       errors:
         no_selection: Please answer all the questions
         invalid_selection: Please check your selection
+        mobile_phone: Please tell us if you have a mobile phone or tablet
+        smart_phone: Please tell us if you can install apps
     will_it_work_for_me:
       title: Can I be verified?
       heading: About you

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -881,3 +881,5 @@ en:
       other_ways: "Try again later or choose another way to "
       other_ways_link: "prove your identity online"
     no_selection: Please answer all the questions
+    form:
+      there_is_a_problem: There is a problem

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -436,9 +436,9 @@ en:
         no_documents: I don’t have any of these documents with me
       errors:
         no_selection: Please select the documents you have
-        no_driving_license_selection: Please select if you have a driving license
-        no_passport_selection: Please select if you have a passport
-        no_driving_licence_issuer_selection: Please select the issuer of your driving license
+        no_driving_license_selection: Select if you have a driving licence
+        no_passport_selection: Select if you have a UK passport
+        no_driving_licence_issuer_selection: Select where your driving licence was issued
       neither_documents: I don't have either of these documents
       where_driving_licence_issued: Where was your driving licence issued?
       driving_licence_details:
@@ -448,6 +448,8 @@ en:
       title: Other identity documents
       title_other_identity_documents: Other identity documents
       non_uk_id_document: Do you have a non-UK passport, ID card or driving licence?
+      errors:
+        non_uk_docs: Tell us if you have a non-UK passport, ID card or driving licence
     select_phone:
       title: Do you have a mobile phone or tablet?
       explanation: Some companies send security codes to your mobile.
@@ -460,9 +462,9 @@ en:
         smart_phone_subtitle: "Some companies ask you to download a free app and use your phone's camera as part of verifying your identity."
       errors:
         no_selection: Please answer all the questions
-        invalid_selection: Please check your selection
-        mobile_phone: Please tell us if you have a mobile phone or tablet
-        smart_phone: Please tell us if you can install apps
+        invalid_selection: Check your selection
+        mobile_phone: Tell us if you have a mobile phone or tablet
+        smart_phone: Tell us if you can install apps
     will_it_work_for_me:
       title: Can I be verified?
       heading: About you
@@ -477,9 +479,9 @@ en:
           no_address: I don’t have a UK address
         errors:
           no_selection: Please answer all the questions
-          age_threshold: Please tell us if you are 20 or over
-          resident_12_months: Please tell us if you lived in the UK for the last 12 months
-          not_resident_reason: Please tell us why you haven't lived in the UK for the last 12 months
+          age_threshold: Tell us if you're 20 or over
+          resident_12_months: Tell us if you've lived in the UK for the last 12 months
+          not_resident_reason: Tell us why you have not lived in the UK for the last 12 months
     idp_wont_work_for_you_one_doc:
       title: "%{idp_name} cannot verify your identity"
       heading: "%{idp_name} cannot verify your identity"
@@ -582,7 +584,7 @@ en:
       choose_another_certified_company_link: choose another company
       identity_documents: You need your identity documents with you so you can enter details from them, or take a picture of them.
       or_html: or %{choose_another_company_link}
-      validation_message: Please answer the question
+      validation_message: Select an option
     confirm_your_identity:
       title: Confirm your identity
       use_other_idp: If this isn’t the company that verified you, %{sign_in_link}.
@@ -704,13 +706,13 @@ en:
         email_hint: We’ll only use this to reply to your message.
       errors:
         heading: There was a problem submitting the form
-        what: Please tell us what were you trying to do?
-        details: Please provide further details of your question, problem or feedback?
+        what: Tell us what were you trying to do
+        details: Provide further details of your question, problem or feedback
         too_long: This field can be up to %{max_length} characters  #TODO TT-1461: confirm text
-        name: Please enter a name
-        email: Please enter a valid email address
+        name: Enter your name
+        email: Enter a valid email address
         send_failure: Unfortunately, we are unable to record your feedback at the moment. Please try again later.
-        reply: Please select an option
+        reply: Tell us if you want a reply
       send_message: Send message
     feedback_disabled:
       title: Feedback Disabled

--- a/spec/features/user_visits_feedback_page_spec.rb
+++ b/spec/features/user_visits_feedback_page_spec.rb
@@ -68,7 +68,6 @@ RSpec.feature 'When the user visits the feedback page' do
     click_button t('hub.feedback.send_message')
 
     expect(page).to have_css('.govuk-form-group.govuk-form-group--error', count: 4)
-    expect(page).to have_css('.govuk-error-summary__list', text: t('hub.feedback.errors.no_selection'))
     expect(page).to have_css('.govuk-error-message', text: t('hub.feedback.errors.name'))
     expect(page).to have_css('.govuk-error-message', text: t('hub.feedback.errors.email'))
     expect(page).to have_css('.govuk-error-message', text: t('hub.feedback.errors.what'))
@@ -96,7 +95,6 @@ RSpec.feature 'When the user visits the feedback page' do
     click_button t('hub.feedback.send_message')
 
     expect(page).to have_css('.govuk-form-group.govuk-form-group--error', count: 2)
-    expect(page).to have_css('.govuk-error-summary__list', text: t('hub.feedback.errors.no_selection'))
     expect(page).to_not have_css('.govuk-error-message', text: t('hub.feedback.errors.name'))
     expect(page).to_not have_css('.govuk-error-message', text: t('hub.feedback.errors.email'))
   end
@@ -109,7 +107,6 @@ RSpec.feature 'When the user visits the feedback page' do
 
     expect(page).to have_css('.govuk-form-group.govuk-form-group--error', count: 3)
     expect(page).to have_css('.govuk-error-message', text: t('hub.feedback.errors.reply'))
-    expect(page).to have_css('.govuk-error-summary__list', text: t('hub.feedback.errors.no_selection'))
   end
 
   it 'should report on the what box character limit', js: true do

--- a/spec/features/user_visits_further_information_page_spec.rb
+++ b/spec/features/user_visits_further_information_page_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe 'user visits further information page' do
 
       expect(page.current_path).to eql(further_information_path)
       expect(page).to have_css(
-        '.error-message',
+        '.govuk-error-message',
         text: t('hub.further_information.attribute_validation_message', cycle_three_name: attribute_name)
       )
       expect(page.find('#cycle_three_attribute_cycle_three_data').value).to eql invalid_input

--- a/spec/features/user_visits_select_phone_page_spec.rb
+++ b/spec/features/user_visits_select_phone_page_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe 'When the user visits the select phone page' do
       visit '/select-phone'
       click_button t('navigation.continue')
 
-      expect(page).to have_css '.govuk-error-summary__list', text: 'Please tell us if you have a mobile phone or tablet'
+      expect(page).to have_css '.govuk-error-summary__list', text: 'Tell us if you have a mobile phone or tablet'
       expect(page).to have_css '.govuk-form-group--error'
     end
   end

--- a/spec/features/user_visits_select_phone_page_spec.rb
+++ b/spec/features/user_visits_select_phone_page_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe 'When the user visits the select phone page' do
       visit '/select-phone'
       click_button t('navigation.continue')
 
-      expect(page).to have_css '.govuk-error-summary__list', text: 'Please answer all the questions'
+      expect(page).to have_css '.govuk-error-summary__list', text: 'Please tell us if you have a mobile phone or tablet'
       expect(page).to have_css '.govuk-form-group--error'
     end
   end

--- a/spec/features/user_visits_will_it_work_for_me_page_spec.rb
+++ b/spec/features/user_visits_will_it_work_for_me_page_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe 'When the user visits the will it work for me page' do
       click_button t('navigation.continue')
 
       expect(page).to have_current_path(will_it_work_for_me_path)
-      expect(page).to have_content 'Please tell us if you are 20 or over'
-      expect(page).to have_content 'Please tell us if you lived in the UK for the last 12 months'
+      expect(page).to have_content "Tell us if you're 20 or over"
+      expect(page).to have_content "Tell us if you've lived in the UK for the last 12 months"
     end
 
     it 'when js is on', js: true do

--- a/spec/features/user_visits_will_it_work_for_me_page_spec.rb
+++ b/spec/features/user_visits_will_it_work_for_me_page_spec.rb
@@ -18,7 +18,8 @@ RSpec.describe 'When the user visits the will it work for me page' do
       click_button t('navigation.continue')
 
       expect(page).to have_current_path(will_it_work_for_me_path)
-      expect(page).to have_content 'Please answer all the questions'
+      expect(page).to have_content 'Please tell us if you are 20 or over'
+      expect(page).to have_content 'Please tell us if you lived in the UK for the last 12 months'
     end
 
     it 'when js is on', js: true do

--- a/spec/models/cycle_three/cycle_three_attribute_spec.rb
+++ b/spec/models/cycle_three/cycle_three_attribute_spec.rb
@@ -8,6 +8,10 @@ module CycleThree
         define_method(:pattern) do
           Regexp.new('^[a-z]*$')
         end
+
+        define_method(:name) do
+          'Sausage'
+        end
       end
     }
 
@@ -35,7 +39,7 @@ module CycleThree
       form = form_class.new(cycle_three_data: '123')
 
       expect(form).to_not be_valid
-      expect(form.errors.full_messages).to eql ['Cycle three data hub.further_information.attribute_validation_message']
+      expect(form.errors.full_messages).to eql ['Cycle three data Enter a valid Sausage']
     end
 
     it 'should not allow nullable fields by default' do

--- a/spec/models/feedback_form_spec.rb
+++ b/spec/models/feedback_form_spec.rb
@@ -10,9 +10,8 @@ describe FeedbackForm do
     what_error_message = 'What ' + I18n.t('hub.feedback.errors.what')
     details_error_message = 'Details ' + I18n.t('hub.feedback.errors.details')
     name_error_message = 'Name ' + I18n.t('hub.feedback.errors.name')
-    no_selection_error_message = I18n.t('hub.feedback.errors.no_selection')
     email_error_message = 'Email ' + I18n.t('hub.feedback.errors.email')
-    reply_error_message = 'Reply ' + I18n.t('hub.feedback.errors.reply')
+    reply_error_message = 'Reply true ' + I18n.t('hub.feedback.errors.reply')
     long_length_error = I18n.t('hub.feedback.errors.too_long', max_length: long_text_limit)
     short_length_error = I18n.t('hub.feedback.errors.too_long', max_length: short_text_limit)
 
@@ -20,14 +19,16 @@ describe FeedbackForm do
       form = FeedbackForm.new({})
 
       expect(form).to_not be_valid
-      expect(form.errors.full_messages).to include no_selection_error_message
+      expect(form.errors.full_messages).to include what_error_message
+      expect(form.errors.full_messages).to include details_error_message
+      expect(form.errors.full_messages).to include reply_error_message
     end
 
     it 'reply question is not answered' do
       form = FeedbackForm.new(what: 'what i was doing', details: 'what happened')
 
       expect(form).to_not be_valid
-      expect(form.errors.full_messages).to eql [no_selection_error_message, reply_error_message]
+      expect(form.errors.full_messages).to eql [reply_error_message]
     end
 
     it 'what were you trying to do question was not answered' do
@@ -91,8 +92,7 @@ describe FeedbackForm do
                               email: 'bob@smith.com')
 
       expect(form).to_not be_valid
-      expect(form.errors.full_messages).to eql [no_selection_error_message,
-                                                name_error_message]
+      expect(form.errors.full_messages).to eql [name_error_message]
     end
 
     it 'email is not provided when reply requested' do
@@ -102,8 +102,7 @@ describe FeedbackForm do
                               name: 'bob smith')
 
       expect(form).to_not be_valid
-      expect(form.errors.full_messages).to eql [no_selection_error_message,
-                                                email_error_message]
+      expect(form.errors.full_messages).to eql [email_error_message]
     end
 
     it 'email contains whitespace' do
@@ -119,8 +118,7 @@ describe FeedbackForm do
                                                     email: whitespaced_email)
 
         expect(form).to_not be_valid
-        expect(form.errors.full_messages).to eql [no_selection_error_message,
-                                                  email_error_message]
+        expect(form.errors.full_messages).to eql [email_error_message]
       end
     end
 
@@ -134,8 +132,7 @@ describe FeedbackForm do
                                                     email: bad_email)
 
         expect(form).to_not be_valid
-        expect(form.errors.full_messages).to eql [no_selection_error_message,
-                                                  email_error_message]
+        expect(form.errors.full_messages).to eql [email_error_message]
       end
     end
 
@@ -150,7 +147,7 @@ describe FeedbackForm do
       )
 
       expect(form).to_not be_valid
-      expect(form.errors.full_messages).to eql [no_selection_error_message, email_error_message]
+      expect(form.errors.full_messages).to eql [email_error_message]
     end
   end
 

--- a/spec/models/other_identity_documents_form_spec.rb
+++ b/spec/models/other_identity_documents_form_spec.rb
@@ -7,7 +7,7 @@ describe OtherIdentityDocumentsForm do
       it 'should be invalid if all inputs are empty' do
         form = OtherIdentityDocumentsForm.new({})
         expect(form).to_not be_valid
-        expect(form.errors.full_messages).to eql ['Non uk id document true Please select the documents you have']
+        expect(form.errors.full_messages).to eql ['Non uk id document true Tell us if you have a non-UK passport, ID card or driving licence']
       end
 
       it 'should be invalid if input is not true or false' do

--- a/spec/models/other_identity_documents_form_spec.rb
+++ b/spec/models/other_identity_documents_form_spec.rb
@@ -7,7 +7,7 @@ describe OtherIdentityDocumentsForm do
       it 'should be invalid if all inputs are empty' do
         form = OtherIdentityDocumentsForm.new({})
         expect(form).to_not be_valid
-        expect(form.errors.full_messages).to eql ['Please select the documents you have']
+        expect(form.errors.full_messages).to eql ['Non uk id document true Please select the documents you have']
       end
 
       it 'should be invalid if input is not true or false' do

--- a/spec/models/select_documents_form_spec.rb
+++ b/spec/models/select_documents_form_spec.rb
@@ -4,19 +4,25 @@ require 'rails_helper'
 describe SelectDocumentsForm do
   context '#validations' do
     context '#invalid form' do
+      any_driving_license_error_message = 'Any driving licence true ' + I18n.t('hub.select_documents.errors.no_driving_license_selection')
+      passport_error_message = 'Passport true ' + I18n.t('hub.select_documents.errors.no_passport_selection')
+      driving_license_issuer_error_message = 'Driving licence great britain ' + I18n.t('hub.select_documents.errors.no_driving_licence_issuer_selection')
+
       it 'should be invalid if all inputs are empty' do
         form = SelectDocumentsForm.new({})
         expect(form).to_not be_valid
-        expect(form.errors.full_messages).to eql ['Please select the documents you have']
+        expect(form.errors.full_messages).to include any_driving_license_error_message
+        expect(form.errors.full_messages).to include passport_error_message
+        expect(form.errors.full_messages).not_to include driving_license_issuer_error_message
       end
 
-      it 'should be invalid if no driving licence details are given' do
+      it 'should be invalid if no driving licence issuer details are given' do
         form = SelectDocumentsForm.new(
           any_driving_licence: 'true',
           passport: 'false'
         )
         expect(form).to_not be_valid
-        expect(form.errors.full_messages).to eql ['Please select the documents you have']
+        expect(form.errors.full_messages).to eql [driving_license_issuer_error_message]
       end
 
       it 'should be invalid if user only inputs driving licence details' do
@@ -25,7 +31,7 @@ describe SelectDocumentsForm do
           driving_licence: 'great_britain'
         )
         expect(form).to_not be_valid
-        expect(form.errors.full_messages).to eql ['Please select the documents you have']
+        expect(form.errors.full_messages).to eql [passport_error_message]
       end
 
       it 'should be invalid if user only inputs passport details' do
@@ -33,7 +39,7 @@ describe SelectDocumentsForm do
           passport: 'true'
         )
         expect(form).to_not be_valid
-        expect(form.errors.full_messages).to eql ['Please select the documents you have']
+        expect(form.errors.full_messages).to eql [any_driving_license_error_message]
       end
     end
 
@@ -41,7 +47,7 @@ describe SelectDocumentsForm do
       it 'should be valid if answers are given to every question' do
         form = SelectDocumentsForm.new(
           any_driving_licence: 'false',
-          passport: 'true',
+          passport: 'true'
         )
         expect(form).to be_valid
       end

--- a/spec/models/select_phone_form_spec.rb
+++ b/spec/models/select_phone_form_spec.rb
@@ -2,27 +2,59 @@ require 'spec_helper'
 require 'rails_helper'
 
 describe SelectPhoneForm do
-  it 'should be invalid when neither mobile nor smartphone answered' do
-    test_form_missing_data
+  mobile_phone_error = 'Mobile phone true ' + I18n.t('hub.select_phone.errors.mobile_phone')
+  mobile_phone_invalid_error = 'Mobile phone true ' + I18n.t('hub.select_phone.errors.invalid_selection')
+  smart_phone_error = 'Smart phone true ' + I18n.t('hub.select_phone.errors.smart_phone')
+  smart_phone_invalid_error = 'Smart phone true ' + I18n.t('hub.select_phone.errors.invalid_selection')
+
+  describe 'should be valid' do
+    it 'when mobile is answered yes and smartphone is answered' do
+      %w(true false do_not_know).each do |smart_phone_answer|
+        form = SelectPhoneForm.new(mobile_phone: 'true', smart_phone: smart_phone_answer)
+
+        expect(form.valid?).to eql true
+        expect(form.errors.full_messages).to eql []
+      end
+    end
+
+    it 'when mobile is answered no and smartphone is unanswered' do
+      form = SelectPhoneForm.new(mobile_phone: 'false')
+
+      expect(form.valid?).to eql true
+      expect(form.errors.full_messages).to eql []
+    end
+
+    it 'when smartphone is answered and mobile phone is unanswered' do
+      %w(true false do_not_know).each do |smart_phone_answer|
+        form = SelectPhoneForm.new(smart_phone: smart_phone_answer)
+
+        expect(form.valid?).to eql true
+        expect(form.errors.full_messages).to eql []
+      end
+    end
   end
 
-  it 'should be valid when smartphone is answered and mobile phone is unanswered' do
-    test_form_valid smart_phone: 'false'
-    test_form_valid smart_phone: 'true'
-  end
+  describe 'should be invalid' do
+    it 'when mobile is answered no and smartphone is answered yes' do
+      form = SelectPhoneForm.new(mobile_phone: 'false', smart_phone: 'true')
 
-  it 'should be invalid when mobile is answered no and smartphone is answered yes' do
-    test_form_inconsistent_data mobile_phone: 'false', smart_phone: 'true'
-  end
+      expect(form.valid?).to eql false
+      expect(form.errors.full_messages).to eql [mobile_phone_invalid_error, smart_phone_invalid_error]
+    end
 
-  it 'should be invalid when mobile is answered yes and smartphone is unanswered' do
-    test_form_missing_data mobile_phone: 'true'
-  end
+    it 'when neither mobile nor smartphone answered' do
+      form = SelectPhoneForm.new({})
 
-  it 'should be valid when mobile is answered yes and smartphone is answered' do
-    test_form_valid mobile_phone: 'true', smart_phone: 'false'
-    test_form_valid mobile_phone: 'true', smart_phone: 'true'
-    test_form_valid mobile_phone: 'true', smart_phone: 'do_not_know'
+      expect(form.valid?).to eql false
+      expect(form.errors.full_messages).to eql [mobile_phone_error]
+    end
+
+    it 'when mobile is answered yes and smartphone is unanswered' do
+      form = SelectPhoneForm.new(mobile_phone: 'true')
+
+      expect(form.valid?).to eql false
+      expect(form.errors.full_messages).to eql [smart_phone_error]
+    end
   end
 
   describe '#selected_answers' do
@@ -51,23 +83,5 @@ describe SelectPhoneForm do
       answers = form.selected_answers
       expect(answers).to eql(mobile_phone: true)
     end
-  end
-
-  def test_form_valid(form_fields = {})
-    form = SelectPhoneForm.new(form_fields)
-    expect(form.valid?).to eql true
-    expect(form.errors.full_messages).to eql []
-  end
-
-  def test_form_missing_data(form_fields = {})
-    form = SelectPhoneForm.new(form_fields)
-    expect(form.valid?).to eql false
-    expect(form.errors.full_messages).to eql ['Please answer all the questions']
-  end
-
-  def test_form_inconsistent_data(form_fields = {})
-    form = SelectPhoneForm.new(form_fields)
-    expect(form.valid?).to eql false
-    expect(form.errors.full_messages).to eql ['Please check your selection']
   end
 end

--- a/spec/models/will_it_work_for_me_form_spec.rb
+++ b/spec/models/will_it_work_for_me_form_spec.rb
@@ -3,40 +3,42 @@ require 'rails_helper'
 
 describe WillItWorkForMeForm do
   context 'is not valid when' do
-    expected_errors = ['Please answer all the questions']
+    age_threshold_error = 'Above age threshold true ' + I18n.t('hub.will_it_work_for_me.question.errors.age_threshold')
+    resident_12_months_error = 'Resident last 12 months true ' + I18n.t('hub.will_it_work_for_me.question.errors.resident_12_months')
+    not_resident_reason_error = 'Not resident reason moved recently ' + I18n.t('hub.will_it_work_for_me.question.errors.not_resident_reason')
     it 'no answers given' do
       form = WillItWorkForMeForm.new({})
 
       expect(form).to_not be_valid
-      expect(form.errors.full_messages).to eql expected_errors
+      expect(form.errors.full_messages).to eql [age_threshold_error, resident_12_months_error]
     end
 
     it 'age threshold is answered, resident for last 12 months is no and non resident reason is not provided' do
       form = WillItWorkForMeForm.new(above_age_threshold: 'false', resident_last_12_months: 'false')
 
       expect(form).to_not be_valid
-      expect(form.errors.full_messages).to eql expected_errors
+      expect(form.errors.full_messages).to eql [not_resident_reason_error]
     end
 
     it 'no answer for age threshold is provided and the residency questions are answered' do
       form = WillItWorkForMeForm.new(resident_last_12_months: 'false', not_resident_reason: 'AddressButNotResident')
 
       expect(form).to_not be_valid
-      expect(form.errors.full_messages).to eql expected_errors
+      expect(form.errors.full_messages).to eql [age_threshold_error]
     end
 
     it 'no answer for age threshold is provided and the resident for last 12 months is answered yes' do
       form = WillItWorkForMeForm.new(resident_last_12_months: 'true')
 
       expect(form).to_not be_valid
-      expect(form.errors.full_messages).to eql expected_errors
+      expect(form.errors.full_messages).to eql [age_threshold_error]
     end
 
     it 'age threshold is answered and no answer provided for residency questions' do
       form = WillItWorkForMeForm.new(above_age_threshold: 'false')
 
       expect(form).to_not be_valid
-      expect(form.errors.full_messages).to eql expected_errors
+      expect(form.errors.full_messages).to eql [resident_12_months_error]
     end
   end
 


### PR DESCRIPTION
This PR removes the use of the base element from the form models used in the Verify frontend, and instead applies validation messages to the individual element themselves.

This has required creating some new content for new validation messages. This will need to be checked by someone with content skills.

It also moves the validation summary above the H1 on the relevant pages as per the design system recommendations.

As well as this, the links in the summary will now take you either to the relevant text input field, or in the case of radio buttons, the first one in the group.

**Note**
These changes are only to the server side rendering of the validation messages. To view then you will need to turn your JS off. When JS is on it controls the validation messages.

Also note, a lot of these forms are going away soon due to the short hub changes due to be implemented by the end of March. As such, we've decided to not get Welsh translations. Except for the "will it work for me" page - we've requested translations for the updated content.

Example screenshots:
| Before  | After |
| ------------- | ------------- |
| ![www signin service gov uk_start(Laptop with HiDPI screen)](https://user-images.githubusercontent.com/13836290/75455232-29760b80-5971-11ea-8f06-592609637885.png)  | ![localhost_50300_start(Laptop with HiDPI screen)](https://user-images.githubusercontent.com/13836290/75455436-55918c80-5971-11ea-87b6-cc1cf2665030.png)  |
| ![www signin service gov uk_will-it-work-for-me(Laptop with HiDPI screen) (1)](https://user-images.githubusercontent.com/13836290/75455630-7fe34a00-5971-11ea-864a-0a01fadf5ef2.png)  | ![localhost_50300_will-it-work-for-me(Laptop with HiDPI screen) (1)](https://user-images.githubusercontent.com/13836290/75455656-8671c180-5971-11ea-8e4f-e0e7170e10f4.png)  |


