### PR TITLE
HUB-720 Align the ab_test.yml with prod

### DIFF
--- a/spec/features/user_sends_authn_request_spec.rb
+++ b/spec/features/user_sends_authn_request_spec.rb
@@ -3,9 +3,8 @@ require "api_test_helper"
 require "piwik_test_helper"
 
 AB_TEST_COOKIE_DEFAULTS = {
-  "short_hub_2019_q3" => "short_hub_2019_q3_control_a",
-  "select_documents_v2" => "select_documents_v2_control",
-  "about_companies" => "about_companies_with_logo",
+  "short_hub_2019_q3-preview" => "short_hub_2019_q3-preview_control_a",
+  "short_hub_2019_q3" => "short_hub_2019_q3_variant_c_2_idp_short_hub",
 }.freeze
 
 describe "user sends authn requests" do

--- a/stub/ab_test.yml
+++ b/stub/ab_test.yml
@@ -9,27 +9,11 @@
 #         - name: 'no_logo'
 #           percent: 25
 #         - name: 'no_logo_privacy'
-#           percent: 0
-#   - idp_ordering:
-#       alternatives:
-#         - name: 'alphabetical'
-#           percent: 75
-#         - name: 'popularity'
-#           percent: 25
 #
-# Experiments should follow the above structure.
-# While a test is running, only the percentages should change. Only use whole numbers.
-# To make all users see the winning alternative, all the other alternatives should be removed, e.g.
-#
-#  experiments:
-#   - about_companies:
-#       alternatives:
-#         - name: 'no_logo'
-#           percent: 100
-#
+# Only the percentages should be changed, and they must be whole numbers, no decimals.
 # The value reported to Piwik will be the experiment name followed by the alternative name, e.g. "about_companies_with_logo"
-# Only the current experiment should have multiple alternatives so that Piwik reports just that experiment.
 # The first alternative will be used as the default for any issues.
+#
 # This file must exist and must contain at least:
 # experiments:
 #
@@ -47,7 +31,3 @@ experiments:
           percent: 0
         - name: 'variant_c_2_idp_short_hub'
           percent: 100
-
-# Note that the 'preview' short_hub_2019_q3 experiment will need to appear simultaneously
-# with the 'real' experiment', until a verify-frontend that does not depend upon the existence
-# of the 'preview' has been deployed.

--- a/stub/ab_test.yml
+++ b/stub/ab_test.yml
@@ -9,31 +9,45 @@
 #         - name: 'no_logo'
 #           percent: 25
 #         - name: 'no_logo_privacy'
+#           percent: 0
+#   - idp_ordering:
+#       alternatives:
+#         - name: 'alphabetical'
+#           percent: 75
+#         - name: 'popularity'
+#           percent: 25
 #
-# Only the percentages should be changed, and they must be whole numbers, no decimals.
+# Experiments should follow the above structure.
+# While a test is running, only the percentages should change. Only use whole numbers.
+# To make all users see the winning alternative, all the other alternatives should be removed, e.g.
+#
+#  experiments:
+#   - about_companies:
+#       alternatives:
+#         - name: 'no_logo'
+#           percent: 100
+#
 # The value reported to Piwik will be the experiment name followed by the alternative name, e.g. "about_companies_with_logo"
+# Only the current experiment should have multiple alternatives so that Piwik reports just that experiment.
 # The first alternative will be used as the default for any issues.
-#
 # This file must exist and must contain at least:
 # experiments:
 #
 
 experiments:
-  - short_hub_2019_q3:
+  - short_hub_2019_q3-preview:
       alternatives:
         - name: 'control_a'
           percent: 100
         - name: 'variant_c_2_idp_short_hub'
           percent: 0
-  - select_documents_v2:
+  - short_hub_2019_q3:
       alternatives:
-        - name: 'control'
-          percent: 100
-  - about_companies:
-      alternatives:
-        - name: 'with_logo'
-          percent: 100
-        - name: 'no_logo'
+        - name: 'control_a'
           percent: 0
-        - name: 'no_logo_privacy'
-          percent: 0
+        - name: 'variant_c_2_idp_short_hub'
+          percent: 100
+
+# Note that the 'preview' short_hub_2019_q3 experiment will need to appear simultaneously
+# with the 'real' experiment', until a verify-frontend that does not depend upon the existence
+# of the 'preview' has been deployed.


### PR DESCRIPTION
This file hasn't been maintained but it is used by verify-local-startup and should be maintained, ideally with the same config we have in production.