### PR TITLE
BAU: Add a clarification to the Start page for the "sign-up" option

### DIFF
--- a/app/assets/stylesheets/pages/_slides.scss
+++ b/app/assets/stylesheets/pages/_slides.scss
@@ -37,7 +37,8 @@
     color: govuk-colour("white");
   }
 
-  h2 {
+  h2,
+  span {
     color: govuk-colour("white");
   }
 

--- a/app/views/start/start.html.erb
+++ b/app/views/start/start.html.erb
@@ -23,6 +23,7 @@
           <div class="govuk-radios__item">
             <%= f.radio_button :selection, false, {required: true, data: { msg: t('hub.start.error_message')}, piwik_event_tracking: 'journey_user_type', class: "govuk-radios__input"}%>
             <%= f.label :selection_false, t('hub.start.answer_no'), class: "govuk-label govuk-radios__label"%>
+            <span class="govuk-hint govuk-radios__hint"><%= t('hub.start.answer_no_hint') %></span>
           </div>
         </div>
       </fieldset>

--- a/config/initializers/00_configuration.rb
+++ b/config/initializers/00_configuration.rb
@@ -47,7 +47,6 @@ CONFIG = Configuration.load! do
   option_string 'cycle_three_attributes_directory', 'CYCLE_THREE_ATTRIBUTES_DIRECTORY', default: "#{FED_CONFIG_DIR}/cycle-three-attributes/"
   option_string 'ab_test_file', 'AB_TEST_FILE', allow_missing: true
 
-
   option_string 'saml_proxy_host', 'SAML_PROXY_HOST'
   option_bool 'feedback_disabled', 'FEEDBACK_DISABLED', default: false
   # Feature flags

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -325,6 +325,7 @@ cy:
       heading: Mewngofnodi gyda GOV.UK Verify
       answer_yes: Dyma’r tro cyntaf i mi ddefnyddio Verify
       answer_no: Rwyf wedi defnyddio Verify o’r blaen
+      answer_no_hint: ""
       continue: Parhau
       error_message: Dewiswch opsiwn
     signin:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -325,7 +325,8 @@ en:
       title: Start
       heading: Sign in with GOV.UK Verify
       answer_yes: This is my first time using GOV.UK Verify
-      answer_no: I’ve used GOV.UK Verify before
+      answer_no: I've already signed up for Verify
+      answer_no_hint: This includes if you've got part way through creating an identity account
       continue: Continue
       error_message: Please select an option
     signin:


### PR DESCRIPTION
Only the English version is affected - Welsh remains the same

<img width="1044" alt="Screenshot 2020-03-23 at 18 46 43" src="https://user-images.githubusercontent.com/3608562/77352823-b83f3380-6d37-11ea-8513-3370524eb8ea.png">