### PR TITLE
BAU: Fix styling after design system migration

### DIFF
--- a/app/assets/stylesheets/verify-frontend.scss
+++ b/app/assets/stylesheets/verify-frontend.scss
@@ -38,3 +38,9 @@
   display: none;
   visibility: hidden;
 }
+
+.page-with-back-button {
+  @include govuk-media-query($from: tablet) {
+    margin-top: -50px;
+  }
+}

--- a/app/views/choose_a_certified_company/_idp_option.html.erb
+++ b/app/views/choose_a_certified_company/_idp_option.html.erb
@@ -2,7 +2,7 @@
   <%= form_for(identity_provider, url: choose_a_certified_company_submit_path, html: {class: nil, id: nil}) do |f| %>
     <%= hidden_field_tag 'entity_id', identity_provider.entity_id, id: nil %>
     <div class="company-logo">
-      <div class="">
+      <div>
         <%= image_submit_tag(identity_provider.logo_path, alt: "#{identity_provider.display_name} logo") %>
       </div>
       <p class="govuk-body-s">

--- a/app/views/paused_registration/resume.html.erb
+++ b/app/views/paused_registration/resume.html.erb
@@ -3,7 +3,7 @@
 <% content_for :feedback_source, 'RESUME_PAGE' %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds js-continue-to-idp" data-location="<%= url_for(controller: 'paused_registration', action: 'resume_with_idp_ajax', locale: I18n.locale)  %>">
+  <div class="govuk-grid-column-full js-continue-to-idp" data-location="<%= url_for(controller: 'paused_registration', action: 'resume_with_idp_ajax', locale: I18n.locale)  %>">
     <h1 class="govuk-heading-l"><%= t 'hub.paused_registration.resume.heading', display_name: @idp.display_name %></h1>
 
     <p class="govuk-body"><%= t 'hub.paused_registration.resume.intro', display_name: @idp.display_name, service_name: @transaction[:name] %></p>

--- a/app/views/shared/_idp_list.erb
+++ b/app/views/shared/_idp_list.erb
@@ -1,7 +1,7 @@
   <% identity_providers.each_with_index do |identity_provider, idx| %>
     <%= form_for(identity_provider, url: sign_in_submit_path, html: {class: 'idp-option js-idp-form', id: nil}) do |f| %>
       <%= hidden_field_tag 'entity_id', identity_provider.entity_id, id: nil, class: 'js-entity-id' %>
-      <div class="govuk-grid-column-one-third company-wrapper <%= idx % 3 == 0 ? 'clear-left' : nil %>">
+      <div class="<%= identity_providers.length == 1 ? 'govuk-grid-column-one-half' : 'govuk-grid-column-one-third' %> company-wrapper <%= idx % 3 == 0 ? 'clear-left' : nil %>">
         <div class="company">
           <div class="company-inner">
             <div class="company-logo">

--- a/app/views/sign_in/index.html.erb
+++ b/app/views/sign_in/index.html.erb
@@ -19,7 +19,7 @@
         </div>
       <% else %>
         <div class="govuk-grid-row">
-          <div class="">
+          <div>
             <%= render partial: 'shared/disconnected_suggested_idp_list', locals: {identity_provider: @suggested_idp} %>
           </div>
         </div>

--- a/app/views/sign_in/index.html.erb
+++ b/app/views/sign_in/index.html.erb
@@ -2,8 +2,8 @@
 <% content_for :feedback_source, 'SIGN_IN_PAGE' %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
-    <p><%= link_to t('navigation.back'), start_path, class: 'govuk-back-link' %></p>
+  <div class="govuk-grid-column-two-thirds page-with-back-button">
+    <%= link_to t('navigation.back'), start_path, class: 'govuk-back-link' %>
 
     <h1 class="govuk-heading-l"><%= t 'hub.signin.heading' %></h1>
     <p class="lede"><%= t 'hub.signin.registration_message_html', href: link_to(t('hub.signin.about_link'), begin_registration_path, id: 'begin-registration-route') %></p>
@@ -30,18 +30,23 @@
         </div>
       </div>
     <% end %>
-    <div class="govuk-grid-row">
-      <div class="js-continue-to-idp" data-location="<%= url_for(controller: 'sign_in', action: 'select_idp_ajax', locale: I18n.locale) %>">
-        <%= render partial: 'shared/idp_list', locals: {identity_providers: @identity_providers} %>
-        <%= render partial: 'shared/continue_to_idp_form' %>
-      </div>
+  </div>
+</div>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <div class="js-continue-to-idp" data-location="<%= url_for(controller: 'sign_in', action: 'select_idp_ajax', locale: I18n.locale) %>">
+      <%= render partial: 'shared/idp_list', locals: {identity_providers: @identity_providers} %>
+      <%= render partial: 'shared/continue_to_idp_form' %>
     </div>
     <% if @unavailable_identity_providers.any? %>
       <%= render partial: 'shared/unavailable_idp_list', locals: {unavailable_identity_providers: @unavailable_identity_providers} %>
     <% end %>
-
+  </div>
+</div>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
     <p><%= link_to t('hub.signin.forgot_company'), forgot_company_path %></p>
-    
+
     <% if @disconnected_idps.any? %>
       <%= render partial: 'shared/disconnected_idp_list', locals: {disconnected_identity_providers: @disconnected_idps} %>
     <% end %>

--- a/app/views/single_idp_journey/continue_to_your_idp.html.erb
+++ b/app/views/single_idp_journey/continue_to_your_idp.html.erb
@@ -2,7 +2,7 @@
 <% content_for :feedback_source, 'CONTINUE_TO_YOUR_IDP_PAGE' %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds js-continue-to-idp no-right-hand-logo" data-location="<%= url_for(controller: 'single_idp_journey', action: 'continue_ajax', locale: I18n.locale)  %>">
+  <div class="govuk-grid-column-full js-continue-to-idp" data-location="<%= url_for(controller: 'single_idp_journey', action: 'continue_ajax', locale: I18n.locale)  %>">
       <h1 class="govuk-heading-l"><%= t 'hub.single_idp_journey.heading', display_name: @idp.display_name %></h1>
 
       <p class="govuk-body"><%= t 'hub.single_idp_journey.intro', idp_display_name: @idp.display_name, service_display_name: @service_name %></p>
@@ -11,7 +11,7 @@
             <%= hidden_field_tag 'entity_id', @idp.entity_id, id: nil, class: 'js-entity-id' %>
             <%= hidden_field_tag 'singleIdpJourneyIdentifier', @uuid %>
             <%= button_tag t('hub.single_idp_journey.continue_button', display_name: @idp.display_name),
-                          class: 'govuk-button',
+                          class: 'govuk-button verify-inverse-btn button',
                           id: 'continue-to-idp-button',
                           type: 'submit'
             %>


### PR DESCRIPTION
1. Fix the resume page width - https://github.com/alphagov/verify-frontend/commit/b95a49527cfdeb5341422c446085abc5ff103dda

**Before:**
<img width="978" alt="image" src="https://user-images.githubusercontent.com/30629434/78585042-150b1580-7831-11ea-8a68-545a3ad1b08f.png">

**After:**
<img width="975" alt="image" src="https://user-images.githubusercontent.com/30629434/78585056-1b998d00-7831-11ea-97f8-ed8c0a53f38c.png">

=== === ===

2. Fix the sign-in page width and spacing - https://github.com/alphagov/verify-frontend/commit/eff234a46a9a15b55ec760495936ccbd1bb8e6cc

**Before:**
<img width="995" alt="image" src="https://user-images.githubusercontent.com/30629434/78585142-3ff56980-7831-11ea-9bc8-d71d9622342e.png">

**After:**
<img width="980" alt="image" src="https://user-images.githubusercontent.com/30629434/78585152-4388f080-7831-11ea-9fe6-d5e12ea895e0.png">

=== === ===

3. Fix the single IDP screen width and button colour - https://github.com/alphagov/verify-frontend/commit/dcaa918d51b665eb09ce5db15b4682113b21030f

**Before:**
<img width="969" alt="image" src="https://user-images.githubusercontent.com/30629434/78585234-67e4cd00-7831-11ea-944a-a69998b69efb.png">

**After:**
<img width="973" alt="image" src="https://user-images.githubusercontent.com/30629434/78585240-6b785400-7831-11ea-8350-b694dd102714.png">

