### PR TITLE
HUB-545: Hide IDPs disconnecting for registration an amount of time before the actual cut-off time

### DIFF
--- a/.env
+++ b/.env
@@ -21,6 +21,8 @@ AB_TEST_FILE=stub/ab_test.yml
 SEGMENT_DEFINITIONS=stub/segment_definitions.yml
 SEGMENT_DEFINITIONS_VARIANT_C=stub/segment_definitions_variant_c.yml
 
+HIDE_IDPS_DISCONNECTING_FOR_REGISTRATION_MINUTES_BEFORE=15
+
 RULES_DIRECTORY=stub/idp-rules
 RULES_C_DIRECTORY=stub/idp-rules-variant-c
 ABC_VARIANTS_CONFIG=stub/special-cases/abc-variants.yml

--- a/app/controllers/choose_a_certified_company_loa2_controller.rb
+++ b/app/controllers/choose_a_certified_company_loa2_controller.rb
@@ -7,7 +7,7 @@ class ChooseACertifiedCompanyLoa2Controller < ApplicationController
 
   def index
     session[:selected_answers]&.delete('interstitial')
-    suggestions = recommendation_engine.get_suggested_idps(current_identity_providers_for_loa, selected_evidence, current_transaction_simple_id)
+    suggestions = recommendation_engine.get_suggested_idps_for_registration(current_identity_providers_for_loa, selected_evidence, current_transaction_simple_id)
     @recommended_idps = IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate_collection(suggestions[:recommended])
     @recommended_idps = order_with_unavailable_last(@recommended_idps)
     @non_recommended_idps = IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate_collection(suggestions[:unlikely])

--- a/app/controllers/choose_a_certified_company_loa2_variant_c_controller.rb
+++ b/app/controllers/choose_a_certified_company_loa2_variant_c_controller.rb
@@ -11,7 +11,7 @@ class ChooseACertifiedCompanyLoa2VariantCController < RedirectToIdpWarningContro
   def index
     session[:selected_answers]&.delete('interstitial')
     idps = current_identity_providers_for_loa_by_variant('c')
-    suggestions = recommendation_engine.get_suggested_idps(idps, selected_evidence, current_transaction_simple_id)
+    suggestions = recommendation_engine.get_suggested_idps_for_registration(idps, selected_evidence, current_transaction_simple_id)
     @recommended_idps = IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate_collection(suggestions[:recommended])
     @recommended_idps = order_with_unavailable_last(@recommended_idps)
     @non_recommended_idps = IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate_collection(suggestions[:unlikely])

--- a/app/controllers/select_documents_variant_c_controller.rb
+++ b/app/controllers/select_documents_variant_c_controller.rb
@@ -23,7 +23,7 @@ class SelectDocumentsVariantCController < ApplicationController
   end
 
   def advice
-    suggestions = IDP_RECOMMENDATION_ENGINE_variant_c.get_suggested_idps(current_identity_providers_for_loa_by_variant('c'), selected_evidence, current_transaction_simple_id)
+    suggestions = IDP_RECOMMENDATION_ENGINE_variant_c.get_suggested_idps_for_registration(current_identity_providers_for_loa_by_variant('c'), selected_evidence, current_transaction_simple_id)
 
     @evidence = selected_evidence
     @advice_codes = segment_advice(suggestions[:user_segments])

--- a/app/models/identity_provider.rb
+++ b/app/models/identity_provider.rb
@@ -1,7 +1,7 @@
 class IdentityProvider
   include ActiveModel::Model
 
-  attr_reader :simple_id, :entity_id, :levels_of_assurance, :authentication_enabled, :unavailable
+  attr_reader :simple_id, :entity_id, :levels_of_assurance, :authentication_enabled, :provide_registration_until, :unavailable
   validates_presence_of :simple_id, :entity_id, :levels_of_assurance
 
   def initialize(hash)
@@ -10,6 +10,7 @@ class IdentityProvider
     @levels_of_assurance = hash['levelsOfAssurance']
     @authentication_enabled = hash.fetch('authenticationEnabled', true)
     @unavailable = hash.fetch('temporarilyUnavailable', false)
+    @provide_registration_until = DateTime.parse(hash['provideRegistrationUntil']) unless hash['provideRegistrationUntil'].nil?
   end
 
   def ==(other)

--- a/config/initializers/00_configuration.rb
+++ b/config/initializers/00_configuration.rb
@@ -28,6 +28,8 @@ CONFIG = Configuration.load! do
   option_int 'read_timeout', 'READ_TIMEOUT', default: 60
   option_int 'connect_timeout', 'CONNECT_TIMEOUT', default: 4
 
+  option_int 'hide_idps_disconnecting_for_registration_minutes_before', 'HIDE_IDPS_DISCONNECTING_FOR_REGISTRATION_MINUTES_BEFORE'
+
   option_string 'rules_directory', 'RULES_DIRECTORY', default: "#{FED_CONFIG_DIR}/idp-rules/"
   option_string 'segment_definitions', 'SEGMENT_DEFINITIONS', default: "#{FED_CONFIG_DIR}/segment_definitions.yml"
 

--- a/config/initializers/30_federation.rb
+++ b/config/initializers/30_federation.rb
@@ -60,10 +60,10 @@ Rails.application.config.after_initialize do
 
   # Recommendation Engines
   transaction_grouper = TransactionGroups::TransactionGrouper.new(RP_CONFIG)
-  IDP_RECOMMENDATION_ENGINE = RecommendationsEngine.new(idp_rules, segment_matcher, transaction_grouper)
+  IDP_RECOMMENDATION_ENGINE = RecommendationsEngine.new(idp_rules, segment_matcher, transaction_grouper, CONFIG.hide_idps_disconnecting_for_registration_minutes_before)
 
   # HUH-234 variant c
-  IDP_RECOMMENDATION_ENGINE_variant_c = RecommendationsEngine.new(idp_rules_variant_c, segment_matcher_variant_c, transaction_grouper)
+  IDP_RECOMMENDATION_ENGINE_variant_c = RecommendationsEngine.new(idp_rules_variant_c, segment_matcher_variant_c, transaction_grouper, CONFIG.hide_idps_disconnecting_for_registration_minutes_before)
 
   # ABC testing variation config
   # HUH-234 variant c

--- a/spec/models/identity_provider_spec.rb
+++ b/spec/models/identity_provider_spec.rb
@@ -33,4 +33,14 @@ describe IdentityProvider do
     idp = IdentityProvider.new('simpleId' => 'simpleId1', 'entityId' => 'entityId1', 'authenticationEnabled' => false)
     expect(idp.authentication_enabled).to eql false
   end
+
+  it 'provides provide registration until date if it is supplied' do
+    idp = IdentityProvider.new('simpleId' => 'simpleId1', 'entityId' => 'entityId1', 'provideRegistrationUntil' => '2020-03-10T11:15:30+00:00')
+    expect(idp.provide_registration_until.year).to eql 2020
+    expect(idp.provide_registration_until.month).to eql 3
+    expect(idp.provide_registration_until.day).to eql 10
+    expect(idp.provide_registration_until.hour).to eql 11
+    expect(idp.provide_registration_until.min).to eql 15
+    expect(idp.provide_registration_until.second).to eql 30
+  end
 end


### PR DESCRIPTION
This is to avoid a timing issue where the button to select an IDP gets rendered shortly before the cut-off time and the user fails to press is before that cut-off time. In that case the user will see an error for a reason completely outside of their control.

Hiding IDPs disconnecting for registration a short period of time before the cut-off time is a crude solution to this as the Hub will still accept requests for those IDPs until the actual cut-off time. This doesn't eliminate the problem completely but given an appropriate time interval it reduces it greatly as most people are not likely to spend more than a few minutes on the picker.

Added a new config value to the `env` file and added logic to the recommendations engine to hide IDPs which have the `provide_registration_until` flag set and if, measured from now, the cut-off time is within the number of minutes specified in the config.