### PR TITLE
BAU: document advice page layout

### DIFF
--- a/app/views/select_documents_variant_c/advice.html.erb
+++ b/app/views/select_documents_variant_c/advice.html.erb
@@ -1,37 +1,37 @@
 <%= page_title 'hub_variant_c.select_documents.title' %>
 <% content_for :feedback_source, 'SELECT_DOCUMENTS_ADVICE_PAGE' %>
+
 <div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-column-full govuk-!-margin-bottom-4">
+      <h1 class="govuk-heading-l govuk-!-margin-bottom-0"><%=t "hub_variant_c.select_documents_advice.advice_html.heading" %></h1>
+      <h2 class="govuk-heading-m govuk-!-padding-top-4 govuk-body govuk-!-margin-bottom-0">
+        <%=t "hub_variant_c.select_documents_advice.advice_html.#{@documents.values.any? ? 'sub_heading' : 'no_evidence_intro_html'}" %>
+      </h2>
+    </div>
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <div class="govuk-grid-column-full govuk-heading-l">
-        <%=t "hub_variant_c.select_documents_advice.advice_html.heading" %>
-        <div class="govuk-body govuk-!-padding-top-4">
-          <%=t "hub_variant_c.select_documents_advice.advice_html.#{ @documents.values.any? ? 'sub_heading' : 'no_evidence_intro_html'}" %>
-        </div>
-      </div>
-      <% @documents.group_by(&:last).each do |key, values| %>
-        <div class=<%="govuk-grid-column#{ @documents.values.any? ? '-one-half' : '-full'}" %>>
-          <% if @documents.values.any? %>
-            <h2 class="govuk-heading-s">
-              <%= t "hub_variant_c.select_documents_advice.advice_html.#{key ? 'specified' : 'unspecified'}" %>
-            </h2>
+    <% @documents.group_by(&:last).each do |key, values| %>
+      <div class=<%="govuk-grid-column#{@documents.values.any? ? '-one-half' : '-full'}" %>>
+        <% if @documents.values.any? %>
+          <h2 class="govuk-heading-s govuk-!-margin-bottom-2">
+            <%= t "hub_variant_c.select_documents_advice.advice_html.#{key ? 'specified' : 'unspecified'}" %>
+          </h2>
+        <% end %>
+        <ul id=<%="#evidence_#{key ? 'specified' : 'unspecified'}"%> class="govuk-list <%='govuk-list--bullet govuk-!-margin-top-0' unless @documents.values.any? %>">
+          <% values.map(&:first).each do |evidence| %>
+            <%= @documents.values.any? ? content_tag(:li, evidence, class: :underline) : content_tag(:li, evidence.to_s.downcase) %>
           <% end %>
-          <ul id=<%="#evidence_#{key ? 'specified' : 'unspecified'}"%> class="govuk-list <% unless @documents.values.any? %> govuk-list--bullet  govuk-!-margin-top-0<% end %>">
-            <% values.map(&:first).each do |evidence| %>
-              <% if @documents.values.any? %><li class="underline"><%=evidence%></li><% else %><li><%=evidence%></li><% end %>
-            <% end %>
-          </ul>
-        </div>
-      <% end %>
-
-      <div class="govuk-grid-column-full">
-        <h2 class="govuk-heading-m"><%=t("hub_variant_c.select_documents_advice.what_to_do_next.heading")%></h2>
-        <%= t("hub_variant_c.select_documents_advice.what_to_do_next.content_html",
-          change_your_answers_link: link_to(t("hub_variant_c.select_documents_advice.what_to_do_next.change_your_answers_link"), select_documents_path, class: "govuk-link"),
-          prove_your_identity_link: link_to(t("hub_variant_c.select_documents_advice.what_to_do_next.prove_your_identity_link"), prove_your_identity_another_way_path, class: "govuk-link")
-        ) %>
+        </ul>
       </div>
+    <% end %>
+
+    <div class="govuk-grid-column-full">
+      <h2 class="govuk-heading-m"><%=t("hub_variant_c.select_documents_advice.what_to_do_next.heading")%></h2>
+      <%= t("hub_variant_c.select_documents_advice.what_to_do_next.content_html",
+        change_your_answers_link: link_to(t("hub_variant_c.select_documents_advice.what_to_do_next.change_your_answers_link"), select_documents_path, class: "govuk-link"),
+        prove_your_identity_link: link_to(t("hub_variant_c.select_documents_advice.what_to_do_next.prove_your_identity_link"), prove_your_identity_another_way_path, class: "govuk-link")
+      ) %>
     </div>
   </div>
 </div>
+

--- a/spec/features/user_visits_select_documents_advice_page_spec.rb
+++ b/spec/features/user_visits_select_documents_advice_page_spec.rb
@@ -10,7 +10,9 @@ RSpec.feature "user visits select documents advice pages", type: :feature do
 
   it "includes the appropriate feedback source" do
     visit select_documents_advice_path
-    expect_feedback_source_to_be(page, "SELECT_DOCUMENTS_ADVICE_PAGE", "/select-documents-advice")
+
+    expect(page).to have_title t("hub_variant_c.select_documents.title")
+    expect_feedback_source_to_be(page, "SELECT_DOCUMENTS_ADVICE_PAGE", select_documents_advice_path)
   end
 
   it "lists things you do not have with you when 'None of the above is checked'" do
@@ -23,11 +25,12 @@ RSpec.feature "user visits select documents advice pages", type: :feature do
       .and have_content(t("hub_variant_c.select_documents_advice.advice_html.heading"))
       .and have_content("You said you have none of these things with you right now:")
       .and have_content(t("hub_variant_c.select_documents_advice.what_to_do_next.heading"))
+
     expect_things_you_do_not_have_column_to_contain(
-      t("hub_variant_c.select_documents.has_valid_passport"),
-      t("hub_variant_c.select_documents.has_driving_license"),
-      t("hub_variant_c.select_documents.has_phone_can_app"),
-      t("hub_variant_c.select_documents.has_credit_card"),
+      t("hub_variant_c.select_documents.has_valid_passport").downcase,
+      t("hub_variant_c.select_documents.has_driving_license").downcase,
+      t("hub_variant_c.select_documents.has_phone_can_app").downcase,
+      t("hub_variant_c.select_documents.has_credit_card").downcase,
     )
   end
 


### PR DESCRIPTION
Minor content tweaks, for when you select 'None of the above' check box on the Select Document page under short hub variant (short_hub_2019_q3-preview_variant_c_2_idp_short_hub) and click on continue
- make bullet list start with lower case
- Remove spaces above bullet list
**Before**
![image](https://user-images.githubusercontent.com/3749690/85149785-9fb4bb80-b249-11ea-8223-63c7d5f50a7c.png)
**After**
![image](https://user-images.githubusercontent.com/3749690/85149908-c541c500-b249-11ea-9d0e-51a40c8dbe04.png)

