### PR TITLE
HUB-518 Handle cases where the entityID found in the resume cookie is…

### DIFF
--- a/spec/api_test_helper.rb
+++ b/spec/api_test_helper.rb
@@ -258,6 +258,10 @@ module ApiTestHelper
     stub_request(:get, config_api_uri(transaction_display_data_endpoint(default_transaction_entity_id))).to_return(body: transaction_details_stub_response(options).to_json, status: 200)
   end
 
+  def stub_missing_transaction_details
+    stub_request(:get, config_api_uri(transaction_display_data_endpoint(default_transaction_entity_id))).to_return(body: { message: "NONE", type: "NONE", id: "NONE", Referer: "" }.to_json, status: 404)
+  end
+
   def transaction_details_stub_response(options)
     defaults = {
         "simpleId" => "test-rp",

--- a/spec/controllers/paused_registration_controller_spec.rb
+++ b/spec/controllers/paused_registration_controller_spec.rb
@@ -154,9 +154,25 @@ describe PausedRegistrationController do
       expect(subject).to redirect_to start_path
     end
 
+    it "redirects to start page when invalid RP present in cookie" do
+      stub_missing_transaction_details
+      front_journey_hint_cookie = {
+          STATE: {
+              IDP: :valid_idp,
+              RP: :'we-changed-our-entityID',
+              STATUS: "PENDING",
+          },
+          RESUMELINK: {
+              IDP: "stub-idp-two",
+          },
+      }
+      cookies.encrypted[CookieNames::VERIFY_FRONT_JOURNEY_HINT] = front_journey_hint_cookie.to_json
+      expect(subject).to redirect_to start_path
+    end
+
+
     it "should render error page when user has no session" do
       session.clear
-
       expect(subject).to render_template(:something_went_wrong)
     end
   end


### PR DESCRIPTION
… no longer valid

HMRC changed their entityIDs which means that some users with the resume cookie are getting an error page because the entityId isn't registered with Config.

Now the users get the same experience as they would if the IDP was no longer found (they end up at the start page).