### PR TITLE
BAU: Cookie monster is now no longer needed

### DIFF
--- a/app/controllers/partials/user_cookies_partial_controller.rb
+++ b/app/controllers/partials/user_cookies_partial_controller.rb
@@ -31,7 +31,6 @@ module UserCookiesPartialController
     return if idp_entity_id.nil?
 
     journey_hint_by_status_value = journey_hint_value || {}
-    journey_hint_by_status_value = eat_journey_hint_cookie(journey_hint_by_status_value) unless journey_hint_by_status_value.empty?
     journey_hint_by_status_value['SUCCESS'] = idp_entity_id if status == 'SUCCESS'
     journey_hint_by_status_value['STATE'] = { IDP: idp_entity_id,
                                               RP: rp_entity_id.nil? ? session[:transaction_entity_id] : rp_entity_id,
@@ -79,16 +78,5 @@ private
     MultiJson.load(cookies.encrypted[CookieNames::VERIFY_FRONT_JOURNEY_HINT])
   rescue MultiJson::ParseError
     nil
-  end
-
-  # Clean up users' existing cookies, remove in March 2020
-  def eat_journey_hint_cookie(cookie)
-    yummy_cookie = cookie
-
-    bad_crumbs = %w(CANCEL FAILED FAILED_UPLIFT PENDING OTHER entity_id)
-
-    bad_crumbs.each { |old_status| yummy_cookie.delete(old_status) }
-
-    yummy_cookie
   end
 end

--- a/spec/support/tracking_cookie_examples.rb
+++ b/spec/support/tracking_cookie_examples.rb
@@ -30,25 +30,6 @@ shared_examples 'tracking cookie' do
     it { should eq cookie_with_just_success_status }
   end
 
-  context 'receiving SUCCESS and has cookie with existing entity id' do
-    let(:cookie_with_success_status_and_old_entity) {
-      {
-        SUCCESS: 'http://idcorp.com',
-        STATE:  {
-                  IDP: 'http://idcorp.com',
-                  RP: 'http://www.test-rp.gov.uk/SAML2/MD',
-                  STATUS: 'SUCCESS'
-        }
-      }.to_json
-    }
-    let!(:existing_cookie) {
-      cookies.encrypted[CookieNames::VERIFY_FRONT_JOURNEY_HINT] = {
-        'entity_id' => 'http://idcorp.com'
-      }.to_json
-    }
-    it { should eq cookie_with_success_status_and_old_entity }
-  end
-
   context 'receiving SUCCESS and has cookie with existing status' do
     let(:cookie_with_new_success_status) {
       {
@@ -62,7 +43,6 @@ shared_examples 'tracking cookie' do
     }
     let!(:existing_cookie) {
       cookies.encrypted[CookieNames::VERIFY_FRONT_JOURNEY_HINT] = {
-        'entity_id' => 'http://old-idcorp.com',
         'SUCCESS' => 'http://old-idcorp.com',
         'STATE' => {
                       'IDP' => 'http://old-idcorp.com',
@@ -91,7 +71,6 @@ shared_examples 'tracking cookie' do
       cookies.encrypted[CookieNames::VERIFY_FRONT_JOURNEY_HINT] = {
         'ATTEMPT' => 'http://attempt-idcorp.com',
         'SUCCESS' => 'http://success-idcorp.com',
-        'FAILED_UPLIFT' => 'http://idcorp.com',
         'STATE' =>  {
                       'IDP' => 'http://idcorp.com',
                       'RP' => 'http://www.test-rp.gov.uk/SAML2/MD',


### PR DESCRIPTION
Our cookie monster was implemented in Sep 2018. At that time we changed
the structure/schema of the journey hint cookie. It's been cleaning users'
cookie from the old structure/schema. Given the 18 months cookie
expiry, it's now to safe to remove it as there should be no more users with the old
schema.