### PR TITLE
HUB-599 Reverted the removal of short hub

### DIFF
--- a/config/main_routes.rb
+++ b/config/main_routes.rb
@@ -9,7 +9,9 @@ get "begin_sign_in", to: "start#sign_in", as: :begin_sign_in
 # TEMPORARY TEAR DOWN
 # HUH-233 short hub 2019 q3 multivariate tests - LOA2 only
 SHORT_HUB_2019_Q3 = "short_hub_2019_q3-preview".freeze
+# rubocop:disable UselessAssignment
 short_hub_v3_preview = AbTestConstraint.configure(ab_test_name: "short_hub_2019_q3-preview", experiment_loa: "LEVEL_2")
+# rubocop:enable UselessAssignment
 short_hub_v3 = AbTestConstraint.configure(ab_test_name: "short_hub_2019_q3", experiment_loa: "LEVEL_2")
 
 constraints IsLoa1 do

--- a/config/main_routes.rb
+++ b/config/main_routes.rb
@@ -6,13 +6,9 @@ get "sign_in", to: "sign_in#index", as: :sign_in
 post "sign_in", to: "sign_in#select_idp", as: :sign_in_submit
 get "begin_sign_in", to: "start#sign_in", as: :begin_sign_in
 
-# TEMPORARY TEAR DOWN
 # HUH-233 short hub 2019 q3 multivariate tests - LOA2 only
 SHORT_HUB_2019_Q3 = "short_hub_2019_q3-preview".freeze
-# rubocop:disable UselessAssignment
-short_hub_v3_preview = AbTestConstraint.configure(ab_test_name: "short_hub_2019_q3-preview", experiment_loa: "LEVEL_2")
-# rubocop:enable UselessAssignment
-short_hub_v3 = AbTestConstraint.configure(ab_test_name: "short_hub_2019_q3", experiment_loa: "LEVEL_2")
+short_hub_v3 = AbTestConstraint.configure(ab_test_name: SHORT_HUB_2019_Q3, experiment_loa: "LEVEL_2")
 
 constraints IsLoa1 do
   get "prove_identity", to: "prove_identity#index", as: :prove_identity

--- a/config/main_routes.rb
+++ b/config/main_routes.rb
@@ -8,8 +8,10 @@ get "begin_sign_in", to: "start#sign_in", as: :begin_sign_in
 
 # TEMPORARY TEAR DOWN
 # HUH-233 short hub 2019 q3 multivariate tests - LOA2 only
-#short_hub_v3_preview = AbTestConstraint.configure(ab_test_name: "short_hub_2019_q3-preview", experiment_loa: "LEVEL_2")
-#short_hub_v3 = AbTestConstraint.configure(ab_test_name: "short_hub_2019_q3", experiment_loa: "LEVEL_2")
+SHORT_HUB_2019_Q3 = "short_hub_2019_q3-preview".freeze
+short_hub_v3_preview = AbTestConstraint.configure(ab_test_name: "short_hub_2019_q3-preview", experiment_loa: "LEVEL_2")
+short_hub_v3 = AbTestConstraint.configure(ab_test_name: "short_hub_2019_q3", experiment_loa: "LEVEL_2")
+
 constraints IsLoa1 do
   get "prove_identity", to: "prove_identity#index", as: :prove_identity
   get "prove_identity_retry", to: "prove_identity#retry_eidas_journey", as: :prove_identity_retry
@@ -44,28 +46,28 @@ constraints IsLoa2 do
   get "start_ignore_hint", to: "start#ignore_hint", as: :start_ignore_hint
   get "begin_registration", to: "start#register", as: :begin_registration
 
-  get "about", to: "about_loa2#index", as: :about
-  get "about_certified_companies", to: "about_loa2#certified_companies", as: :about_certified_companies
-  get "about_identity_accounts", to: "about_loa2#identity_accounts", as: :about_identity_accounts
-  get "about_choosing_a_company", to: "about_loa2#choosing_a_company", as: :about_choosing_a_company
+  # get "about", to: "about_loa2#index", as: :about
+  # get "about_certified_companies", to: "about_loa2#certified_companies", as: :about_certified_companies
+  # get "about_identity_accounts", to: "about_loa2#identity_accounts", as: :about_identity_accounts
+  # get "about_choosing_a_company", to: "about_loa2#choosing_a_company", as: :about_choosing_a_company
 
-  get "will_it_work_for_me", to: "will_it_work_for_me#index", as: :will_it_work_for_me
-  post "will_it_work_for_me", to: "will_it_work_for_me#will_it_work_for_me", as: :will_it_work_for_me_submit
+  # get "will_it_work_for_me", to: "will_it_work_for_me#index", as: :will_it_work_for_me
+  # post "will_it_work_for_me", to: "will_it_work_for_me#will_it_work_for_me", as: :will_it_work_for_me_submit
   get "why_might_this_not_work_for_me", to: "will_it_work_for_me#why_might_this_not_work_for_me", as: :why_might_this_not_work_for_me
   get "may_not_work_if_you_live_overseas", to: "will_it_work_for_me#may_not_work_if_you_live_overseas", as: :may_not_work_if_you_live_overseas
   get "will_not_work_without_uk_address", to: "will_it_work_for_me#will_not_work_without_uk_address", as: :will_not_work_without_uk_address
-  get "select_documents", to: "select_documents#index", as: :select_documents
-  get "select_documents_none", to: "select_documents#no_documents", as: :select_documents_no_documents
-  post "select_documents", to: "select_documents#select_documents", as: :select_documents_submit
+  # get "select_documents", to: "select_documents#index", as: :select_documents
+  # get "select_documents_none", to: "select_documents#no_documents", as: :select_documents_no_documents
+  # post "select_documents", to: "select_documents#select_documents", as: :select_documents_submit
   get "other_identity_documents", to: "other_identity_documents#index", as: :other_identity_documents
   post "other_identity_documents", to: "other_identity_documents#select_other_documents", as: :other_identity_documents_submit
   get "select_phone", to: "select_phone#index", as: :select_phone
   post "select_phone", to: "select_phone#select_phone", as: :select_phone_submit
   get "verify_will_not_work_for_you", to: "select_phone#verify_will_not_work_for_you", as: :verify_will_not_work_for_you
 
-  get "choose_a_certified_company", to: "choose_a_certified_company_loa2#index", as: :choose_a_certified_company
-  get "choose_a_certified_company/:company", to: "choose_a_certified_company_loa2#about", as: :choose_a_certified_company_about
-  post "choose_a_certified_company", to: "choose_a_certified_company_loa2#select_idp", as: :choose_a_certified_company_submit
+  # get "choose_a_certified_company", to: "choose_a_certified_company_loa2#index", as: :choose_a_certified_company
+  # get "choose_a_certified_company/:company", to: "choose_a_certified_company_loa2#about", as: :choose_a_certified_company_about
+  # post "choose_a_certified_company", to: "choose_a_certified_company_loa2#select_idp", as: :choose_a_certified_company_submit
 
   get "why_companies", to: "why_companies_loa2#index", as: :why_companies
   get "failed_registration", to: "failed_registration_loa2#index", as: :failed_registration
@@ -127,48 +129,46 @@ if SINGLE_IDP_FEATURE
   get "single_idp_start_page", to: "single_idp_journey#rp_start_page", as: :single_idp_start_page
 end
 
-## TEMPORARY TEAR DOWN
+# HUH-233 short hub 2019 q3 multivariate tests - LOA2 only
+# Control A = unaffected
+# Variant C = 2 IDPs and new shorter hub journey
 
-# # HUH-233 short hub 2019 q3 multivariate tests - LOA2 only
-# # Control A = unaffected
-# # Variant C = 2 IDPs and new shorter hub journey
+# HUH-233: implement control A route
+constraints short_hub_v3.use(alternative: "control_a") do
+  get "about", to: "about_loa2#index", as: :about
+  get "about_certified_companies", to: "about_loa2#certified_companies", as: :about_certified_companies
+  get "about_identity_accounts", to: "about_loa2#identity_accounts", as: :about_identity_accounts
+  get "about_choosing_a_company", to: "about_loa2#choosing_a_company", as: :about_choosing_a_company
 
-# # HUH-233: implement control A route
-# constraints short_hub_v3.use(alternative: "control_a") do
-#   get "about", to: "about_loa2#index", as: :about
-#   get "about_certified_companies", to: "about_loa2#certified_companies", as: :about_certified_companies
-#   get "about_identity_accounts", to: "about_loa2#identity_accounts", as: :about_identity_accounts
-#   get "about_choosing_a_company", to: "about_loa2#choosing_a_company", as: :about_choosing_a_company
+  get "will_it_work_for_me", to: "will_it_work_for_me#index", as: :will_it_work_for_me
+  post "will_it_work_for_me", to: "will_it_work_for_me#will_it_work_for_me", as: :will_it_work_for_me_submit
 
-#   get "will_it_work_for_me", to: "will_it_work_for_me#index", as: :will_it_work_for_me
-#   post "will_it_work_for_me", to: "will_it_work_for_me#will_it_work_for_me", as: :will_it_work_for_me_submit
+  get "select_documents", to: "select_documents#index", as: :select_documents
+  get "select_documents_none", to: "select_documents#no_documents", as: :select_documents_no_documents
+  post "select_documents", to: "select_documents#select_documents", as: :select_documents_submit
 
-#   get "select_documents", to: "select_documents#index", as: :select_documents
-#   get "select_documents_none", to: "select_documents#no_documents", as: :select_documents_no_documents
-#   post "select_documents", to: "select_documents#select_documents", as: :select_documents_submit
+  get "select_phone", to: "select_phone#index", as: :select_phone
+  post "select_phone", to: "select_phone#select_phone", as: :select_phone_submit
+  get "verify_will_not_work_for_you", to: "select_phone#verify_will_not_work_for_you", as: :verify_will_not_work_for_you
 
-#   get "select_phone", to: "select_phone#index", as: :select_phone
-#   post "select_phone", to: "select_phone#select_phone", as: :select_phone_submit
-#   get "verify_will_not_work_for_you", to: "select_phone#verify_will_not_work_for_you", as: :verify_will_not_work_for_you
+  get "choose_a_certified_company", to: "choose_a_certified_company_loa2#index", as: :choose_a_certified_company
+  get "choose_a_certified_company/:company", to: "choose_a_certified_company_loa2#about", as: :choose_a_certified_company_about
+  post "choose_a_certified_company", to: "choose_a_certified_company_loa2#select_idp", as: :choose_a_certified_company_submit
+end
 
-#   get "choose_a_certified_company", to: "choose_a_certified_company_loa2#index", as: :choose_a_certified_company
-#   get "choose_a_certified_company/:company", to: "choose_a_certified_company_loa2#about", as: :choose_a_certified_company_about
-#   post "choose_a_certified_company", to: "choose_a_certified_company_loa2#select_idp", as: :choose_a_certified_company_submit
-# end
+# HUH-234: implement appropriate variant C routes
+constraints short_hub_v3.use(alternative: "variant_c_2_idp_short_hub") do
+  get "about", to: "about_loa2_variant_c#index", as: :about
+  get "will_it_work_for_me", to: "will_it_work_for_me#index", as: :will_it_work_for_me
+  post "will_it_work_for_me", to: "will_it_work_for_me#will_it_work_for_me", as: :will_it_work_for_me_submit
 
-# # HUH-234: implement appropriate variant C routes
-# constraints short_hub_v3.use(alternative: "variant_c_2_idp_short_hub") do
-#   get "about", to: "about_loa2_variant_c#index", as: :about
-#   get "will_it_work_for_me", to: "will_it_work_for_me#index", as: :will_it_work_for_me
-#   post "will_it_work_for_me", to: "will_it_work_for_me#will_it_work_for_me", as: :will_it_work_for_me_submit
+  get "select_documents", to: "select_documents_variant_c#index", as: :select_documents
 
-#   get "select_documents", to: "select_documents_variant_c#index", as: :select_documents
+  get "select_documents_none", to: "select_documents_variant_c#no_documents", as: :select_documents_no_documents
+  post "select_documents", to: "select_documents_variant_c#select_documents", as: :select_documents_submit
+  get "select_documents_advice", to: "select_documents_variant_c#advice", as: :select_documents_advice
 
-#   get "select_documents_none", to: "select_documents_variant_c#no_documents", as: :select_documents_no_documents
-#   post "select_documents", to: "select_documents_variant_c#select_documents", as: :select_documents_submit
-#   get "select_documents_advice", to: "select_documents_variant_c#advice", as: :select_documents_advice
-
-#   get "choose_a_certified_company", to: "choose_a_certified_company_loa2_variant_c#index", as: :choose_a_certified_company
-#   get "choose_a_certified_company/:company", to: "choose_a_certified_company_loa2_variant_c#about", as: :choose_a_certified_company_about
-#   post "choose_a_certified_company", to: "choose_a_certified_company_loa2_variant_c#select_idp", as: :choose_a_certified_company_submit
-# end
+  get "choose_a_certified_company", to: "choose_a_certified_company_loa2_variant_c#index", as: :choose_a_certified_company
+  get "choose_a_certified_company/:company", to: "choose_a_certified_company_loa2_variant_c#about", as: :choose_a_certified_company_about
+  post "choose_a_certified_company", to: "choose_a_certified_company_loa2_variant_c#select_idp", as: :choose_a_certified_company_submit
+end

--- a/spec/controllers/about_loa2_variant_c_controller_spec.rb
+++ b/spec/controllers/about_loa2_variant_c_controller_spec.rb
@@ -4,7 +4,6 @@ require "api_test_helper"
 require "variant_test_helper"
 
 describe AboutLoa2VariantCController do
-  before { skip("Short hub AB test temporarily teared down") }
 
   let(:identity_provider_display_decorator) { double(:IdentityProviderDisplayDecorator) }
 

--- a/spec/controllers/about_loa2_variant_c_controller_spec.rb
+++ b/spec/controllers/about_loa2_variant_c_controller_spec.rb
@@ -4,7 +4,6 @@ require "api_test_helper"
 require "variant_test_helper"
 
 describe AboutLoa2VariantCController do
-
   let(:identity_provider_display_decorator) { double(:IdentityProviderDisplayDecorator) }
 
   before(:each) do

--- a/spec/controllers/choose_a_certified_company_loa2_variant_c_controller_spec.rb
+++ b/spec/controllers/choose_a_certified_company_loa2_variant_c_controller_spec.rb
@@ -4,7 +4,6 @@ require "api_test_helper"
 require "piwik_test_helper"
 
 describe ChooseACertifiedCompanyLoa2VariantCController do
-
   let(:stub_idp_one) {
     {
         "simpleId" => "stub-idp-one",

--- a/spec/controllers/choose_a_certified_company_loa2_variant_c_controller_spec.rb
+++ b/spec/controllers/choose_a_certified_company_loa2_variant_c_controller_spec.rb
@@ -4,7 +4,6 @@ require "api_test_helper"
 require "piwik_test_helper"
 
 describe ChooseACertifiedCompanyLoa2VariantCController do
-  before { skip("Short hub AB test temporarily teared down") }
 
   let(:stub_idp_one) {
     {

--- a/spec/controllers/select_documents_variant_c_controller_spec.rb
+++ b/spec/controllers/select_documents_variant_c_controller_spec.rb
@@ -7,7 +7,6 @@ require "piwik_test_helper"
 require "models/display/viewable_identity_provider"
 
 describe SelectDocumentsVariantCController do
-
   before(:each) do
     experiment = "short_hub_2019_q3-preview"
     variant = "variant_c_2_idp_short_hub"

--- a/spec/controllers/select_documents_variant_c_controller_spec.rb
+++ b/spec/controllers/select_documents_variant_c_controller_spec.rb
@@ -7,7 +7,6 @@ require "piwik_test_helper"
 require "models/display/viewable_identity_provider"
 
 describe SelectDocumentsVariantCController do
-  before { skip("Short hub AB test temporarily teared down") }
 
   before(:each) do
     experiment = "short_hub_2019_q3-preview"

--- a/spec/features/user_visits_about_page_variant_spec.rb
+++ b/spec/features/user_visits_about_page_variant_spec.rb
@@ -4,7 +4,6 @@ require "piwik_test_helper"
 require "api_test_helper"
 
 RSpec.describe "When the user visits the about page" do
-  before { skip("Short hub AB test temporarily teared down") }
 
   context "session cookie also contains variant c" do
     before(:each) do

--- a/spec/features/user_visits_about_page_variant_spec.rb
+++ b/spec/features/user_visits_about_page_variant_spec.rb
@@ -4,7 +4,6 @@ require "piwik_test_helper"
 require "api_test_helper"
 
 RSpec.describe "When the user visits the about page" do
-
   context "session cookie also contains variant c" do
     before(:each) do
       stub_api_idp_list_for_registration

--- a/spec/features/user_visits_choose_a_certified_company_variant_c_page_spec.rb
+++ b/spec/features/user_visits_choose_a_certified_company_variant_c_page_spec.rb
@@ -2,7 +2,6 @@ require "feature_helper"
 require "api_test_helper"
 
 describe "When the user visits the choose a certified company variant page" do
-
   let(:stub_idp_one) {
     {
         "simpleId" => "stub-idp-one",

--- a/spec/features/user_visits_choose_a_certified_company_variant_c_page_spec.rb
+++ b/spec/features/user_visits_choose_a_certified_company_variant_c_page_spec.rb
@@ -2,7 +2,6 @@ require "feature_helper"
 require "api_test_helper"
 
 describe "When the user visits the choose a certified company variant page" do
-  before { skip("Short hub AB test temporarily teared down") }
 
   let(:stub_idp_one) {
     {

--- a/spec/features/user_visits_select_documents_variant_c_page_spec.rb
+++ b/spec/features/user_visits_select_documents_variant_c_page_spec.rb
@@ -2,7 +2,6 @@ require "feature_helper"
 require "api_test_helper"
 
 RSpec.feature "When user visits document selection page" do
-
   before(:each) do
     experiment = { "short_hub_2019_q3-preview" => "short_hub_2019_q3-preview_variant_c_2_idp_short_hub" }
     set_session_and_ab_session_cookies!(experiment)

--- a/spec/features/user_visits_select_documents_variant_c_page_spec.rb
+++ b/spec/features/user_visits_select_documents_variant_c_page_spec.rb
@@ -2,7 +2,6 @@ require "feature_helper"
 require "api_test_helper"
 
 RSpec.feature "When user visits document selection page" do
-  before { skip("Short hub AB test temporarily teared down") }
 
   before(:each) do
     experiment = { "short_hub_2019_q3-preview" => "short_hub_2019_q3-preview_variant_c_2_idp_short_hub" }


### PR DESCRIPTION
We as a team have agreed to pursue the short hub AB test.  This commit is to revert the commit which disabled it in the first place.  That commit was:

https://github.com/alphagov/verify-frontend/pull/823

Jira Ticket: https://govukverify.atlassian.net/browse/HUB-599