### PR TITLE
HUB-468, PS-53, create new persistent session id

### DIFF
--- a/app/controllers/partials/analytics_cookie_partial_controller.rb
+++ b/app/controllers/partials/analytics_cookie_partial_controller.rb
@@ -3,19 +3,15 @@ require "securerandom"
 # analytics_session_id is disconnected from matomo and generated if not present
 module AnalyticsCookiePartialController
   def analytics_session_id
-    cookie_value = cookies.fetch(persistent_cookie_name, nil)
+    cookie_value = cookies.fetch(CookieNames::PERSISTENT_SESSION_ID_COOKIE_NAME, nil)
     if cookie_value.nil?
       cookie_value = SecureRandom.uuid
-      cookies[persistent_cookie_name] = { value: cookie_value, expires: 13.months.from_now }
+      cookies[CookieNames::PERSISTENT_SESSION_ID_COOKIE_NAME] = { value: cookie_value, expires: 13.months.from_now }
     end
     cookie_value
   end
 
 private
-
-  def persistent_cookie_name
-    CookieNames::PERSISTENT_SESSION_ID_COOKIE_NAME
-  end
 
   def analytics_cookie_name
     cookies.each { |name, _value| return name if name.starts_with? CookieNames::ANALYTICS_SESSION_COOKIE_PREFIX }

--- a/app/controllers/partials/analytics_cookie_partial_controller.rb
+++ b/app/controllers/partials/analytics_cookie_partial_controller.rb
@@ -1,13 +1,18 @@
 require "securerandom"
 
-# analytics_session_id is disconnected from matomo and generated if not present
+# persistent session id is taken from matomo if available, and generated if not
 module AnalyticsCookiePartialController
   def analytics_session_id
     cookie_value = cookies.fetch(CookieNames::PERSISTENT_SESSION_ID_COOKIE_NAME, nil)
     if cookie_value.nil?
-      cookie_value = SecureRandom.uuid
-      cookies[CookieNames::PERSISTENT_SESSION_ID_COOKIE_NAME] = { value: cookie_value, expires: 13.months.from_now }
+      matomo_value = cookies.fetch(analytics_cookie_name, nil)
+      cookie_value = matomo_value.split(".").first unless matomo_value.nil?
+      if cookie_value.nil?
+        cookie_value = SecureRandom.uuid
+      end
     end
+    # analytics session id lasts for 13 months from use - so always refresh the cookie
+    cookies[CookieNames::PERSISTENT_SESSION_ID_COOKIE_NAME] = { value: cookie_value, expires: 13.months.from_now }
     cookie_value
   end
 

--- a/app/controllers/partials/analytics_cookie_partial_controller.rb
+++ b/app/controllers/partials/analytics_cookie_partial_controller.rb
@@ -1,10 +1,21 @@
+require "securerandom"
+
+# analytics_session_id is disconnected from matomo and generated if not present
 module AnalyticsCookiePartialController
   def analytics_session_id
-    cookie_value = cookies.fetch(analytics_cookie_name, nil)
-    cookie_value.split(".").first unless cookie_value.nil?
+    cookie_value = cookies.fetch(persistent_cookie_name, nil)
+    if cookie_value.nil?
+      cookie_value = SecureRandom.uuid
+      cookies[persistent_cookie_name] = { value: cookie_value, expires: 13.months.from_now }
+    end
+    cookie_value
   end
 
 private
+
+  def persistent_cookie_name
+    CookieNames::PERSISTENT_SESSION_ID_COOKIE_NAME
+  end
 
   def analytics_cookie_name
     cookies.each { |name, _value| return name if name.starts_with? CookieNames::ANALYTICS_SESSION_COOKIE_PREFIX }

--- a/app/controllers/partials/analytics_cookie_partial_controller.rb
+++ b/app/controllers/partials/analytics_cookie_partial_controller.rb
@@ -2,7 +2,7 @@ require "securerandom"
 
 # persistent session id is taken from matomo if available, and generated if not
 module AnalyticsCookiePartialController
-  def analytics_session_id
+  def persistent_session_id
     cookie_value = cookies.fetch(CookieNames::PERSISTENT_SESSION_ID_COOKIE_NAME, nil)
     if cookie_value.nil?
       matomo_value = cookies.fetch(analytics_cookie_name, nil)

--- a/app/controllers/paused_registration_controller.rb
+++ b/app/controllers/paused_registration_controller.rb
@@ -153,7 +153,7 @@ private
                             entity_id,
                             session[:requested_loa],
                             false,
-                            analytics_session_id,
+                            persistent_session_id,
                             session[:journey_type],
                             ab_test_with_alternative_name)
     set_attempt_journey_hint(entity_id)

--- a/app/controllers/redirect_to_idp_controller.rb
+++ b/app/controllers/redirect_to_idp_controller.rb
@@ -100,7 +100,7 @@ private
                             entity_id,
                             session[:requested_loa],
                             false,
-                            analytics_session_id,
+                            persistent_session_id,
                             session[:journey_type],
                             ab_test_with_alternative_name)
     set_attempt_journey_hint(entity_id)

--- a/app/controllers/redirect_to_idp_warning_controller.rb
+++ b/app/controllers/redirect_to_idp_warning_controller.rb
@@ -48,7 +48,7 @@ private
                             idp.entity_id,
                             session[:requested_loa],
                             true,
-                            analytics_session_id,
+                            persistent_session_id,
                             session[:journey_type],
                             ab_test_with_alternative_name)
     set_journey_hint_followed(idp.entity_id)

--- a/app/controllers/sign_in_controller.rb
+++ b/app/controllers/sign_in_controller.rb
@@ -50,7 +50,7 @@ private
                             entity_id,
                             session[:requested_loa],
                             false,
-                            analytics_session_id,
+                            persistent_session_id,
                             session[:journey_type],
                             ab_test_with_alternative_name)
     set_attempt_journey_hint(entity_id)

--- a/app/controllers/single_idp_journey_controller.rb
+++ b/app/controllers/single_idp_journey_controller.rb
@@ -177,7 +177,7 @@ private
                             entity_id,
                             session[:requested_loa],
                             false,
-                            analytics_session_id,
+                            persistent_session_id,
                             session[:journey_type],
                             ab_test_with_alternative_name)
     set_attempt_journey_hint(entity_id)

--- a/app/models/policy_endpoints.rb
+++ b/app/models/policy_endpoints.rb
@@ -10,7 +10,7 @@ module PolicyEndpoints
   PARAM_SELECTED_ENTITY_ID = "selectedIdpEntityId".freeze
   PARAM_REGISTRATION = "registration".freeze
   PARAM_REQUESTED_LOA = "requestedLoa".freeze
-  PARAM_ANALYTICS_SESSION_ID = "analyticsSessionId".freeze
+  PARAM_PERSISTENT_SESSION_ID = "analyticsSessionId".freeze
   PARAM_JOURNEY_TYPE = "journeyType".freeze
   PARAM_VARIANT = "abTestVariant".freeze
   CYCLE_THREE_SUFFIX = "cycle-3-attribute".freeze

--- a/app/models/policy_proxy.rb
+++ b/app/models/policy_proxy.rb
@@ -21,7 +21,7 @@ class PolicyProxy
       PARAM_PRINCIPAL_IP => originating_ip,
       PARAM_REGISTRATION => registration,
       PARAM_REQUESTED_LOA => requested_loa,
-      PARAM_ANALYTICS_SESSION_ID => persistent_session_id,
+      PARAM_PERSISTENT_SESSION_ID => persistent_session_id,
       PARAM_JOURNEY_TYPE => journey_type,
       PARAM_VARIANT => variant,
     }

--- a/app/models/policy_proxy.rb
+++ b/app/models/policy_proxy.rb
@@ -15,13 +15,13 @@ class PolicyProxy
     SignInProcessDetailsResponse.validated_response(response)
   end
 
-  def select_idp(session_id, entity_id, requested_loa, registration = false, analytics_session_id = nil, journey_type = nil, variant = nil)
+  def select_idp(session_id, entity_id, requested_loa, registration = false, persistent_session_id = nil, journey_type = nil, variant = nil)
     body = {
       PARAM_SELECTED_ENTITY_ID => entity_id,
       PARAM_PRINCIPAL_IP => originating_ip,
       PARAM_REGISTRATION => registration,
       PARAM_REQUESTED_LOA => requested_loa,
-      PARAM_ANALYTICS_SESSION_ID => analytics_session_id,
+      PARAM_ANALYTICS_SESSION_ID => persistent_session_id,
       PARAM_JOURNEY_TYPE => journey_type,
       PARAM_VARIANT => variant,
     }

--- a/lib/cookie_names.rb
+++ b/lib/cookie_names.rb
@@ -1,7 +1,7 @@
 module CookieNames
   SESSION_COOKIE_NAME = "_verify-frontend_session".freeze
   SESSION_ID_COOKIE_NAME = "x_govuk_session_cookie".freeze
-  PERSISTENT_SESSION_ID_COOKIE_NAME = "_verify-persistent-session-id".freeze
+  PERSISTENT_SESSION_ID_COOKIE_NAME = "verify-persistent-session-id".freeze
   VERIFY_FRONT_JOURNEY_HINT = "verify-front-journey-hint".freeze
   VERIFY_SINGLE_IDP_JOURNEY = "verify-single-idp-journey".freeze
   VERIFY_LOCALE = "x_verify_locale".freeze

--- a/lib/cookie_names.rb
+++ b/lib/cookie_names.rb
@@ -1,6 +1,7 @@
 module CookieNames
   SESSION_COOKIE_NAME = "_verify-frontend_session".freeze
   SESSION_ID_COOKIE_NAME = "x_govuk_session_cookie".freeze
+  PERSISTENT_SESSION_ID_COOKIE_NAME = "_verify-persistent-session-id".freeze
   VERIFY_FRONT_JOURNEY_HINT = "verify-front-journey-hint".freeze
   VERIFY_SINGLE_IDP_JOURNEY = "verify-single-idp-journey".freeze
   VERIFY_LOCALE = "x_verify_locale".freeze

--- a/spec/controllers/redirect_to_idp_controller_spec.rb
+++ b/spec/controllers/redirect_to_idp_controller_spec.rb
@@ -269,13 +269,13 @@ describe RedirectToIdpController do
           .to receive(:ab_test_with_alternative_name).and_return(nil)
 
         expect(POLICY_PROXY).to receive(:select_idp)
-                                  .with(instance_of(String),
-                                        "http://idcorp-two.com",
-                                        "LEVEL_1",
-                                        false,
-                                        nil,
-                                        "sign-in-last-sucessful-idp",
-                                        nil)
+                                  .with(instance_of(String),          # sessionId
+                                        "http://idcorp-two.com",      # entityId
+                                        "LEVEL_1",                    # LOA
+                                        false,                        # registration
+                                        instance_of(String),          # analyticsSessionId - not from matomo
+                                        "sign-in-last-sucessful-idp", # journeyType
+                                        nil)                          # variant
 
         subject
 

--- a/spec/features/idp_selections_reported_to_piwik_spec.rb
+++ b/spec/features/idp_selections_reported_to_piwik_spec.rb
@@ -102,7 +102,7 @@ def stub_idp_select_request(idp_entity_id)
     PolicyEndpoints::PARAM_PRINCIPAL_IP => originating_ip,
     PolicyEndpoints::PARAM_REGISTRATION => true,
     PolicyEndpoints::PARAM_REQUESTED_LOA => "LEVEL_2",
-    PolicyEndpoints::PARAM_ANALYTICS_SESSION_ID => instance_of(String), # no longer comes from matomo
+    PolicyEndpoints::PARAM_PERSISTENT_SESSION_ID => instance_of(String), # no longer comes from matomo
     PolicyEndpoints::PARAM_JOURNEY_TYPE => nil,
     PolicyEndpoints::PARAM_VARIANT => nil,
   )

--- a/spec/features/idp_selections_reported_to_piwik_spec.rb
+++ b/spec/features/idp_selections_reported_to_piwik_spec.rb
@@ -1,7 +1,6 @@
 require "feature_helper"
 require "api_test_helper"
 require "piwik_test_helper"
-require "securerandom"
 
 RSpec.describe "When the user selects an IDP" do
   let(:selected_answers) {

--- a/spec/features/idp_selections_reported_to_piwik_spec.rb
+++ b/spec/features/idp_selections_reported_to_piwik_spec.rb
@@ -1,6 +1,7 @@
 require "feature_helper"
 require "api_test_helper"
 require "piwik_test_helper"
+require "securerandom"
 
 RSpec.describe "When the user selects an IDP" do
   let(:selected_answers) {
@@ -97,9 +98,12 @@ end
 def stub_idp_select_request(idp_entity_id)
   stub_session_select_idp_request(
     encrypted_entity_id,
-    PolicyEndpoints::PARAM_SELECTED_ENTITY_ID => idp_entity_id, PolicyEndpoints::PARAM_PRINCIPAL_IP => originating_ip,
-    PolicyEndpoints::PARAM_REGISTRATION => true, PolicyEndpoints::PARAM_REQUESTED_LOA => "LEVEL_2",
-    PolicyEndpoints::PARAM_ANALYTICS_SESSION_ID => nil, PolicyEndpoints::PARAM_JOURNEY_TYPE => nil,
-    PolicyEndpoints::PARAM_VARIANT => nil
+    PolicyEndpoints::PARAM_SELECTED_ENTITY_ID => idp_entity_id,
+    PolicyEndpoints::PARAM_PRINCIPAL_IP => originating_ip,
+    PolicyEndpoints::PARAM_REGISTRATION => true,
+    PolicyEndpoints::PARAM_REQUESTED_LOA => "LEVEL_2",
+    PolicyEndpoints::PARAM_ANALYTICS_SESSION_ID => instance_of(String), # no longer comes from matomo
+    PolicyEndpoints::PARAM_JOURNEY_TYPE => nil,
+    PolicyEndpoints::PARAM_VARIANT => nil,
   )
 end

--- a/spec/features/user_visits_continue_to_your_idp_page_spec.rb
+++ b/spec/features/user_visits_continue_to_your_idp_page_spec.rb
@@ -11,10 +11,13 @@ RSpec.describe "When the user visits the continue to your IDP page" do
   let(:select_idp_stub_request) {
     stub_session_select_idp_request(
       encrypted_entity_id,
-      PolicyEndpoints::PARAM_SELECTED_ENTITY_ID => idp_entity_id, PolicyEndpoints::PARAM_PRINCIPAL_IP => originating_ip,
-      PolicyEndpoints::PARAM_REGISTRATION => false, PolicyEndpoints::PARAM_REQUESTED_LOA => "LEVEL_2",
-      PolicyEndpoints::PARAM_ANALYTICS_SESSION_ID => piwik_session_id, PolicyEndpoints::PARAM_JOURNEY_TYPE => "single-idp",
-      PolicyEndpoints::PARAM_VARIANT => nil
+      PolicyEndpoints::PARAM_SELECTED_ENTITY_ID => idp_entity_id,
+      PolicyEndpoints::PARAM_PRINCIPAL_IP => originating_ip,
+      PolicyEndpoints::PARAM_REGISTRATION => false,
+      PolicyEndpoints::PARAM_REQUESTED_LOA => "LEVEL_2",
+      PolicyEndpoints::PARAM_ANALYTICS_SESSION_ID => instance_of(String), # no longer comes from matomo
+      PolicyEndpoints::PARAM_JOURNEY_TYPE => "single-idp",
+      PolicyEndpoints::PARAM_VARIANT => nil,
     )
   }
   let(:set_single_idp_journey_cookie) {

--- a/spec/features/user_visits_continue_to_your_idp_page_spec.rb
+++ b/spec/features/user_visits_continue_to_your_idp_page_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "When the user visits the continue to your IDP page" do
       PolicyEndpoints::PARAM_PRINCIPAL_IP => originating_ip,
       PolicyEndpoints::PARAM_REGISTRATION => false,
       PolicyEndpoints::PARAM_REQUESTED_LOA => "LEVEL_2",
-      PolicyEndpoints::PARAM_ANALYTICS_SESSION_ID => instance_of(String), # no longer comes from matomo
+      PolicyEndpoints::PARAM_PERSISTENT_SESSION_ID => instance_of(String), # no longer comes from matomo
       PolicyEndpoints::PARAM_JOURNEY_TYPE => "single-idp",
       PolicyEndpoints::PARAM_VARIANT => nil,
     )

--- a/spec/features/user_visits_redirect_to_idp_warning_page_spec.rb
+++ b/spec/features/user_visits_redirect_to_idp_warning_page_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe "When the user visits the redirect to IDP warning page" do
       PolicyEndpoints::PARAM_PRINCIPAL_IP => originating_ip,
       PolicyEndpoints::PARAM_REGISTRATION => true,
       PolicyEndpoints::PARAM_REQUESTED_LOA => "LEVEL_2",
-      PolicyEndpoints::PARAM_ANALYTICS_SESSION_ID => instance_of(String), # no longer comes from matomo
+      PolicyEndpoints::PARAM_PERSISTENT_SESSION_ID => instance_of(String), # no longer comes from matomo
       PolicyEndpoints::PARAM_JOURNEY_TYPE => nil,
       PolicyEndpoints::PARAM_VARIANT => nil,
     )

--- a/spec/features/user_visits_redirect_to_idp_warning_page_spec.rb
+++ b/spec/features/user_visits_redirect_to_idp_warning_page_spec.rb
@@ -53,10 +53,13 @@ RSpec.describe "When the user visits the redirect to IDP warning page" do
   let(:select_idp_stub_request) {
     stub_session_select_idp_request(
       encrypted_entity_id,
-      PolicyEndpoints::PARAM_SELECTED_ENTITY_ID => idp_entity_id, PolicyEndpoints::PARAM_PRINCIPAL_IP => originating_ip,
-      PolicyEndpoints::PARAM_REGISTRATION => true, PolicyEndpoints::PARAM_REQUESTED_LOA => "LEVEL_2",
-      PolicyEndpoints::PARAM_ANALYTICS_SESSION_ID => piwik_session_id, PolicyEndpoints::PARAM_JOURNEY_TYPE => nil,
-      PolicyEndpoints::PARAM_VARIANT => nil
+      PolicyEndpoints::PARAM_SELECTED_ENTITY_ID => idp_entity_id,
+      PolicyEndpoints::PARAM_PRINCIPAL_IP => originating_ip,
+      PolicyEndpoints::PARAM_REGISTRATION => true,
+      PolicyEndpoints::PARAM_REQUESTED_LOA => "LEVEL_2",
+      PolicyEndpoints::PARAM_ANALYTICS_SESSION_ID => instance_of(String), # no longer comes from matomo
+      PolicyEndpoints::PARAM_JOURNEY_TYPE => nil,
+      PolicyEndpoints::PARAM_VARIANT => nil,
     )
   }
 

--- a/spec/features/user_visits_resume_registration_page_spec.rb
+++ b/spec/features/user_visits_resume_registration_page_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "When the user visits the resume registration page and " do
       PolicyEndpoints::PARAM_PRINCIPAL_IP => originating_ip,
       PolicyEndpoints::PARAM_REGISTRATION => false,
       PolicyEndpoints::PARAM_REQUESTED_LOA => "LEVEL_2",
-      PolicyEndpoints::PARAM_ANALYTICS_SESSION_ID => instance_of(String), # no longer comes from matomo
+      PolicyEndpoints::PARAM_PERSISTENT_SESSION_ID => instance_of(String), # no longer comes from matomo
       PolicyEndpoints::PARAM_JOURNEY_TYPE => "resuming",
       PolicyEndpoints::PARAM_VARIANT => nil,
     )

--- a/spec/features/user_visits_resume_registration_page_spec.rb
+++ b/spec/features/user_visits_resume_registration_page_spec.rb
@@ -14,10 +14,13 @@ RSpec.describe "When the user visits the resume registration page and " do
   let(:select_idp_stub_request) {
     stub_session_select_idp_request(
       encrypted_entity_id,
-      PolicyEndpoints::PARAM_SELECTED_ENTITY_ID => idp_entity_id, PolicyEndpoints::PARAM_PRINCIPAL_IP => originating_ip,
-      PolicyEndpoints::PARAM_REGISTRATION => false, PolicyEndpoints::PARAM_REQUESTED_LOA => "LEVEL_2",
-      PolicyEndpoints::PARAM_ANALYTICS_SESSION_ID => piwik_session_id, PolicyEndpoints::PARAM_JOURNEY_TYPE => "resuming",
-      PolicyEndpoints::PARAM_VARIANT => nil
+      PolicyEndpoints::PARAM_SELECTED_ENTITY_ID => idp_entity_id,
+      PolicyEndpoints::PARAM_PRINCIPAL_IP => originating_ip,
+      PolicyEndpoints::PARAM_REGISTRATION => false,
+      PolicyEndpoints::PARAM_REQUESTED_LOA => "LEVEL_2",
+      PolicyEndpoints::PARAM_ANALYTICS_SESSION_ID => instance_of(String), # no longer comes from matomo
+      PolicyEndpoints::PARAM_JOURNEY_TYPE => "resuming",
+      PolicyEndpoints::PARAM_VARIANT => nil,
     )
   }
 

--- a/spec/features/user_visits_sign_in_page_spec.rb
+++ b/spec/features/user_visits_sign_in_page_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe "user selects an IDP on the sign in page" do
                            PolicyEndpoints::PARAM_PRINCIPAL_IP => originating_ip,
                            PolicyEndpoints::PARAM_REGISTRATION => false,
                            PolicyEndpoints::PARAM_REQUESTED_LOA => "LEVEL_2",
-                           PolicyEndpoints::PARAM_ANALYTICS_SESSION_ID => instance_of(String), # no longer comes from matomo
+                           PolicyEndpoints::PARAM_PERSISTENT_SESSION_ID => instance_of(String), # no longer comes from matomo
                            PolicyEndpoints::PARAM_JOURNEY_TYPE => nil,
                            PolicyEndpoints::PARAM_VARIANT => ab_value })).to have_been_made.once
     expect(a_request(:get, saml_proxy_api_uri(authn_request_endpoint(default_session_id)))

--- a/spec/features/user_visits_sign_in_page_spec.rb
+++ b/spec/features/user_visits_sign_in_page_spec.rb
@@ -43,9 +43,12 @@ RSpec.describe "user selects an IDP on the sign in page" do
     expect(cookie_value("verify-front-journey-hint")).to_not be_nil
 
     expect(a_request(:post, policy_api_uri(select_idp_endpoint(default_session_id)))
-             .with(body: { PolicyEndpoints::PARAM_SELECTED_ENTITY_ID => idp_entity_id, PolicyEndpoints::PARAM_PRINCIPAL_IP => originating_ip,
-                           PolicyEndpoints::PARAM_REGISTRATION => false, PolicyEndpoints::PARAM_REQUESTED_LOA => "LEVEL_2",
-                           PolicyEndpoints::PARAM_ANALYTICS_SESSION_ID => piwik_session_id, PolicyEndpoints::PARAM_JOURNEY_TYPE => nil,
+             .with(body: { PolicyEndpoints::PARAM_SELECTED_ENTITY_ID => idp_entity_id,
+                           PolicyEndpoints::PARAM_PRINCIPAL_IP => originating_ip,
+                           PolicyEndpoints::PARAM_REGISTRATION => false,
+                           PolicyEndpoints::PARAM_REQUESTED_LOA => "LEVEL_2",
+                           PolicyEndpoints::PARAM_ANALYTICS_SESSION_ID => instance_of(String), # no longer comes from matomo
+                           PolicyEndpoints::PARAM_JOURNEY_TYPE => nil,
                            PolicyEndpoints::PARAM_VARIANT => ab_value })).to have_been_made.once
     expect(a_request(:get, saml_proxy_api_uri(authn_request_endpoint(default_session_id)))
              .with(headers: { "X_FORWARDED_FOR" => originating_ip })).to have_been_made.once

--- a/spec/models/policy_proxy_spec.rb
+++ b/spec/models/policy_proxy_spec.rb
@@ -19,7 +19,7 @@ describe PolicyProxy do
       ip_address = "1.1.1.1"
       body = { PolicyEndpoints::PARAM_SELECTED_ENTITY_ID => "an-entity-id", PolicyEndpoints::PARAM_PRINCIPAL_IP => ip_address,
                PolicyEndpoints::PARAM_REGISTRATION => false, PolicyEndpoints::PARAM_REQUESTED_LOA => "LEVEL_2",
-               PolicyEndpoints::PARAM_ANALYTICS_SESSION_ID => "an-analytics-session-id", PolicyEndpoints::PARAM_JOURNEY_TYPE => "a-journey-type",
+               PolicyEndpoints::PARAM_PERSISTENT_SESSION_ID => "an-analytics-session-id", PolicyEndpoints::PARAM_JOURNEY_TYPE => "a-journey-type",
                PolicyEndpoints::PARAM_VARIANT => nil }
       expect(api_client).to receive(:post)
         .with(endpoint(PolicyProxy::SELECT_IDP_SUFFIX), body)
@@ -31,7 +31,7 @@ describe PolicyProxy do
       ip_address = "1.1.1.1"
       body = { PolicyEndpoints::PARAM_SELECTED_ENTITY_ID => "an-entity-id", PolicyEndpoints::PARAM_PRINCIPAL_IP => ip_address,
                PolicyEndpoints::PARAM_REGISTRATION => false, PolicyEndpoints::PARAM_REQUESTED_LOA => "LEVEL_1",
-               PolicyEndpoints::PARAM_ANALYTICS_SESSION_ID => "an-analytics-session-id", PolicyEndpoints::PARAM_JOURNEY_TYPE => "a-journey-type",
+               PolicyEndpoints::PARAM_PERSISTENT_SESSION_ID => "an-analytics-session-id", PolicyEndpoints::PARAM_JOURNEY_TYPE => "a-journey-type",
                PolicyEndpoints::PARAM_VARIANT => nil }
       expect(api_client).to receive(:post)
                                 .with(endpoint(PolicyProxy::SELECT_IDP_SUFFIX), body)
@@ -43,7 +43,7 @@ describe PolicyProxy do
       ip_address = "1.1.1.1"
       body = { PolicyEndpoints::PARAM_SELECTED_ENTITY_ID => "an-entity-id", PolicyEndpoints::PARAM_PRINCIPAL_IP => ip_address,
                PolicyEndpoints::PARAM_REGISTRATION => true, PolicyEndpoints::PARAM_REQUESTED_LOA => "LEVEL_2",
-               PolicyEndpoints::PARAM_ANALYTICS_SESSION_ID => "an-analytics-session-id", PolicyEndpoints::PARAM_JOURNEY_TYPE => "a-journey-type",
+               PolicyEndpoints::PARAM_PERSISTENT_SESSION_ID => "an-analytics-session-id", PolicyEndpoints::PARAM_JOURNEY_TYPE => "a-journey-type",
                PolicyEndpoints::PARAM_VARIANT => nil }
       expect(api_client).to receive(:post)
         .with(endpoint(PolicyProxy::SELECT_IDP_SUFFIX), body)


### PR DESCRIPTION
* This PR updates the `analytics_session_id` method in `AnalyticsCookiePartialController` to generate and return its own cookie, distinct from Matomo.
* The cookie holds a random id, with an expiry of 13 months (matching the current behaviour).
* Tests that expect `analytics_session_id` to be `nil` are updated to reflect the fact that this id is always generated.

For context, see:

* [HUB-468](https://govukverify.atlassian.net/browse/HUB-468) (jira)
* [PS-53](https://trello.com/c/CxxaKSUg/53-preserve-ability-to-report-investigate-fraud-using-non-analytics-cookie) (trello)