### PR TITLE
BAU: Upgrade web-console

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,7 @@ gem 'browser'
 
 group :development do
   # Access an IRB console on exception pages or by using <%= console %> in views
-  gem 'web-console', '~> 2.0'
+  gem 'web-console', '~> 3.7'
 
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,8 +50,7 @@ GEM
     ast (2.4.0)
     autoprefixer-rails (9.7.6)
       execjs
-    binding_of_caller (0.8.0)
-      debug_inspector (>= 0.0.1)
+    bindex (0.8.1)
     browser (4.1.0)
     builder (3.2.4)
     byebug (11.1.3)
@@ -72,7 +71,6 @@ GEM
       safe_yaml (~> 1.0.0)
     crass (1.0.6)
     daemons (1.3.1)
-    debug_inspector (0.0.3)
     diff-lcs (1.3)
     docile (1.3.2)
     domain_name (0.5.20190701)
@@ -296,11 +294,11 @@ GEM
       unf_ext
     unf_ext (0.0.7.7)
     unicode-display_width (1.7.0)
-    web-console (2.3.0)
-      activemodel (>= 4.0)
-      binding_of_caller (>= 0.7.2)
-      railties (>= 4.0)
-      sprockets-rails (>= 2.0, < 4.0)
+    web-console (3.7.0)
+      actionview (>= 5.0)
+      activemodel (>= 5.0)
+      bindex (>= 0.4.0)
+      railties (>= 5.0)
     webmock (3.8.3)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -360,7 +358,7 @@ DEPENDENCIES
   thin
   tzinfo-data
   uglifier (~> 2.7.0)
-  web-console (~> 2.0)
+  web-console (~> 3.7)
   webmock
   win32-process
   windows-pr


### PR DESCRIPTION
The old version is not compatible with the recent upgrades to other test libraries.

We can't use the newest version because we're not on the latest version of Rails and this causes dependency conflicts.