### PR TITLE
Send analytic id and journey type to saml proxy on IDP response

### DIFF
--- a/app/controllers/authn_response_controller.rb
+++ b/app/controllers/authn_response_controller.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
 require "partials/user_cookies_partial_controller"
+require "partials/analytics_cookie_partial_controller"
 
 class AuthnResponseController < SamlController
+  include AnalyticsCookiePartialController
+
   protect_from_forgery except: %i[idp_response country_response]
 
   SIGNING_IN_STATE = "SIGN_IN_WITH_IDP"
@@ -26,7 +29,7 @@ class AuthnResponseController < SamlController
   def idp_response
     raise_error_if_params_invalid(params, session[:verify_session_id])
 
-    response = SAML_PROXY_API.idp_authn_response(session[:verify_session_id], params["SAMLResponse"])
+    response = SAML_PROXY_API.idp_authn_response(session[:verify_session_id], params["SAMLResponse"], persistent_session_id, session[:journey_type])
     status = response.idp_result
     remove_resume_link_journey_hint unless journey_hint_value.nil?
 

--- a/app/models/saml_proxy_api.rb
+++ b/app/models/saml_proxy_api.rb
@@ -34,11 +34,13 @@ class SamlProxyApi
     ResponseForRp.validated_response(response)
   end
 
-  def idp_authn_response(session_id, saml_response)
+  def idp_authn_response(session_id, saml_response, persistent_session_id, journey_type)
     body = {
         PARAM_RELAY_STATE => session_id,
         PARAM_SAML_REQUEST => saml_response,
         PARAM_IP_SEEN_BY_FRONTEND => originating_ip,
+        PARAM_PERSISTENT_SESSION_ID => persistent_session_id,
+        PARAM_JOURNEY_TYPE => journey_type,
     }
     response = @api_client.post(IDP_AUTHN_RESPONSE_ENDPOINT, body)
 

--- a/app/models/saml_proxy_endpoints.rb
+++ b/app/models/saml_proxy_endpoints.rb
@@ -5,6 +5,8 @@ module SamlProxyEndpoints
   PARAM_SAML_REQUEST = "samlRequest".freeze
   PARAM_RELAY_STATE = "relayState".freeze
   PARAM_IP_SEEN_BY_FRONTEND = "principalIpAsSeenByFrontend".freeze
+  PARAM_JOURNEY_TYPE = "journeyType".freeze
+  PARAM_PERSISTENT_SESSION_ID = "analyticsSessionId".freeze
   RESPONSE_FOR_RP_PATH = "/SAML2/SSO/API/SENDER/RESPONSE".freeze
   AUTHN_REQUEST_PATH = "/SAML2/SSO/API/SENDER/AUTHN_REQ".freeze
   ERROR_RESPONSE_FOR_RP_PATH = "/SAML2/SSO/API/SENDER/ERROR_RESPONSE".freeze

--- a/spec/api_test_helper.rb
+++ b/spec/api_test_helper.rb
@@ -317,6 +317,8 @@ module ApiTestHelper
         PARAM_SAML_REQUEST => "my-saml-response",
         PARAM_RELAY_STATE => relay_state,
         PARAM_IP_SEEN_BY_FRONTEND => "<PRINCIPAL IP ADDRESS COULD NOT BE DETERMINED>",
+        PARAM_PERSISTENT_SESSION_ID => instance_of(String),
+        PARAM_JOURNEY_TYPE => nil,
     }
 
     stub_request(:post, saml_proxy_api_uri(IDP_AUTHN_RESPONSE_ENDPOINT))

--- a/spec/controllers/authn_response_controller_spec.rb
+++ b/spec/controllers/authn_response_controller_spec.rb
@@ -88,7 +88,10 @@ describe AuthnResponseController do
       set_session_and_cookies_with_loa("LEVEL_1")
       session[:verify_session_id] = "non-existent"
 
-      post :country_response, params: { "RelayState" => "my-session-id-cookie", "SAMLResponse" => "a-saml-response", locale: "en" }
+      post :country_response, params: {
+        "RelayState" => "my-session-id-cookie", "SAMLResponse" => "a-saml-response",
+        locale: "en"
+      }
 
       expect(subject).to render_template(:something_went_wrong)
     end

--- a/spec/models/saml_proxy_api_spec.rb
+++ b/spec/models/saml_proxy_api_spec.rb
@@ -8,6 +8,8 @@ describe SamlProxyApi do
   let(:api_client) { double(:api_client) }
   let(:originating_ip_store) { double(:originating_ip_store) }
   let(:session_id) { "my-session-id" }
+  let(:journey_type) { "sign-in" }
+  let(:persistent_session_id) { "my-persistent_session_id" }
   let(:cookies) {
     {
         CookieNames::SESSION_ID_COOKIE_NAME => session_id,
@@ -88,7 +90,9 @@ describe SamlProxyApi do
   describe "#idp_authn_response" do
     it "should return a confirmation result" do
       ip_address = "1.2.3.4"
-      expected_request = { "samlRequest" => "saml-response", "relayState" => "my-session-id", SamlProxyApi::PARAM_IP_SEEN_BY_FRONTEND => ip_address }
+      expected_request = { "samlRequest" => "saml-response", "relayState" => "my-session-id",
+        SamlProxyApi::PARAM_IP_SEEN_BY_FRONTEND => ip_address, SamlProxyApi::PARAM_PERSISTENT_SESSION_ID => "my-persistent_session_id",
+        "journeyType" => "sign-in" }
       expect(originating_ip_store).to receive(:get).and_return(ip_address)
       expect(api_client).to receive(:post)
         .with(SamlProxyApi::IDP_AUTHN_RESPONSE_ENDPOINT, expected_request)
@@ -98,7 +102,7 @@ describe SamlProxyApi do
           "loaAchieved" => "LEVEL_2",
         )
 
-      response = saml_proxy_api.idp_authn_response(session_id, "saml-response")
+      response = saml_proxy_api.idp_authn_response(session_id, "saml-response", persistent_session_id, journey_type)
 
       attributes = {
           idp_result: "some-location",
@@ -110,20 +114,24 @@ describe SamlProxyApi do
 
     it "should raise an error when fields are missing from the api response" do
       ip_address = "1.2.3.4"
-      expected_request = { "samlRequest" => "saml-response", "relayState" => "my-session-id", SamlProxyApi::PARAM_IP_SEEN_BY_FRONTEND => ip_address }
+      expected_request = { "samlRequest" => "saml-response", "relayState" => "my-session-id",
+        SamlProxyApi::PARAM_IP_SEEN_BY_FRONTEND => ip_address, SamlProxyApi::PARAM_PERSISTENT_SESSION_ID => "my-persistent_session_id",
+        "journeyType" => "sign-in" }
       expect(originating_ip_store).to receive(:get).and_return(ip_address)
       expect(api_client).to receive(:post)
         .with(SamlProxyApi::IDP_AUTHN_RESPONSE_ENDPOINT, expected_request)
         .and_return({})
 
       expect {
-        saml_proxy_api.idp_authn_response(session_id, "saml-response")
+        saml_proxy_api.idp_authn_response(session_id, "saml-response", persistent_session_id, journey_type)
       }.to raise_error Api::Response::ModelError, "Idp result can't be blank, Is registration is not included in the list"
     end
 
     it "should raise an error when loa_achieved is not an accepted value" do
       ip_address = "1.2.3.4"
-      expected_request = { "samlRequest" => "saml-response", "relayState" => "my-session-id", SamlProxyApi::PARAM_IP_SEEN_BY_FRONTEND => ip_address }
+      expected_request = { "samlRequest" => "saml-response", "relayState" => "my-session-id",
+         SamlProxyApi::PARAM_IP_SEEN_BY_FRONTEND => ip_address, SamlProxyApi::PARAM_PERSISTENT_SESSION_ID => "my-persistent_session_id",
+         "journeyType" => "sign-in" }
       expect(originating_ip_store).to receive(:get).and_return(ip_address)
       expect(api_client).to receive(:post)
         .with(SamlProxyApi::IDP_AUTHN_RESPONSE_ENDPOINT, expected_request)
@@ -134,7 +142,7 @@ describe SamlProxyApi do
         )
 
       expect {
-        saml_proxy_api.idp_authn_response(session_id, "saml-response")
+        saml_proxy_api.idp_authn_response(session_id, "saml-response", persistent_session_id, journey_type)
       }.to raise_error Api::Response::ModelError, "Loa achieved is not included in the list"
     end
   end


### PR DESCRIPTION
**What**
- When we receive a response from a IDP at the frontend, we want to add on the analytic id and journey type before sending it on to saml proxy. This will allow us to log each of these attributes in policy.

**Why**
- Because we're not currently doing it and it is resulting in Policy logging null for these attributes. It would be useful to see the journey type and analytic id in the responses. This will allow us to filter in kibana based on if a user has come back from a sign-in or registration journey etc. 