### PR TITLE
HUB-518 Handle cases where the entityID found in the resume cookie is…

### DIFF
--- a/app/controllers/paused_registration_controller.rb
+++ b/app/controllers/paused_registration_controller.rb
@@ -121,7 +121,11 @@ private
   def get_rp_details(last_rp_value)
     return nil if last_rp_value.nil?
 
-    CONFIG_PROXY.get_transaction_details(last_rp_value)
+    begin
+      CONFIG_PROXY.get_transaction_details(last_rp_value)
+    rescue APIResponseMismatchError
+      logger.warn "last_rp_value not found: #{last_rp_value}"
+    end
   end
 
   def get_translated_service_name(simple_id)

--- a/spec/controllers/paused_registration_controller_spec.rb
+++ b/spec/controllers/paused_registration_controller_spec.rb
@@ -154,6 +154,18 @@ describe PausedRegistrationController do
       expect(subject).to redirect_to start_path
     end
 
+    it "redirects to start page when invalid RP present in cookie" do
+      front_journey_hint_cookie = {
+          STATE: {
+              IDP: :valid_idp,
+              RP: :'we-changed-our-entityID',
+              STATUS: "PENDING",
+          },
+      }
+      cookies.encrypted[CookieNames::VERIFY_FRONT_JOURNEY_HINT] = front_journey_hint_cookie.to_json
+      expect(subject).to redirect_to start_path
+    end
+
     it "should render error page when user has no session" do
       session.clear
 


### PR DESCRIPTION
… no longer valid

HMRC changed their entityIDs which means that some users with the resume cookie are getting an error page because the entityId isn't registered with Config.

Now the users get the same experience as they would if the IDP was no longer found.

We log this as a warning. If we don't log anything then the linter gets upset about us supressing exceptions and we can't explicitely return nil because the linter gets upset about that instead.