### PR TITLE
HUB-545: Rename registration flow methods for more clarity and consistency

### DIFF
--- a/app/controllers/about_loa1_controller.rb
+++ b/app/controllers/about_loa1_controller.rb
@@ -11,7 +11,7 @@ class AboutLoa1Controller < ApplicationController
   end
 
   def certified_companies
-    @loa1_idps = IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate_collection(current_identity_providers_for_loa)
+    @loa1_idps = IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate_collection(current_available_identity_providers_for_registration)
     render 'about/certified_companies_LOA1'
   end
 

--- a/app/controllers/about_loa2_controller.rb
+++ b/app/controllers/about_loa2_controller.rb
@@ -11,7 +11,7 @@ class AboutLoa2Controller < ApplicationController
   end
 
   def certified_companies
-    @identity_providers = IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate_collection(current_identity_providers_for_loa)
+    @identity_providers = IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate_collection(current_available_identity_providers_for_registration)
     render 'about/certified_companies_LOA2'
   end
 

--- a/app/controllers/choose_a_certified_company_about.rb
+++ b/app/controllers/choose_a_certified_company_about.rb
@@ -5,10 +5,10 @@ module ChooseACertifiedCompanyAbout
 
   def about
     simple_id = params[:company]
-    matching_idp = current_identity_providers_for_loa.detect { |idp| idp.simple_id == simple_id }
+    matching_idp = current_available_identity_providers_for_registration.detect { |idp| idp.simple_id == simple_id }
     @idp = IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate(matching_idp)
     if @idp.viewable?
-      @recommended = IDP_RECOMMENDATION_ENGINE.recommended?(@idp, current_identity_providers_for_loa, selected_evidence, current_transaction_simple_id)
+      @recommended = IDP_RECOMMENDATION_ENGINE.recommended?(@idp, current_available_identity_providers_for_registration, selected_evidence, current_transaction_simple_id)
       render 'choose_a_certified_company/about'
     else
       render 'errors/404', status: 404

--- a/app/controllers/choose_a_certified_company_loa1_controller.rb
+++ b/app/controllers/choose_a_certified_company_loa1_controller.rb
@@ -6,7 +6,7 @@ class ChooseACertifiedCompanyLoa1Controller < ApplicationController
   skip_before_action :render_cross_gov_ga, only: %i{about}
 
   def index
-    @recommended_idps = IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate_collection(current_identity_providers_for_loa)
+    @recommended_idps = IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate_collection(current_available_identity_providers_for_registration)
     @recommended_idps = order_with_unavailable_last(@recommended_idps)
     FEDERATION_REPORTER.report_number_of_idps_recommended(current_transaction, request, @recommended_idps.length)
     render 'choose_a_certified_company/choose_a_certified_company_LOA1'
@@ -15,7 +15,7 @@ class ChooseACertifiedCompanyLoa1Controller < ApplicationController
   def select_idp
     if params[:entity_id].present?
       selected_answer_store.store_selected_answers('interstitial', {})
-      select_viewable_idp_for_loa(params.fetch('entity_id')) do |decorated_idp|
+      select_viewable_idp_for_registration(params.fetch('entity_id')) do |decorated_idp|
         session[:selected_idp_was_recommended] = true
         redirect_to warning_or_question_page(decorated_idp)
       end

--- a/app/controllers/choose_a_certified_company_loa2_controller.rb
+++ b/app/controllers/choose_a_certified_company_loa2_controller.rb
@@ -7,7 +7,7 @@ class ChooseACertifiedCompanyLoa2Controller < ApplicationController
 
   def index
     session[:selected_answers]&.delete('interstitial')
-    suggestions = recommendation_engine.get_suggested_idps_for_registration(current_identity_providers_for_loa, selected_evidence, current_transaction_simple_id)
+    suggestions = recommendation_engine.get_suggested_idps_for_registration(current_available_identity_providers_for_registration, selected_evidence, current_transaction_simple_id)
     @recommended_idps = IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate_collection(suggestions[:recommended])
     @recommended_idps = order_with_unavailable_last(@recommended_idps)
     @non_recommended_idps = IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate_collection(suggestions[:unlikely])
@@ -19,8 +19,8 @@ class ChooseACertifiedCompanyLoa2Controller < ApplicationController
 
   def select_idp
     if params[:entity_id].present?
-      select_viewable_idp_for_loa(params.fetch('entity_id')) do |decorated_idp|
-        session[:selected_idp_was_recommended] = recommendation_engine.recommended?(decorated_idp.identity_provider, current_identity_providers_for_loa, selected_evidence, current_transaction_simple_id)
+      select_viewable_idp_for_registration(params.fetch('entity_id')) do |decorated_idp|
+        session[:selected_idp_was_recommended] = recommendation_engine.recommended?(decorated_idp.identity_provider, current_available_identity_providers_for_registration, selected_evidence, current_transaction_simple_id)
         redirect_to warning_or_question_page(decorated_idp)
       end
     else

--- a/app/controllers/choose_a_certified_company_loa2_variant_c_controller.rb
+++ b/app/controllers/choose_a_certified_company_loa2_variant_c_controller.rb
@@ -29,7 +29,7 @@ class ChooseACertifiedCompanyLoa2VariantCController < RedirectToIdpWarningContro
 
   def select_idp
     if params[:entity_id].present?
-      select_viewable_idp_for_loa(params.fetch('entity_id')) do |decorated_idp|
+      select_viewable_idp_for_registration(params.fetch('entity_id')) do |decorated_idp|
         session[:selected_idp_was_recommended] = recommendation_engine.recommended?(decorated_idp.identity_provider, current_identity_providers_for_loa_by_variant('c'), selected_evidence, current_transaction_simple_id)
         # TODO - do the spinny thing page
         do_redirect(decorated_idp)

--- a/app/controllers/confirm_your_identity_controller.rb
+++ b/app/controllers/confirm_your_identity_controller.rb
@@ -12,7 +12,7 @@ class ConfirmYourIdentityController < ApplicationController
       cookie_error('missing verify-front-journey-hint')
     else
       @transaction_name = current_transaction.name
-      @identity_providers = journey_hint_entity_id.nil? ? [] : retrieve_decorated_singleton_idp_array_by_entity_id(current_identity_providers_for_loa, journey_hint_entity_id)
+      @identity_providers = journey_hint_entity_id.nil? ? [] : retrieve_decorated_singleton_idp_array_by_entity_id(current_available_identity_providers_for_registration, journey_hint_entity_id)
 
       if @identity_providers.empty?
         cookie_error("invalid verify-front-journey-hint entity-id #{journey_hint_entity_id}")

--- a/app/controllers/partials/variant_partial_controller.rb
+++ b/app/controllers/partials/variant_partial_controller.rb
@@ -1,6 +1,6 @@
 module VariantPartialController
   def current_identity_providers_for_loa_by_variant(variant)
-    current_identity_providers_for_loa.select { |idp| ABC_VARIANTS_CONFIG["variant_#{variant}_idp_set"].include?(idp.simple_id) }
+    current_available_identity_providers_for_registration.select { |idp| ABC_VARIANTS_CONFIG["variant_#{variant}_idp_set"].include?(idp.simple_id) }
   end
 
   def segment_advice(segments)

--- a/app/controllers/partials/viewable_idp_partial_controller.rb
+++ b/app/controllers/partials/viewable_idp_partial_controller.rb
@@ -6,8 +6,8 @@ module ViewableIdpPartialController
     end
   end
 
-  def select_viewable_idp_for_loa(entity_id)
-    for_viewable_idp(entity_id, current_identity_providers_for_loa) do |decorated_idp|
+  def select_viewable_idp_for_registration(entity_id)
+    for_viewable_idp(entity_id, current_available_identity_providers_for_registration) do |decorated_idp|
       store_selected_idp_for_session(decorated_idp.identity_provider)
       yield decorated_idp
     end
@@ -32,8 +32,8 @@ module ViewableIdpPartialController
     end
   end
 
-  def current_identity_providers_for_loa
-    CONFIG_PROXY.get_idp_list_for_loa(session[:transaction_entity_id], session[:requested_loa]).idps
+  def current_available_identity_providers_for_registration
+    CONFIG_PROXY.get_available_idp_list_for_registration(session[:transaction_entity_id], session[:requested_loa]).idps
   end
 
   def current_identity_providers_for_sign_in

--- a/app/controllers/redirect_to_idp_warning_controller.rb
+++ b/app/controllers/redirect_to_idp_warning_controller.rb
@@ -92,6 +92,6 @@ private
   end
 
   def idp_is_providing_registrations?(idp)
-    current_identity_providers_for_loa.any? { |check_idp| check_idp.simple_id == idp.simple_id }
+    current_available_identity_providers_for_registration.any? { |check_idp| check_idp.simple_id == idp.simple_id }
   end
 end

--- a/app/controllers/select_phone_controller.rb
+++ b/app/controllers/select_phone_controller.rb
@@ -11,7 +11,7 @@ class SelectPhoneController < ApplicationController
     @form = SelectPhoneForm.new(params['select_phone_form'] || {})
     if @form.valid?
       selected_answer_store.store_selected_answers('phone', @form.selected_answers)
-      idps_available = IDP_RECOMMENDATION_ENGINE.any?(current_identity_providers_for_loa, selected_evidence, current_transaction_simple_id)
+      idps_available = IDP_RECOMMENDATION_ENGINE.any?(current_available_identity_providers_for_registration, selected_evidence, current_transaction_simple_id)
       redirect_to idps_available ? choose_a_certified_company_path : verify_will_not_work_for_you_path
     else
       flash.now[:errors] = @form.errors.full_messages.join(', ')

--- a/app/models/config_endpoints.rb
+++ b/app/models/config_endpoints.rb
@@ -1,7 +1,7 @@
 module ConfigEndpoints
   PATH = '/config'.freeze
   PATH_PREFIX = Pathname(PATH)
-  IDP_LIST_SUFFIX = 'idps/idp-list/%<transaction_name>s/%<loa>s'.freeze
+  IDP_LIST_REGISTRATION_SUFFIX = 'idps/idp-list-for-registration/%<transaction_name>s/%<loa>s'.freeze
   IDP_LIST_SIGN_IN_SUFFIX = 'idps/idp-list-for-sign-in/%<transaction_name>s'.freeze
   IDP_LIST_SINGLE_IDP_SUFFIX = 'idps/idp-list-for-single-idp/%<transaction_name>s'.freeze
   DISPLAY_DATA_SUFFIX = 'transactions/%<transaction_entity_id>s/display-data'.freeze
@@ -9,8 +9,8 @@ module ConfigEndpoints
   TRANSACTIONS_SUFFIX = 'transactions/enabled'.freeze
   TRANSACTIONS_FOR_SINGLE_IDP_LIST_SUFFIX = 'transactions/single-idp-enabled-list'.freeze
 
-  def idp_list_for_loa_endpoint(transaction_id, loa)
-    PATH_PREFIX.join(IDP_LIST_SUFFIX % { transaction_name: CGI.escape(transaction_id), loa: CGI.escape(loa) }).to_s
+  def idp_list_for_registration_endpoint(transaction_id, loa)
+    PATH_PREFIX.join(IDP_LIST_REGISTRATION_SUFFIX % { transaction_name: CGI.escape(transaction_id), loa: CGI.escape(loa) }).to_s
   end
 
   def idp_list_for_sign_in_endpoint(transaction_id)

--- a/app/models/config_proxy.rb
+++ b/app/models/config_proxy.rb
@@ -35,8 +35,8 @@ class ConfigProxy
     @api_client.get(transactions_for_single_idp_list_endpoint)
   end
 
-  def get_idp_list_for_loa(transaction_id, loa)
-    response = @api_client.get(idp_list_for_loa_endpoint(transaction_id, loa))
+  def get_available_idp_list_for_registration(transaction_id, loa)
+    response = @api_client.get(idp_list_for_registration_endpoint(transaction_id, loa))
     IdpListResponse.validated_response(response)
   end
 

--- a/config/initializers/00_configuration.rb
+++ b/config/initializers/00_configuration.rb
@@ -28,7 +28,7 @@ CONFIG = Configuration.load! do
   option_int 'read_timeout', 'READ_TIMEOUT', default: 60
   option_int 'connect_timeout', 'CONNECT_TIMEOUT', default: 4
 
-  option_int 'hide_idps_disconnecting_for_registration_minutes_before', 'HIDE_IDPS_DISCONNECTING_FOR_REGISTRATION_MINUTES_BEFORE', default: 15
+  option_int 'hide_idps_disconnecting_for_registration_minutes_before', 'HIDE_IDPS_DISCONNECTING_FOR_REGISTRATION_MINUTES_BEFORE', default: 30
 
   option_string 'rules_directory', 'RULES_DIRECTORY', default: "#{FED_CONFIG_DIR}/idp-rules/"
   option_string 'segment_definitions', 'SEGMENT_DEFINITIONS', default: "#{FED_CONFIG_DIR}/segment_definitions.yml"

--- a/spec/api_test_helper.rb
+++ b/spec/api_test_helper.rb
@@ -336,8 +336,8 @@ module ApiTestHelper
         .to_return(body: an_error_response(code).to_json, status: 500)
   end
 
-  def stub_api_idp_list_for_loa(idps = default_idps, loa = 'LEVEL_2')
-    stub_request(:get, config_api_uri(idp_list_for_loa_endpoint(default_transaction_entity_id, loa))).to_return(body: idps.to_json)
+  def stub_api_idp_list_for_registration(idps = default_idps, loa = 'LEVEL_2')
+    stub_request(:get, config_api_uri(idp_list_for_registration_endpoint(default_transaction_entity_id, loa))).to_return(body: idps.to_json)
   end
 
   def stub_api_idp_list_for_sign_in(idps = default_idps)
@@ -367,7 +367,7 @@ module ApiTestHelper
       { 'simpleId' => 'stub-idp-two', 'entityId' => 'other-entity-id', 'levelsOfAssurance' => %w(LEVEL_2) },
       { 'simpleId' => 'stub-idp-three', 'entityId' => 'a-different-entity-id', 'levelsOfAssurance' => %w(LEVEL_2) },
     ]
-    stub_api_idp_list_for_loa(idps)
+    stub_api_idp_list_for_registration(idps)
   end
 
   def stub_hub_config_healthcheck(status: 200)

--- a/spec/controllers/about_loa1_controller_spec.rb
+++ b/spec/controllers/about_loa1_controller_spec.rb
@@ -6,7 +6,7 @@ describe AboutLoa1Controller do
   let(:identity_provider_display_decorator) { double(:IdentityProviderDisplayDecorator) }
 
   before(:each) do
-    stub_api_idp_list_for_loa
+    stub_api_idp_list_for_registration
   end
 
   context 'GET about#certified_companies' do
@@ -14,7 +14,7 @@ describe AboutLoa1Controller do
 
     before(:each) do
       stub_const('IDENTITY_PROVIDER_DISPLAY_DECORATOR', identity_provider_display_decorator)
-      stub_api_idp_list_for_loa(default_idps, 'LEVEL_1')
+      stub_api_idp_list_for_registration(default_idps, 'LEVEL_1')
     end
 
     it 'renders the certified companies LOA1 template when LEVEL_1 is the requested LOA' do

--- a/spec/controllers/about_loa2_controller_spec.rb
+++ b/spec/controllers/about_loa2_controller_spec.rb
@@ -8,7 +8,7 @@ describe AboutLoa2Controller do
 
   before(:each) do
     stub_request(:get, CONFIG.config_api_host + '/config/transactions/enabled')
-    stub_api_idp_list_for_loa
+    stub_api_idp_list_for_registration
   end
 
   context 'GET about#certified_companies' do

--- a/spec/controllers/about_loa2_variant_c_controller_spec.rb
+++ b/spec/controllers/about_loa2_variant_c_controller_spec.rb
@@ -11,7 +11,7 @@ describe AboutLoa2VariantCController do
     experiment = 'short_hub_2019_q3-preview'
     variant = 'variant_c_2_idp_short_hub'
     set_session_and_cookies_with_loa_and_variant('LEVEL_2', experiment, variant)
-    stub_api_idp_list_for_loa
+    stub_api_idp_list_for_registration
   end
 
   context 'GET about' do

--- a/spec/controllers/choose_a_certified_company_loa1_controller_spec.rb
+++ b/spec/controllers/choose_a_certified_company_loa1_controller_spec.rb
@@ -30,7 +30,7 @@ describe ChooseACertifiedCompanyLoa1Controller do
 
   context '#index' do
     before :each do
-      stub_api_idp_list_for_loa([stub_idp_loa1, stub_idp_loa1_with_interstitial], 'LEVEL_1')
+      stub_api_idp_list_for_registration([stub_idp_loa1, stub_idp_loa1_with_interstitial], 'LEVEL_1')
     end
 
     it 'renders IDP list' do
@@ -51,7 +51,7 @@ describe ChooseACertifiedCompanyLoa1Controller do
   context '#select_idp' do
     before :each do
       set_session_and_cookies_with_loa('LEVEL_1')
-      stub_api_idp_list_for_loa([stub_idp_loa1, stub_idp_loa1_with_interstitial], 'LEVEL_1')
+      stub_api_idp_list_for_registration([stub_idp_loa1, stub_idp_loa1_with_interstitial], 'LEVEL_1')
     end
 
     it 'resets interstitial answer to no value when IDP is selected' do
@@ -74,7 +74,7 @@ describe ChooseACertifiedCompanyLoa1Controller do
     end
 
     it 'redirects to IDP warning page by default' do
-      stub_api_idp_list_for_loa([stub_idp_no_interstitial], 'LEVEL_1')
+      stub_api_idp_list_for_registration([stub_idp_no_interstitial], 'LEVEL_1')
       post :select_idp, params: { locale: 'en', entity_id: 'http://idcorp-two.com' }
 
       expect(subject).to redirect_to redirect_to_idp_warning_path
@@ -103,7 +103,7 @@ describe ChooseACertifiedCompanyLoa1Controller do
   context '#about' do
     it 'returns 404 page if no display data exists for IDP' do
       set_session_and_cookies_with_loa('LEVEL_1')
-      stub_api_idp_list_for_loa([stub_idp_loa1], 'LEVEL_1')
+      stub_api_idp_list_for_registration([stub_idp_loa1], 'LEVEL_1')
 
       get :about, params: { locale: 'en', company: 'unknown-idp' }
 

--- a/spec/controllers/choose_a_certified_company_loa2_controller_spec.rb
+++ b/spec/controllers/choose_a_certified_company_loa2_controller_spec.rb
@@ -23,7 +23,7 @@ describe ChooseACertifiedCompanyLoa2Controller do
   context '#index' do
     it 'renders the certified companies LOA2 template when LEVEL_2 is the requested LOA' do
       set_session_and_cookies_with_loa('LEVEL_2')
-      stub_api_idp_list_for_loa([stub_idp_loa1, stub_idp_one_doc])
+      stub_api_idp_list_for_registration([stub_idp_loa1, stub_idp_one_doc])
       session[:selected_answers] = {
         'documents' => { 'driving_licence' => true, 'mobile_phone' => true },
         'device_type' => { 'device_type_other' => true }
@@ -42,7 +42,7 @@ describe ChooseACertifiedCompanyLoa2Controller do
 
     it 'removes interstitial answer when IDP picker page is rendered' do
       set_session_and_cookies_with_loa('LEVEL_2')
-      stub_api_idp_list_for_loa([stub_idp_loa1, stub_idp_one_doc])
+      stub_api_idp_list_for_registration([stub_idp_loa1, stub_idp_one_doc])
       session[:selected_answers] = {
         'documents' => { 'driving_licence' => true, 'mobile_phone' => true },
         'device_type' => { 'device_type_other' => true },
@@ -59,7 +59,7 @@ describe ChooseACertifiedCompanyLoa2Controller do
   context '#select_idp' do
     before :each do
       set_session_and_cookies_with_loa('LEVEL_2')
-      stub_api_idp_list_for_loa([stub_idp_loa1, stub_idp_one_doc])
+      stub_api_idp_list_for_registration([stub_idp_loa1, stub_idp_one_doc])
     end
 
     it 'sets selected IDP in user session' do
@@ -117,7 +117,7 @@ describe ChooseACertifiedCompanyLoa2Controller do
   context '#about' do
     it 'returns 404 page if no display data exists for IDP' do
       set_session_and_cookies_with_loa('LEVEL_2')
-      stub_api_idp_list_for_loa([stub_idp_loa1, stub_idp_one_doc])
+      stub_api_idp_list_for_registration([stub_idp_loa1, stub_idp_one_doc])
 
       get :about, params: { locale: 'en', company: 'unknown-idp' }
 

--- a/spec/controllers/choose_a_certified_company_loa2_variant_c_controller_spec.rb
+++ b/spec/controllers/choose_a_certified_company_loa2_variant_c_controller_spec.rb
@@ -34,7 +34,7 @@ describe ChooseACertifiedCompanyLoa2VariantCController do
     variant = 'variant_c_2_idp_short_hub'
     stub_api_select_idp
     set_session_and_cookies_with_loa_and_variant('LEVEL_2', experiment, variant)
-    stub_api_idp_list_for_loa([stub_idp_one, stub_idp_three])
+    stub_api_idp_list_for_registration([stub_idp_one, stub_idp_three])
   end
 
   context '#index' do

--- a/spec/controllers/other_identity_documents_controller_spec.rb
+++ b/spec/controllers/other_identity_documents_controller_spec.rb
@@ -6,7 +6,7 @@ require 'piwik_test_helper'
 describe OtherIdentityDocumentsController do
   before(:each) do
     set_session_and_cookies_with_loa('LEVEL_1')
-    stub_api_idp_list_for_loa
+    stub_api_idp_list_for_registration
   end
 
   it 'should go to select phone path and set selected answers when user has other identity documents' do

--- a/spec/controllers/redirect_to_idp_warning_controller_spec.rb
+++ b/spec/controllers/redirect_to_idp_warning_controller_spec.rb
@@ -6,7 +6,7 @@ require 'piwik_test_helper'
 describe RedirectToIdpWarningController do
   before :each do
     stub_api_select_idp
-    stub_api_idp_list_for_loa
+    stub_api_idp_list_for_registration
     stub_request(:get, INTERNAL_PIWIK.url).with(query: hash_including({}))
     set_session_and_cookies_with_loa('LEVEL_2')
     session[:selected_idp_was_recommended] = [true, false].sample
@@ -39,7 +39,7 @@ describe RedirectToIdpWarningController do
             'levelsOfAssurance' => %w(LEVEL_2),
         },
       ]
-      stub_api_idp_list_for_loa(stub_idp)
+      stub_api_idp_list_for_registration(stub_idp)
       set_selected_idp(
         'simple_id' => 'stub-idp-two',
         'entity_id' => 'http://idcorp.com',

--- a/spec/controllers/select_documents_variant_c_controller_spec.rb
+++ b/spec/controllers/select_documents_variant_c_controller_spec.rb
@@ -11,9 +11,9 @@ describe SelectDocumentsVariantCController do
     experiment = 'short_hub_2019_q3-preview'
     variant = 'variant_c_2_idp_short_hub'
     set_session_and_cookies_with_loa_and_variant('LEVEL_2', experiment, variant)
-    stub_api_idp_list_for_loa([{ 'simpleId' => 'stub-idp-one',
-      'entityId' => 'http://idcorp.com',
-      'levelsOfAssurance' => %w(LEVEL_2) }], 'LEVEL_2')
+    stub_api_idp_list_for_registration([{ 'simpleId' => 'stub-idp-one',
+                                          'entityId' => 'http://idcorp.com',
+                                          'levelsOfAssurance' => %w(LEVEL_2) }], 'LEVEL_2')
     session[:selected_answers] = {
       'device_type' => { device_type_other: true }
     }

--- a/spec/controllers/select_phone_controller_spec.rb
+++ b/spec/controllers/select_phone_controller_spec.rb
@@ -20,21 +20,21 @@ describe SelectPhoneController do
     subject { post :select_phone, params: { locale: 'en', select_phone_form: valid_phone_evidence } }
 
     it 'redirects to choose certified company page when eligible IDPs exist' do
-      stub_api_idp_list_for_loa([{ 'simpleId' => 'stub-idp-one',
-                                   'entityId' => 'http://idcorp.com',
-                                   'levelsOfAssurance' => %w(LEVEL_2) }], 'LEVEL_2')
+      stub_api_idp_list_for_registration([{ 'simpleId' => 'stub-idp-one',
+                                            'entityId' => 'http://idcorp.com',
+                                            'levelsOfAssurance' => %w(LEVEL_2) }], 'LEVEL_2')
 
       expect(subject).to redirect_to('/choose-a-certified-company')
     end
 
     it 'redirects to no mobile phone page when no eligible IDPs' do
-      stub_api_idp_list_for_loa([], 'LEVEL_2')
+      stub_api_idp_list_for_registration([], 'LEVEL_2')
 
       expect(subject).to redirect_to('/verify-will-not-work-for-you')
     end
 
     it 'captures form values in session cookie' do
-      stub_api_idp_list_for_loa(default_idps, 'LEVEL_2')
+      stub_api_idp_list_for_registration(default_idps, 'LEVEL_2')
       expect(subject).to redirect_to('/choose-a-certified-company')
       expect(session[:selected_answers]['phone']).to eq(mobile_phone: true, smart_phone: true)
     end

--- a/spec/features/idp_selections_reported_to_piwik_spec.rb
+++ b/spec/features/idp_selections_reported_to_piwik_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'When the user selects an IDP' do
 
   before(:each) do
     set_session_and_session_cookies!
-    stub_api_idp_list_for_loa
+    stub_api_idp_list_for_registration
     stub_transactions_list
     stub_session_idp_authn_request(originating_ip, location, false)
     stub_idp_select_request(idp_1_entity_id)

--- a/spec/features/localisation_set_from_different_sources_spec.rb
+++ b/spec/features/localisation_set_from_different_sources_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'locale is set based on multiple sources', type: :feature do
   }
   before(:each) do
     set_session_and_session_cookies!
-    stub_api_idp_list_for_loa
+    stub_api_idp_list_for_registration
   end
 
   def set_locale_cookie_to(locale)

--- a/spec/features/server_sends_analytics_spec.rb
+++ b/spec/features/server_sends_analytics_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'When a page with a virtual page view is visited' do
   it 'sends a virtual page view to analytics' do
     page.set_rack_session(transaction_simple_id: 'test-rp')
     set_session_and_session_cookies!
-    stub_api_idp_list_for_loa
+    stub_api_idp_list_for_registration
 
 
     Capybara.current_session.driver.header('User-Agent', 'my user agent')

--- a/spec/features/user_gets_soft_session_timeout_page_spec.rb
+++ b/spec/features/user_gets_soft_session_timeout_page_spec.rb
@@ -4,7 +4,7 @@ require 'api_test_helper'
 RSpec.describe 'When the user visits a page that triggers an API call when the session has soft timed out' do
   before(:each) do
     set_session_and_session_cookies!
-    stub_api_idp_list_for_loa
+    stub_api_idp_list_for_registration
   end
 
   it 'should render the soft session timeout page when SESSION_TIMEOUT received from the API and have a correct link' do

--- a/spec/features/user_sends_authn_response_spec.rb
+++ b/spec/features/user_sends_authn_response_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'User returns from an IDP with an AuthnResponse' do
 
   before :each do
     set_session_and_session_cookies!
-    stub_api_idp_list_for_loa
+    stub_api_idp_list_for_registration
   end
 
   it 'will show the something went wrong page when relay state and session id mismatch' do

--- a/spec/features/user_submits_feedback_page_spec.rb
+++ b/spec/features/user_submits_feedback_page_spec.rb
@@ -45,7 +45,7 @@ RSpec.feature 'When the user submits the feedback page' do
 
     it 'when session has timed out should show invalid session link' do
       set_session_and_session_cookies!
-      stub_api_idp_list_for_loa
+      stub_api_idp_list_for_registration
 
       expired_start_time = 2.hours.ago.to_i * 1000
       page.set_rack_session(start_time: expired_start_time)
@@ -87,7 +87,7 @@ RSpec.feature 'When the user submits the feedback page' do
   context 'user session valid' do
     before :each do
       set_session_and_session_cookies!
-      stub_api_idp_list_for_loa
+      stub_api_idp_list_for_registration
     end
 
     it 'should show user link back to start page' do

--- a/spec/features/user_submits_start_page_form_spec.rb
+++ b/spec/features/user_submits_start_page_form_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'when user submits start page form' do
   end
 
   it 'will display about page when user chooses yes (registration)' do
-    stub_api_idp_list_for_loa
+    stub_api_idp_list_for_registration
     stub_request(:get, INTERNAL_PIWIK.url)
     visit '/start'
     choose('start_form_selection_true')
@@ -48,7 +48,7 @@ RSpec.describe 'when user submits start page form' do
   end
 
   it 'will prompt for an answer if no answer is given' do
-    stub_api_idp_list_for_loa
+    stub_api_idp_list_for_registration
     visit '/start'
     click_button('next-button')
     expect(page).to have_content t('hub.start.error_message')

--- a/spec/features/user_visits_about_certified_companies_page_spec.rb
+++ b/spec/features/user_visits_about_certified_companies_page_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'When the user visits the about certified companies page' do
   context 'loa2' do
     before(:each) do
       stub_transactions_list
-      stub_api_idp_list_for_loa(default_idps, 'LEVEL_2')
+      stub_api_idp_list_for_registration(default_idps, 'LEVEL_2')
       set_session_and_session_cookies!
     end
 
@@ -51,7 +51,7 @@ RSpec.describe 'When the user visits the about certified companies page' do
   context 'loa1' do
     before(:each) do
       stub_transactions_list
-      stub_api_idp_list_for_loa(default_idps, 'LEVEL_1')
+      stub_api_idp_list_for_registration(default_idps, 'LEVEL_1')
       set_session_and_session_cookies!
       set_loa_in_session('LEVEL_1')
     end

--- a/spec/features/user_visits_about_choosing_a_company_page_spec.rb
+++ b/spec/features/user_visits_about_choosing_a_company_page_spec.rb
@@ -4,7 +4,7 @@ require 'cookie_names'
 RSpec.describe 'When the user visits the about choosing a company page' do
   before(:each) do
     set_session_and_session_cookies!
-    stub_api_idp_list_for_loa
+    stub_api_idp_list_for_registration
   end
 
   it 'will include the appropriate feedback source' do

--- a/spec/features/user_visits_about_identity_accounts_page_spec.rb
+++ b/spec/features/user_visits_about_identity_accounts_page_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'When the user visits the about identity accounts page' do
   before(:each) do
     set_session_and_session_cookies!
     stub_transactions_list
-    stub_api_idp_list_for_loa(default_idps)
+    stub_api_idp_list_for_registration(default_idps)
   end
 
   it 'includes the appropriate feedback source' do
@@ -38,7 +38,7 @@ RSpec.describe 'When the user visits the about identity accounts page' do
   end
 
   it 'will go to choose a certified company page when start now is clicked if user on LOA1 journey' do
-    stub_api_idp_list_for_loa(default_idps, 'LEVEL_1')
+    stub_api_idp_list_for_registration(default_idps, 'LEVEL_1')
     page.set_rack_session(requested_loa: 'LEVEL_1')
     visit '/about-identity-accounts'
     click_link('Start now')

--- a/spec/features/user_visits_about_page_spec.rb
+++ b/spec/features/user_visits_about_page_spec.rb
@@ -6,7 +6,7 @@ require 'api_test_helper'
 RSpec.describe 'When the user visits the about page' do
   before(:each) do
     set_session_and_session_cookies!
-    stub_api_idp_list_for_loa
+    stub_api_idp_list_for_registration
   end
 
   context 'session cookie contains transaction id' do

--- a/spec/features/user_visits_about_page_variant_spec.rb
+++ b/spec/features/user_visits_about_page_variant_spec.rb
@@ -6,7 +6,7 @@ require 'api_test_helper'
 RSpec.describe 'When the user visits the about page' do
   context 'session cookie also contains variant c' do
     before(:each) do
-      stub_api_idp_list_for_loa
+      stub_api_idp_list_for_registration
       page.set_rack_session(transaction_simple_id: 'test-rp')
       experiment = { "short_hub_2019_q3-preview" => "short_hub_2019_q3-preview_variant_c_2_idp_short_hub" }
       set_session_and_ab_session_cookies!(experiment)

--- a/spec/features/user_visits_choose_a_certified_company_page_spec.rb
+++ b/spec/features/user_visits_choose_a_certified_company_page_spec.rb
@@ -4,7 +4,7 @@ require 'api_test_helper'
 describe 'When the user visits the choose a certified company page' do
   before(:each) do
     set_session_and_session_cookies!
-    stub_api_idp_list_for_loa(default_idps)
+    stub_api_idp_list_for_registration(default_idps)
   end
 
   context 'user has two docs and a mobile' do
@@ -21,10 +21,10 @@ describe 'When the user visits the choose a certified company page' do
     end
 
     it 'marks the unavailable IDP as unavailable' do
-      stub_api_idp_list_for_loa([{ 'simpleId' => 'stub-idp-one',
-                                   'entityId' => 'http://idcorp.com',
-                                   'levelsOfAssurance' => %w(LEVEL_2),
-                                   'temporarilyUnavailable' => true }])
+      stub_api_idp_list_for_registration([{ 'simpleId' => 'stub-idp-one',
+                                            'entityId' => 'http://idcorp.com',
+                                            'levelsOfAssurance' => %w(LEVEL_2),
+                                            'temporarilyUnavailable' => true }])
       visit '/choose-a-certified-company'
       expect(page).to have_content t('hub.certified_companies_unavailable.title', count: 1, company: 'IDCorp')
     end
@@ -82,7 +82,7 @@ describe 'When the user visits the choose a certified company page' do
 
   context 'user is from an LOA1 service' do
     before(:each) do
-      stub_api_idp_list_for_loa(default_idps, 'LEVEL_1')
+      stub_api_idp_list_for_registration(default_idps, 'LEVEL_1')
       page.set_rack_session(
         transaction_simple_id: 'test-rp',
         requested_loa: 'LEVEL_1',
@@ -105,10 +105,10 @@ describe 'When the user visits the choose a certified company page' do
     end
 
     it 'unavailable LEVEL_1 recommended IDPs are marked as unavailable' do
-      stub_api_idp_list_for_loa([{ 'simpleId' => 'stub-idp-one',
-                                   'entityId' => 'http://idcorp.com',
-                                   'levelsOfAssurance' => %w(LEVEL_1),
-                                   'temporarilyUnavailable' => true }], 'LEVEL_1')
+      stub_api_idp_list_for_registration([{ 'simpleId' => 'stub-idp-one',
+                                           'entityId' => 'http://idcorp.com',
+                                           'levelsOfAssurance' => %w(LEVEL_1),
+                                           'temporarilyUnavailable' => true }], 'LEVEL_1')
       visit '/choose-a-certified-company'
       expect(page).to have_content t('hub.certified_companies_unavailable.title', count: 1, company: 'IDCorp')
     end
@@ -198,7 +198,7 @@ describe 'When the user visits the choose a certified company page' do
   context 'Google Analytics elements are rendered correctly' do
     context 'when coming from an LOA2 service' do
       before :each do
-        stub_api_idp_list_for_loa(default_idps, 'LEVEL_2')
+        stub_api_idp_list_for_registration(default_idps, 'LEVEL_2')
         page.set_rack_session(
           transaction_simple_id: 'test-rp',
           requested_loa: 'LEVEL_2',
@@ -227,7 +227,7 @@ describe 'When the user visits the choose a certified company page' do
 
     context 'when coming from an LOA1 service' do
       before :each do
-        stub_api_idp_list_for_loa(default_idps, 'LEVEL_1')
+        stub_api_idp_list_for_registration(default_idps, 'LEVEL_1')
         page.set_rack_session(
           transaction_simple_id: 'test-rp',
           requested_loa: 'LEVEL_1',

--- a/spec/features/user_visits_choose_a_certified_company_variant_c_page_spec.rb
+++ b/spec/features/user_visits_choose_a_certified_company_variant_c_page_spec.rb
@@ -29,7 +29,7 @@ describe 'When the user visits the choose a certified company page' do
   before(:each) do
     experiment = { "short_hub_2019_q3-preview" => "short_hub_2019_q3-preview_variant_c_2_idp_short_hub" }
     set_session_and_ab_session_cookies!(experiment)
-    stub_api_idp_list_for_loa([stub_idp_one, stub_idp_three])
+    stub_api_idp_list_for_registration([stub_idp_one, stub_idp_three])
   end
 
   context 'user has two docs and a mobile' do
@@ -47,10 +47,10 @@ describe 'When the user visits the choose a certified company page' do
     end
 
     it 'marks the unavailable IDP as unavailable' do
-      stub_api_idp_list_for_loa([{ 'simpleId' => 'stub-idp-one',
-                                   'entityId' => 'http://idcorp.com',
-                                   'levelsOfAssurance' => %w(LEVEL_2),
-                                   'temporarilyUnavailable' => true }])
+      stub_api_idp_list_for_registration([{ 'simpleId' => 'stub-idp-one',
+                                            'entityId' => 'http://idcorp.com',
+                                            'levelsOfAssurance' => %w(LEVEL_2),
+                                            'temporarilyUnavailable' => true }])
       visit '/choose-a-certified-company'
       expect(page).to have_content t('hub.certified_companies_unavailable.title', count: 1, company: 'IDCorp')
     end
@@ -90,7 +90,7 @@ describe 'When the user visits the choose a certified company page' do
 
   context 'user is from an LOA1 service' do
     before(:each) do
-      stub_api_idp_list_for_loa(default_idps, 'LEVEL_1')
+      stub_api_idp_list_for_registration(default_idps, 'LEVEL_1')
       page.set_rack_session(
         transaction_simple_id: 'test-rp',
         requested_loa: 'LEVEL_1',
@@ -113,10 +113,10 @@ describe 'When the user visits the choose a certified company page' do
     end
 
     it 'unavailable LEVEL_1 recommended IDPs are marked as unavailable' do
-      stub_api_idp_list_for_loa([{ 'simpleId' => 'stub-idp-one',
-                                   'entityId' => 'http://idcorp.com',
-                                   'levelsOfAssurance' => %w(LEVEL_1),
-                                   'temporarilyUnavailable' => true }], 'LEVEL_1')
+      stub_api_idp_list_for_registration([{ 'simpleId' => 'stub-idp-one',
+                                            'entityId' => 'http://idcorp.com',
+                                            'levelsOfAssurance' => %w(LEVEL_1),
+                                            'temporarilyUnavailable' => true }], 'LEVEL_1')
       visit '/choose-a-certified-company'
       expect(page).to have_content t('hub.certified_companies_unavailable.title', count: 1, company: 'IDCorp')
     end
@@ -157,7 +157,7 @@ describe 'When the user visits the choose a certified company page' do
   context 'Google Analytics elements are rendered correctly' do
     context 'when coming from an LOA2 service' do
       before :each do
-        stub_api_idp_list_for_loa(default_idps, 'LEVEL_2')
+        stub_api_idp_list_for_registration(default_idps, 'LEVEL_2')
         page.set_rack_session(
           transaction_simple_id: 'test-rp',
           requested_loa: 'LEVEL_2',
@@ -185,7 +185,7 @@ describe 'When the user visits the choose a certified company page' do
 
     context 'when coming from an LOA1 service' do
       before :each do
-        stub_api_idp_list_for_loa(default_idps, 'LEVEL_1')
+        stub_api_idp_list_for_registration(default_idps, 'LEVEL_1')
         page.set_rack_session(
           transaction_simple_id: 'test-rp',
           requested_loa: 'LEVEL_1',

--- a/spec/features/user_visits_choose_a_country_page_spec.rb
+++ b/spec/features/user_visits_choose_a_country_page_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'When the user visits the choose a country page' do
   let(:originating_ip) { '<PRINCIPAL IP ADDRESS COULD NOT BE DETERMINED>' }
   before(:each) do
     set_session_and_session_cookies!
-    stub_api_idp_list_for_loa
+    stub_api_idp_list_for_registration
     stub_transactions_list
     stub_countries_list
   end

--- a/spec/features/user_visits_confirm_your_identity_page_spec.rb
+++ b/spec/features/user_visits_confirm_your_identity_page_spec.rb
@@ -9,7 +9,7 @@ end
 
 def set_up_session(idp_entity_id)
   stub_api_and_analytics(idp_location)
-  stub_api_idp_list_for_loa(default_idps, 'LEVEL_1')
+  stub_api_idp_list_for_registration(default_idps, 'LEVEL_1')
   set_session_and_session_cookies!
   set_journey_hint_cookie(idp_entity_id)
   page.set_rack_session(

--- a/spec/features/user_visits_confirmation_page_spec.rb
+++ b/spec/features/user_visits_confirmation_page_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'When user visits the confirmation page' do
     )
     set_selected_idp_in_session(entity_id: 'http://idcorp.com', simple_id: 'stub-idp-one')
     set_session_and_session_cookies!
-    stub_api_idp_list_for_loa
+    stub_api_idp_list_for_registration
   end
 
   it 'includes the appropriate feedback source, title and content' do

--- a/spec/features/user_visits_failed_registration_page_spec.rb
+++ b/spec/features/user_visits_failed_registration_page_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'When the user visits the failed registration page and' do
 
   before(:each) do
     set_session_and_session_cookies!
-    stub_api_idp_list_for_loa
+    stub_api_idp_list_for_registration
     set_selected_idp_in_session(entity_id: 'http://idcorp.com', simple_id: 'stub-idp-one')
   end
 

--- a/spec/features/user_visits_failed_sign_in_page_spec.rb
+++ b/spec/features/user_visits_failed_sign_in_page_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'When the user visits the failed sign in page' do
 
   context '#idp' do
     before(:each) do
-      stub_api_idp_list_for_loa
+      stub_api_idp_list_for_registration
       set_selected_idp_in_session(entity_id: 'http://idcorp.com', simple_id: 'stub-idp-one')
     end
 

--- a/spec/features/user_visits_forgot_company_page_spec.rb
+++ b/spec/features/user_visits_forgot_company_page_spec.rb
@@ -4,7 +4,7 @@ require 'api_test_helper'
 RSpec.describe 'When the user visits the forgot company page' do
   before(:each) do
     set_session_and_session_cookies!
-    stub_api_idp_list_for_loa
+    stub_api_idp_list_for_registration
   end
 
   it 'includes the expected content' do

--- a/spec/features/user_visits_redirect_to_idp_warning_page_spec.rb
+++ b/spec/features/user_visits_redirect_to_idp_warning_page_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe 'When the user visits the redirect to IDP warning page' do
   }
 
   before(:each) do
-    stub_api_idp_list_for_loa
+    stub_api_idp_list_for_registration
     session = default_session.merge(user_segments: ['test-segment'])
     set_session_and_session_cookies!(cookie_hash: create_cookie_hash_with_piwik_session, session: session)
   end

--- a/spec/features/user_visits_select_documents_variant_c_page_spec.rb
+++ b/spec/features/user_visits_select_documents_variant_c_page_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature 'When user visits document selection page' do
   before(:each) do
     experiment = { "short_hub_2019_q3-preview" => "short_hub_2019_q3-preview_variant_c_2_idp_short_hub" }
     set_session_and_ab_session_cookies!(experiment)
-    stub_api_idp_list_for_loa
+    stub_api_idp_list_for_registration
     visit '/select-documents'
   end
 

--- a/spec/features/user_visits_select_phone_page_spec.rb
+++ b/spec/features/user_visits_select_phone_page_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'When the user visits the select phone page' do
 
   before(:each) do
     set_session_and_session_cookies!
-    stub_api_idp_list_for_loa
+    stub_api_idp_list_for_registration
   end
 
   context 'with javascript disabled' do

--- a/spec/features/user_visits_the_choose_a_certified_company_about_idp_page_spec.rb
+++ b/spec/features/user_visits_the_choose_a_certified_company_about_idp_page_spec.rb
@@ -4,7 +4,7 @@ require 'api_test_helper'
 RSpec.feature 'user visits the choose a certified company about idp page', type: :feature do
   before(:each) do
     set_session_and_session_cookies!
-    stub_api_idp_list_for_loa
+    stub_api_idp_list_for_registration
   end
 
   let(:selected_answers) {
@@ -23,7 +23,7 @@ RSpec.feature 'user visits the choose a certified company about idp page', type:
   }
   scenario 'user chooses a recommended idp' do
     entity_id = 'my-entity-id'
-    stub_api_idp_list_for_loa([{ 'simpleId' => 'stub-idp-one', 'entityId' => entity_id, 'levelsOfAssurance' => %w(LEVEL_1 LEVEL_2) }])
+    stub_api_idp_list_for_registration([{ 'simpleId' => 'stub-idp-one', 'entityId' => entity_id, 'levelsOfAssurance' => %w(LEVEL_1 LEVEL_2) }])
     given_a_session_with_selected_answers
     visit choose_a_certified_company_about_path('stub-idp-one')
     expect(page).to have_content('ID Corp is the premier identity proofing service around.')
@@ -45,7 +45,7 @@ RSpec.feature 'user visits the choose a certified company about idp page', type:
 
   scenario 'user clicks back link' do
     entity_id = 'my-entity-id'
-    stub_api_idp_list_for_loa([{ 'simpleId' => 'stub-idp-one', 'entityId' => entity_id, 'levelsOfAssurance' => %w(LEVEL_1 LEVEL_2) }])
+    stub_api_idp_list_for_registration([{ 'simpleId' => 'stub-idp-one', 'entityId' => entity_id, 'levelsOfAssurance' => %w(LEVEL_1 LEVEL_2) }])
     given_a_session_with_selected_answers
     visit choose_a_certified_company_about_path('stub-idp-one')
     click_link t('navigation.back')

--- a/stub/api/stub_api.rb
+++ b/stub/api/stub_api.rb
@@ -58,7 +58,7 @@ class StubApi < Sinatra::Base
     end
   end
 
-  get '/config/idps/idp-list/:transaction_id/:level_of_assurance' do
+  get '/config/idps/idp-list-for-registration/:transaction_id/:level_of_assurance' do
     if params['level_of_assurance'] == 'LEVEL_1'
     '[{
         "simpleId":"stub-idp-one",

--- a/stub/api/stub_api_spec.rb
+++ b/stub/api/stub_api_spec.rb
@@ -28,9 +28,9 @@ describe StubApi do
    JSON.parse(last_response.body)
   end
 
-  context '#get /config/idps/idp-list/http%3A%2F%2Fwww.test-rp.gov.uk%2FSAML2%2FMD/LEVEL_1' do
+  context '#get /config/idps/idp-list-for-registration/http%3A%2F%2Fwww.test-rp.gov.uk%2FSAML2%2FMD/LEVEL_1' do
     it 'should respond with valid IdpListResponse', skip_before: true do
-      get '/config/idps/idp-list/http%3A%2F%2Fwww.test-rp.gov.uk%2FSAML2%2FMD/LEVEL_1'
+      get '/config/idps/idp-list-for-registration/http%3A%2F%2Fwww.test-rp.gov.uk%2FSAML2%2FMD/LEVEL_1'
       expect(last_response).to be_ok
       response = IdpListResponse.new(last_response_json)
       expect(response).to be_valid


### PR DESCRIPTION
Rename methods ending in `_for_loa` to `_for_registration`. This is because the `_for_loa` bit doesn't say anything about the purpose of the method and also for sign-in we have `_for_sign_in` everywhere so the naming for the registration should also follow that convention.

Use new IDP list for registration endpoint introduced in alphagov/verify-hub#435

Change the default IDP hiding period to 30 mins