### PR TITLE
HUB-580: Enable running feature tests separately

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -10,6 +10,13 @@ Rails.application.configure do
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that
   # preloads Rails for running tests, you may have to set it to true.
+
+  # HUB-580: The way we use caching for the transaction translations requires us
+  # to either refactor it or enable eager_load to initialize the cache and not ending
+  # up with a deadlock when Capybara uses a single tread and preventing us to run
+  # feature tests separately. For now, this has been done for feature tests only in
+  # the feature_helper file.
+  # IMPACT: The test runtime increases by 3 seconds
   config.eager_load = false
 
   # Configure static file server for tests with Cache-Control for performance.

--- a/spec/feature_helper.rb
+++ b/spec/feature_helper.rb
@@ -11,6 +11,12 @@ RSpec.configure do |config|
   config.before(:each, js: true) do
     page.driver.browser.manage.window.resize_to(1280, 1024)
   end
+  # HUB-580: To run feature tests separately
+  # Due to our multi-threading logic in the loading_cache for
+  # transactions translations we have to boot up the application
+  # to avoid deadlocks after each test
+  VerifyFrontend::Application.eager_load!
+
   config.include AbstractController::Translation
 end
 


### PR DESCRIPTION
The feature tests do not work when run separately using `bundle exec rspec spec/features/some_feature_spec.rb`
This is due to the fact we introduced multithreading for in our loading_cache.
When Capybara runs it uses a single thread causing a deadlock since the
thread gets lost. This change allows the test boostrap the application including
the cache and threads.

This can also be enabled in the test.rb config globally, however we only need
it for the feature tests, so adding it to the feature_helper.