### PR TITLE
BAU: Fix (hopefully) logging to logstash

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -42,3 +42,7 @@ Layout/LeadingCommentSpace:
 Style/PercentLiteralDelimiters:
   PreferredDelimiters:
     Default: ()
+
+Style/StringLiterals:
+  Exclude:
+    - 'config/initializers/*.rb'

--- a/app/controllers/authn_request_controller.rb
+++ b/app/controllers/authn_request_controller.rb
@@ -63,11 +63,11 @@ private
   end
 
   def set_requested_loa(levels_of_assurance)
-    if levels_of_assurance.include? "LEVEL_1"
-      puts requested_loa = "LEVEL_1"
-    else
-      requested_loa = levels_of_assurance.first
-    end
+    requested_loa = if levels_of_assurance.include? "LEVEL_1"
+                      "LEVEL_1"
+                    else
+                      levels_of_assurance.first
+                    end
     session[:requested_loa] = requested_loa
   end
 

--- a/config/initializers/logging.rb
+++ b/config/initializers/logging.rb
@@ -2,12 +2,12 @@
 if Rails.env == "production"
   LogStashLogger.configure do |config|
     config.customize_event do |event|
-      event["SessionId"] = RequestStore.store[:session_id] || "no-current-session"
-      event["level"] = event.remove "severity"
-      event["service-name"] = "front"
+      event['SessionId'] = RequestStore.store[:session_id] || 'no-current-session'
+      event['level'] = event.remove 'severity'
+      event['service-name'] = 'front'
     end
   end
-  logger = LogStashLogger.new(type: :file, path: "log/front.logstash.log", formatter: :json_lines)
+  logger = LogStashLogger.new(type: :file, path: 'log/front.logstash.log', formatter: :json_lines)
   Rails.logger.extend(ActiveSupport::Logger.broadcast(logger))
 end
 


### PR DESCRIPTION
Since the latest linter changes, we're not logging to logstash. We
suspect it's the linter issue and logstash differentiate between ' and ".
Let's give this a go.

Also removed a `puts` statement...