### PR TITLE
Allow any LOA1 service that has eIDAS enabled to see the prove identity page

### DIFF
--- a/config/main_routes.rb
+++ b/config/main_routes.rb
@@ -19,6 +19,8 @@ sign_in_hint_control = SelectRoute.new(SIGN_IN_HINT, "control", experiment_loa: 
 sign_in_hint_variant = SelectRoute.new(SIGN_IN_HINT, "variant", experiment_loa: "LEVEL_2")
 
 constraints IsLoa1 do
+  get "prove_identity", to: "prove_identity#index", as: :prove_identity
+  get "prove_identity_retry", to: "prove_identity#retry_eidas_journey", as: :prove_identity_retry
   get "start", to: "start#index", as: :start
   post "start", to: "start#request_post", as: :start
   get "begin_registration", to: "start#register", as: :begin_registration

--- a/spec/api_test_helper.rb
+++ b/spec/api_test_helper.rb
@@ -61,6 +61,10 @@ module ApiTestHelper
         "simpleId" => "test-rp-with-custom-hint", "serviceHomepage" => "http://localhost:50130/test-rp-with-custom-hint",
         "loaList" => %w(LEVEL_2), "headlessStartpage" => "http://localhost:50130/success?rp-name=test-rp-with-custom-hint"
       },
+      {
+        "simpleId" => "loa1-test-rp", "serviceHomepage" => "http://localhost:50130/loa1-test-rp",
+        "loaList" => %w(LEVEL_1 LEVEL_2), "headlessStartpage" => "http://localhost:50130/success?rp-name=loa1-test-rp"
+      },
     ]
 
     stub_request(:get, api_transactions_endpoint).to_return(body: transactions.to_json, status: 200)
@@ -113,6 +117,8 @@ module ApiTestHelper
       }'
     stub_request(:get, api_translations_endpoint("test-rp-noc3", "en")).to_return(body: test_rp_noc3_translations, status: 200)
     stub_request(:get, api_translations_endpoint("test-rp-noc3", "cy")).to_return(body: "{}", status: 200)
+    stub_request(:get, api_translations_endpoint("loa1-test-rp", "en")).to_return(body: test_rp_noc3_translations, status: 200)
+    stub_request(:get, api_translations_endpoint("loa1-test-rp", "cy")).to_return(body: "{}", status: 200)
     stub_request(:get, api_translations_endpoint("headless-rp", "en")).to_return(body: en_translation_data, status: 200)
     stub_request(:get, api_translations_endpoint("headless-rp", "cy")).to_return(body: "{}", status: 200)
     stub_request(:get, api_translations_endpoint("test-rp-with-continue-on-fail", "en")).to_return(body: en_translation_data, status: 200)

--- a/spec/features/user_sends_authn_request_spec.rb
+++ b/spec/features/user_sends_authn_request_spec.rb
@@ -35,6 +35,19 @@ describe "user sends authn requests" do
       expect(page.get_rack_session["transaction_supports_eidas"]).to eql false
     end
 
+    it "will redirect the user to /choose-a-country for an eidas journey where eidas is enabled and RP LOA is LEVEL_1" do
+      stub_session_creation("simpleId" => "loa1-test-rp", "transactionSupportsEidas" => true)
+      stub_transactions_list
+      stub_countries_list
+
+      visit("/test-saml")
+      click_button "saml-post-eidas"
+
+      expect(page).to have_title t("hub.choose_a_country.title")
+      expect(page.get_rack_session["requested_loa"]).to eql "LEVEL_1"
+      expect(page.get_rack_session["transaction_supports_eidas"]).to eql true
+    end
+
     it "will redirect the user to /choose-a-country for an eidas journey where eidas is enabled" do
       stub_session_creation("transactionSupportsEidas" => true)
       stub_transactions_list

--- a/spec/models/config_proxy_spec.rb
+++ b/spec/models/config_proxy_spec.rb
@@ -14,6 +14,10 @@ describe "ConfigProxy" do
               "loaList" => %w(LEVEL_2), "headlessStartpage" => "http://localhost:50130/success?rp-name=test-rp"
           },
           {
+            "simpleId" => "loa1-test-rp", "serviceHomepage" => "http://localhost:50130/loa1-test-rp",
+            "loaList" => %w(LEVEL_2), "headlessStartpage" => "http://localhost:50130/success?rp-name=loa1-test-rp"
+        },
+          {
               "simpleId" => "test-rp-noc3", "serviceHomepage" => "http://localhost:50130/test-rp-noc3",
               "loaList" => %w(LEVEL_2), "headlessStartpage" => nil
           },


### PR DESCRIPTION
- We want any service that use this ordering of LOAs [LOA2, LOA1] to be able to see the prove identity page when they have eIDAS enabled in their transaction config.
- To achieve this we need to add the prove identity to the LOA1 routes.