### PR TITLE
Hub 636 bau change short hub logic and kick out pages

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -39,6 +39,7 @@ $govuk-fonts-path: "govuk-frontend/govuk/assets/fonts/";
 @import "pages/privacy-notice";
 @import "pages/response-processing";
 @import "pages/select-documents";
+@import "pages/select-documents-advice";
 @import "pages/select-phone";
 @import "pages/slides";
 

--- a/app/assets/stylesheets/pages/_select-documents-advice.scss
+++ b/app/assets/stylesheets/pages/_select-documents-advice.scss
@@ -1,0 +1,4 @@
+.underline {
+  border-bottom: 1px solid govuk-colour("mid-grey");
+  padding: 10px 20px 10px 0;
+}

--- a/app/controllers/select_documents_variant_c_controller.rb
+++ b/app/controllers/select_documents_variant_c_controller.rb
@@ -33,7 +33,6 @@ class SelectDocumentsVariantCController < ApplicationController
   end
 
   def prove_your_identity_another_way
-    @other_ways_description = current_transaction.other_ways_description
     @other_ways_text = current_transaction.other_ways_text
     @service_name = current_transaction.name
 

--- a/app/controllers/select_documents_variant_c_controller.rb
+++ b/app/controllers/select_documents_variant_c_controller.rb
@@ -26,7 +26,8 @@ class SelectDocumentsVariantCController < ApplicationController
   def advice
     answers = selected_answer_store.selected_answers.fetch("documents", {})
     mappings = t("hub_variant_c.select_documents").select { |k, _| k.to_s.start_with?("has") }.transform_keys!(&:to_s)
-    @documents = answers.transform_keys(&mappings.method(:[]))
+    documents = answers.transform_keys(&mappings.method(:[]))
+    @documents = documents.sort_by { |_, v| v ? 0 : 1 }.to_h
 
     render :advice
   end

--- a/app/views/select_documents_variant_c/advice.html.erb
+++ b/app/views/select_documents_variant_c/advice.html.erb
@@ -7,7 +7,7 @@
       <div class="govuk-grid-column-full govuk-heading-l">
         <%=t "hub_variant_c.select_documents_advice.advice_html.heading" %>
         <div class="govuk-body govuk-!-padding-top-4">
-          <%=t "hub_variant_c.select_documents_advice.advice_html.#{ @documents.values.any? ? 'sub_heading' : 'none_heading_html'}" %>
+          <%=t "hub_variant_c.select_documents_advice.advice_html.#{ @documents.values.any? ? 'sub_heading' : 'no_evidence_intro_html'}" %>
         </div>
       </div>
       <% @documents.group_by(&:last).each do |key, values| %>

--- a/app/views/select_documents_variant_c/advice.html.erb
+++ b/app/views/select_documents_variant_c/advice.html.erb
@@ -6,30 +6,31 @@
     <div class="govuk-grid-column-two-thirds">
       <div class="govuk-grid-column-full govuk-heading-l">
         <%=t "hub_variant_c.select_documents_advice.advice_html.heading" %>
-        <div class="govuk-body govuk-!-padding-top-4"><%=t "hub_variant_c.select_documents_advice.advice_html.sub_heading" %></div>
+        <div class="govuk-body govuk-!-padding-top-4">
+          <%=t "hub_variant_c.select_documents_advice.advice_html.#{ @documents.values.any? ? 'sub_heading' : 'none_heading_html'}" %>
+        </div>
       </div>
-
-      <% @documents.group_by(&:last).each do |key, value| %>
-        <div class="govuk-grid-column-one-half">
-          <h2 class="govuk-heading-s">
-            <%= t "hub_variant_c.select_documents_advice.advice_html.#{key ? 'specified' : 'unspecified'}" %>
-          </h2>
-          <dl id=<%="#evidence_#{key ? 'specified' : 'unspecified'}"%> class="govuk-summary-list">
-            <% value.map(&:first).each do |evidence| %>
-              <div class="govuk-summary-list__row">
-                <dd class="govuk-summary-list__value"><%=evidence%></dd>
-              </div>
+      <% @documents.group_by(&:last).each do |key, values| %>
+        <div class=<%="govuk-grid-column#{ @documents.values.any? ? '-one-half' : '-full'}" %>>
+          <% if @documents.values.any? %>
+            <h2 class="govuk-heading-s">
+              <%= t "hub_variant_c.select_documents_advice.advice_html.#{key ? 'specified' : 'unspecified'}" %>
+            </h2>
+          <% end %>
+          <ul id=<%="#evidence_#{key ? 'specified' : 'unspecified'}"%> class="govuk-list <% unless @documents.values.any? %> govuk-list--bullet  govuk-!-margin-top-0<% end %>">
+            <% values.map(&:first).each do |evidence| %>
+              <% if @documents.values.any? %><li class="underline"><%=evidence%></li><% else %><li><%=evidence%></li><% end %>
             <% end %>
-          </dl>
+          </ul>
         </div>
       <% end %>
 
       <div class="govuk-grid-column-full">
         <h2 class="govuk-heading-m"><%=t("hub_variant_c.select_documents_advice.what_to_do_next.heading")%></h2>
-          <%= t("hub_variant_c.select_documents_advice.what_to_do_next.content_html",
-            change_your_answers_link: link_to(t("hub_variant_c.select_documents_advice.what_to_do_next.change_your_answers_link"), select_documents_path, class: "govuk-link"),
-            prove_your_identity_link: link_to(t("hub_variant_c.select_documents_advice.what_to_do_next.prove_your_identity_link"), prove_your_identity_another_way_path, class: "govuk-link")
-          ) %>
+        <%= t("hub_variant_c.select_documents_advice.what_to_do_next.content_html",
+          change_your_answers_link: link_to(t("hub_variant_c.select_documents_advice.what_to_do_next.change_your_answers_link"), select_documents_path, class: "govuk-link"),
+          prove_your_identity_link: link_to(t("hub_variant_c.select_documents_advice.what_to_do_next.prove_your_identity_link"), prove_your_identity_another_way_path, class: "govuk-link")
+        ) %>
       </div>
     </div>
   </div>

--- a/app/views/select_documents_variant_c/prove_your_identity_another_way.html.erb
+++ b/app/views/select_documents_variant_c/prove_your_identity_another_way.html.erb
@@ -5,7 +5,8 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l"><%= t("hub_variant_c.prove_your_identity_another_way.heading") %></h1>
     <p class="govuk-body"><%= t("hub_variant_c.prove_your_identity_another_way.sub_heading", service_name: @service_name) %></p>
-
-    <%= render partial: 'shared/other_ways', locals: {other_ways_text: @other_ways_text, other_ways_description: @other_ways_description} %>
+      <div class="other-ways-to-complete-transaction">
+        <%= raw @other_ways_text %>
+      </div>
   </div>
 </div>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -142,7 +142,7 @@ cy:
       advice_html:
         heading: Based on your answers, you cannot use GOV.UK Verify
         sub_heading: Make sure you selected all the things you have with you.
-        none_heading_html: |
+        no_evidence_intro_html: |
           <p class="govuk-body">To set up an identity account, you need to provide evidence for the companies to check.</p>
           <p class="govuk-body govuk-!-margin-bottom-0">You said you have none of these things with you right now:</p>
         specified: Things you have with you

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -115,10 +115,10 @@ cy:
       heading: Which of these do you have available right now?
       explanation: This will help us tell you if GOV.UK Verify will work for you. The more items you have, the more likely it is that you can verify your identity.
       select_all_that_apply: "Select all that apply:"
-      has_valid_passport: Your valid passport
-      has_driving_license: Your current driving licence, full or provisional, with your photo on it
+      has_valid_passport: A valid passport
+      has_driving_license: A valid driving licence, full or provisional, with your photo on it
       has_phone_can_app: A phone or tablet that can download an app
-      has_credit_card: Your credit or debit card
+      has_credit_card: A credit or debit card
       has_nothing: None of the above
       further_explanation:
         title: What GOV.UK Verify uses these for
@@ -142,6 +142,9 @@ cy:
       advice_html:
         heading: Based on your answers, you cannot use GOV.UK Verify
         sub_heading: Make sure you selected all the things you have with you.
+        none_heading_html: |
+          <p class="govuk-body">To set up an identity account, you need to provide evidence for the companies to check.</p>
+          <p class="govuk-body govuk-!-margin-bottom-0">You said you have none of these things with you right now:</p>
         specified: Things you have with you
         unspecified: Things you do not have with you
       what_to_do_next:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -143,7 +143,7 @@ en:
       advice_html:
         heading: Based on your answers, you cannot use GOV.UK Verify
         sub_heading: Make sure you selected all the things you have with you.
-        none_heading_html: |
+        no_evidence_intro_html: |
           <p class="govuk-body">To set up an identity account, you need to provide evidence for the companies to check.</p>
           <p class="govuk-body govuk-!-margin-bottom-0">You said you have none of these things with you right now:</p>
         specified: Things you have with you

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -116,10 +116,10 @@ en:
       heading: Which of these do you have available right now?
       explanation: This will help us tell you if GOV.UK Verify will work for you. The more items you have, the more likely it is that you can verify your identity.
       select_all_that_apply: "Select all that apply:"
-      has_valid_passport: Your valid passport
-      has_driving_license: Your current driving licence, full or provisional, with your photo on it
+      has_valid_passport: A valid passport
+      has_driving_license: A valid driving licence, full or provisional, with your photo on it
       has_phone_can_app: A phone or tablet that can download an app
-      has_credit_card: Your credit or debit card
+      has_credit_card: A credit or debit card
       has_nothing: None of the above
       further_explanation:
         title: What GOV.UK Verify uses these for
@@ -143,6 +143,9 @@ en:
       advice_html:
         heading: Based on your answers, you cannot use GOV.UK Verify
         sub_heading: Make sure you selected all the things you have with you.
+        none_heading_html: |
+          <p class="govuk-body">To set up an identity account, you need to provide evidence for the companies to check.</p>
+          <p class="govuk-body govuk-!-margin-bottom-0">You said you have none of these things with you right now:</p>
         specified: Things you have with you
         unspecified: Things you do not have with you
       what_to_do_next:
@@ -180,7 +183,7 @@ en:
         close: close
     prove_your_identity_another_way:
       heading: Prove your identity another way
-      sub_heading: You can still %{service_name}
+      sub_heading: You can still %{service_name}.
   hub:
     other_ways_title: Other ways to access the service
     other_ways_heading: Other ways to %{other_ways_description}

--- a/spec/features/user_visits_select_documents_advice_page_spec.rb
+++ b/spec/features/user_visits_select_documents_advice_page_spec.rb
@@ -22,8 +22,7 @@ RSpec.feature "user visits select documents advice pages", type: :feature do
 
     expect(page).to have_current_path(select_documents_advice_path)
       .and have_content(t("hub_variant_c.select_documents_advice.advice_html.heading"))
-      .and have_content(t("hub_variant_c.select_documents_advice.advice_html.sub_heading"))
-      .and have_content(t("hub_variant_c.select_documents_advice.advice_html.unspecified"))
+      .and have_content("You said you have none of these things with you right now:")
       .and have_content(t("hub_variant_c.select_documents_advice.what_to_do_next.heading"))
     expect_things_you_do_not_have_column_to_contain(
       t("hub_variant_c.select_documents.has_valid_passport"),

--- a/spec/features/user_visits_select_documents_advice_page_spec.rb
+++ b/spec/features/user_visits_select_documents_advice_page_spec.rb
@@ -1,6 +1,5 @@
 require "feature_helper"
 require "api_test_helper"
-require "models/selected_answer_store"
 
 RSpec.feature "user visits select documents advice pages", type: :feature do
   before(:each) do


### PR DESCRIPTION
These are changes to fix comments from Beth, in addition changed Summary list to Ul list due to HTML validation issue, where Summary list require 'dt' tag

Some of the kick out pages have the columns the wrong way round. These are the ones for:

- driving licence + phone
- driving licence + card
-  phone + card

1. They all have the 'things you do not have with you' column first. This is confusing if a user has been back and forth a couple of times, and are expecting that column to be the same as the other pages.

2. The 'none of the above' version of the kick out page does not include the correct content - it should be like the 'none of the above' row of the table in this document: https://docs.google.com/document/d/1wDXEkqigqcy4q5-_xhFffO6kFCFdR559i-_gKuhVR8Q/edit#heading=h.p5rhhpvlqt6k

3. The ‘other ways' page includes the 'Other ways' h2 which should not be there, like the design: https://docs.google.com/drawings/d/1zCBOKqsLQSJQl5NNqWUzs5FhlY0EXoy6JOxfRtv--qM/edit
(Sorry if the design wasn’t clear enough here!)

4. The 'other ways page needs full stop after the service name in the first sentence.