### PR TITLE
Fix for JavaScript SameSite issue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ gem 'browser'
 # has started causing issues for endusers.  This gem works round the
 # issue.  See Chromium issue: https://www.chromium.org/updates/same-site
 
-gem 'rails_same_site_cookie', :git => "https://github.com/alphagov/rails_same_site_cookie.git", :ref => "704c1958bf2518ba8248fe3d21a49361e38e911a"
+gem 'rails_same_site_cookie', :git => "https://github.com/alphagov/rails-same-site-cookie.git", :ref => "704c1958bf2518ba8248fe3d21a49361e38e911a"
 
 group :development do
   # Access an IRB console on exception pages or by using <%= console %> in views

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: https://github.com/alphagov/rails_same_site_cookie.git
+  remote: https://github.com/alphagov/rails-same-site-cookie.git
   revision: 704c1958bf2518ba8248fe3d21a49361e38e911a
   ref: 704c1958bf2518ba8248fe3d21a49361e38e911a
   specs:

--- a/app/assets/javascripts/00-cookies.js
+++ b/app/assets/javascripts/00-cookies.js
@@ -41,7 +41,7 @@
       cookieString = cookieString + "; expires=" + date.toGMTString();
     }
     if (document.location.protocol == 'https:') {
-      cookieString = cookieString + "; Secure";
+      cookieString = cookieString + "; SameSite=None; Secure";
     }
     document.cookie = cookieString;
   };

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -43,7 +43,7 @@
                   <%= link_to t('cookie_message.link'), cookies_path %>
                 </p>
             </div>
-            <script>document.cookie = 'seen_cookie_message=yes; expires=' + new Date(new Date(Date.now()).setMonth(new Date(Date.now()).getMonth() + 1)) + ';'</script>
+            <script>document.cookie = 'seen_cookie_message=yes; expires=' + new Date(new Date(Date.now()).setMonth(new Date(Date.now()).getMonth() + 1)) + ';SameSite=None;secure'</script>
             </div>
           </div>
         </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -53,7 +53,7 @@ module VerifyFrontend
         # if the scripts in that file change, or more are added, use a command similar to
         # this to generate the digests:
         # `echo "'sha256-"$(echo -n "inline javascript text" | openssl dgst -sha256 -binary | openssl enc -base64)"'"`
-        "script-src 'self' 'unsafe-eval' 'sha256-l1eTVSK8DTnK8+yloud7wZUqFrI0atVo6VlC6PJvYaQ=' 'sha256-z+w14eMdBnQz5R7dNjibxeljAXmb/YS1Ldn35EM+png=' 'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=' 'sha256-G29/qSW/JHHANtFhlrZVDZW1HOkCDRc78ggbqwwIJ2g=' 'sha256-Q4QUjejvbTKD2vc18z+Lm8re547rtOd8EcBB111VRLU' 'unsafe-inline' www.google-analytics.com; " +
+        "script-src 'self' 'unsafe-eval' 'sha256-l1eTVSK8DTnK8+yloud7wZUqFrI0atVo6VlC6PJvYaQ=' 'sha256-z+w14eMdBnQz5R7dNjibxeljAXmb/YS1Ldn35EM+png=' 'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=' 'sha256-G29/qSW/JHHANtFhlrZVDZW1HOkCDRc78ggbqwwIJ2g=' 'sha256-Q4QUjejvbTKD2vc18z+Lm8re547rtOd8EcBB111VRLU' 'sha256-XtNXdOiMcIxK6AyojaxR2Nyuq+9yD49R6eC2CJf1mcQ=' 'unsafe-inline' www.google-analytics.com; " +
         "style-src 'self' 'unsafe-inline'",
     }
 


### PR DESCRIPTION
We've already fixed the Ruby SameSite cookie issue.  This is the first cookie to try to fix the SameSite cookie issue which results from cookies set using JavaScript.

The command and output for generating the hash.
```
echo "'sha256-"$(echo -n "document.cookie = 'seen_cookie_message=yes; expires=' + new Date(new Date(Date.now()).setMonth(new Date(Date.now()).getMonth() + 1)) + ';SameSite=None;secure'" | openssl dgst -sha256 -binary | openssl enc -base64)"'"
'sha256-XtNXdOiMcIxK6AyojaxR2Nyuq+9yD49R6eC2CJf1mcQ='
```