### PR TITLE
BAU: Fix Ruby 2.6.6 expecting a newer version of system library

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,10 @@ gem 'browser'
 
 gem 'rails_same_site_cookie', :git => "https://github.com/alphagov/rails-same-site-cookie.git", :ref => "704c1958bf2518ba8248fe3d21a49361e38e911a"
 
+# Gem ffi in Ruby 2.6.6 requires a version of the system library `/usr/lib/libffi.dylib` that's not available on MacOS Mojave.
+# Revert the gem to a previous version that works with the library available on our dev machines.
+gem 'ffi', '1.12.2'
+
 group :development do
   # Access an IRB console on exception pages or by using <%= console %> in views
   gem 'web-console', '~> 3.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,7 +95,7 @@ GEM
     execjs (2.7.0)
     faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
-    ffi (1.13.1)
+    ffi (1.12.2)
     geckodriver-helper (0.24.0)
       archive-zip (~> 0.7)
     globalid (0.4.2)
@@ -338,6 +338,7 @@ DEPENDENCIES
   connection_pool
   dotenv-rails
   email_validator (~> 1.6)
+  ffi (= 1.12.2)
   geckodriver-helper
   headless
   http (~> 2.0.0)


### PR DESCRIPTION
After upgrading Ruby to 2.6.6, the gem ffi got updated to a newer version that requires a version of the system library `/usr/lib/libffi.dylib` that's not available on MacOS Mojave. This commit reverts the gem to a previous version that works with the library available on our dev machines.

Ideally we'd be running everything in Docker and this wouldn't be an issue but as a temporary solution we can use an older version of the library to make this work on our machines.