### PR TITLE
HUB-533: Update hub to prepare users for IDP queueing

### DIFF
--- a/app/controllers/choose_a_certified_company_loa1_controller.rb
+++ b/app/controllers/choose_a_certified_company_loa1_controller.rb
@@ -30,7 +30,7 @@ private
     if interstitial_question_flag_enabled_for(decorated_idp)
       redirect_to_idp_question_path
     else
-      redirect_to_idp_warning_path
+      what_happens_next_path
     end
   end
 

--- a/app/controllers/choose_a_certified_company_loa2_controller.rb
+++ b/app/controllers/choose_a_certified_company_loa2_controller.rb
@@ -44,7 +44,7 @@ private
     if not_more_than_one_uk_doc_selected && interstitial_question_flag_enabled_for(decorated_idp)
       redirect_to_idp_question_path
     else
-      redirect_to_idp_warning_path
+      what_happens_next_path
     end
   end
 

--- a/app/controllers/what_happens_next_controller.rb
+++ b/app/controllers/what_happens_next_controller.rb
@@ -1,0 +1,5 @@
+class WhatHappensNextController < ApplicationController
+  def index
+    @idp = IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate(selected_identity_provider)
+  end
+end

--- a/app/models/feedback_source_mapper.rb
+++ b/app/models/feedback_source_mapper.rb
@@ -53,7 +53,8 @@ class FeedbackSourceMapper
       'PAUSED_REGISTRATION_PAGE' => 'paused_registration',
       'TIMEOUT_PAGE' => 'further_information_timeout',
       'ACCESSIBILITY_PAGE' => 'accessibility',
-      'COMPLETED_REGISTRATION' => 'completed_registration'
+      'COMPLETED_REGISTRATION' => 'completed_registration',
+      'WHAT_HAPPENS_NEXT_PAGE' => 'what_happens_next',
   }.freeze
   end
 

--- a/app/views/redirect_to_idp_warning/redirect_to_idp_warning.html.erb
+++ b/app/views/redirect_to_idp_warning/redirect_to_idp_warning.html.erb
@@ -3,11 +3,8 @@
 
 <div class="govuk-grid-row js-continue-to-idp no-right-hand-logo" data-location="<%= url_for(controller: 'redirect_to_idp_warning', action: 'continue_ajax', locale: I18n.locale)  %>">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l"><%= t 'hub.redirect_to_idp_warning.create_account', display_name: @idp.display_name %></h1>
-
-    <%= t 'hub.redirect_to_idp_warning.identity_account_use_html', display_name: @idp.display_name %>
-    <p><%= t 'hub.redirect_to_idp_warning.service_use', service_name: @service_name %></p>
-
+    <h1 class="govuk-heading-l"><%= t 'hub.redirect_to_idp_warning.heading', idp: @idp.display_name %></h1>
+    <%= t 'hub.redirect_to_idp_warning.queue_warning_html', idp: @idp.display_name %>
     <%= form_tag('', class: 'js-idp-form') do %>
         <%= button_tag t('hub.redirect_to_idp_warning.continue_website', display_name: @idp.display_name),
                        class: 'govuk-button',

--- a/app/views/what_happens_next/index.html.erb
+++ b/app/views/what_happens_next/index.html.erb
@@ -1,0 +1,11 @@
+<%= page_title 'hub.what_happens_next.title' %>
+<% content_for :feedback_source, 'WHAT_HAPPENS_NEXT_PAGE' %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l"><%= t 'hub.what_happens_next.heading' %></h1>
+    <%= t('hub.what_happens_next.what_happens_next_html', idp: @idp.display_name) %>
+    <div class="actions">
+      <%= button_link_to t('navigation.continue'), redirect_to_idp_warning_path, id: 'continue-button', class: "govuk-button"%>
+    </div>
+  </div>
+</div>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -5,6 +5,7 @@ cy:
     prove_identity_retry: profi-hunaniaeth-ailgeisio
     begin_registration: dechrau-cofrestru
     begin_sign_in: dechrau-mewngofnodi
+    what_happens_next: what-happens-next-cy
     about: am
     sign_in: mewngofnodi
     about_certified_companies: am-gwmniau-ardystiedig
@@ -355,6 +356,15 @@ cy:
       title: Dod o hyd i’r gwasanaeth rydych yn ei ddefnyddio i ddechrau eto
       hint: Dilynnwch y cyfarwyddiadau rydych wedi’u derbyn.
       other_services: Gwasanaethau eraill
+    what_happens_next:
+      title: What happens next
+      heading: What happens next
+      what_happens: |
+        <ol class="govuk-list govuk-list--number">
+          <li>You'll now go to the %{idp} website and answer questions about yourself.</li>
+          <li>Once you’re verified, you’ll have an identity account that you can use wherever you see the GOV.UK Verify logo.</li>
+          <li>You’ll then need to go back to the government service you need to access and sign in using your new identity account details.</li>
+        </ol> 
     about:
       title: Am
       verify_is_a_service: Mae GOV.UK Verify yn wasanaeth diogel a adeiladwyd i frwydro yn erbyn y broblem gynyddol o ddwyn hunaniaeth ar-lein.
@@ -561,11 +571,11 @@ cy:
         <p class="govuk-body">Nid oes effaith ar eich sgor credyd.</p>
     redirect_to_idp_warning:
       title: Byddwch nawr yn cael eich ailgyfeirio
-      create_account: Crëwch eich cyfrif hunaniaeth %{display_name}
+      heading: "%{idp} is currently experiencing long wait times"
       continue_website: Parhau i wefan %{display_name}
-      identity_account_use_html: |
-              <p class="govuk-body">Byddwch nawr yn gwirio pwy ydych chi ar wefan %{display_name}</p>
-              <p class="govuk-body">Byddant yn rhoi cyfrif hunaniaeth i chi y gallwch ei ddefnyddio lle bynnag gwelwch y logo 'GOV.UK Verify' </p>
+      queue_warning_html: |
+        <p class="govuk-body">A lot of people are currently trying to prove their identity with %{idp}. It may take several hours or more for you to get through.</p>
+        <p class="govuk-body">We’re working to improve the wait times as fast as we can.</p>
       service_use: Yna byddwch yn gallu %{service_name}.
       other_ways_link: ffyrdd eraill i %{transaction}
       no_docs_other_ways_message_html: "%{idp_no_docs_requirement}, mae %{other_ways_link}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -9,6 +9,7 @@ en:
     prove_identity_retry: prove-identity-retry
     begin_registration: begin-registration
     begin_sign_in: begin-sign-in
+    what_happens_next: what-happens-next
     about: about
     sign_in: sign-in
     about_certified_companies: about-certified-companies
@@ -356,6 +357,15 @@ en:
       title: Find the service you were using to start again
       hint: Follow the instructions you received.
       other_services: Other services
+    what_happens_next:
+      title: What happens next
+      heading: What happens next
+      what_happens_next_html: |
+        <ol class="govuk-list govuk-list--number">
+          <li>You'll now go to the %{idp} website and answer questions about yourself.</li>
+          <li>Once you’re verified, you’ll have an identity account that you can use wherever you see the GOV.UK Verify logo.</li>
+          <li>You’ll then need to go back to the government service you need to access and sign in using your new identity account details.</li>
+        </ol> 
     about:
       title: About
       verify_is_a_service: GOV.UK Verify is a secure way to prove who you are online. It aims to protect people from the growing problem of online identity theft.
@@ -549,11 +559,11 @@ en:
         <p class="govuk-body">These companies meet strict government privacy standards, so you can trust them with your information. They won’t use your information for any other purpose without your consent.</p>
     redirect_to_idp_warning:
       title: "You'll now be redirected"
-      create_account: Create your %{display_name} identity account
+      heading: "%{idp} is currently experiencing long wait times"
       continue_website: Continue to the %{display_name} website
-      identity_account_use_html: |
-        <p class="govuk-body">You'll now verify your identity on the %{display_name} website.</p>
-        <p class="govuk-body">They'll give you an identity account you can use wherever you see the GOV.UK Verify logo.</p>
+      queue_warning_html: |
+        <p class="govuk-body">A lot of people are currently trying to prove their identity with %{idp}. It may take several hours or more for you to get through.</p>
+        <p class="govuk-body">We’re working to improve the wait times as fast as we can.</p>
       service_use: You'll then be able to %{service_name}.
       other_ways_link: "other ways to %{transaction}"
       no_docs_other_ways_message_html: "%{idp_no_docs_requirement}, there are %{other_ways_link}"

--- a/config/main_routes.rb
+++ b/config/main_routes.rb
@@ -78,6 +78,7 @@ constraints IsLoa2 do
   get 'confirmation_non_matching_journey', to: 'confirmation_loa2#non_matching_journey', as: :confirmation_non_matching_journey
 end
 
+get 'what_happens_next', to: 'what_happens_next#index', as: :what_happens_next
 get 'accessibility', to: 'static#accessibility', as: :accessibility
 get 'privacy_notice', to: 'static#privacy_notice', as: :privacy_notice
 get 'verify_services', to: 'static#verify_services', as: :verify_services

--- a/spec/controllers/choose_a_certified_company_loa1_controller_spec.rb
+++ b/spec/controllers/choose_a_certified_company_loa1_controller_spec.rb
@@ -73,11 +73,11 @@ describe ChooseACertifiedCompanyLoa1Controller do
       expect(session[:selected_idp_was_recommended]).to eql(true)
     end
 
-    it 'redirects to IDP warning page by default' do
+    it 'redirects to what_happens_next page by default' do
       stub_api_idp_list_for_registration([stub_idp_no_interstitial], 'LEVEL_1')
       post :select_idp, params: { locale: 'en', entity_id: 'http://idcorp-two.com' }
 
-      expect(subject).to redirect_to redirect_to_idp_warning_path
+      expect(subject).to redirect_to what_happens_next_path
     end
 
     it 'redirects to IDP question page for LOA1 users when IDP flag is enabled' do

--- a/spec/controllers/choose_a_certified_company_loa2_controller_spec.rb
+++ b/spec/controllers/choose_a_certified_company_loa2_controller_spec.rb
@@ -182,11 +182,11 @@ describe ChooseACertifiedCompanyLoa2Controller do
       expect(session[:selected_idp_was_recommended]).to eql(true)
     end
 
-    it 'redirects to IDP warning page by default' do
+    it 'redirects to what_happens_next page by default' do
       session[:selected_answers] = { 'documents' => { 'driving_licence' => true, 'passport' => true } }
       post :select_idp, params: { locale: 'en', entity_id: 'http://idcorp-loa1.com' }
 
-      expect(subject).to redirect_to redirect_to_idp_warning_path
+      expect(subject).to redirect_to what_happens_next_path
     end
 
     it 'redirects to IDP question page when user has one doc and IDP flag is enabled' do

--- a/spec/controllers/what_happens_next_controller_spec.rb
+++ b/spec/controllers/what_happens_next_controller_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+require 'controller_helper'
+require 'api_test_helper'
+require 'piwik_test_helper'
+
+describe WhatHappensNextController do
+  before(:each) do
+    set_session_and_cookies_with_loa('LEVEL_2')
+  end
+
+  context 'GET what_happens_next#index' do
+    subject { get :index, params: { locale: 'en' } }
+
+    it 'renders what_happens_next page' do
+      expect(subject).to render_template(:index)
+    end
+  end
+end

--- a/spec/controllers/what_happens_next_controller_spec.rb
+++ b/spec/controllers/what_happens_next_controller_spec.rb
@@ -6,6 +6,11 @@ require 'piwik_test_helper'
 describe WhatHappensNextController do
   before(:each) do
     set_session_and_cookies_with_loa('LEVEL_2')
+    set_selected_idp(
+      'simple_id' => 'stub-idp-one',
+      'entity_id' => 'http://idcorp.com',
+      'levels_of_assurance' => %w(LEVEL_1 LEVEL_2)
+    )
   end
 
   context 'GET what_happens_next#index' do

--- a/spec/features/idp_selections_reported_to_piwik_spec.rb
+++ b/spec/features/idp_selections_reported_to_piwik_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe 'When the user selects an IDP' do
 
     visit '/choose-a-certified-company'
     click_button t('hub.choose_a_certified_company.choose_idp', display_name: t('idps.stub-idp-one.name'))
+    click_link t('navigation.continue')
     click_button t('hub.redirect_to_idp_warning.continue_website', display_name: t('idps.stub-idp-one.name'))
 
     expect(piwik_registration_virtual_page).to have_been_made.once
@@ -59,12 +60,14 @@ RSpec.describe 'When the user selects an IDP' do
     )
     visit '/choose-a-certified-company'
     click_button t('hub.choose_a_certified_company.choose_idp', display_name: t('idps.stub-idp-one.name'))
+    click_link t('navigation.continue')
     click_button t('hub.redirect_to_idp_warning.continue_website', display_name: t('idps.stub-idp-one.name'))
 
     expect(idcorp_piwik_request).to have_been_made.once
 
     visit '/choose-a-certified-company'
     click_button t('hub.choose_a_certified_company.choose_idp', display_name: t('idps.stub-idp-two.name'))
+    click_link t('navigation.continue')
     click_button t('hub.redirect_to_idp_warning.continue_website', display_name: t('idps.stub-idp-two.name'))
 
     expect(idcorp_and_bobs_piwik_request).to have_been_made.once
@@ -82,6 +85,7 @@ RSpec.describe 'When the user selects an IDP' do
     page.set_rack_session(selected_idp_names: idps)
     visit '/choose-a-certified-company'
     click_button t('hub.choose_a_certified_company.choose_idp', display_name: t('idps.stub-idp-one.name'))
+    click_link t('navigation.continue')
     click_button t('hub.redirect_to_idp_warning.continue_website', display_name: t('idps.stub-idp-one.name'))
 
     expect(idcorp_piwik_request).to have_been_made.once

--- a/spec/features/user_visits_redirect_to_idp_warning_page_spec.rb
+++ b/spec/features/user_visits_redirect_to_idp_warning_page_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe 'When the user visits the redirect to IDP warning page' do
     visit '/redirect-to-idp-warning'
 
     expect(page.body).to have_content t('hub.redirect_to_idp_warning.continue_website', display_name: 'IDCorp')
-    expect(page.body).to include t('hub.redirect_to_idp_warning.identity_account_use_html', display_name: 'IDCorp')
+    expect(page.body).to include t('hub.redirect_to_idp_warning.queue_warning_html', idp: 'IDCorp')
   end
 
   context 'with JS enabled', js: true do

--- a/spec/features/user_visits_the_choose_a_certified_company_about_idp_page_spec.rb
+++ b/spec/features/user_visits_the_choose_a_certified_company_about_idp_page_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature 'user visits the choose a certified company about idp page', type:
     visit choose_a_certified_company_about_path('stub-idp-one')
     expect(page).to have_content('ID Corp is the premier identity proofing service around.')
     click_button t('hub.choose_a_certified_company.choose_idp', display_name: t('idps.stub-idp-one.name'))
-    expect(page).to have_current_path(redirect_to_idp_warning_path)
+    expect(page).to have_current_path(what_happens_next_path)
     expect(page.get_rack_session_key('selected_provider')['identity_provider']).to include('entity_id' => entity_id, 'simple_id' => 'stub-idp-one', 'levels_of_assurance' => %w(LEVEL_1 LEVEL_2))
     expect(page.get_rack_session_key('selected_idp_was_recommended')).to eql true
   end

--- a/spec/features/user_visits_what_happens_next_page_spec.rb
+++ b/spec/features/user_visits_what_happens_next_page_spec.rb
@@ -1,0 +1,30 @@
+require 'feature_helper'
+require 'cookie_names'
+require 'piwik_test_helper'
+require 'api_test_helper'
+
+RSpec.describe 'When the user visits the what happens next page' do
+  before(:each) do
+    set_session_and_session_cookies!
+    stub_api_idp_list_for_registration
+  end
+
+  context 'session cookie contains transaction id' do
+    before(:each) do
+      page.set_rack_session(transaction_simple_id: 'test-rp')
+    end
+    it "will display the page and report the user's selection to piwik" do
+      visit '/what-happens-next'
+
+      expect(page).to have_content(t('hub.what_happens_next.heading'))
+      expect_feedback_source_to_be(page, 'WHAT_HAPPENS_NEXT_PAGE', '/what-happens-next')
+      expect(page).to have_link('Continue', href: '/redirect-to-idp-warning')
+    end
+
+    it 'will display the what_happens_next page in Welsh' do
+      visit '/what-happens-next-cy'
+      expect(page).to have_content(t('hub.what_happens_next.heading'))
+      expect(page).to have_css 'html[lang=cy]'
+    end
+  end
+end

--- a/spec/features/user_visits_what_happens_next_page_spec.rb
+++ b/spec/features/user_visits_what_happens_next_page_spec.rb
@@ -7,12 +7,10 @@ RSpec.describe 'When the user visits the what happens next page' do
   before(:each) do
     set_session_and_session_cookies!
     stub_api_idp_list_for_registration
+    set_selected_idp_in_session(entity_id: 'http://idcorp.com', simple_id: 'stub-idp-one')
   end
 
   context 'session cookie contains transaction id' do
-    before(:each) do
-      page.set_rack_session(transaction_simple_id: 'test-rp')
-    end
     it "will display the page and report the user's selection to piwik" do
       visit '/what-happens-next'
 


### PR DESCRIPTION
Based on the designs here: https://docs.google.com/drawings/d/1B7vcWXMxTW6CllgNc1Wh4Is24-6XaWddm-Ain-xq5PI/edit

Have created an additional page on the journey. 'What happens next' page.
<img width="1438" alt="Screenshot 2020-03-25 at 18 28 46" src="https://user-images.githubusercontent.com/24409958/77572270-9627eb80-6ec6-11ea-8d94-5f50bcc9c6c8.png">


The original redirect-to-idp-warning page has changed content to show information regarding the long wait time
<img width="1438" alt="Screenshot 2020-03-25 at 18 28 55" src="https://user-images.githubusercontent.com/24409958/77572276-988a4580-6ec6-11ea-99f7-f7c4cb1547cc.png">

ticket: https://govukverify.atlassian.net/secure/RapidBoard.jspa?rapidView=144&projectKey=HUB&modal=detail&selectedIssue=HUB-553