### PR TITLE
Hub-518: crash on paused frontend endpoint

### DIFF
--- a/app/controllers/paused_registration_controller.rb
+++ b/app/controllers/paused_registration_controller.rb
@@ -115,11 +115,16 @@ private
     selected_rp = get_rp_details(last_rp)
     return if selected_rp == nil
 
-    @transaction = {
-      name: get_translated_service_name(selected_rp.simple_id),
-      homepage: selected_rp.transaction_homepage,
-      start_page: preferred_start_page(selected_rp),
-    }
+    begin
+      @transaction = {
+        name: get_translated_service_name(selected_rp.simple_id),
+        homepage: selected_rp.transaction_homepage,
+        start_page: preferred_start_page(selected_rp),
+      }
+    rescue StandardError => e
+      logger.warn e.message
+      nil
+    end
   end
 
   def get_rp_details(last_rp_value)

--- a/app/controllers/paused_registration_controller.rb
+++ b/app/controllers/paused_registration_controller.rb
@@ -102,7 +102,7 @@ private
 
   def set_transaction_from_session
     selected_rp = get_rp_details(current_transaction_entity_id)
-    return if selected_rp == nil
+    return if selected_rp.nil?
 
     @transaction = {
       name: current_transaction.name,
@@ -113,29 +113,22 @@ private
 
   def set_transaction_from_cookie
     selected_rp = get_rp_details(last_rp)
-    return if selected_rp == nil
+    return if selected_rp.nil?
 
-    begin
-      @transaction = {
-        name: get_translated_service_name(selected_rp.simple_id),
-        homepage: selected_rp.transaction_homepage,
-        start_page: preferred_start_page(selected_rp),
-      }
-    rescue StandardError => e
-      logger.warn e.message
-      nil
-    end
+    @transaction = {
+      name: get_translated_service_name(selected_rp.simple_id),
+      homepage: selected_rp.transaction_homepage,
+      start_page: preferred_start_page(selected_rp),
+    }
   end
 
   def get_rp_details(last_rp_value)
     return nil if last_rp_value.nil?
 
-    begin
-      CONFIG_PROXY.get_transaction_details(last_rp_value)
-    rescue StandardError
-      logger.warn "Error trying to retrieve transaction details for #{last_rp_value} from config service"
-      nil
-    end
+    CONFIG_PROXY.get_transaction_details(last_rp_value)
+  rescue Api::Error => e
+    logger.warn "Error trying to retrieve transaction details for #{last_rp_value}. #{e}"
+    nil
   end
 
   def get_translated_service_name(simple_id)

--- a/app/controllers/paused_registration_controller.rb
+++ b/app/controllers/paused_registration_controller.rb
@@ -102,24 +102,24 @@ private
 
   def set_transaction_from_session
     selected_rp = get_rp_details(current_transaction_entity_id)
-    if selected_rp != nil
-      @transaction = {
-        name: current_transaction.name,
-        homepage: current_transaction_homepage,
-        start_page: preferred_start_page(selected_rp),
-      }
-    end
+    return if selected_rp == nil
+
+    @transaction = {
+      name: current_transaction.name,
+      homepage: current_transaction_homepage,
+      start_page: preferred_start_page(selected_rp),
+    }
   end
 
   def set_transaction_from_cookie
     selected_rp = get_rp_details(last_rp)
-    if selected_rp != nil
-      @transaction = {
-        name: get_translated_service_name(selected_rp.simple_id),
-        homepage: selected_rp.transaction_homepage,
-        start_page: preferred_start_page(selected_rp),
-      }
-    end
+    return if selected_rp == nil
+
+    @transaction = {
+      name: get_translated_service_name(selected_rp.simple_id),
+      homepage: selected_rp.transaction_homepage,
+      start_page: preferred_start_page(selected_rp),
+    }
   end
 
   def get_rp_details(last_rp_value)
@@ -128,7 +128,7 @@ private
     begin
       CONFIG_PROXY.get_transaction_details(last_rp_value)
     rescue StandardError
-      logger.warn "Error trying to retrieve transaction details for #{last_rp_value}"
+      logger.warn "Error trying to retrieve transaction details for #{last_rp_value} from config service"
       nil
     end
   end

--- a/app/models/config_proxy.rb
+++ b/app/models/config_proxy.rb
@@ -16,7 +16,7 @@ class ConfigProxy
       translations_for_locale = TransactionTranslationResponse.validated_response(response)
 
       translations_for_locale.to_h
-    rescue StandardError
+    rescue Api::Error, TypeError
       {}
     end
   end

--- a/lib/api/eidas_error.rb
+++ b/lib/api/eidas_error.rb
@@ -1,5 +1,5 @@
 module Api
-  class EidasSchemeUnavailableError < StandardError
+  class EidasSchemeUnavailableError < Api::Error
     TYPES = %w(METADATA_PROVIDER_EXCEPTION).freeze
   end
 end

--- a/lib/api/session_error.rb
+++ b/lib/api/session_error.rb
@@ -1,5 +1,5 @@
 module Api
-  class SessionError < StandardError
+  class SessionError < Api::Error
     TYPE = "SESSION_ERROR".freeze
 
     #This was called SESSION_ERROR by frontend api

--- a/lib/api/session_timeout_error.rb
+++ b/lib/api/session_timeout_error.rb
@@ -1,5 +1,5 @@
 module Api
-  class SessionTimeoutError < StandardError
+  class SessionTimeoutError < Api::Error
     TYPE = "SESSION_TIMEOUT".freeze
   end
 end

--- a/lib/api/upstream_error.rb
+++ b/lib/api/upstream_error.rb
@@ -1,5 +1,5 @@
 module Api
-  class UpstreamError < StandardError
+  class UpstreamError < Api::Error
     attr_reader :hub_type
 
     def initialize(hub_type = nil)

--- a/spec/api_test_helper.rb
+++ b/spec/api_test_helper.rb
@@ -258,8 +258,8 @@ module ApiTestHelper
     stub_request(:get, config_api_uri(transaction_display_data_endpoint(default_transaction_entity_id))).to_return(body: transaction_details_stub_response(options).to_json, status: 200)
   end
 
-  def stub_missing_transaction_details
-    stub_request(:get, config_api_uri(transaction_display_data_endpoint(default_transaction_entity_id))).to_return(body: { message: "NONE", type: "NONE", id: "NONE", Referer: "" }.to_json, status: 404)
+  def stub_missing_transaction_details(body: { clientMessage: "NONE", exceptionType: "NONE", errorId: "NONE", Referer: "" }, status: 400)
+    stub_request(:get, config_api_uri(transaction_display_data_endpoint(default_transaction_entity_id))).to_return(body: body.to_json, status: status)
   end
 
   def transaction_details_stub_response(options)


### PR DESCRIPTION
see: https://govukverify.atlassian.net/browse/HUB-518
From https://sentry.tools.signin.service.gov.uk/verify/prod-frontend/issues/4309/?query=is:unresolved
https://www.signin.service.gov.uk/paused
Api::Error: Unexpected error whilst trying to communicate wth the Hub. Received 404 with error message: 'NONE', type: 'NONE' and id: 'NONE', Referer: ''
The Hub may be unreachable. Check all services are running and are accessible

This is (now) an expected case: the user has a pause-and-resume cookie indicating an RP using an entity ID that no longer exists.

We are seeing these because of a change to HMRC’s entity id’s.

We should catch these exceptions and the user should get the same behaviour as when they go to that URI with no pause-and-resume cookie.

We think that the function where we might catch this error