### PR TITLE
HUB-555: Added a /completed page for IDPs to return the users

### DIFF
--- a/app/controllers/completed_registration_controller.rb
+++ b/app/controllers/completed_registration_controller.rb
@@ -1,0 +1,30 @@
+require 'partials/user_cookies_partial_controller'
+require 'partials/viewable_idp_partial_controller'
+require 'partials/journey_hinting_partial_controller'
+
+class CompletedRegistrationController < ApplicationController
+  include UserCookiesPartialController
+  include ViewableIdpPartialController
+  include JourneyHintingPartialController
+
+  skip_before_action :validate_session
+  skip_before_action :set_piwik_custom_variables
+
+  def index
+    idp_simple_id = params[:idp]
+    @idp = IDP_DISPLAY_REPOSITORY.fetch(idp_simple_id, nil)
+    if @idp.nil?
+      redirect_to verify_services_path
+    else
+      # Hack - we need and IDP list, but the current API needs a transaction
+      session[:transaction_entity_id] = 'https://wwwm.universal-credit.service.gov.uk'
+      identity_providers = current_available_identity_providers_for_sign_in
+      session[:transaction_entity_id] = nil
+
+      entity_id = retrieve_decorated_singleton_idp_array_by_simple_id(identity_providers, idp_simple_id).first.entity_id
+      set_attempt_journey_hint(entity_id)
+      set_journey_hint_by_status(entity_id, 'SUCCESS')
+      render :index
+    end
+  end
+end

--- a/app/models/feedback_source_mapper.rb
+++ b/app/models/feedback_source_mapper.rb
@@ -53,6 +53,7 @@ class FeedbackSourceMapper
       'PAUSED_REGISTRATION_PAGE' => 'paused_registration',
       'TIMEOUT_PAGE' => 'further_information_timeout',
       'ACCESSIBILITY_PAGE' => 'accessibility',
+      'COMPLETED_REGISTRATION' => 'completed_registration'
   }.freeze
   end
 

--- a/app/views/completed_registration/index.erb
+++ b/app/views/completed_registration/index.erb
@@ -1,0 +1,14 @@
+<%= page_title 'hub.completed_registration.title' %>
+
+<% content_for :feedback_source, 'COMPLETED_REGISTRATION_PAGE' %>
+<% content_for :show_to_search_engine, false %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l"><%= t 'hub.completed_registration.heading', idp_name: @idp.display_name %></h1>
+    <p><%= t 'hub.completed_registration.message_one' %></p>
+    <p><%= t 'hub.completed_registration.message_two', idp_name: @idp.display_name %></p>
+    <h2 class="govuk-heading-m"><%= t 'hub.completed_registration.select_service' %></h2>
+    <%= render partial: 'shared/transaction_list' %>
+  </div>
+</div>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -68,6 +68,7 @@ cy:
     proxy_node_error: proxy-node-error-cy
     accessibility: accessibility-cy
     select_documents_advice: select-documents-advice-cy
+    completed_registration: completed-cy/:idp
   common:
     logo: "logo %{name}"
   title:
@@ -833,6 +834,12 @@ cy:
       alternative_two: gweld ffyrdd eraill i %{service_display_name}
     accessibility:
       title: Accessibility
+    completed_registration:
+      title: You've successfully proved your identity
+      heading: You’ve successfully proved your identity with %{idp_name}
+      message_one: You now need to return to the government service you were trying to access.
+      message_two: When the service asks you to prove your identity, you can do so by signing in to your %{idp_name} identity account.
+      select_service: Select the service you need
   errors:
     cookie_expired:
       title: Mae eich sesiwn wedi amseru allan

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -72,6 +72,7 @@ en:
     proxy_node_error: proxy-node-error
     accessibility: accessibility
     select_documents_advice: select-documents-advice
+    completed_registration: completed/:idp
   common:
     logo: "%{name} logo"
   title:
@@ -822,6 +823,12 @@ en:
       alternative_two: see other ways to %{service_display_name}
     accessibility:
       title: Accessibility
+    completed_registration:
+      title: You've successfully proved your identity
+      heading: You’ve successfully proved your identity with %{idp_name}
+      message_one: You now need to return to the government service you were trying to access.
+      message_two: When the service asks you to prove your identity, you can do so by signing in to your %{idp_name} identity account.
+      select_service: Select the service you need
   errors:
     cookie_expired:
       title: Your session has timed out

--- a/config/main_routes.rb
+++ b/config/main_routes.rb
@@ -116,6 +116,8 @@ get 'paused_registration', to: 'paused_registration#index', as: :paused_registra
 get 'paused_registration_resume_link', to: 'paused_registration#from_resume_link', as: :paused_registration_resume_link
 get 'resume_registration', to: 'paused_registration#resume', as: :resume_registration
 post 'resume_registration', to: 'paused_registration#resume_with_idp', as: :resume_registration_submit
+get 'completed_registration', to: 'completed_registration#index', as: :completed_registration
+
 
 if SINGLE_IDP_FEATURE
   get 'redirect_to_single_idp', to: 'redirect_to_idp#single_idp', as: :redirect_to_single_idp

--- a/spec/controllers/completed_registration_controller_spec.rb
+++ b/spec/controllers/completed_registration_controller_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+require 'controller_helper'
+require 'spec_helper'
+require 'api_test_helper'
+
+describe CompletedRegistrationController do
+  let(:valid_idp_simple_id) { 'stub-idp-one' }
+  let(:entity_id) { 'http://idcorp.com' }
+  let(:transaction_id) { 'https://wwwm.universal-credit.service.gov.uk' }
+
+  context '#index' do
+    it 'renders the page when the IDP is valid' do
+      stub_api_idp_list_for_sign_in_without_session([
+        { 'simpleId' => 'stub-idp-one',
+          'entityId' => entity_id,
+          'levelsOfAssurance' => %w(LEVEL_2) }
+        ],
+          transaction_id)
+      get :index, params: { locale: 'en', idp: valid_idp_simple_id }
+
+      expect(subject).to render_template(:index)
+
+      cookie_hint = MultiJson.load(cookies.encrypted[CookieNames::VERIFY_FRONT_JOURNEY_HINT])
+
+      expect(cookie_hint['ATTEMPT']).to eq(entity_id)
+      expect(cookie_hint['SUCCESS']).to eq(entity_id)
+    end
+
+    it 'redirects to the verify services page and does not set the journey hint cookie if IDP invalid' do
+      stub_transaction_details
+      get :index, params: { locale: 'en', idp: 'invalid-idp' }
+      expect(subject).to redirect_to verify_services_path
+
+      expect(cookies.encrypted[CookieNames::VERIFY_FRONT_JOURNEY_HINT]).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
If the IDP no longer has the original SAML request for the user, they're not able
to issue a SAML response back to the hub. This new page will allow them to send the
user back. Also the page updates the journey hint to hint the user next time round.