### PR TITLE
HUB-583: Handle not available IDPs on paused/resume pages

### DIFF
--- a/app/controllers/partials/viewable_idp_partial_controller.rb
+++ b/app/controllers/partials/viewable_idp_partial_controller.rb
@@ -52,8 +52,8 @@ module ViewableIdpPartialController
     current_identity_providers_for_sign_in.reject(&:authentication_enabled)
   end
 
-  def current_identity_providers_for_rp_sign_in(rp_entity_id)
-    CONFIG_PROXY.get_idp_list_for_sign_in(rp_entity_id).idps
+  def current_identity_providers_for_registration_rp_loa2(rp_entity_id)
+    CONFIG_PROXY.get_available_idp_list_for_registration(rp_entity_id, 'LEVEL_2').idps
   end
 
   def current_identity_providers_for_single_idp

--- a/app/controllers/paused_registration_controller.rb
+++ b/app/controllers/paused_registration_controller.rb
@@ -80,9 +80,9 @@ private
     from_resume_link_idp_value = resume_link_idp
     if from_resume_link_idp_value.nil?
       last_idp_value = last_idp
-      last_idp_value.nil? ? nil : retrieve_decorated_singleton_idp_array_by_entity_id(current_available_identity_providers_for_sign_in, last_idp_value).first
+      last_idp_value.nil? ? nil : retrieve_decorated_singleton_idp_array_by_entity_id(current_available_identity_providers_for_registration, last_idp_value).first
     else
-      retrieve_decorated_singleton_idp_array_by_simple_id(current_available_identity_providers_for_sign_in, from_resume_link_idp_value).first
+      retrieve_decorated_singleton_idp_array_by_simple_id(current_available_identity_providers_for_registration, from_resume_link_idp_value).first
     end
   end
 
@@ -129,7 +129,7 @@ private
   end
 
   def get_idp_list(transaction_id)
-    list = CONFIG_PROXY.get_idp_list_for_sign_in(transaction_id)
+    list = CONFIG_PROXY.get_available_idp_list_for_registration(transaction_id, 'LEVEL_2')
     return nil if list.nil?
 
     list.idps
@@ -148,7 +148,7 @@ private
   def is_resume_link_for_pending_idp?(idp_simple_id)
     return false unless is_last_status?(PENDING_STATUS)
 
-    idp = retrieve_decorated_singleton_idp_array_by_entity_id(current_identity_providers_for_rp_sign_in(last_rp), last_idp).first
+    idp = retrieve_decorated_singleton_idp_array_by_entity_id(current_identity_providers_for_registration_rp_loa2(last_rp), last_idp).first
 
     idp.simple_id == idp_simple_id
   end

--- a/spec/controllers/paused_registration_controller_spec.rb
+++ b/spec/controllers/paused_registration_controller_spec.rb
@@ -11,7 +11,7 @@ describe PausedRegistrationController do
   before(:each) do
     set_selected_idp('entity_id' => 'http://idcorp.com', 'simple_id' => 'stub-idp-one', 'levels_of_assurance' => %w(LEVEL_1 LEVEL_2))
     set_session_and_cookies_with_loa('LEVEL_2', 'test-rp')
-    stub_api_idp_list_for_sign_in
+    stub_api_idp_list_for_registration
     stub_transaction_details
   end
 

--- a/spec/features/user_visits_paused_page_spec.rb
+++ b/spec/features/user_visits_paused_page_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'When the user is sent to the paused registration page' do
   }
 
   before(:each) do
-    stub_api_idp_list_for_sign_in
+    stub_api_idp_list_for_registration
     set_selected_idp_in_session(entity_id: idp_entity_id, simple_id: 'stub-idp-one')
     set_journey_hint_cookie(idp_entity_id, 'PENDING', 'en', rp_entity_id)
     stub_translations

--- a/spec/features/user_visits_resume_registration_page_spec.rb
+++ b/spec/features/user_visits_resume_registration_page_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe 'When the user visits the resume registration page and ' do
 
   before(:each) do
     set_session_and_session_cookies!(cookie_hash: create_cookie_hash_with_piwik_session)
+    stub_api_idp_list_for_registration
     stub_api_idp_list_for_sign_in
     set_selected_idp_in_session(entity_id: idp_entity_id, simple_id: 'stub-idp-one')
     stub_translations


### PR DESCRIPTION
Currently, a resume page will show for IDPs who are no longer accepting
registrations. This change is to make a switch to check the IDP against the list of registration
IDPs, instead of the one for sign-in. Similar change is on the paused page.
The IDP's simple ID gets now checked with the registration list and
the behaviour is the same when user types in a non-existent IDP