### PR TITLE
BAU Make the non-preview shorthub AB test live [DO NOT MERGE]

### DIFF
--- a/config/main_routes.rb
+++ b/config/main_routes.rb
@@ -7,7 +7,7 @@ post "sign_in", to: "sign_in#select_idp", as: :sign_in_submit
 get "begin_sign_in", to: "start#sign_in", as: :begin_sign_in
 
 # HUH-233 short hub 2019 q3 multivariate tests - LOA2 only
-SHORT_HUB_2019_Q3 = "short_hub_2019_q3-preview".freeze
+SHORT_HUB_2019_Q3 = "short_hub_2019_q3".freeze
 short_hub_v3 = AbTestConstraint.configure(ab_test_name: SHORT_HUB_2019_Q3, experiment_loa: "LEVEL_2")
 
 constraints IsLoa1 do

--- a/spec/controllers/about_loa2_variant_c_controller_spec.rb
+++ b/spec/controllers/about_loa2_variant_c_controller_spec.rb
@@ -8,7 +8,7 @@ describe AboutLoa2VariantCController do
 
   before(:each) do
     stub_request(:get, CONFIG.config_api_host + "/config/transactions/enabled")
-    experiment = "short_hub_2019_q3-preview"
+    experiment = "short_hub_2019_q3"
     variant = "variant_c_2_idp_short_hub"
     set_session_and_cookies_with_loa_and_variant("LEVEL_2", experiment, variant)
     stub_api_idp_list_for_registration

--- a/spec/controllers/choose_a_certified_company_loa2_variant_c_controller_spec.rb
+++ b/spec/controllers/choose_a_certified_company_loa2_variant_c_controller_spec.rb
@@ -30,7 +30,7 @@ describe ChooseACertifiedCompanyLoa2VariantCController do
 
   before(:each) do
     stub_request(:get, CONFIG.config_api_host + "/config/transactions/enabled")
-    experiment = "short_hub_2019_q3-preview"
+    experiment = "short_hub_2019_q3"
     variant = "variant_c_2_idp_short_hub"
     stub_api_select_idp
     set_session_and_cookies_with_loa_and_variant("LEVEL_2", experiment, variant)

--- a/spec/controllers/select_documents_variant_c_controller_spec.rb
+++ b/spec/controllers/select_documents_variant_c_controller_spec.rb
@@ -8,7 +8,7 @@ require "models/display/viewable_identity_provider"
 
 describe SelectDocumentsVariantCController do
   before(:each) do
-    experiment = "short_hub_2019_q3-preview"
+    experiment = "short_hub_2019_q3"
     variant = "variant_c_2_idp_short_hub"
     set_session_and_cookies_with_loa_and_variant("LEVEL_2", experiment, variant)
     stub_api_idp_list_for_registration([{ "simpleId" => "stub-idp-one",

--- a/spec/features/user_sends_authn_request_spec.rb
+++ b/spec/features/user_sends_authn_request_spec.rb
@@ -3,7 +3,6 @@ require "api_test_helper"
 require "piwik_test_helper"
 
 AB_TEST_COOKIE_DEFAULTS = {
-  "short_hub_2019_q3-preview" => "short_hub_2019_q3-preview_control_a",
   "short_hub_2019_q3" => "short_hub_2019_q3_control_a",
   "select_documents_v2" => "select_documents_v2_control",
   "about_companies" => "about_companies_with_logo",

--- a/spec/features/user_visits_about_page_variant_spec.rb
+++ b/spec/features/user_visits_about_page_variant_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "When the user visits the about page" do
     before(:each) do
       stub_api_idp_list_for_registration
       page.set_rack_session(transaction_simple_id: "test-rp")
-      experiment = { "short_hub_2019_q3-preview" => "short_hub_2019_q3-preview_variant_c_2_idp_short_hub" }
+      experiment = { "short_hub_2019_q3" => "short_hub_2019_q3_variant_c_2_idp_short_hub" }
       set_session_and_ab_session_cookies!(experiment)
     end
 

--- a/spec/features/user_visits_choose_a_certified_company_variant_c_page_spec.rb
+++ b/spec/features/user_visits_choose_a_certified_company_variant_c_page_spec.rb
@@ -27,7 +27,7 @@ describe "When the user visits the choose a certified company variant page" do
   }
 
   before(:each) do
-    experiment = { "short_hub_2019_q3-preview" => "short_hub_2019_q3-preview_variant_c_2_idp_short_hub" }
+    experiment = { "short_hub_2019_q3" => "short_hub_2019_q3_variant_c_2_idp_short_hub" }
     set_session_and_ab_session_cookies!(experiment)
     stub_api_idp_list_for_registration([stub_idp_one, stub_idp_three])
   end

--- a/spec/features/user_visits_prove_your_identity_another_way_page_spec.rb
+++ b/spec/features/user_visits_prove_your_identity_another_way_page_spec.rb
@@ -4,7 +4,7 @@ require "api_test_helper"
 RSpec.feature "when user visits prove your identity another way page", type: :feature do
   let(:service_name) { "test GOV.UK Verify user journeys" }
   before(:each) do
-    experiment = { "short_hub_2019_q3-preview" => "short_hub_2019_q3-preview_variant_c_2_idp_short_hub" }
+    experiment = { "short_hub_2019_q3" => "short_hub_2019_q3_variant_c_2_idp_short_hub" }
     set_session_and_ab_session_cookies!(experiment)
     stub_api_idp_list_for_registration
   end

--- a/spec/features/user_visits_select_documents_advice_page_spec.rb
+++ b/spec/features/user_visits_select_documents_advice_page_spec.rb
@@ -3,7 +3,7 @@ require "api_test_helper"
 
 RSpec.feature "user visits select documents advice pages", type: :feature do
   before(:each) do
-    experiment = { "short_hub_2019_q3-preview" => "short_hub_2019_q3-preview_variant_c_2_idp_short_hub" }
+    experiment = { "short_hub_2019_q3" => "short_hub_2019_q3_variant_c_2_idp_short_hub" }
     set_session_and_ab_session_cookies!(experiment)
     stub_api_idp_list_for_registration
   end

--- a/spec/features/user_visits_select_documents_variant_c_page_spec.rb
+++ b/spec/features/user_visits_select_documents_variant_c_page_spec.rb
@@ -3,7 +3,7 @@ require "api_test_helper"
 
 RSpec.feature "When user visits document selection page" do
   before(:each) do
-    experiment = { "short_hub_2019_q3-preview" => "short_hub_2019_q3-preview_variant_c_2_idp_short_hub" }
+    experiment = { "short_hub_2019_q3" => "short_hub_2019_q3_variant_c_2_idp_short_hub" }
     set_session_and_ab_session_cookies!(experiment)
     stub_api_idp_list_for_registration
     visit "/select-documents"

--- a/stub/ab_test.yml
+++ b/stub/ab_test.yml
@@ -19,12 +19,6 @@
 #
 
 experiments:
-  - short_hub_2019_q3-preview:
-      alternatives:
-        - name: 'control_a'
-          percent: 100
-        - name: 'variant_c_2_idp_short_hub'
-          percent: 0
   - short_hub_2019_q3:
       alternatives:
         - name: 'control_a'


### PR DESCRIPTION
Don't deploy this until the corresponding config has been updated!

Remove '-preview' from `SHORT_HUB_2019_Q3` constant.

Update `stub/ab_test.yml` to reflect new constant

Don't remove long dead tests from `stub/ab_test.yml` because it turns out they're used in some of the tests.