### PR TITLE
BUGFIX: Missing link to the service on session expired page

### DIFF
--- a/app/controllers/partials/user_errors_partial_controller.rb
+++ b/app/controllers/partials/user_errors_partial_controller.rb
@@ -1,6 +1,13 @@
 module UserErrorsPartialController
   def render_error(partial, status)
     set_locale
+    if partial == :session_timeout
+      @redirect_to_destination = if CONTINUE_ON_FAILED_REGISTRATION_RPS.include?(current_transaction_simple_id)
+                                   '/redirect-to-service/error'
+                                 else
+                                   session[:transaction_homepage]
+                                 end
+    end
     respond_to do |format|
       format.html { render "errors/#{partial}", status: status, layout: 'application' }
       format.json { render json: {}, status: status }

--- a/app/controllers/redirect_to_idp_controller.rb
+++ b/app/controllers/redirect_to_idp_controller.rb
@@ -67,7 +67,7 @@ class RedirectToIdpController < ApplicationController
       FEDERATION_REPORTER.report_single_idp_journey_selection(current_transaction, request, session[:selected_idp_name])
       render :redirect_to_idp
     else
-      render_error 'session_timeout', :forbidden
+      render_error 'session_error', :bad_request
     end
   end
 

--- a/app/models/session_validator/validation_failure.rb
+++ b/app/models/session_validator/validation_failure.rb
@@ -7,7 +7,7 @@ class SessionValidator
     def self.session_expired(session, minutes_ago)
       message = "session \"#{session[:verify_session_id]}\" has expired #{minutes_ago} minutes ago"
       ActiveSupport::Notifications.instrument('session_timeout', minutes_ago: minutes_ago, service: session[:transaction_entity_id], idp: session[:selected_idp_name])
-      ValidationFailure.new(:session_timeout, :bad_request, message)
+      ValidationFailure.new(:session_timeout, :forbidden, message)
     end
 
     def self.no_cookies

--- a/spec/controllers/redirect_to_idp_controller_spec.rb
+++ b/spec/controllers/redirect_to_idp_controller_spec.rb
@@ -13,9 +13,9 @@ describe RedirectToIdpController do
   context 'single idp journey without cookies' do
     subject { get :single_idp, params: { locale: 'en' } }
 
-    it 'renders a session timeout page' do
+    it 'renders a session error page' do
       cookies.delete CookieNames::VERIFY_SINGLE_IDP_JOURNEY
-      expect(subject).to render_template(:session_timeout)
+      expect(subject).to render_template(:session_error)
       subject
     end
   end

--- a/spec/features/user_visits_start_page_spec.rb
+++ b/spec/features/user_visits_start_page_spec.rb
@@ -103,8 +103,9 @@ RSpec.describe 'When the user visits the start page' do
       page.set_rack_session(start_time: expired_start_time)
       visit '/start'
       expect(page).to have_content t('errors.session_timeout.return_to_service')
-      expect(page).to have_http_status :bad_request
+      expect(page).to have_http_status :forbidden
       expect(page).to have_link 'feedback', href: '/feedback-landing?feedback-source=EXPIRED_ERROR_PAGE'
+      expect(page).to have_link 'Continue', href: 'http://www.test-rp.gov.uk/'
     end
   end
 

--- a/spec/features/user_visits_start_page_variant_spec.rb
+++ b/spec/features/user_visits_start_page_variant_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe 'When the user visits the start page' do
       page.set_rack_session(start_time: expired_start_time)
       visit '/start'
       expect(page).to have_content t('errors.session_timeout.return_to_service')
-      expect(page).to have_http_status :bad_request
+      expect(page).to have_http_status :forbidden
       expect(page).to have_link 'feedback', href: '/feedback-landing?feedback-source=EXPIRED_ERROR_PAGE'
     end
   end


### PR DESCRIPTION
- the button on the "new" timeout page had a link missing because the instance
variable (`@redirect_to_destination`) did not get set.
- reclassified the HTTP code for session expiry to be
403 Forbidden to be consistent
- render error page when Single IDP cookie is invalid instead of session timeout