### PR TITLE
HUB-582: Include service name on the session_timeout page

### DIFF
--- a/app/controllers/partials/user_errors_partial_controller.rb
+++ b/app/controllers/partials/user_errors_partial_controller.rb
@@ -2,6 +2,7 @@ module UserErrorsPartialController
   def render_error(partial, status)
     set_locale
     if partial == :session_timeout
+      @other_ways_description = current_transaction.other_ways_description
       @redirect_to_destination = if CONTINUE_ON_FAILED_REGISTRATION_RPS.include?(current_transaction_simple_id)
                                    '/redirect-to-service/error'
                                  else
@@ -29,7 +30,7 @@ module UserErrorsPartialController
                                else
                                  session[:transaction_homepage]
                                end
-    render_error('session_timeout', :forbidden)
+    render_error(:session_timeout, :forbidden)
   end
 
   def session_error(exception)

--- a/app/views/errors/session_timeout.html.erb
+++ b/app/views/errors/session_timeout.html.erb
@@ -1,11 +1,12 @@
-<%= page_title 'errors.session_timeout.title' %>
+<%= page_title 'errors.something_went_wrong.heading' %>
 <% content_for :feedback_source, 'EXPIRED_ERROR_PAGE' %>
 <% content_for :piwik_custom_path, '/errors/timeout-error' %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l"><%= t 'errors.session_timeout.title' %></h1>
-    <p class="govuk-heading-m"><%= t 'errors.session_timeout.return_to_service_html' %></p>
-    <p class="govuk-body"><%= link_to t('errors.session_timeout.start_again'), @redirect_to_destination, class: 'govuk-button' %></p>
+    <h1 class="govuk-heading-l"><%= t 'errors.something_went_wrong.heading' %></h1>
+    <p class="govuk-body"><%= t 'errors.session_timeout.try_again', other_ways_description: @other_ways_description %></p>
+    <p class="govuk-body"><%= t 'errors.session_timeout.return_to_service_html' %></p>
+    <%= button_link_to t('errors.session_timeout.start_again'), @redirect_to_destination, class: "govuk-button" %>
   </div>
 </div>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -874,11 +874,9 @@ cy:
       feedback_message: Defnyddiwch yr %{feedback_link} i ofyn cwestiwn, hysbysu problem neu awgrymu gwelliant.
       feedback: adborth
     session_timeout:
-      title: Mae eich sesiwn wedi amseru allan
+      try_again: Mae eich sesiwn wedi amseru allan
       return_to_service_html: Dylech fynd yn ôl at eich gwasanaeth i ddechrau eto.
       start_again: Dechrau eto
-      feedback_message: Defnyddiwch yr %{feedback_link} i ofyn cwestiwn, hysbysu problem neu awgrymu gwelliant.
-      feedback: adborth
     something_went_wrong:
       title: Mae rhywbeth wedi mynd o’i le
       heading: Mae’n ddrwg gennym, mae rhywbeth wedi mynd o’i le

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -863,12 +863,10 @@ en:
       feedback_message: Use the %{feedback_link} to ask a question, report a problem or suggest an improvement.
       feedback: feedback
     session_timeout:
-      title: Return to the government service you need
+      try_again: "You need to try again so you can %{other_ways_description}."
       return_to_service_html: |
-        <p class="govuk-body">Sorry, something went wrong.</p>
-        <p class="govuk-body">You need to try again.</p>
         <ol class="govuk-list govuk-list--number">
-            <li>Return to the government service you were trying to use.</li>
+            <li>Return to the service.</li>
             <li>When you’re asked to prove your identity, create a new identity account or sign in with an existing one.</li>
         </ol>
       start_again: Return to the service

--- a/spec/api_test_helper.rb
+++ b/spec/api_test_helper.rb
@@ -236,7 +236,7 @@ module ApiTestHelper
     stub_request(:post, saml_proxy_api_uri(NEW_SESSION_ENDPOINT)).with(body: authn_request_body).to_return(body: default_session_id.to_json, status: 200)
   end
 
-  def stub_policy_sign_in_process_details(options)
+  def stub_policy_sign_in_process_details(options = {})
     stub_request(:get, policy_api_uri(sign_in_process_details_endpoint(default_session_id))).to_return(body: sign_in_process_details_stub_response(options).to_json, status: 200)
   end
 

--- a/spec/features/user_encounters_error_page_spec.rb
+++ b/spec/features/user_encounters_error_page_spec.rb
@@ -94,12 +94,18 @@ RSpec.describe 'user encounters error page' do
       end
 
       it 'will present a session timeout error page when the API returns session timeout' do
-        error_body = { errorId: '0', exceptionType: 'SESSION_TIMEOUT' }
-        stub_request(:post, api_saml_endpoint).to_return(body: error_body.to_json, status: 400)
+        stub_saml_proxy_authn_request_endpoint
+        stub_policy_sign_in_process_details
+        stub_transaction_details
+
         visit('/test-saml')
         click_button 'saml-post'
-        expect(page).to have_content t('errors.session_timeout.title')
+        visit('/test-saml')
+        click_button 'saml-post-trigger-session-expiry'
+
+        expect(page).to have_content t('errors.session_timeout.try_again', other_ways_description: t('rps.test-rp.other_ways_description'))
         expect(page.body).to include t('errors.session_timeout.return_to_service_html')
+        expect(page).to have_link t('errors.session_timeout.start_again'), href: "http://www.test-rp.gov.uk/"
         expect(page).to have_css "#piwik-custom-url", text: "errors/timeout-error"
         expect(page).to have_css "a[href*=EXPIRED_ERROR_PAGE]"
         expect(page.status_code).to eq(403)

--- a/stub/api/stub_api.rb
+++ b/stub/api/stub_api.rb
@@ -26,7 +26,7 @@ class StubApi < Sinatra::Base
     status 200
     "{
       \"simpleId\":\"test-rp\",
-      \"serviceHomepage\":\"www.example.com\",
+      \"serviceHomepage\":\"http://localhost:50300/test-saml\",
       \"loaList\":[\"#{level_of_assurance}\"],
       \"headlessStartpage\":\"http://example.com/success\"
     }"


### PR DESCRIPTION
This page is now used for session timeouts and the content needs to reflect that.

<img width="905" alt="Screenshot 2020-04-08 at 14 16 16" src="https://user-images.githubusercontent.com/3608562/78788286-7f43c780-79a3-11ea-9fe3-a541de1e4ae6.png">