### PR TITLE
BUGFIX: Incorrect custom variable for JS client

### DIFF
--- a/app/controllers/partials/analytics_partial_controller.rb
+++ b/app/controllers/partials/analytics_partial_controller.rb
@@ -40,7 +40,7 @@ private
       Analytics::CustomVariable.build_for_js_client(:rp, current_transaction.analytics_description),
       Analytics::CustomVariable.build_for_js_client(:loa_requested, session[:requested_loa])
     ]
-    @piwik_custom_variables.push(ab_test_variant) unless ab_test_variant.nil?
+    @piwik_custom_variables.push(Analytics::CustomVariable.build_for_js_client(:ab_test, ab_test_variant)) unless ab_test_variant.nil?
   end
 
   def custom_variables_for_img_tracker


### PR DESCRIPTION
The custom variable for AB_TEST has been wrongly build, using the standard
build function instead of build_for_js one. The impact was that the
variant name did not get reported.