### PR TITLE
HUB-582: Update session_timeout page content

### DIFF
--- a/app/views/errors/session_timeout.html.erb
+++ b/app/views/errors/session_timeout.html.erb
@@ -5,7 +5,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l"><%= t 'errors.session_timeout.title' %></h1>
-    <h2 class="govuk-heading-m"><%= t 'errors.session_timeout.return_to_service' %></h2>
+    <p class="govuk-heading-m"><%= t 'errors.session_timeout.return_to_service_html' %></p>
     <p class="govuk-body"><%= link_to t('errors.session_timeout.start_again'), @redirect_to_destination, class: 'govuk-button' %></p>
   </div>
 </div>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -875,7 +875,7 @@ cy:
       feedback: adborth
     session_timeout:
       title: Mae eich sesiwn wedi amseru allan
-      return_to_service: Dylech fynd yn ôl at eich gwasanaeth i ddechrau eto.
+      return_to_service_html: Dylech fynd yn ôl at eich gwasanaeth i ddechrau eto.
       start_again: Dechrau eto
       feedback_message: Defnyddiwch yr %{feedback_link} i ofyn cwestiwn, hysbysu problem neu awgrymu gwelliant.
       feedback: adborth

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -863,9 +863,15 @@ en:
       feedback_message: Use the %{feedback_link} to ask a question, report a problem or suggest an improvement.
       feedback: feedback
     session_timeout:
-      title: Continue to the government service you need
-      return_to_service: Please go to the government service you were trying to access to continue.
-      start_again: Continue
+      title: Return to the government service you need
+      return_to_service_html: |
+        <p class="govuk-body">Sorry, something went wrong.</p>
+        <p class="govuk-body">You need to try again.</p>
+        <ol class="govuk-list govuk-list--number">
+            <li>Return to the government service you were trying to use.</li>
+            <li>When you’re asked to prove your identity, create a new identity account or sign in with an existing one.</li>
+        </ol>
+      start_again: Return to the service
     something_went_wrong:
       title: Something went wrong
       heading: Sorry, something went wrong

--- a/spec/features/user_encounters_error_page_spec.rb
+++ b/spec/features/user_encounters_error_page_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe 'user encounters error page' do
         visit('/test-saml')
         click_button 'saml-post'
         expect(page).to have_content t('errors.session_timeout.title')
-        expect(page).to have_content t('errors.session_timeout.return_to_service')
+        expect(page.body).to include t('errors.session_timeout.return_to_service_html')
         expect(page).to have_css "#piwik-custom-url", text: "errors/timeout-error"
         expect(page).to have_css "a[href*=EXPIRED_ERROR_PAGE]"
         expect(page.status_code).to eq(403)

--- a/spec/features/user_visits_start_page_spec.rb
+++ b/spec/features/user_visits_start_page_spec.rb
@@ -102,10 +102,10 @@ RSpec.describe 'When the user visits the start page' do
       expired_start_time = 2.hours.ago.to_i * 1000
       page.set_rack_session(start_time: expired_start_time)
       visit '/start'
-      expect(page).to have_content t('errors.session_timeout.return_to_service')
+      expect(page.body).to include t('errors.session_timeout.return_to_service_html')
       expect(page).to have_http_status :forbidden
       expect(page).to have_link 'feedback', href: '/feedback-landing?feedback-source=EXPIRED_ERROR_PAGE'
-      expect(page).to have_link 'Continue', href: 'http://www.test-rp.gov.uk/'
+      expect(page).to have_link t('errors.session_timeout.start_again'), href: 'http://www.test-rp.gov.uk/'
     end
   end
 

--- a/spec/features/user_visits_start_page_variant_spec.rb
+++ b/spec/features/user_visits_start_page_variant_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe 'When the user visits the start page' do
       expired_start_time = 2.hours.ago.to_i * 1000
       page.set_rack_session(start_time: expired_start_time)
       visit '/start'
-      expect(page).to have_content t('errors.session_timeout.return_to_service')
+      expect(page.body).to include t('errors.session_timeout.return_to_service_html')
       expect(page).to have_http_status :forbidden
       expect(page).to have_link 'feedback', href: '/feedback-landing?feedback-source=EXPIRED_ERROR_PAGE'
     end


### PR DESCRIPTION
This page is now used for all session timeouts and the content needs to reflect that.

<img width="904" alt="Screenshot 2020-04-06 at 18 34 35" src="https://user-images.githubusercontent.com/3608562/78587755-530a3880-7835-11ea-9a77-340dfda063b7.png">