### PR TITLE
HUB-551: Enable throttling of traffic

### DIFF
--- a/.env
+++ b/.env
@@ -17,6 +17,7 @@ RP_CONFIG=stub/relying_parties.yml
 IDP_CONFIG=stub/identity_providers.yml
 CYCLE_THREE_ATTRIBUTES_DIRECTORY=stub/attributes
 AB_TEST_FILE=stub/ab_test.yml
+THROTTLING_FILE=stub/throttling.yml
 
 SEGMENT_DEFINITIONS=stub/segment_definitions.yml
 SEGMENT_DEFINITIONS_VARIANT_C=stub/segment_definitions_variant_c.yml

--- a/app/controllers/choose_a_certified_company_loa2_controller.rb
+++ b/app/controllers/choose_a_certified_company_loa2_controller.rb
@@ -78,7 +78,7 @@ private
 
   def set_throttling_cookie
     idp_name = THROTTLING.get_ab_test_name(rand)
-    cookies.encrypted[CookieNames::THROTTLING] = { value: idp_name, expires: 7.days.from_now }
+    cookies.encrypted[CookieNames::THROTTLING] = { value: idp_name, expires: 21.days.from_now }
     idp_name
   end
 end

--- a/app/controllers/test_throttling_cookie_controller.rb
+++ b/app/controllers/test_throttling_cookie_controller.rb
@@ -1,0 +1,10 @@
+class TestThrottlingCookieController < ApplicationController
+  skip_before_action :validate_session
+  skip_before_action :set_piwik_custom_variables
+  skip_after_action :store_locale_in_cookie
+
+  def set_cookie
+    cookies.encrypted[CookieNames::THROTTLING] = params[:idp]
+    head :no_content
+  end
+end

--- a/app/views/static/cookies.cy.html.erb
+++ b/app/views/static/cookies.cy.html.erb
@@ -54,6 +54,13 @@ end %>
           <td class="govuk-table__cell">90 munud</td>
         </tr>
       <% end %>
+      <% if THROTTLING_ENABLED %>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell"><var>throttling</var></td>
+          <td class="govuk-table__cell">This cookie allows us to remember you and to distribute the traffic more evenly.</td>
+          <td class="govuk-table__cell">7 days</td>
+        </tr>
+      <% end %>
       <tr class="govuk-table__row">
         <td class="govuk-table__cell"><var>x_verify_locale</var></td>
         <td class="govuk-table__cell">Mae hyn yn nodi os ydych yn defnyddio fersiwn Saesneg neu Gymraeg o GOV.UK Verify. Rydym yn defnyddio hyn i ddangos y safle i chi yn eich dewis iaith</td>

--- a/app/views/static/cookies.cy.html.erb
+++ b/app/views/static/cookies.cy.html.erb
@@ -58,7 +58,7 @@ end %>
         <tr class="govuk-table__row">
           <td class="govuk-table__cell"><var>throttling</var></td>
           <td class="govuk-table__cell">This cookie allows us to remember you and to distribute the traffic more evenly.</td>
-          <td class="govuk-table__cell">7 days</td>
+          <td class="govuk-table__cell">21 days</td>
         </tr>
       <% end %>
       <tr class="govuk-table__row">

--- a/app/views/static/cookies.en.html.erb
+++ b/app/views/static/cookies.en.html.erb
@@ -64,7 +64,7 @@ end %>
         <tr class="govuk-table__row">
           <td class="govuk-table__cell"><var>throttling</var></td>
           <td class="govuk-table__cell">This cookie allows us to remember you and to distribute the traffic more evenly.</td>
-          <td class="govuk-table__cell">7 days</td>
+          <td class="govuk-table__cell">21 days</td>
         </tr>
       <% end %>
       <tr class="govuk-table__row">

--- a/app/views/static/cookies.en.html.erb
+++ b/app/views/static/cookies.en.html.erb
@@ -60,6 +60,13 @@ end %>
           <td class="govuk-table__cell">90 minutes</td>
         </tr>
       <% end %>
+      <% if THROTTLING_ENABLED %>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell"><var>throttling</var></td>
+          <td class="govuk-table__cell">This cookie allows us to remember you and to distribute the traffic more evenly.</td>
+          <td class="govuk-table__cell">7 days</td>
+        </tr>
+      <% end %>
       <tr class="govuk-table__row">
         <td class="govuk-table__cell">x_verify_locale</td>
         <td class="govuk-table__cell">This identifies if you’re using the English or Welsh version of GOV.UK Verify. We use

--- a/config/initializers/00_configuration.rb
+++ b/config/initializers/00_configuration.rb
@@ -47,6 +47,9 @@ CONFIG = Configuration.load! do
   option_string 'cycle_three_attributes_directory', 'CYCLE_THREE_ATTRIBUTES_DIRECTORY', default: "#{FED_CONFIG_DIR}/cycle-three-attributes/"
   option_string 'ab_test_file', 'AB_TEST_FILE', allow_missing: true
 
+  option_bool 'throttling_enabled', 'THROTTLING_ENABLED', default: false
+  option_string 'throttling_file', 'THROTTLING_FILE', allow_missing: true
+
   option_string 'saml_proxy_host', 'SAML_PROXY_HOST'
   option_bool 'feedback_disabled', 'FEEDBACK_DISABLED', default: false
   # Feature flags

--- a/config/initializers/30_federation.rb
+++ b/config/initializers/30_federation.rb
@@ -70,6 +70,7 @@ Rails.application.config.after_initialize do
   ABC_VARIANTS_CONFIG = YAML.load_file(CONFIG.abc_variants_config)
 
   FEEDBACK_DISABLED = CONFIG.feedback_disabled
+  THROTTLING_ENABLED = CONFIG.throttling_enabled
 
   # Feature flags
   IDP_FEATURE_FLAGS_CHECKER = IdpConfiguration::IdpFeatureFlagsLoader.new(YamlLoader.new)

--- a/config/initializers/throttling.rb
+++ b/config/initializers/throttling.rb
@@ -1,0 +1,14 @@
+def env_var_set?
+  CONFIG.throttling_file
+end
+
+def build_logic_hash
+  if !env_var_set? then return {}.freeze end
+
+  options = YAML.load_file(CONFIG.throttling_file)
+  if !options then return {}.freeze end
+
+  AbTest::Experiment.new(options)
+end
+
+THROTTLING = build_logic_hash

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,7 @@ Rails.application.routes.draw do
     post 'test-initiate-journey' => 'test_saml#initiate_journey_session'
     post 'another-idp-endpoint' => 'test_saml#idp_request'
     get 'test-journey-hint' => 'test_journey_hint_cookie#index', as: :test_journey_hint
+    get 'test-throttling-cookie/:idp' => 'test_throttling_cookie#set_cookie'
     post 'test-journey-hint' => 'test_journey_hint_cookie#set_cookie', as: :test_journey_hint_submit
     get 'test-single-idp-journey' => 'test_single_idp_journey#index'
     # route analytics through frontend URI, as like prod, to not violate our csp policy

--- a/lib/cookie_names.rb
+++ b/lib/cookie_names.rb
@@ -9,6 +9,7 @@ module CookieNames
   AB_TEST = 'ab_test'.freeze
   AB_TEST_TRIAL = 'ab_test_trial'.freeze
   ANALYTICS_SESSION_COOKIE_PREFIX = '_pk_id.'.freeze
+  THROTTLING = 'throttling'.freeze
 
   def self.session_cookies
     [SESSION_ID_COOKIE_NAME, SESSION_COOKIE_NAME]

--- a/stub/throttling.yml
+++ b/stub/throttling.yml
@@ -1,0 +1,6 @@
+idps:
+  alternatives:
+    - name: 'stub-idp-one'
+      percent: 50
+    - name: 'stub-idp-two'
+      percent: 50


### PR DESCRIPTION
- this change works with 2 IDPs and allows us to toggle a split between traffic
- this is only a temporary solution to better distribute traffic between the existing IDPs
- it uses a new cookie to remember which IDP has been assigned
- it's using some of the existing AB logic to work out the split