### PR TITLE
BAU: Remove prompt to try with another IDP on registration failure

### DIFF
--- a/app/views/failed_registration/_continue_rp.html.erb
+++ b/app/views/failed_registration/_continue_rp.html.erb
@@ -9,13 +9,3 @@
 
 <%= button_link_to t('navigation.continue'), redirect_to_service_error_path, class: 'govuk-button' %>
 
-<h2 class="govuk-heading-m"><%= t 'hub.failed_registration.try_another_summary' %></h2>
-<div>
-  <p class="govuk-body"><%= t 'hub.failed_registration.try_another_text', idp_name: @idp.display_name %></p>
-  <%= link_to t('hub.failed_registration.try_another_company'), try_another_company_path %>
-</div>
-
-<h2 class="govuk-heading-m"><%= t 'hub.failed_registration.contact_details_intro', idp_name: idp.display_name %></h2>
-<div>
-  <%= raw idp.contact_details %>
-</div>

--- a/app/views/failed_registration/_custom_failed_registration.html.erb
+++ b/app/views/failed_registration/_custom_failed_registration.html.erb
@@ -6,13 +6,3 @@
   <%= raw transaction.custom_fail_other_options %>
 </h2>
 
-<h2 class="govuk-heading-m"><%= raw transaction.custom_fail_try_another_summary %></h2>
-<div>
-  <%= raw(transaction.custom_fail_try_another_text % { idp_name: idp.display_name }) %>
-  <%= link_to t('hub.failed_registration.start_again'), start_again_path %>
-</div>
-
-<h2 class="govuk-heading-m"><%= raw(transaction.custom_fail_contact_details_intro % { idp_name: idp.display_name }) %></h2>
-<div>
-  <%= raw idp.contact_details %>
-</div>

--- a/app/views/failed_registration/_non_continue_rp.html.erb
+++ b/app/views/failed_registration/_non_continue_rp.html.erb
@@ -2,18 +2,8 @@
 
 <p class="govuk-body"><%= t 'hub.failed_registration.reasons_html', service_name: @transaction.name %></p>
 
-<h2 class="govuk-heading-m"><%= t 'hub.failed_registration.try_another_summary' %></h2>
-<div>
-  <p class="govuk-body"><%= t 'hub.failed_registration.try_another_text', idp_name: @idp.display_name %></p>
-  <p class="govuk-body"><%= link_to t('hub.failed_registration.start_again'), start_again_path %></p>
-</div>
-
 <h2 class="govuk-heading-m"><%= t 'hub.failed_registration.other_ways_summary', other_ways_description: raw(transaction.other_ways_description) %></h2>
 <div class="govuk-body">
   <%= raw transaction.other_ways_text %>
 </div>
 
-<h2 class="govuk-heading-m"><%= t 'hub.failed_registration.contact_details_intro', idp_name: idp.display_name %></h2>
-<div class="govuk-body">
-  <%= raw idp.contact_details %>
-</div>

--- a/spec/features/user_visits_failed_registration_page_spec.rb
+++ b/spec/features/user_visits_failed_registration_page_spec.rb
@@ -24,7 +24,6 @@ RSpec.describe 'When the user visits the failed registration page and' do
       expect_page_to_have_main_content
       expect(page).to have_content t('hub.failed_registration.continue_text', rp_name: 'Test RP')
       expect(page).to have_link t('navigation.continue'), href: redirect_to_service_error_path
-      expect(page).to have_link t('hub.failed_registration.try_another_company'), href: select_documents_path
     end
 
     it 'includes expected content for LOA1 journey' do
@@ -34,7 +33,6 @@ RSpec.describe 'When the user visits the failed registration page and' do
       expect_page_to_have_main_content
       expect(page).to have_content t('hub.failed_registration.continue_text', rp_name: 'Test RP')
       expect(page).to have_link t('navigation.continue'), href: redirect_to_service_error_path
-      expect(page).to have_link t('hub.failed_registration.try_another_company'), href: choose_a_certified_company_path
     end
   end
 
@@ -50,7 +48,6 @@ RSpec.describe 'When the user visits the failed registration page and' do
       expect_page_to_have_main_content
       expect(page).to have_content t('hub.failed_registration.other_ways_summary',
                                           other_ways_description: 'test GOV.UK Verify user journeys')
-      expect(page).to have_link t('hub.failed_registration.start_again'), href: select_documents_path
     end
 
     it 'includes expected content when LOA1 journey' do
@@ -60,7 +57,6 @@ RSpec.describe 'When the user visits the failed registration page and' do
       expect_page_to_have_main_content
       expect(page).to have_content t('hub.failed_registration.other_ways_summary',
                                           other_ways_description: 'test GOV.UK Verify user journeys')
-      expect(page).to have_link t('hub.failed_registration.start_again'), href: choose_a_certified_company_path
     end
   end
 
@@ -74,7 +70,6 @@ RSpec.describe 'When the user visits the failed registration page and' do
       visit '/cofrestru-wedi-methu'
       expect(page).to have_content "This is a custom fail page in welsh."
       expect(page).to have_content "Custom text to be provided by RP."
-      expect(page).to have_link t('hub.failed_registration.start_again', locale: :cy), href: select_documents_cy_path
     end
 
     it 'includes expected content when custom fail LOA2 journey' do
@@ -82,15 +77,12 @@ RSpec.describe 'When the user visits the failed registration page and' do
       visit '/failed-registration'
       expect(page).to have_content "This is a custom fail page."
       expect(page).to have_content "Custom text to be provided by RP."
-      expect(page).to have_link t('hub.failed_registration.start_again'), href: select_documents_path
     end
   end
-
 
   def expect_page_to_have_main_content
     expect_feedback_source_to_be(page, 'FAILED_REGISTRATION_PAGE', '/failed-registration')
     expect(page).to have_title t('hub.failed_registration.title')
     expect(page).to have_content t('hub.failed_registration.heading', idp_name: 'IDCorp')
-    expect(page).to have_content t('hub.failed_registration.contact_details_intro', idp_name: 'IDCorp')
   end
 end


### PR DESCRIPTION
This is because due to traffic splitting the user will only ever see one IDP.
This is a temporary measure until we fix the splitting logic to be more clever.

As per https://docs.google.com/document/d/1UsYvR21RATKHG2e2-v-zvx0x8GFQJZBar30g926IxBg/edit#

Also don't show IDP contact details for now.

### **Registration failure pages before**
<img width="938" alt="Screenshot 2020-03-27 at 18 47 54" src="https://user-images.githubusercontent.com/3608562/77792949-2dc14180-7061-11ea-98c9-2026f85112e4.png">
<img width="972" alt="Screenshot 2020-03-27 at 18 54 06" src="https://user-images.githubusercontent.com/3608562/77792952-2e59d800-7061-11ea-8c05-acd45386f884.png">
<img width="932" alt="Screenshot 2020-03-27 at 19 04 10" src="https://user-images.githubusercontent.com/3608562/77792954-2ef26e80-7061-11ea-8b30-04ace329eab6.png">

### **And after**
<img width="868" alt="Screenshot 2020-03-27 at 19 07 41" src="https://user-images.githubusercontent.com/3608562/77792966-33b72280-7061-11ea-8dc7-7de00a524ca3.png">
<img width="900" alt="Screenshot 2020-03-27 at 19 08 26" src="https://user-images.githubusercontent.com/3608562/77792969-34e84f80-7061-11ea-91a7-fe2fa4dcafd2.png">
<img width="918" alt="Screenshot 2020-03-27 at 19 09 08" src="https://user-images.githubusercontent.com/3608562/77792970-34e84f80-7061-11ea-84c1-b128e132c631.png">
