### PR TITLE
Ensure correct loa is set in session 

### DIFF
--- a/app/controllers/authn_request_controller.rb
+++ b/app/controllers/authn_request_controller.rb
@@ -63,7 +63,11 @@ private
   end
 
   def set_requested_loa(levels_of_assurance)
-    requested_loa = levels_of_assurance.first
+    if levels_of_assurance.include? "LEVEL_1"
+      puts requested_loa = "LEVEL_1"
+    else
+      requested_loa = levels_of_assurance.first
+    end
     session[:requested_loa] = requested_loa
   end
 

--- a/stub/api/stub_api.rb
+++ b/stub/api/stub_api.rb
@@ -192,6 +192,12 @@ class StubApi < Sinatra::Base
         "serviceHomepage":"http://example.com/test-rp-loa1",
         "loaList":["LEVEL_1","LEVEL_2"],
         "headlessStartpage":"http://example.com/test-rp-loa1/success"
+      }],
+      {
+        "simpleId": "loa2-loa1-test-rp",
+        "serviceHomepage":"http://example.com/test-rp-loa2-loa1",
+        "loaList":["LEVEL_2","LEVEL_1"],
+        "headlessStartpage":"http://example.com/test-rp-loa2-loa1/success"
       }]'
    end
 
@@ -207,6 +213,12 @@ class StubApi < Sinatra::Base
         "redirectUrl":"http://example.com/test-rp-loa1",
         "loaList":["LEVEL_1","LEVEL_2"],
         "entityId": "http://example.com/test-rp-loa1"
+      }],
+      {
+        "simpleId": "loa2-loa1-test-rp",
+        "redirectUrl":"http://example.com/test-rp-loa1",
+        "loaList":["LEVEL_2","LEVEL_1",],
+        "entityId": "http://example.com/test-rp-loa2-loa1"
       }]'
   end
 

--- a/stub/relying_parties.yml
+++ b/stub/relying_parties.yml
@@ -14,6 +14,7 @@ transaction_type:
     - test-rp
     - test-rp-noc3
     - loa1-test-rp
+    - loa2-loa1-test-rp
 redirect_to_rp:
   test-rp:
     url: 'http://localhost:50300/test-saml'


### PR DESCRIPTION
- Currently if any service has LOA1 in their transaction config, then it always appears first in the request. This means the logic which sets the loa in the frontend currently makes sense. However as there will be a new RP where LOA1 comes second and the RP needs to go through the LOA1 hub, then this logic no longer makes sense. 
- Check if any LOA is LEVEL_1 and if it is, then set the LOA in the session to LEVEL_1.
- Add the new loa2_loa1_test_rp to the list of stubs. 