### PR TITLE
BAU: Temporary short hub AB test tear-down

### DIFF
--- a/config/main_routes.rb
+++ b/config/main_routes.rb
@@ -6,10 +6,11 @@ get 'sign_in', to: 'sign_in#index', as: :sign_in
 post 'sign_in', to: 'sign_in#select_idp', as: :sign_in_submit
 get 'begin_sign_in', to: 'start#sign_in', as: :begin_sign_in
 
+# TEMPORARY TEAR DOWN
 # HUH-233 short hub 2019 q3 multivariate tests - LOA2 only
-SHORT_HUB_2019_Q3 = "short_hub_2019_q3-preview".freeze
-short_hub_v3_control_a = SelectRoute.new(SHORT_HUB_2019_Q3, 'control_a', experiment_loa: 'LEVEL_2')
-short_hub_v3_variant_c = SelectRoute.new(SHORT_HUB_2019_Q3, 'variant_c_2_idp_short_hub', experiment_loa: 'LEVEL_2')
+#SHORT_HUB_2019_Q3 = "short_hub_2019_q3-preview".freeze
+#short_hub_v3_control_a = SelectRoute.new(SHORT_HUB_2019_Q3, 'control_a', experiment_loa: 'LEVEL_2')
+#short_hub_v3_variant_c = SelectRoute.new(SHORT_HUB_2019_Q3, 'variant_c_2_idp_short_hub', experiment_loa: 'LEVEL_2')
 
 constraints IsLoa1 do
   get 'start', to: 'start#index', as: :start
@@ -41,28 +42,28 @@ constraints IsLoa2 do
   post 'start', to: 'start#request_post', as: :start
   get 'begin_registration', to: 'start#register', as: :begin_registration
 
-  # get 'about', to: 'about_loa2#index', as: :about
-  # get 'about_certified_companies', to: 'about_loa2#certified_companies', as: :about_certified_companies
-  # get 'about_identity_accounts', to: 'about_loa2#identity_accounts', as: :about_identity_accounts
-  # get 'about_choosing_a_company', to: 'about_loa2#choosing_a_company', as: :about_choosing_a_company
+  get 'about', to: 'about_loa2#index', as: :about
+  get 'about_certified_companies', to: 'about_loa2#certified_companies', as: :about_certified_companies
+  get 'about_identity_accounts', to: 'about_loa2#identity_accounts', as: :about_identity_accounts
+  get 'about_choosing_a_company', to: 'about_loa2#choosing_a_company', as: :about_choosing_a_company
 
-  #get 'will_it_work_for_me', to: 'will_it_work_for_me#index', as: :will_it_work_for_me
-  #post 'will_it_work_for_me', to: 'will_it_work_for_me#will_it_work_for_me', as: :will_it_work_for_me_submit
+  get 'will_it_work_for_me', to: 'will_it_work_for_me#index', as: :will_it_work_for_me
+  post 'will_it_work_for_me', to: 'will_it_work_for_me#will_it_work_for_me', as: :will_it_work_for_me_submit
   get 'why_might_this_not_work_for_me', to: 'will_it_work_for_me#why_might_this_not_work_for_me', as: :why_might_this_not_work_for_me
   get 'may_not_work_if_you_live_overseas', to: 'will_it_work_for_me#may_not_work_if_you_live_overseas', as: :may_not_work_if_you_live_overseas
   get 'will_not_work_without_uk_address', to: 'will_it_work_for_me#will_not_work_without_uk_address', as: :will_not_work_without_uk_address
-  #get 'select_documents', to: 'select_documents#index', as: :select_documents
-  #get 'select_documents_none', to: 'select_documents#no_documents', as: :select_documents_no_documents
-  #post 'select_documents', to: 'select_documents#select_documents', as: :select_documents_submit
+  get 'select_documents', to: 'select_documents#index', as: :select_documents
+  get 'select_documents_none', to: 'select_documents#no_documents', as: :select_documents_no_documents
+  post 'select_documents', to: 'select_documents#select_documents', as: :select_documents_submit
   get 'other_identity_documents', to: 'other_identity_documents#index', as: :other_identity_documents
   post 'other_identity_documents', to: 'other_identity_documents#select_other_documents', as: :other_identity_documents_submit
-  # get 'select_phone', to: 'select_phone#index', as: :select_phone
-  # post 'select_phone', to: 'select_phone#select_phone', as: :select_phone_submit
-  # get 'verify_will_not_work_for_you', to: 'select_phone#verify_will_not_work_for_you', as: :verify_will_not_work_for_you
+  get 'select_phone', to: 'select_phone#index', as: :select_phone
+  post 'select_phone', to: 'select_phone#select_phone', as: :select_phone_submit
+  get 'verify_will_not_work_for_you', to: 'select_phone#verify_will_not_work_for_you', as: :verify_will_not_work_for_you
 
-  # get 'choose_a_certified_company', to: 'choose_a_certified_company_loa2#index', as: :choose_a_certified_company
-  # get 'choose_a_certified_company/:company', to: 'choose_a_certified_company_loa2#about', as: :choose_a_certified_company_about
-  # post 'choose_a_certified_company', to: 'choose_a_certified_company_loa2#select_idp', as: :choose_a_certified_company_submit
+  get 'choose_a_certified_company', to: 'choose_a_certified_company_loa2#index', as: :choose_a_certified_company
+  get 'choose_a_certified_company/:company', to: 'choose_a_certified_company_loa2#about', as: :choose_a_certified_company_about
+  post 'choose_a_certified_company', to: 'choose_a_certified_company_loa2#select_idp', as: :choose_a_certified_company_submit
 
   get 'why_companies', to: 'why_companies_loa2#index', as: :why_companies
   get 'failed_registration', to: 'failed_registration_loa2#index', as: :failed_registration
@@ -125,46 +126,48 @@ if SINGLE_IDP_FEATURE
   get 'single_idp_start_page', to: 'single_idp_journey#rp_start_page', as: :single_idp_start_page
 end
 
-# HUH-233 short hub 2019 q3 multivariate tests - LOA2 only
-# Control A = unaffected
-# Variant C = 2 IDPs and new shorter hub journey
+## TEMPORARY TEAR DOWN
 
-# HUH-233: implement control A route
-constraints short_hub_v3_control_a do
-  get 'about', to: 'about_loa2#index', as: :about
-  get 'about_certified_companies', to: 'about_loa2#certified_companies', as: :about_certified_companies
-  get 'about_identity_accounts', to: 'about_loa2#identity_accounts', as: :about_identity_accounts
-  get 'about_choosing_a_company', to: 'about_loa2#choosing_a_company', as: :about_choosing_a_company
+# # HUH-233 short hub 2019 q3 multivariate tests - LOA2 only
+# # Control A = unaffected
+# # Variant C = 2 IDPs and new shorter hub journey
 
-  get 'will_it_work_for_me', to: 'will_it_work_for_me#index', as: :will_it_work_for_me
-  post 'will_it_work_for_me', to: 'will_it_work_for_me#will_it_work_for_me', as: :will_it_work_for_me_submit
+# # HUH-233: implement control A route
+# constraints short_hub_v3_control_a do
+#   get 'about', to: 'about_loa2#index', as: :about
+#   get 'about_certified_companies', to: 'about_loa2#certified_companies', as: :about_certified_companies
+#   get 'about_identity_accounts', to: 'about_loa2#identity_accounts', as: :about_identity_accounts
+#   get 'about_choosing_a_company', to: 'about_loa2#choosing_a_company', as: :about_choosing_a_company
 
-  get 'select_documents', to: 'select_documents#index', as: :select_documents
-  get 'select_documents_none', to: 'select_documents#no_documents', as: :select_documents_no_documents
-  post 'select_documents', to: 'select_documents#select_documents', as: :select_documents_submit
+#   get 'will_it_work_for_me', to: 'will_it_work_for_me#index', as: :will_it_work_for_me
+#   post 'will_it_work_for_me', to: 'will_it_work_for_me#will_it_work_for_me', as: :will_it_work_for_me_submit
 
-  get 'select_phone', to: 'select_phone#index', as: :select_phone
-  post 'select_phone', to: 'select_phone#select_phone', as: :select_phone_submit
-  get 'verify_will_not_work_for_you', to: 'select_phone#verify_will_not_work_for_you', as: :verify_will_not_work_for_you
+#   get 'select_documents', to: 'select_documents#index', as: :select_documents
+#   get 'select_documents_none', to: 'select_documents#no_documents', as: :select_documents_no_documents
+#   post 'select_documents', to: 'select_documents#select_documents', as: :select_documents_submit
 
-  get 'choose_a_certified_company', to: 'choose_a_certified_company_loa2#index', as: :choose_a_certified_company
-  get 'choose_a_certified_company/:company', to: 'choose_a_certified_company_loa2#about', as: :choose_a_certified_company_about
-  post 'choose_a_certified_company', to: 'choose_a_certified_company_loa2#select_idp', as: :choose_a_certified_company_submit
-end
+#   get 'select_phone', to: 'select_phone#index', as: :select_phone
+#   post 'select_phone', to: 'select_phone#select_phone', as: :select_phone_submit
+#   get 'verify_will_not_work_for_you', to: 'select_phone#verify_will_not_work_for_you', as: :verify_will_not_work_for_you
 
-# HUH-234: implement appropriate variant C routes
-constraints short_hub_v3_variant_c do
-  get 'about', to: 'about_loa2_variant_c#index', as: :about
-  get 'will_it_work_for_me', to: 'will_it_work_for_me#index', as: :will_it_work_for_me
-  post 'will_it_work_for_me', to: 'will_it_work_for_me#will_it_work_for_me', as: :will_it_work_for_me_submit
+#   get 'choose_a_certified_company', to: 'choose_a_certified_company_loa2#index', as: :choose_a_certified_company
+#   get 'choose_a_certified_company/:company', to: 'choose_a_certified_company_loa2#about', as: :choose_a_certified_company_about
+#   post 'choose_a_certified_company', to: 'choose_a_certified_company_loa2#select_idp', as: :choose_a_certified_company_submit
+# end
 
-  get 'select_documents', to: 'select_documents_variant_c#index', as: :select_documents
+# # HUH-234: implement appropriate variant C routes
+# constraints short_hub_v3_variant_c do
+#   get 'about', to: 'about_loa2_variant_c#index', as: :about
+#   get 'will_it_work_for_me', to: 'will_it_work_for_me#index', as: :will_it_work_for_me
+#   post 'will_it_work_for_me', to: 'will_it_work_for_me#will_it_work_for_me', as: :will_it_work_for_me_submit
 
-  get 'select_documents_none', to: 'select_documents_variant_c#no_documents', as: :select_documents_no_documents
-  post 'select_documents', to: 'select_documents_variant_c#select_documents', as: :select_documents_submit
-  get 'select_documents_advice', to: 'select_documents_variant_c#advice', as: :select_documents_advice
+#   get 'select_documents', to: 'select_documents_variant_c#index', as: :select_documents
 
-  get 'choose_a_certified_company', to: 'choose_a_certified_company_loa2_variant_c#index', as: :choose_a_certified_company
-  get 'choose_a_certified_company/:company', to: 'choose_a_certified_company_loa2_variant_c#about', as: :choose_a_certified_company_about
-  post 'choose_a_certified_company', to: 'choose_a_certified_company_loa2_variant_c#select_idp', as: :choose_a_certified_company_submit
-end
+#   get 'select_documents_none', to: 'select_documents_variant_c#no_documents', as: :select_documents_no_documents
+#   post 'select_documents', to: 'select_documents_variant_c#select_documents', as: :select_documents_submit
+#   get 'select_documents_advice', to: 'select_documents_variant_c#advice', as: :select_documents_advice
+
+#   get 'choose_a_certified_company', to: 'choose_a_certified_company_loa2_variant_c#index', as: :choose_a_certified_company
+#   get 'choose_a_certified_company/:company', to: 'choose_a_certified_company_loa2_variant_c#about', as: :choose_a_certified_company_about
+#   post 'choose_a_certified_company', to: 'choose_a_certified_company_loa2_variant_c#select_idp', as: :choose_a_certified_company_submit
+# end

--- a/spec/controllers/about_loa2_variant_c_controller_spec.rb
+++ b/spec/controllers/about_loa2_variant_c_controller_spec.rb
@@ -4,6 +4,8 @@ require 'api_test_helper'
 require 'variant_test_helper'
 
 describe AboutLoa2VariantCController do
+  before { skip("Short hub AB test temporarily teared down") }
+
   let(:identity_provider_display_decorator) { double(:IdentityProviderDisplayDecorator) }
 
   before(:each) do

--- a/spec/controllers/choose_a_certified_company_loa2_variant_c_controller_spec.rb
+++ b/spec/controllers/choose_a_certified_company_loa2_variant_c_controller_spec.rb
@@ -4,6 +4,8 @@ require 'api_test_helper'
 require 'piwik_test_helper'
 
 describe ChooseACertifiedCompanyLoa2VariantCController do
+  before { skip("Short hub AB test temporarily teared down") }
+
   let(:stub_idp_one) {
     {
         'simpleId' => 'stub-idp-one',

--- a/spec/controllers/select_documents_variant_c_controller_spec.rb
+++ b/spec/controllers/select_documents_variant_c_controller_spec.rb
@@ -7,6 +7,8 @@ require 'piwik_test_helper'
 require 'models/display/viewable_identity_provider'
 
 describe SelectDocumentsVariantCController do
+  before { skip("Short hub AB test temporarily teared down") }
+
   before(:each) do
     experiment = 'short_hub_2019_q3-preview'
     variant = 'variant_c_2_idp_short_hub'

--- a/spec/features/user_visits_about_page_variant_spec.rb
+++ b/spec/features/user_visits_about_page_variant_spec.rb
@@ -4,6 +4,8 @@ require 'piwik_test_helper'
 require 'api_test_helper'
 
 RSpec.describe 'When the user visits the about page' do
+  before { skip("Short hub AB test temporarily teared down") }
+
   context 'session cookie also contains variant c' do
     before(:each) do
       stub_api_idp_list_for_registration

--- a/spec/features/user_visits_choose_a_certified_company_variant_c_page_spec.rb
+++ b/spec/features/user_visits_choose_a_certified_company_variant_c_page_spec.rb
@@ -1,7 +1,9 @@
 require 'feature_helper'
 require 'api_test_helper'
 
-describe 'When the user visits the choose a certified company page' do
+describe 'When the user visits the choose a certified company variant page' do
+  before { skip("Short hub AB test temporarily teared down") }
+
   let(:stub_idp_one) {
     {
         'simpleId' => 'stub-idp-one',

--- a/spec/features/user_visits_select_documents_variant_c_page_spec.rb
+++ b/spec/features/user_visits_select_documents_variant_c_page_spec.rb
@@ -2,6 +2,8 @@ require 'feature_helper'
 require 'api_test_helper'
 
 RSpec.feature 'When user visits document selection page' do
+  before { skip("Short hub AB test temporarily teared down") }
+
   before(:each) do
     experiment = { "short_hub_2019_q3-preview" => "short_hub_2019_q3-preview_variant_c_2_idp_short_hub" }
     set_session_and_ab_session_cookies!(experiment)


### PR DESCRIPTION
We want to run a different AB test, so partially tearing the short hub one.
All the code is left, the routes are just put back and tests skipped.