### PR TITLE
BUGFIX: Add GOV.UK fonts to the asset manifest

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,4 +1,5 @@
 //= link_tree ../../../lib/node_modules/govuk-frontend/govuk/assets/images
+//= link_tree ../../../lib/node_modules/govuk-frontend/govuk/assets/fonts
 //= link_tree ../images
 //= link_directory ../javascripts .js
 //= link application.css


### PR DESCRIPTION
With latest uprade to Rails, we need to explicitly link the directories