### PR TITLE
HUB-566: Change how AB test is reported

### DIFF
--- a/app/constraints/select_route.rb
+++ b/app/constraints/select_route.rb
@@ -2,19 +2,17 @@ require 'cookies/cookies'
 require 'ab_test/ab_test'
 
 class SelectRoute
-  def initialize(experiment_name, route, config = { is_start_of_test: false,
-                                                    experiment_loa: nil,
+  def initialize(experiment_name, route, config = { experiment_loa: nil,
                                                     trial_enabled: false })
     @experiment_name = experiment_name
     @experiment_route = "#{@experiment_name}_#{route}"
     @experiment_loa = config[:experiment_loa]
-    @is_start_of_test = config[:is_start_of_test]
     @trial_enabled = config[:trial_enabled]
   end
 
   def matches?(request)
     if cookie_matches_experiment?(request)
-      AbTest.report_ab_test_details(request, @experiment_name) if @is_start_of_test && loa_matches_experiment?(request)
+      AbTest.report_ab_test_details(request, @experiment_name) if loa_matches_experiment?(request)
       true
     else
       false

--- a/app/controllers/partials/analytics_partial_controller.rb
+++ b/app/controllers/partials/analytics_partial_controller.rb
@@ -40,6 +40,7 @@ private
       Analytics::CustomVariable.build_for_js_client(:rp, current_transaction.analytics_description),
       Analytics::CustomVariable.build_for_js_client(:loa_requested, session[:requested_loa])
     ]
+    @piwik_custom_variables.push(ab_test_variant) unless ab_test_variant.nil?
   end
 
   def custom_variables_for_img_tracker
@@ -47,6 +48,13 @@ private
     loa_requested_custom_variable = Analytics::CustomVariable.build(:loa_requested, session[:requested_loa])
     @piwik_custom_variables_img_tracker =
       current_transaction_custom_variable.merge(loa_requested_custom_variable)
+    @piwik_custom_variables_img_tracker.merge!(ab_test_variant) unless ab_test_variant.nil?
+  end
+
+  def ab_test_variant
+    unless flash[:ab_test_variant].nil?
+      Analytics::CustomVariable.build(:ab_test, flash[:ab_test_variant])
+    end
   end
 
   def report_user_outcome_to_piwik(response_status)

--- a/app/models/ab_test/ab_test.rb
+++ b/app/models/ab_test/ab_test.rb
@@ -45,7 +45,7 @@ module AbTest
 
     if experiment_is_valid(transaction_id, experiment_name)
       alternative_name = self.get_alternative_name(request, experiment_name)
-      FEDERATION_REPORTER.report_ab_test(transaction_id, request, alternative_name)
+      request.flash[:ab_test_variant] = alternative_name
     end
   end
 

--- a/app/models/analytics/federation_reporter.rb
+++ b/app/models/analytics/federation_reporter.rb
@@ -1,6 +1,5 @@
 module Analytics
   class FederationReporter
-    AB_TEST_ACTION_NAME = 'The user has started an AB test'.freeze
     EXTERNAL_AB_TEST_ACTION_NAME = 'The user has started an external AB test'.freeze
 
     def initialize(analytics_reporter)
@@ -39,20 +38,6 @@ module Analytics
         'The user has started a single idp journey',
         Analytics::CustomVariable.build(:journey_type, 'SINGLE_IDP')
       )
-    end
-
-    def report_ab_test(transaction_id, request, alternative_name)
-      unless transaction_id.nil?
-        current_transaction = RP_DISPLAY_REPOSITORY.get_translations(transaction_id)
-        ab_test_custom_var = Analytics::CustomVariable.build(:ab_test, alternative_name)
-
-        report_action(
-          current_transaction,
-          request,
-          AB_TEST_ACTION_NAME,
-          ab_test_custom_var
-        )
-      end
     end
 
     def report_external_ab_test(request, ab_test_name)

--- a/config/main_routes.rb
+++ b/config/main_routes.rb
@@ -8,10 +8,8 @@ get 'begin_sign_in', to: 'start#sign_in', as: :begin_sign_in
 
 # HUH-233 short hub 2019 q3 multivariate tests - LOA2 only
 SHORT_HUB_2019_Q3 = "short_hub_2019_q3-preview".freeze
-short_hub_v3_control_a_piwik = SelectRoute.new(SHORT_HUB_2019_Q3, 'control_a', is_start_of_test: true, experiment_loa: 'LEVEL_2')
-short_hub_v3_variant_c_piwik = SelectRoute.new(SHORT_HUB_2019_Q3, 'variant_c_2_idp_short_hub', is_start_of_test: true, experiment_loa: 'LEVEL_2')
-short_hub_v3_control_a = SelectRoute.new(SHORT_HUB_2019_Q3, 'control_a', is_start_of_test: false, experiment_loa: 'LEVEL_2')
-short_hub_v3_variant_c = SelectRoute.new(SHORT_HUB_2019_Q3, 'variant_c_2_idp_short_hub', is_start_of_test: false, experiment_loa: 'LEVEL_2')
+short_hub_v3_control_a = SelectRoute.new(SHORT_HUB_2019_Q3, 'control_a', experiment_loa: 'LEVEL_2')
+short_hub_v3_variant_c = SelectRoute.new(SHORT_HUB_2019_Q3, 'variant_c_2_idp_short_hub', experiment_loa: 'LEVEL_2')
 
 constraints IsLoa1 do
   get 'start', to: 'start#index', as: :start
@@ -131,18 +129,9 @@ end
 # Control A = unaffected
 # Variant C = 2 IDPs and new shorter hub journey
 
-# HUH-233: implement piwik control A starting route
-constraints short_hub_v3_control_a_piwik do
-  get 'about', to: 'about_loa2#index', as: :about
-end
-
-# HUH-234: implement piwik variant C starting route
-constraints short_hub_v3_variant_c_piwik do
-  get 'about', to: 'about_loa2_variant_c#index', as: :about
-end
-
 # HUH-233: implement control A route
 constraints short_hub_v3_control_a do
+  get 'about', to: 'about_loa2#index', as: :about
   get 'about_certified_companies', to: 'about_loa2#certified_companies', as: :about_certified_companies
   get 'about_identity_accounts', to: 'about_loa2#identity_accounts', as: :about_identity_accounts
   get 'about_choosing_a_company', to: 'about_loa2#choosing_a_company', as: :about_choosing_a_company
@@ -165,6 +154,7 @@ end
 
 # HUH-234: implement appropriate variant C routes
 constraints short_hub_v3_variant_c do
+  get 'about', to: 'about_loa2_variant_c#index', as: :about
   get 'will_it_work_for_me', to: 'will_it_work_for_me#index', as: :will_it_work_for_me
   post 'will_it_work_for_me', to: 'will_it_work_for_me#will_it_work_for_me', as: :will_it_work_for_me_submit
 

--- a/spec/constraints/select_route_spec.rb
+++ b/spec/constraints/select_route_spec.rb
@@ -24,7 +24,7 @@ describe SelectRoute do
     end
 
     it 'evaluates true when experiment and route both match' do
-      expect(experiment_stub).to receive(:alternative_name).with(ALTERNATIVE_NAME).and_return(ALTERNATIVE_NAME)
+      expect(experiment_stub).to receive(:alternative_name).twice.with(ALTERNATIVE_NAME).and_return(ALTERNATIVE_NAME)
 
       cookies = create_ab_test_cookie(EXP_NAME, ALTERNATIVE_NAME)
       request = RequestStub.new(session, cookies)
@@ -51,7 +51,7 @@ describe SelectRoute do
 
   context 'reporting for any LOA' do
     before(:each) do
-      select_route = SelectRoute.new(EXP_NAME, 'variant', is_start_of_test: true)
+      select_route = SelectRoute.new(EXP_NAME, 'variant')
     end
 
     it 'executes ab_reporter when experiment matches' do
@@ -84,7 +84,7 @@ describe SelectRoute do
 
       cookies = create_ab_test_cookie(EXP_NAME, ALTERNATIVE_NAME)
 
-      select_route = SelectRoute.new(EXP_NAME, 'variant', is_start_of_test: true, experiment_loa: 'LEVEL_1')
+      select_route = SelectRoute.new(EXP_NAME, 'variant', experiment_loa: 'LEVEL_1')
     end
 
     it 'executes ab_reporter when LOA matches' do
@@ -164,10 +164,16 @@ private
     def to_str
       'request example'
     end
+
+    def flash
+      {}
+    end
   end
 
   class MockExperiment
     def alternative_name(something); end
+
+    def concluded?; end
   end
 
   def create_ab_test_cookie(experiment_name, alternative_name)

--- a/spec/models/analytics/federation_reporter_spec.rb
+++ b/spec/models/analytics/federation_reporter_spec.rb
@@ -255,28 +255,6 @@ module Analytics
       end
     end
 
-    describe '#report_ab_test' do
-      before(:each) do
-        RP_DISPLAY_REPOSITORY = double
-        transaction = double
-        allow(transaction).to receive(:analytics_description).and_return('description')
-        allow(RP_DISPLAY_REPOSITORY).to receive(:get_translations).with('test-rp').and_return(transaction)
-      end
-
-      it 'should report an ab test custom variable' do
-        alternative_name = 'alternative_name'
-        expect(analytics_reporter).to receive(:report_action)
-          .with(
-            request,
-            'The user has started an AB test',
-            1 => %w(RP description),
-            2 => %w(LOA_REQUESTED LEVEL_2),
-            6 => ['AB_TEST', alternative_name]
-          )
-        federation_reporter.report_ab_test('test-rp', request, alternative_name)
-      end
-    end
-
     describe '#report_external_ab_test' do
       before(:each) do
         transaction = double


### PR DESCRIPTION
Piwik/Matomo tracks what variant the user is in during an AB test. This is achieved by setting a custom
variable for AB_TEST. Currently this gets set by reporting a virtual page view
"The user has started an AB test" at the start of the test.

This change stops using the extra call to piwik, but instead adds the custom variable
our existing array (along with LOA and RP). Which gets reported with a standard page view.
This eliminates the race condition between the virtual page view and a standard page view.

It's using flash on the request, as it's not needed to persist across and is only required
when user visits the routes which are being AB-tested.

Additionally, it also simplifies the set up of the AB test, since we no longer need
two set of constraints for piwik reporting and normal routes.