### PR TITLE
HUB-579: Enhance tracking of session timeouts

### DIFF
--- a/app/models/session_validator/session_start_time_validator.rb
+++ b/app/models/session_validator/session_start_time_validator.rb
@@ -18,8 +18,8 @@ class SessionValidator
 
     def validate_expiry(session, session_start_time)
       if session_start_time <= @session_duration.minutes.ago
-        session_id = session[:verify_session_id]
-        ValidationFailure.session_expired(session_id)
+        minutes_ago = ((DateTime.now - session_start_time) * 24 * 60).to_i
+        ValidationFailure.session_expired(session, minutes_ago)
       else
         SuccessfulValidation
       end

--- a/app/models/session_validator/validation_failure.rb
+++ b/app/models/session_validator/validation_failure.rb
@@ -4,8 +4,9 @@ class SessionValidator
       ValidationFailure.new(:something_went_wrong, :internal_server_error, message)
     end
 
-    def self.session_expired(session_id)
-      message = "session \"#{session_id}\" has expired"
+    def self.session_expired(session, minutes_ago)
+      message = "session \"#{session[:verify_session_id]}\" has expired #{minutes_ago} minutes ago"
+      ActiveSupport::Notifications.instrument('session_timeout', minutes_ago: minutes_ago, service: session[:transaction_entity_id], idp: session[:selected_idp_name])
       ValidationFailure.new(:session_timeout, :bad_request, message)
     end
 

--- a/config/initializers/prometheus.rb
+++ b/config/initializers/prometheus.rb
@@ -9,4 +9,7 @@ if CONFIG.prometheus_enabled
 
   api_request_reporter = Prometheus::ApiRequestReporter.new
   event_subscriber.subscribe(/api_request/, api_request_reporter)
+
+  session_timeout_reporter = Prometheus::SessionTimeoutReporter.new
+  event_subscriber.subscribe(/session_timeout/, session_timeout_reporter)
 end

--- a/lib/prometheus.rb
+++ b/lib/prometheus.rb
@@ -1,6 +1,7 @@
 require 'prometheus/api_request_reporter'
 require 'prometheus/controller_action_reporter'
 require 'prometheus/event_subscriber'
+require 'prometheus/session_timeout_reporter'
 
 module Prometheus
 end

--- a/lib/prometheus/session_timeout_reporter.rb
+++ b/lib/prometheus/session_timeout_reporter.rb
@@ -1,0 +1,13 @@
+module Prometheus
+  class SessionTimeoutReporter
+    def initialize(prometheus = Prometheus::Client.registry)
+      @counter = prometheus.counter(:verify_frontend_session_timeout_total, docstring: "Number of session timeouts", labels: %i(service idp))
+      @summary = prometheus.summary(:verify_frontend_session_timeout_minutes_ago, docstring: "Ago minutes when the session expired", labels: %i(service idp))
+    end
+
+    def report(_name, _start, _finish, _id, payload)
+      @summary.observe(payload[:minutes_ago], labels: { service: payload[:service], idp: payload[:idp] })
+      @counter.increment(labels: { service: payload[:service], idp: payload[:idp] })
+    end
+  end
+end

--- a/spec/features/user_visits_start_page_spec.rb
+++ b/spec/features/user_visits_start_page_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe 'When the user visits the start page' do
     it 'will display the timeout expiration error when the session start cookie is old' do
       session_id_cookie = create_cookie_hash[CookieNames::SESSION_ID_COOKIE_NAME]
       allow(Rails.logger).to receive(:info)
-      expect(Rails.logger).to receive(:info).with("session \"#{session_id_cookie}\" has expired").at_least(:once)
+      expect(Rails.logger).to receive(:info).with("session \"#{session_id_cookie}\" has expired 120 minutes ago").at_least(:once)
       set_session_and_session_cookies!
       expired_start_time = 2.hours.ago.to_i * 1000
       page.set_rack_session(start_time: expired_start_time)

--- a/spec/features/user_visits_start_page_variant_spec.rb
+++ b/spec/features/user_visits_start_page_variant_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe 'When the user visits the start page' do
     it 'will display the timeout expiration error when the session start cookie is old' do
       session_id_cookie = create_cookie_hash[CookieNames::SESSION_ID_COOKIE_NAME]
       allow(Rails.logger).to receive(:info)
-      expect(Rails.logger).to receive(:info).with("session \"#{session_id_cookie}\" has expired").at_least(:once)
+      expect(Rails.logger).to receive(:info).with("session \"#{session_id_cookie}\" has expired 120 minutes ago").at_least(:once)
       set_session_and_session_cookies!
       expired_start_time = 2.hours.ago.to_i * 1000
       page.set_rack_session(start_time: expired_start_time)

--- a/spec/lib/prometheus/session_timeout_reporter_spec.rb
+++ b/spec/lib/prometheus/session_timeout_reporter_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+require 'prometheus'
+require 'prometheus/session_timeout_reporter'
+
+module Prometheus
+  describe SessionTimeoutReporter do
+    let(:prometheus) { double(:prometheus_registry) }
+    let(:counter) { double(:counter) }
+    let(:summary) { double(:summary) }
+    let(:reporter) { SessionTimeoutReporter.new(prometheus) }
+
+    before(:each) do
+      expect(prometheus).to receive(:counter)
+                              .with(:verify_frontend_session_timeout_total, docstring: /Number of session timeouts/, labels: %i(service idp))
+                              .and_return(counter)
+      expect(prometheus).to receive(:summary)
+                              .with(:verify_frontend_session_timeout_minutes_ago, docstring: /Ago minutes when the session expired/, labels: %i(service idp))
+                              .and_return(summary)
+    end
+
+    it 'should send total session timeouts' do
+      minutes_ago = 10
+      payload = { minutes_ago: minutes_ago, service: 'test-rp', idp: 'stub-idp' }
+      expect(counter).to receive(:increment).with(labels: { service: 'test-rp', idp: 'stub-idp' })
+      expect(summary).to receive(:observe).with(minutes_ago, labels: { service: 'test-rp', idp: 'stub-idp' })
+      reporter.report('event_name', 'start', 'finish', 'notification_id', payload)
+    end
+  end
+end

--- a/spec/models/session_validator_spec.rb
+++ b/spec/models/session_validator_spec.rb
@@ -88,7 +88,7 @@ describe SessionValidator do
     validation = session_validator.validate(cookies, session)
     expect(validation).to_not be_ok
     expect(validation.type).to eql :session_timeout
-    expect(validation.message).to eql 'session "my-session-id" has expired'
+    expect(validation.message).to eql 'session "my-session-id" has expired 120 minutes ago'
   end
 
   it "will fail validation if session id in session is set to 'no-current-session'" do


### PR DESCRIPTION
We'd like to know how long people take to complete and when their session
expire. This adds a prometheus metrics to measure number of timeouts and also
a metric when their session expired (in minutes). Also enhanced the current log message
to include the time as well.