### PR TITLE
BAU: Remove old GOV.UK gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,10 +17,6 @@ gem 'autoprefixer-rails'
 gem 'uglifier', '~> 2.7.0'
 gem 'jquery-rails'
 
-gem 'govuk_template'
-gem 'govuk_frontend_toolkit'
-gem 'govuk_elements_rails'
-
 gem 'mini_racer'
 
 # Use statsd-ruby to talk collect and send metrics to graphite

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,15 +117,6 @@ GEM
       rubocop (~> 0.64)
       rubocop-rspec (~> 1.28)
       scss_lint
-    govuk_elements_rails (3.1.3)
-      govuk_frontend_toolkit (>= 6.0.2)
-      rails (>= 4.1.0)
-      sass (>= 3.2.0)
-    govuk_frontend_toolkit (8.1.0)
-      railties (>= 3.1.0)
-      sass (>= 3.2.0)
-    govuk_template (0.26.0)
-      rails (>= 3.1)
     hashdiff (0.3.8)
     hashie (3.6.0)
     headless (2.3.1)
@@ -378,9 +369,6 @@ DEPENDENCIES
   email_validator (~> 1.6)
   geckodriver-helper
   govuk-lint
-  govuk_elements_rails
-  govuk_frontend_toolkit
-  govuk_template
   headless
   http (~> 2.0.0)
   jasmine

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,5 +1,5 @@
+//= link application.css
 //= link_tree ../../../lib/node_modules/govuk-frontend/govuk/assets/images
 //= link_tree ../../../lib/node_modules/govuk-frontend/govuk/assets/fonts
 //= link_tree ../images
 //= link_directory ../javascripts .js
-//= link application.css

--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -1,6 +1,5 @@
 //= require jquery
 //= require jquery_ujs
-//= require govuk/shim-links-with-button-role
 //= require ga
 //= require_tree .
 //= require piwik
@@ -11,8 +10,6 @@
     https://stackoverflow.com/questions/7602393/rails-3-1-sprockets-require-directives-is-there-a-way-to-exclude-particular-fi
 */
 //= stub "piwik_idp_picker_tracking"
-
-window.GOVUK.shimLinksWithButtonRole.init();
 
 window.GOVUK.validation.init();
 window.GOVUK.selectDocuments.init();


### PR DESCRIPTION
After the migration to GOV.UK Frontend 3 (Design System), we no longer
use/need the legacy gems for elements, frontend toolkit and template.