### PR TITLE
EID-2069 Brexit transition messaging on country picker page

### DIFF
--- a/app/views/choose_a_country/choose_a_country.html.erb
+++ b/app/views/choose_a_country/choose_a_country.html.erb
@@ -5,7 +5,9 @@
     
     <h1 class="govuk-heading-l"><%= t('hub.choose_a_country.heading') %></h1>
     <p><%= t 'hub.choose_a_country.description' %></p>
-  </div>
+    <div class="govuk-inset-text">
+      <p><%= t 'hub.choose_a_country.eu_exit_warn' %></p>
+    </div>
 </div>
 
 <div class="govuk-grid-row">

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -207,6 +207,7 @@ cy:
       title: Dewiswch wlad
       heading: Defnyddio hunaniaeth digidol o wlad Ewropeaidd arall
       description: Gallwch ddefnyddio hunaniaeth digidol o wlad Ewropeaidd arall i gael mynediad i wasanaethau ar GOV.UK.
+      eu_exit_warn: You will not be able to use your European digital identity to access services on GOV.UK after the UK leaves the EU on 1 January 2021.
       country_not_listed_heading: Nid yw fy ngwlad wedi'i restru
       country_not_listed_description: "Os nad yw cynllun hunaniaeth ddigidol eich gwlad ar gael eto, gwelwch sut arall y gallwch "
       country_not_listed_link: "%{other_ways_description}."

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -207,7 +207,7 @@ cy:
       title: Dewiswch wlad
       heading: Defnyddio hunaniaeth digidol o wlad Ewropeaidd arall
       description: Gallwch ddefnyddio hunaniaeth digidol o wlad Ewropeaidd arall i gael mynediad i wasanaethau ar GOV.UK.
-      eu_exit_warn: You will not be able to use your European digital identity to access services on GOV.UK after the UK leaves the EU on 1 January 2021.
+      eu_exit_warn: Ni fyddwch yn gallu defnyddio hunaniaeth digidol o wlad Ewropeaidd arall i gael mynediad i wasanaethau ar GOV.UK ar ôl 31 Rhagfyr 2020.
       country_not_listed_heading: Nid yw fy ngwlad wedi'i restru
       country_not_listed_description: "Os nad yw cynllun hunaniaeth ddigidol eich gwlad ar gael eto, gwelwch sut arall y gallwch "
       country_not_listed_link: "%{other_ways_description}."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -208,6 +208,7 @@ en:
       title: Choose a country
       heading: Use a digital identity from another European country
       description: You can use a digital identity from another European country to access services on GOV.UK.
+      eu_exit_warn: You will not be able to use your European digital identity to access services on GOV.UK after the UK leaves the EU on 1 January 2021.
       country_not_listed_heading: My country isn't listed
       country_not_listed_description: "If your country's digital identity scheme isn't available yet, see how else you can "
       country_not_listed_link: "%{other_ways_description}."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -208,7 +208,7 @@ en:
       title: Choose a country
       heading: Use a digital identity from another European country
       description: You can use a digital identity from another European country to access services on GOV.UK.
-      eu_exit_warn: You will not be able to use your European digital identity to access services on GOV.UK after the UK leaves the EU on 1 January 2021.
+      eu_exit_warn: You will not be able to use a digital identity from another European country to access services on GOV.UK after 31 December 2020.
       country_not_listed_heading: My country isn't listed
       country_not_listed_description: "If your country's digital identity scheme isn't available yet, see how else you can "
       country_not_listed_link: "%{other_ways_description}."


### PR DESCRIPTION
Update the content on the country picker page to include Brexit transition messaging, in Welsh and English. Screenshots of changes that indicate the new intended text:

### Welsh
<img width="874" alt="Screenshot 2020-11-22 at 17 27 38" src="https://user-images.githubusercontent.com/137389/99910995-621cf880-2ce9-11eb-82e8-0b1f8cf164b1.png">

### English
<img width="860" alt="Screenshot 2020-11-22 at 17 27 18" src="https://user-images.githubusercontent.com/137389/99911001-68ab7000-2ce9-11eb-8935-034893b228a4.png">
