### PR TITLE
Revert "HUB-584: Update Rake version"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,9 @@ group :development do
 
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
+
+  # Used by jenkins.sh to package the frontend
+  gem 'pkgr', '~> 1.5.1'
 end
 
 group :test, :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    CFPropertyList (2.3.6)
     actioncable (5.2.4.2)
       actionpack (= 5.2.4.2)
       nio4r (~> 2.0)
@@ -47,14 +48,18 @@ GEM
     archive-zip (0.12.0)
       io-like (~> 0.3.0)
     arel (9.0.0)
+    arr-pm (0.0.10)
+      cabin (> 0)
     ast (2.4.0)
     autoprefixer-rails (9.5.0)
       execjs
+    backports (3.12.0)
     binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
     browser (2.5.3)
     builder (3.2.4)
     byebug (11.0.1)
+    cabin (0.9.0)
     capybara (2.18.0)
       addressable
       mini_mime (>= 0.1.3)
@@ -64,6 +69,7 @@ GEM
       xpath (>= 2.0, < 4.0)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
+    clamp (1.0.1)
     codacy-coverage (2.1.0)
       simplecov
     concurrent-ruby (1.1.6)
@@ -86,9 +92,23 @@ GEM
     erubi (1.9.0)
     eventmachine (1.2.7)
     execjs (2.7.0)
+    facter (2.5.1)
+    facter (2.5.1-universal-darwin)
+      CFPropertyList (~> 2.2)
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
     ffi (1.10.0)
+    fpm (1.11.0)
+      arr-pm (~> 0.0.10)
+      backports (>= 2.6.2)
+      cabin (>= 0.6.0)
+      childprocess (= 0.9.0)
+      clamp (~> 1.0.0)
+      ffi
+      json (>= 1.7.7, < 2.0)
+      pleaserun (~> 0.0.29)
+      ruby-xz (~> 0.2.3)
+      stud
     geckodriver-helper (0.23.0)
       archive-zip (~> 0.7)
     globalid (0.4.2)
@@ -108,6 +128,7 @@ GEM
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     inflection (1.0.0)
+    insist (1.0.0)
     io-like (0.3.0)
     jaro_winkler (1.5.4)
     jasmine (3.3.0)
@@ -144,8 +165,11 @@ GEM
     mini_racer (0.2.5)
       libv8 (>= 6.9.411)
     minitest (5.14.0)
+    mixlib-log (1.7.1)
+    mixlib-shellout (1.6.1)
     multi_json (1.13.1)
     multipart-post (2.0.0)
+    mustache (0.99.8)
     nio4r (2.5.2)
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
@@ -153,6 +177,20 @@ GEM
     parser (2.7.1.0)
       ast (~> 2.4.0)
     phantomjs (2.1.1.0)
+    pkgr (1.5.1)
+      facter (~> 2.1)
+      fpm (~> 1.1)
+      mixlib-log (~> 1.6)
+      mixlib-shellout (~> 1.4)
+      rake (~> 10.0)
+      thor (~> 0.19)
+    pleaserun (0.0.30)
+      cabin (> 0)
+      clamp
+      dotenv
+      insist
+      mustache (= 0.99.8)
+      stud
     prometheus-client (0.10.0.pre.alpha.1)
       concurrent-ruby
     public_suffix (3.0.3)
@@ -198,7 +236,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.19.0, < 2.0)
     rainbow (3.0.0)
-    rake (13.0.1)
+    rake (10.5.0)
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
@@ -245,6 +283,9 @@ GEM
     rubocop-rspec (1.38.1)
       rubocop (>= 0.68.1)
     ruby-progressbar (1.10.1)
+    ruby-xz (0.2.3)
+      ffi (~> 1.9)
+      io-like (~> 0.3)
     rubyzip (1.3.0)
     safe_yaml (1.0.5)
     sass (3.7.3)
@@ -279,6 +320,7 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     statsd-ruby (1.3.0)
+    stud (0.0.23)
     thin (1.7.2)
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0, >= 1.0.4)
@@ -337,6 +379,7 @@ DEPENDENCIES
   logstash-logger
   mini_racer
   multi_json
+  pkgr (~> 1.5.1)
   prometheus-client (~> 0.10.0.pre.alpha.1)
   puma
   rack-handlers


### PR DESCRIPTION
Reverts alphagov/verify-frontend#848

This supposedly broke logging in AWS. Trying to see if it's really the case by reverting this.