### PR TITLE
HUB-595: Render the hint with the correct layout

### DIFF
--- a/app/controllers/partials/journey_hinting_partial_controller.rb
+++ b/app/controllers/partials/journey_hinting_partial_controller.rb
@@ -64,7 +64,7 @@ module JourneyHintingPartialController
     journey_hint_entity_id = success_entity_id
     unless journey_hint_entity_id.nil?
       @identity_provider = decorate_idp_by_entity_id(current_available_identity_providers_for_sign_in, journey_hint_entity_id)
-      return render "shared/sign_in_hint" unless @identity_provider.nil?
+      return render "shared/sign_in_hint", layout: "main_layout" unless @identity_provider.nil?
     end
 
     false

--- a/spec/controllers/prove_identity_controller_spec.rb
+++ b/spec/controllers/prove_identity_controller_spec.rb
@@ -46,6 +46,7 @@ describe ProveIdentityController do
 
       get :index, params: { locale: "en" }
       expect(subject).to render_template("shared/sign_in_hint")
+      expect(subject).to render_template("layouts/main_layout")
     end
 
     it "renders the normal prove-identity page if IDP is invalid" do

--- a/spec/controllers/start_controller_spec.rb
+++ b/spec/controllers/start_controller_spec.rb
@@ -88,7 +88,8 @@ describe StartController do
       stub_api_idp_list_for_sign_in
 
       get :index, params: { locale: "en" }
-      expect(subject).to render_template("shared/sign_in_hint", "layouts/main_layout")
+      expect(subject).to render_template("shared/sign_in_hint")
+      expect(subject).to render_template("layouts/main_layout")
     end
 
     it "renders the normal start page if IDP is invalid" do
@@ -98,7 +99,8 @@ describe StartController do
       stub_api_idp_list_for_sign_in
 
       get :index, params: { locale: "en" }
-      expect(subject).to render_template(:start, "layouts/slides")
+      expect(subject).to render_template(:start)
+      expect(subject).to render_template("layouts/slides")
     end
 
     it "renders the normal start page if success is missing" do
@@ -108,7 +110,8 @@ describe StartController do
       stub_api_idp_list_for_sign_in
 
       get :index, params: { locale: "en" }
-      expect(subject).to render_template(:start, "layouts/slides")
+      expect(subject).to render_template(:start)
+      expect(subject).to render_template("layouts/slides")
     end
 
     it "allows to disregard the hint and deletes the SUCCESS" do


### PR DESCRIPTION
Set the hint layout in the hint controller so it always gets rendered with the correct styles (i.e. no blue background when rendered on the Start page)

Fix the tests so they correctly verify the hint layout - the `render_template` assertion only takes one argument so needs to be called separately with the expected layout