### PR TITLE
BAU Repair the ignore hint route for LOA1

### DIFF
--- a/config/main_routes.rb
+++ b/config/main_routes.rb
@@ -41,7 +41,6 @@ constraints IsLoa2 do
   get "prove_identity_ignore_hint", to: "prove_identity#ignore_hint", as: :prove_identity_ignore_hint
   get "start", to: "start#index", as: :start
   post "start", to: "start#request_post", as: :start
-  get "start_ignore_hint", to: "start#ignore_hint", as: :start_ignore_hint
   get "begin_registration", to: "start#register", as: :begin_registration
 
   # get "about", to: "about_loa2#index", as: :about
@@ -79,6 +78,7 @@ constraints IsLoa2 do
   get "confirmation_non_matching_journey", to: "confirmation_loa2#non_matching_journey", as: :confirmation_non_matching_journey
 end
 
+get "start_ignore_hint", to: "start#ignore_hint", as: :start_ignore_hint
 get "accessibility", to: "static#accessibility", as: :accessibility
 get "privacy_notice", to: "static#privacy_notice", as: :privacy_notice
 get "verify_services", to: "static#verify_services", as: :verify_services

--- a/spec/feature_helper.rb
+++ b/spec/feature_helper.rb
@@ -175,6 +175,18 @@ module FeatureHelper
     post "/test-initiate-journey", params: { journey_hint: journey_hint, journey_hint_rp: journey_hint_rp }
   end
 
+  def default_session_loa1
+    {
+      transaction_simple_id: "test-rp",
+      start_time: start_time_in_millis,
+      verify_session_id: default_session_id,
+      requested_loa: "LEVEL_1",
+      transaction_entity_id: "http://www.test-rp.gov.uk/SAML2/MD",
+      transaction_homepage: "http://www.test-rp.gov.uk/",
+      selected_answers: { device_type: { device_type_other: true } },
+    }
+  end
+
 private
 
   def default_session

--- a/spec/features/user_submits_start_page_form_spec.rb
+++ b/spec/features/user_submits_start_page_form_spec.rb
@@ -84,8 +84,7 @@ RSpec.describe "when user submits start page form" do
     expect(page.get_rack_session_key("selected_provider")["identity_provider"]).to include("entity_id" => idp_entity_id, "simple_id" => "stub-idp-one", "levels_of_assurance" => %w(LEVEL_2))
   end
 
-  it "will destroy the hint when the user rejects the hint at LOA2", js: true do
-    # set_session_and_session_cookies!(session: default_session_loa1)
+  it "will return the user to the start when ignoring the hint at LOA2", js: true do
     allow_any_instance_of(UserCookiesPartialController)
     .to receive(:ab_test_with_alternative_name).and_return(nil)
     stub_session_idp_authn_request(originating_ip, location, false)
@@ -93,13 +92,14 @@ RSpec.describe "when user submits start page form" do
     stub_api_idp_list_for_sign_in
     stub_api_select_idp
     visit "/start"
+    expect(page).to have_title t("hub.sign_in_hint.title")
     expect(page).to have_content t("hub.sign_in_hint.heading")
-    # click the choose another way button
-    visit "/start/ignore-hint"
+    visit "/start/ignore-hint"  # the "choose another way" button
     expect(page).to have_title t("hub.start.title")
+    expect(page).to have_content t("hub.start.heading")
   end
 
-  it "will destroy the hint when the user rejects the hint at LOA1", js: true do
+  it "will return the user to the start when ignoring the hint at LOA1", js: true do
     set_session_and_session_cookies!(session: default_session_loa1)
     allow_any_instance_of(UserCookiesPartialController)
     .to receive(:ab_test_with_alternative_name).and_return(nil)
@@ -108,9 +108,10 @@ RSpec.describe "when user submits start page form" do
     stub_api_idp_list_for_sign_in
     stub_api_select_idp
     visit "/start"
+    expect(page).to have_title t("hub.sign_in_hint.title")
     expect(page).to have_content t("hub.sign_in_hint.heading")
-    # click the choose another way button
-    visit "/start/ignore-hint"
+    visit "/start/ignore-hint"  # the "choose another way" button
     expect(page).to have_title t("hub.start.title")
+    expect(page).to have_content t("hub.start.heading")
   end
 end

--- a/spec/features/user_submits_start_page_form_spec.rb
+++ b/spec/features/user_submits_start_page_form_spec.rb
@@ -83,4 +83,34 @@ RSpec.describe "when user submits start page form" do
     and_the_hints_are_not_set
     expect(page.get_rack_session_key("selected_provider")["identity_provider"]).to include("entity_id" => idp_entity_id, "simple_id" => "stub-idp-one", "levels_of_assurance" => %w(LEVEL_2))
   end
+
+  it "will destroy the hint when the user rejects the hint at LOA2", js: true do
+    # set_session_and_session_cookies!(session: default_session_loa1)
+    allow_any_instance_of(UserCookiesPartialController)
+    .to receive(:ab_test_with_alternative_name).and_return(nil)
+    stub_session_idp_authn_request(originating_ip, location, false)
+    set_journey_hint_cookie(idp_entity_id, "SUCCESS")
+    stub_api_idp_list_for_sign_in
+    stub_api_select_idp
+    visit "/start"
+    expect(page).to have_content t("hub.sign_in_hint.heading")
+    # click the choose another way button
+    visit "/start/ignore-hint"
+    expect(page).to have_title t("hub.start.title")
+  end
+
+  it "will destroy the hint when the user rejects the hint at LOA1", js: true do
+    set_session_and_session_cookies!(session: default_session_loa1)
+    allow_any_instance_of(UserCookiesPartialController)
+    .to receive(:ab_test_with_alternative_name).and_return(nil)
+    stub_session_idp_authn_request(originating_ip, location, false)
+    set_journey_hint_cookie(idp_entity_id, "SUCCESS")
+    stub_api_idp_list_for_sign_in
+    stub_api_select_idp
+    visit "/start"
+    expect(page).to have_content t("hub.sign_in_hint.heading")
+    # click the choose another way button
+    visit "/start/ignore-hint"
+    expect(page).to have_title t("hub.start.title")
+  end
 end


### PR DESCRIPTION
* Amends the routes, pulling the `start_ignore_hint` route out of the LOA2 constraint, and up to root-level.
* Adds `default_session_loa1` to `feature_helper.rb` so as to make it trivial to test under LOA1 circumstances.
* Adds 2 tests to `user_submits_start_page_form.spec` which, technically, isn't quite the right place because this isn't a form submission, it's a simple anchor click - but it still seems like the most theme-appropriate place to put them. They test that the ignore-hint link correctly takes the user to the start page, rather than the 404 (as seen previously).

_Also manually tested without the route fix to show that under LOA1 circumstances, the routing fails and the user sees a 404._