### PR TITLE
BAU Fix an interpolation variable name in cy.yml

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -509,17 +509,17 @@ cy:
     failed_registration:
       title: Methu dilysu eich hunaniaeth
       alt_heading: "%{idp} could not verify your identity"
-      you_can_still: You can still %{service_name}
+      you_can_still: You can still %{service}
       your_account_with_heading: Your account with %{idp}
       your_account_with_text: "%{idp} will not contact you or use your data for anything that is not related to your account. You can contact %{idp} for more help."
       remaining_idps:
         heading: Try verifying with another company
         text: Another company may still be able to verify you.
         link_text: Pick another company.
-        different_way: Try a different way to %{service_name}
+        different_way: Try a different way to %{service}
       last_idp:
         text: However, you will not be able to use GOV.UK Verify to prove who you are, as the companies could not verify your identify.
-        different_way: Use a different way to %{service_name}
+        different_way: Use a different way to %{service}
       heading: Roedd %{idp_name} yn methu dilysu eich hunaniaeth
       try_another_company: Rhowch gynnig ar gwmni ardystiedig arall
       reasons_html: Gallwch barhau i ddal %{service_name}


### PR DESCRIPTION
`service_name` should have been changed to `service` in cy.yml as well as en.yml.