### PR TITLE
HUB-572: Show all IDPs after registration failure while splitting traffic between IDPs

### DIFF
--- a/app/controllers/choose_a_certified_company_loa2_controller.rb
+++ b/app/controllers/choose_a_certified_company_loa2_controller.rb
@@ -1,14 +1,16 @@
+require 'partials/journey_hinting_partial_controller'
 require 'partials/viewable_idp_partial_controller'
 
 class ChooseACertifiedCompanyLoa2Controller < ApplicationController
   include ChooseACertifiedCompanyAbout
+  include JourneyHintingPartialController
   include ViewableIdpPartialController
   skip_before_action :render_cross_gov_ga, only: %i{about}
 
   def index
     session[:selected_answers]&.delete('interstitial')
     suggestions = recommendation_engine.get_suggested_idps_for_registration(current_available_identity_providers_for_registration, selected_evidence, current_transaction_simple_id)
-    if THROTTLING_ENABLED
+    if THROTTLING_ENABLED && !is_last_status?(FAILED_STATUS)
       throttled_idp_name = users_idp(suggestions)
       throttled_idp_name = throttled_idp_name.split("idps_")[1]
       throttled_idp = suggestions[:recommended].select { |idp| idp.simple_id == throttled_idp_name }

--- a/app/controllers/partials/journey_hinting_partial_controller.rb
+++ b/app/controllers/partials/journey_hinting_partial_controller.rb
@@ -1,6 +1,7 @@
 # Shared methods for controllers which use the journey hint cookie to give users IDP suggestions
 module JourneyHintingPartialController
   PENDING_STATUS = 'PENDING'.freeze
+  FAILED_STATUS = 'FAILED'.freeze
 
   def journey_hint_value
     MultiJson.load(cookies.encrypted[CookieNames::VERIFY_FRONT_JOURNEY_HINT])

--- a/app/views/failed_registration/_continue_rp.html.erb
+++ b/app/views/failed_registration/_continue_rp.html.erb
@@ -9,3 +9,13 @@
 
 <%= button_link_to t('navigation.continue'), redirect_to_service_error_path, class: 'govuk-button' %>
 
+<h2 class="govuk-heading-m"><%= t 'hub.failed_registration.try_another_summary' %></h2>
+<div>
+  <p class="govuk-body"><%= t 'hub.failed_registration.try_another_text', idp_name: @idp.display_name %></p>
+  <%= link_to t('hub.failed_registration.try_another_company'), try_another_company_path %>
+</div>
+
+<h2 class="govuk-heading-m"><%= t 'hub.failed_registration.contact_details_intro', idp_name: idp.display_name %></h2>
+<div>
+  <%= raw idp.contact_details %>
+</div>

--- a/app/views/failed_registration/_custom_failed_registration.html.erb
+++ b/app/views/failed_registration/_custom_failed_registration.html.erb
@@ -6,3 +6,13 @@
   <%= raw transaction.custom_fail_other_options %>
 </h2>
 
+<h2 class="govuk-heading-m"><%= raw transaction.custom_fail_try_another_summary %></h2>
+<div>
+  <%= raw(transaction.custom_fail_try_another_text % { idp_name: idp.display_name }) %>
+  <%= link_to t('hub.failed_registration.start_again'), start_again_path %>
+</div>
+
+<h2 class="govuk-heading-m"><%= raw(transaction.custom_fail_contact_details_intro % { idp_name: idp.display_name }) %></h2>
+<div>
+  <%= raw idp.contact_details %>
+</div>

--- a/app/views/failed_registration/_non_continue_rp.html.erb
+++ b/app/views/failed_registration/_non_continue_rp.html.erb
@@ -2,8 +2,18 @@
 
 <p class="govuk-body"><%= t 'hub.failed_registration.reasons_html', service_name: @transaction.name %></p>
 
+<h2 class="govuk-heading-m"><%= t 'hub.failed_registration.try_another_summary' %></h2>
+<div>
+  <p class="govuk-body"><%= t 'hub.failed_registration.try_another_text', idp_name: @idp.display_name %></p>
+  <p class="govuk-body"><%= link_to t('hub.failed_registration.start_again'), start_again_path %></p>
+</div>
+
 <h2 class="govuk-heading-m"><%= t 'hub.failed_registration.other_ways_summary', other_ways_description: raw(transaction.other_ways_description) %></h2>
 <div class="govuk-body">
   <%= raw transaction.other_ways_text %>
 </div>
 
+<h2 class="govuk-heading-m"><%= t 'hub.failed_registration.contact_details_intro', idp_name: idp.display_name %></h2>
+<div class="govuk-body">
+  <%= raw idp.contact_details %>
+</div>

--- a/app/views/failed_registration/index_LOA2.html.erb
+++ b/app/views/failed_registration/index_LOA2.html.erb
@@ -6,7 +6,7 @@
     <% if @custom_fail %>
         <%= render partial: 'failed_registration/custom_failed_registration', locals: {idp: @idp, transaction: @transaction, start_again_path: select_documents_path} %>
     <% else %>
-        <%= render partial: 'failed_registration/non_continue_rp', locals: {idp: @idp, transaction: @transaction, start_again_path: select_documents_path} %>
+        <%= render partial: 'failed_registration/non_continue_rp', locals: {idp: @idp, transaction: @transaction, start_again_path: choose_a_certified_company_path} %>
     <% end %>
   </div>
 </div>

--- a/spec/controllers/hint_controller_spec.rb
+++ b/spec/controllers/hint_controller_spec.rb
@@ -68,7 +68,7 @@ describe HintController do
                                      'https://tax.service.gov.uk/SAML2/PERTAX')
     end
 
-    context 'user has previously succesfully signed in' do
+    context 'user has previously successfully signed in' do
       it 'json object should include simpleId and displayName' do
         cookies.encrypted[CookieNames::VERIFY_FRONT_JOURNEY_HINT] = {
           'SUCCESS' => 'http://idcorp-two.com',

--- a/spec/features/user_visits_choose_a_certified_company_page_spec.rb
+++ b/spec/features/user_visits_choose_a_certified_company_page_spec.rb
@@ -81,6 +81,24 @@ describe 'When the user visits the choose a certified company page' do
       end
     end
 
+    it 'displays all IDPs if last status is FAILED' do
+      idp_in_cookie = "idps_stub-idp-two"
+      visit "/test-throttling-cookie/#{idp_in_cookie}"
+      stub_const("THROTTLING_ENABLED", true)
+      set_journey_hint_cookie(nil, 'FAILED')
+
+      visit '/choose-a-certified-company'
+
+      expect(page).to have_current_path(choose_a_certified_company_path)
+      expect(page).to have_content t('hub.choose_a_certified_company.idp_count_html', company_count: '3 companies')
+
+      within('#matching-idps') do
+        expect(page).to have_button('Choose Bob’s Identity Service')
+        expect(page).to have_button('Choose Carol’s Secure ID')
+        expect(page).to have_button('Choose IDCorp')
+      end
+    end
+
     it 'does not show an IDP if the IDP profile has a subset of the user evidence, but not an exact match' do
       additional_documents = selected_answers[:documents].clone
       additional_documents[:driving_licence] = false

--- a/spec/features/user_visits_failed_registration_page_spec.rb
+++ b/spec/features/user_visits_failed_registration_page_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe 'When the user visits the failed registration page and' do
       expect_page_to_have_main_content
       expect(page).to have_content t('hub.failed_registration.other_ways_summary',
                                           other_ways_description: 'test GOV.UK Verify user journeys')
-      expect(page).to have_link t('hub.failed_registration.start_again'), href: select_documents_path
+      expect(page).to have_link t('hub.failed_registration.start_again'), href: choose_a_certified_company_path
     end
 
     it 'includes expected content when LOA1 journey' do

--- a/spec/features/user_visits_failed_registration_page_spec.rb
+++ b/spec/features/user_visits_failed_registration_page_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe 'When the user visits the failed registration page and' do
       expect_page_to_have_main_content
       expect(page).to have_content t('hub.failed_registration.continue_text', rp_name: 'Test RP')
       expect(page).to have_link t('navigation.continue'), href: redirect_to_service_error_path
+      expect(page).to have_link t('hub.failed_registration.try_another_company'), href: select_documents_path
     end
 
     it 'includes expected content for LOA1 journey' do
@@ -33,6 +34,7 @@ RSpec.describe 'When the user visits the failed registration page and' do
       expect_page_to_have_main_content
       expect(page).to have_content t('hub.failed_registration.continue_text', rp_name: 'Test RP')
       expect(page).to have_link t('navigation.continue'), href: redirect_to_service_error_path
+      expect(page).to have_link t('hub.failed_registration.try_another_company'), href: choose_a_certified_company_path
     end
   end
 
@@ -48,6 +50,7 @@ RSpec.describe 'When the user visits the failed registration page and' do
       expect_page_to_have_main_content
       expect(page).to have_content t('hub.failed_registration.other_ways_summary',
                                           other_ways_description: 'test GOV.UK Verify user journeys')
+      expect(page).to have_link t('hub.failed_registration.start_again'), href: select_documents_path
     end
 
     it 'includes expected content when LOA1 journey' do
@@ -57,6 +60,7 @@ RSpec.describe 'When the user visits the failed registration page and' do
       expect_page_to_have_main_content
       expect(page).to have_content t('hub.failed_registration.other_ways_summary',
                                           other_ways_description: 'test GOV.UK Verify user journeys')
+      expect(page).to have_link t('hub.failed_registration.start_again'), href: choose_a_certified_company_path
     end
   end
 
@@ -70,6 +74,7 @@ RSpec.describe 'When the user visits the failed registration page and' do
       visit '/cofrestru-wedi-methu'
       expect(page).to have_content "This is a custom fail page in welsh."
       expect(page).to have_content "Custom text to be provided by RP."
+      expect(page).to have_link t('hub.failed_registration.start_again', locale: :cy), href: select_documents_cy_path
     end
 
     it 'includes expected content when custom fail LOA2 journey' do
@@ -77,12 +82,15 @@ RSpec.describe 'When the user visits the failed registration page and' do
       visit '/failed-registration'
       expect(page).to have_content "This is a custom fail page."
       expect(page).to have_content "Custom text to be provided by RP."
+      expect(page).to have_link t('hub.failed_registration.start_again'), href: select_documents_path
     end
   end
+
 
   def expect_page_to_have_main_content
     expect_feedback_source_to_be(page, 'FAILED_REGISTRATION_PAGE', '/failed-registration')
     expect(page).to have_title t('hub.failed_registration.title')
     expect(page).to have_content t('hub.failed_registration.heading', idp_name: 'IDCorp')
+    expect(page).to have_content t('hub.failed_registration.contact_details_intro', idp_name: 'IDCorp')
   end
 end


### PR DESCRIPTION
Ignore traffic splitting logic if last status is FAILED
Change the link on the failed page to redirect to the IDP picker page.

Revert changes to the failure page from #821 