### PR TITLE
BAU: Fix broken test due to content being removed

### DIFF
--- a/spec/features/user_visits_start_page_variant_spec.rb
+++ b/spec/features/user_visits_start_page_variant_spec.rb
@@ -133,10 +133,9 @@ RSpec.describe 'When the user visits the start page' do
       expired_start_time = 2.hours.ago.to_i * 1000
       page.set_rack_session(start_time: expired_start_time)
       visit '/start'
-      expect(page).to have_content t('hub.transaction_list.title')
-      expect(page).to have_link 'test GOV.UK Verify user journeys', href: 'http://localhost:50130/test-rp'
+      expect(page).to have_content t('errors.session_timeout.return_to_service')
       expect(page).to have_http_status :bad_request
-      expect(page).to have_link 'feedback', href: '/feedback?feedback-source=EXPIRED_ERROR_PAGE'
+      expect(page).to have_link 'feedback', href: '/feedback-landing?feedback-source=EXPIRED_ERROR_PAGE'
     end
   end
 


### PR DESCRIPTION
Content was removed in a previous PR https://github.com/alphagov/verify-frontend/pull/826, somehow this test managed to get through passing previously. Changed the content to what it should now be.