### PR TITLE
HUB-235: Add additional tracking to short hub variant c abc test

### DIFF
--- a/app/assets/javascripts/select_documents_checkbox_management.js
+++ b/app/assets/javascripts/select_documents_checkbox_management.js
@@ -11,6 +11,7 @@
             $("#select_documents_variant_c_form_has_driving_license").click(this.unsetNothing);
             $("#select_documents_variant_c_form_has_phone_can_app").click(this.unsetNothing);
             $("#select_documents_variant_c_form_has_credit_card").click(this.unsetNothing);
+            $('#progressive_disclosure').on('click', this.track_disclosure);
         },
 
         unsetNothing: function () {
@@ -22,6 +23,11 @@
             $("#select_documents_variant_c_form_has_driving_license").prop("checked", false);
             $("#select_documents_variant_c_form_has_phone_can_app").prop("checked", false);
             $("#select_documents_variant_c_form_has_credit_card").prop("checked", false);
+        },
+
+        track_disclosure: function(event) {
+        // user selects progressive disclosure link track user opens the link
+            return _paq.push(['trackEvent','Engagement','Disclosure link selected', 'Opened']);
         }
     };
 

--- a/app/controllers/select_documents_variant_c_controller.rb
+++ b/app/controllers/select_documents_variant_c_controller.rb
@@ -45,7 +45,6 @@ private
   end
 
   def increase_attempt_number
-    session[:evidence_attempt_number] = 0 if session[:evidence_attempt_number].nil?
-    session[:evidence_attempt_number] = session[:evidence_attempt_number] + 1
+    session[:evidence_attempt_number] = (session[:evidence_attempt_number] || 0) + 1
   end
 end

--- a/app/controllers/select_documents_variant_c_controller.rb
+++ b/app/controllers/select_documents_variant_c_controller.rb
@@ -15,6 +15,7 @@ class SelectDocumentsVariantCController < ApplicationController
     if @form.valid?
       selected_answer_store.store_selected_answers("documents", @form.to_session_storage)
       idps_available = IDP_RECOMMENDATION_ENGINE_variant_c.any?(current_identity_providers_for_loa_by_variant("c"), selected_evidence, current_transaction_simple_id)
+      report_user_evidence_to_piwik(selected_evidence)
       redirect_to idps_available ? choose_a_certified_company_path : select_documents_advice_path
     else
       flash.now[:errors] = @form.errors.full_messages.join(", ")
@@ -24,12 +25,27 @@ class SelectDocumentsVariantCController < ApplicationController
 
   def advice
     suggestions = IDP_RECOMMENDATION_ENGINE_variant_c.get_suggested_idps_for_registration(current_identity_providers_for_loa_by_variant("c"), selected_evidence, current_transaction_simple_id)
-
     @evidence = selected_evidence
     @advice_codes = segment_advice(suggestions[:user_segments])
     @other_ways_description = current_transaction.other_ways_description
     @other_ways_text = current_transaction.other_ways_text
 
     render :advice
+  end
+
+private
+
+  def report_user_evidence_to_piwik(selected_evidence)
+    FEDERATION_REPORTER.report_user_evidence_attempt(
+      current_transaction: current_transaction,
+      request: request,
+      attempt_number: increase_attempt_number,
+      evidence_list: selected_evidence,
+    )
+  end
+
+  def increase_attempt_number
+    session[:evidence_attempt_number] = 0 if session[:evidence_attempt_number].nil?
+    session[:evidence_attempt_number] = session[:evidence_attempt_number] + 1
   end
 end

--- a/app/models/analytics/federation_reporter.rb
+++ b/app/models/analytics/federation_reporter.rb
@@ -151,6 +151,17 @@ module Analytics
       )
     end
 
+    def report_user_evidence_attempt(attempt_number:, current_transaction:, request:, evidence_list: [])
+      list_of_evidence = evidence_list.map { |evidence| evidence.to_s.gsub("has_", "") }
+                                      .sort.join("_")
+                                      .upcase
+      report_action(
+        current_transaction,
+        request,
+        "EVIDENCE_ATTEMPT_#{attempt_number} | #{list_of_evidence} |",
+      )
+    end
+
     def report_number_of_idps_recommended(current_transaction, request, number_of_idps_recommended)
       report_event(
         current_transaction,
@@ -201,15 +212,13 @@ module Analytics
     end
 
     def report_action(current_transaction, request, action, extra_custom_vars = {})
-      begin
-        @analytics_reporter.report_action(
-          request,
-          action,
-          universal_custom_variables(current_transaction, request).merge(extra_custom_vars),
-        )
-      rescue Display::FederationTranslator::TranslationError => e
-        Rails.logger.warn e
-      end
+      @analytics_reporter.report_action(
+        request,
+        action,
+        universal_custom_variables(current_transaction, request).merge(extra_custom_vars),
+      )
+    rescue Display::FederationTranslator::TranslationError => e
+      Rails.logger.warn e
     end
 
     def report_action_without_current_transaction(request, action, extra_custom_vars = {})
@@ -221,17 +230,15 @@ module Analytics
     end
 
     def report_event(current_transaction, request, event_category, event_name, event_action)
-      begin
-        @analytics_reporter.report_event(
-          request,
-          universal_custom_variables(current_transaction, request),
-          event_category,
-          event_name,
-          event_action,
-        )
-      rescue Display::FederationTranslator::TranslationError => e
-        Rails.logger.warn e
-      end
+      @analytics_reporter.report_event(
+        request,
+        universal_custom_variables(current_transaction, request),
+        event_category,
+        event_name,
+        event_action,
+      )
+    rescue Display::FederationTranslator::TranslationError => e
+      Rails.logger.warn e
     end
 
     def report_event_without_current_transaction(request, event_category, event_name, event_action)

--- a/app/views/select_documents_variant_c/index.html.erb
+++ b/app/views/select_documents_variant_c/index.html.erb
@@ -47,7 +47,7 @@
           </div>
         </fieldset>
 
-        <details class="govuk-details govuk-!-padding-top-6" data-module="govuk-details">
+        <details id="progressive_disclosure"  piwik_event_tracking="progressive_disclosure" class="govuk-details govuk-!-padding-top-6" data-module="govuk-details">
           <summary class="govuk-details__summary">
             <span class="govuk-details__summary-text"><%= t 'hub_variant_c.select_documents.further_explanation.title' %></span>
           </summary>

--- a/spec/controllers/select_documents_variant_c_controller_spec.rb
+++ b/spec/controllers/select_documents_variant_c_controller_spec.rb
@@ -12,8 +12,9 @@ describe SelectDocumentsVariantCController do
     variant = "variant_c_2_idp_short_hub"
     set_session_and_cookies_with_loa_and_variant("LEVEL_2", experiment, variant)
     stub_api_idp_list_for_registration([{ "simpleId" => "stub-idp-one",
-                                          "entityId" => "http://idcorp.com",
-                                          "levelsOfAssurance" => %w(LEVEL_2) }], "LEVEL_2")
+      "entityId" => "http://idcorp.com",
+      "levelsOfAssurance" => %w(LEVEL_2) }], "LEVEL_2")
+
     session[:selected_answers] = {
       "device_type" => { device_type_other: true },
     }
@@ -22,6 +23,26 @@ describe SelectDocumentsVariantCController do
   context "when form is valid" do
     it "redirects to the advice page when less than three documents are selected" do
       evidence = { has_valid_passport: "t", has_credit_card: "t" }.freeze
+      expect(FEDERATION_REPORTER).to receive(:report_user_evidence_attempt)
+      .with(
+        current_transaction: a_kind_of(Display::RpDisplayData),
+        request: a_kind_of(ActionDispatch::Request),
+        attempt_number: 1,
+        evidence_list: { device_type_other: true }.merge!(evidence).keys,
+      )
+      post :select_documents, params: { locale: "en", select_documents_variant_c_form: evidence }
+      expect(subject).to redirect_to select_documents_advice_path
+    end
+
+    it "redirects to the advice page when None of the above is selected" do
+      evidence = { has_nothing: "t" }
+      expect(FEDERATION_REPORTER).to receive(:report_user_evidence_attempt)
+      .with(
+        current_transaction: a_kind_of(Display::RpDisplayData),
+        request: a_kind_of(ActionDispatch::Request),
+        attempt_number: 1,
+        evidence_list: { device_type_other: true }.keys,
+      )
       post :select_documents, params: { locale: "en", select_documents_variant_c_form: evidence }
       expect(subject).to redirect_to select_documents_advice_path
     end
@@ -42,7 +63,7 @@ describe SelectDocumentsVariantCController do
     end
 
     it "does not report to Piwik" do
-      expect(ANALYTICS_REPORTER).not_to receive(:report_action)
+      expect(FEDERATION_REPORTER).not_to receive(:report_action)
     end
   end
 end

--- a/spec/controllers/select_documents_variant_c_controller_spec.rb
+++ b/spec/controllers/select_documents_variant_c_controller_spec.rb
@@ -22,28 +22,14 @@ describe SelectDocumentsVariantCController do
 
   context "when form is valid" do
     it "redirects to the advice page when less than three documents are selected" do
-      evidence = { has_valid_passport: "t", has_credit_card: "t" }.freeze
-      expect(FEDERATION_REPORTER).to receive(:report_user_evidence_attempt)
-      .with(
-        current_transaction: a_kind_of(Display::RpDisplayData),
-        request: a_kind_of(ActionDispatch::Request),
-        attempt_number: 1,
-        evidence_list: { device_type_other: true }.merge!(evidence).keys,
-      )
-      post :select_documents, params: { locale: "en", select_documents_variant_c_form: evidence }
+      evidence = { has_valid_passport: "t", has_credit_card: "t", has_nothing: "t" }.freeze
+      expect_federation_reporter_to_receive_user_evidence_when_posted(evidence)
       expect(subject).to redirect_to select_documents_advice_path
     end
 
     it "redirects to the advice page when None of the above is selected" do
       evidence = { has_nothing: "t" }
-      expect(FEDERATION_REPORTER).to receive(:report_user_evidence_attempt)
-      .with(
-        current_transaction: a_kind_of(Display::RpDisplayData),
-        request: a_kind_of(ActionDispatch::Request),
-        attempt_number: 1,
-        evidence_list: { device_type_other: true }.keys,
-      )
-      post :select_documents, params: { locale: "en", select_documents_variant_c_form: evidence }
+      expect_federation_reporter_to_receive_user_evidence_when_posted(evidence)
       expect(subject).to redirect_to select_documents_advice_path
     end
 
@@ -65,5 +51,16 @@ describe SelectDocumentsVariantCController do
     it "does not report to Piwik" do
       expect(FEDERATION_REPORTER).not_to receive(:report_action)
     end
+  end
+
+  def expect_federation_reporter_to_receive_user_evidence_when_posted(evidence)
+    expect(FEDERATION_REPORTER).to receive(:report_user_evidence_attempt)
+    .with(
+      current_transaction: a_kind_of(Display::RpDisplayData),
+      request: a_kind_of(ActionDispatch::Request),
+      attempt_number: 1,
+      evidence_list: { device_type_other: true }.merge!(evidence).keys - %i(has_nothing),
+    )
+    post :select_documents, params: { locale: "en", select_documents_variant_c_form: evidence }
   end
 end

--- a/spec/features/user_visits_select_documents_variant_c_page_spec.rb
+++ b/spec/features/user_visits_select_documents_variant_c_page_spec.rb
@@ -25,7 +25,7 @@ RSpec.feature "When user visits document selection page" do
   it "redirects to the idp picker page when selects 3 documents" do
     visit "/select-documents"
     expect_reporter_to_receive(
-      evidence: %I(has_valid_passport has_driving_license has_credit_card device_type_other),
+      evidence: %i(has_valid_passport has_driving_license has_credit_card device_type_other),
       attempts: 1,
     )
     check "Your current driving licence, full or provisional, with your photo on it", allow_label_click: true
@@ -40,7 +40,7 @@ RSpec.feature "When user visits document selection page" do
   it "redirects to the select advice page when selects 2 documents" do
     visit "/select-documents"
     expect_reporter_to_receive(
-      evidence: %I(has_driving_license has_credit_card device_type_other),
+      evidence: %i(has_driving_license has_credit_card device_type_other),
       attempts: 1,
     )
     check "Your current driving licence, full or provisional, with your photo on it", allow_label_click: true
@@ -54,7 +54,7 @@ RSpec.feature "When user visits document selection page" do
   it "redirects to the select advice page when selects 2 documents and None of the above is checked" do
     visit "/select-documents"
     expect_reporter_to_receive(
-      evidence: %I(has_driving_license has_credit_card device_type_other),
+      evidence: %i(has_driving_license has_credit_card device_type_other),
       attempts: 1,
     )
     check "Your current driving licence, full or provisional, with your photo on it", allow_label_click: true
@@ -68,7 +68,7 @@ RSpec.feature "When user visits document selection page" do
   it "increments attempts" do
     visit "/select-documents"
     expect_reporter_to_receive(
-      evidence: %I(device_type_other),
+      evidence: %i(device_type_other),
       attempts: 1,
     )
     check "None of the above", allow_label_click: true
@@ -77,7 +77,7 @@ RSpec.feature "When user visits document selection page" do
     expect(page).to have_current_path(select_documents_advice_path)
     visit "/select-documents"
     expect_reporter_to_receive(
-      evidence: %I(has_driving_license device_type_other),
+      evidence: %i(has_driving_license device_type_other),
       attempts: 2,
     )
     check "Your current driving licence, full or provisional, with your photo on it", allow_label_click: true
@@ -87,7 +87,7 @@ RSpec.feature "When user visits document selection page" do
 
     visit "/select-documents"
     expect_reporter_to_receive(
-      evidence: %I(has_driving_license has_credit_card device_type_other),
+      evidence: %i(has_driving_license has_credit_card device_type_other),
       attempts: 3,
     )
     check "Your current driving licence, full or provisional, with your photo on it", allow_label_click: true
@@ -98,7 +98,7 @@ RSpec.feature "When user visits document selection page" do
 
     visit "/select-documents"
     expect_reporter_to_receive(
-      evidence: %I(has_valid_passport has_driving_license has_credit_card device_type_other),
+      evidence: %i(has_valid_passport has_driving_license has_credit_card device_type_other),
       attempts: 4,
     )
     check "Your current driving licence, full or provisional, with your photo on it", allow_label_click: true

--- a/spec/javascripts/select_documents_variant_c_spec.js
+++ b/spec/javascripts/select_documents_variant_c_spec.js
@@ -13,32 +13,17 @@ describe('Analytics for select document variant c', function () {
   };
 
   describe('page with disclosure', function() {
-    var htmlWithMarkup = '<details id="progressive_disclosure" class="govuk-details govuk-!-padding-top-6" data-module="govuk-details">' +
-                          '<summary piwik_event_tracking="progressive_disclosure" class="govuk-details__summary">' +
-                            '<span class="govuk-details__summary-text">What GOV.UK Verify uses these for</span>' +
-                          '</summary>' +
-                          '<div class="govuk-details__text">' +
-                            '<p class="govuk-body">' +
-                            'The companies can check your passport and driving licence against official records.' +
-                            'They can also confirm your personal details by accessing information like credit records.' +
-                            "This will help them be sure it's really you." +
-                            '</p>' +
-                            '<p class="govuk-body">' +
-                            'If you only have one photo identity document (ID), you will also need to download a free app and take' +
-                            'pictures of it. This will prove that the ID is yours.' +
-                            '</p>' +
-                            '<p class="govuk-body">' +
-                            'The companies will only use your credit or debit card details as more evidence of your identity.' +
-                            'They cannot see your transactions and cannot charge your account.' +
-                            '</p>' +
-                          '</div>' +
-                        '</details>';
-
       beforeEach(function () {
-          setUp(htmlWithMarkup);
+          setUp('<details id="progressive_disclosure" class="govuk-details govuk-!-padding-top-6" data-module="govuk-details">' +
+          '<summary piwik_event_tracking="progressive_disclosure" class="govuk-details__summary">' +
+            '<span class="govuk-details__summary-text">What GOV.UK Verify uses these for</span>' +
+          '</summary>' +
+          '<div class="govuk-details__text">' +
+          '</div>' +
+        '</details>');
       });
 
-      it('should report to Piwik when evidence is selected', function () {
+      it('should report to Piwik when disclosure link is selected', function () {
         $('#progressive_disclosure').click();
         expect(_paq.push).toHaveBeenCalled();
 

--- a/spec/javascripts/select_documents_variant_c_spec.js
+++ b/spec/javascripts/select_documents_variant_c_spec.js
@@ -1,0 +1,48 @@
+describe('Analytics for select document variant c', function () {
+  function setUp(html) {
+      spyOn(_paq, 'push');
+      setFixtures(html);
+      window.GOVUK.selectDocumentsVariantC.init();
+  }
+  function expectLatestEntryInPiwikQueueToMatch(category, action, name) {
+      var latestEntryInPiwikQueue = _paq.push.calls.mostRecent().args[0];
+      expect(latestEntryInPiwikQueue[0]).toBe('trackEvent');
+      expect(latestEntryInPiwikQueue[1]).toBe(category);
+      expect(latestEntryInPiwikQueue[2]).toBe(action);
+      expect(latestEntryInPiwikQueue[3]).toBe(name);
+  };
+
+  describe('page with disclosure', function() {
+    var htmlWithMarkup = '<details id="progressive_disclosure" class="govuk-details govuk-!-padding-top-6" data-module="govuk-details">' +
+                          '<summary piwik_event_tracking="progressive_disclosure" class="govuk-details__summary">' +
+                            '<span class="govuk-details__summary-text">What GOV.UK Verify uses these for</span>' +
+                          '</summary>' +
+                          '<div class="govuk-details__text">' +
+                            '<p class="govuk-body">' +
+                            'The companies can check your passport and driving licence against official records.' +
+                            'They can also confirm your personal details by accessing information like credit records.' +
+                            "This will help them be sure it's really you." +
+                            '</p>' +
+                            '<p class="govuk-body">' +
+                            'If you only have one photo identity document (ID), you will also need to download a free app and take' +
+                            'pictures of it. This will prove that the ID is yours.' +
+                            '</p>' +
+                            '<p class="govuk-body">' +
+                            'The companies will only use your credit or debit card details as more evidence of your identity.' +
+                            'They cannot see your transactions and cannot charge your account.' +
+                            '</p>' +
+                          '</div>' +
+                        '</details>';
+
+      beforeEach(function () {
+          setUp(htmlWithMarkup);
+      });
+
+      it('should report to Piwik when evidence is selected', function () {
+        $('#progressive_disclosure').click();
+        expect(_paq.push).toHaveBeenCalled();
+
+        expectLatestEntryInPiwikQueueToMatch('Engagement','Disclosure link selected','Opened');
+      });
+  });
+});

--- a/spec/models/analytics/federation_reporter_spec.rb
+++ b/spec/models/analytics/federation_reporter_spec.rb
@@ -362,6 +362,27 @@ module Analytics
       end
     end
 
+    describe "#report_user_evidence_attempt" do
+      attempt_number = 1
+      evidence_list = %w(passport credit_card)
+
+      it "should report attempt correctly when idp selected if first registration" do
+        expect(analytics_reporter).to receive(:report_action)
+          .with(
+            request,
+            "EVIDENCE_ATTEMPT_#{attempt_number} | CREDIT_CARD_PASSPORT |",
+            1 => %w(RP description),
+            2 => %w(LOA_REQUESTED LEVEL_2),
+          )
+        federation_reporter.report_user_evidence_attempt(
+          current_transaction: current_transaction,
+          request: request,
+          attempt_number: attempt_number,
+          evidence_list: evidence_list,
+        )
+      end
+    end
+
     describe "#report_sign_in_journey_ignored" do
       it "should report that the sign in hint was ignored" do
         transaction_simple_id = "test-rp"


### PR DESCRIPTION
see https://govukverify.atlassian.net/browse/HUB-235
**What**

We need to measure a bunch of things as part of the short hub ABC test. Some of those things will require additional tracking.

The user will be asked to select what evidence they have, and may return to that page for several attempts. For example, if the user does not select enough evidence the first time, they get to an ‘other ways’ page, but may use their back button / click “try again” and have another attempt, in which they confess to having a passport.

We think we want to be able to track (in priority order):

evidence selection on submission of the new evidence checkbox page (/select-documents) - what combinations of evidence do users select on each attempt.  (If each combination of ticked evidence becomes a virtual page title e.g. maybe EVIDENCE_CREDIT_CARD_PASSPORT, and with each virtual page view we record a custom variable indicating the “attempt” e.g. ATTEMPT_1, we think we can get useful figures showing how this new page is used.)

use of the progressive disclosure link 'What GOV.UK Verify uses these for' on the new evidence checkbox page (/select-documents)  – again a virtual page view for this.

**Why**

We need to know if users select more evidence when prompted to do so, on subsequent attempts.