### PR TITLE
BUGFIX: When hint ignored, report transaction simpleID

### DIFF
--- a/app/controllers/prove_identity_variant_controller.rb
+++ b/app/controllers/prove_identity_variant_controller.rb
@@ -26,7 +26,7 @@ class ProveIdentityVariantController < ApplicationController
     remove_success_journey_hint
     idp = retrieve_decorated_singleton_idp_array_by_entity_id(current_available_identity_providers_for_sign_in, journey_hint_entity_id).first unless journey_hint_entity_id.nil?
     unless idp.nil?
-      FEDERATION_REPORTER.report_sign_in_journey_ignored(current_transaction, request, idp.display_name)
+      FEDERATION_REPORTER.report_sign_in_journey_ignored(current_transaction, request, idp.display_name, session[:transaction_simple_id])
     end
     redirect_to prove_identity_path
   end

--- a/app/controllers/start_variant_controller.rb
+++ b/app/controllers/start_variant_controller.rb
@@ -30,7 +30,7 @@ class StartVariantController < ApplicationController
     remove_success_journey_hint
     idp = retrieve_decorated_singleton_idp_array_by_entity_id(current_available_identity_providers_for_sign_in, journey_hint_entity_id).first unless journey_hint_entity_id.nil?
     unless idp.nil?
-      FEDERATION_REPORTER.report_sign_in_journey_ignored(current_transaction, request, idp.display_name)
+      FEDERATION_REPORTER.report_sign_in_journey_ignored(current_transaction, request, idp.display_name, session[:transaction_simple_id])
     end
     redirect_to start_path
   end

--- a/app/models/analytics/federation_reporter.rb
+++ b/app/models/analytics/federation_reporter.rb
@@ -58,8 +58,8 @@ module Analytics
       )
     end
 
-    def report_sign_in_journey_ignored(current_transaction, request, idp_display_name)
-      report = "HINT_DELETED | sign-in | #{current_transaction} | #{idp_display_name}"
+    def report_sign_in_journey_ignored(current_transaction, request, idp_display_name, transaction_simple_id)
+      report = "HINT_DELETED | sign-in | #{transaction_simple_id} | #{idp_display_name}"
       report_action(
         current_transaction,
         request,

--- a/spec/controllers/prove_identity_variant_controller_spec.rb
+++ b/spec/controllers/prove_identity_variant_controller_spec.rb
@@ -78,7 +78,8 @@ describe ProveIdentityVariantController do
       expect(FEDERATION_REPORTER).to receive(:report_sign_in_journey_ignored).with(
         a_kind_of(Display::RpDisplayData),
         a_kind_of(ActionDispatch::Request),
-        "IDCorp"
+        "IDCorp",
+        "test-rp"
       )
 
       get :ignore_hint, params: { locale: 'en' }

--- a/spec/controllers/start_variant_controller_spec.rb
+++ b/spec/controllers/start_variant_controller_spec.rb
@@ -121,7 +121,8 @@ describe StartVariantController do
       expect(FEDERATION_REPORTER).to receive(:report_sign_in_journey_ignored).with(
         a_kind_of(Display::RpDisplayData),
         a_kind_of(ActionDispatch::Request),
-        "IDCorp"
+        "IDCorp",
+        "test-rp"
       )
 
       get :ignore_hint, params: { locale: 'en' }

--- a/spec/models/analytics/federation_reporter_spec.rb
+++ b/spec/models/analytics/federation_reporter_spec.rb
@@ -364,7 +364,7 @@ module Analytics
 
     describe '#report_sign_in_journey_ignored' do
       it 'should report that the sign in hint was ignored' do
-        transaction_simple_id = current_transaction
+        transaction_simple_id = 'test-rp'
         idp_name = 'stub-idp'
         expect(analytics_reporter).to receive(:report_action)
                                           .with(
@@ -374,7 +374,7 @@ module Analytics
                                             2 => %w(LOA_REQUESTED LEVEL_2)
                                           )
 
-        federation_reporter.report_sign_in_journey_ignored(current_transaction, request, idp_name)
+        federation_reporter.report_sign_in_journey_ignored(current_transaction, request, idp_name, transaction_simple_id)
       end
     end
   end


### PR DESCRIPTION
We shouldn't be reporting the whole transaction, but only the transaction simpleID.
The simpleID has been still present as part of the custom variables.