### PR TITLE
BAU: fixed error in javascript

### DIFF
--- a/app/assets/javascripts/will_it_work_for_me.js
+++ b/app/assets/javascripts/will_it_work_for_me.js
@@ -37,7 +37,7 @@
             } else {
                 // re-validate the "which of these applies to you" section - if we don't do this, the "Please answer all questions"
                 // message remains for the section even if it's hidden by the user selecting "Yes" to "Have you lived in the UK for the last 12 months?"
-                willItWorkForMe.validator.element('#will_it_work_for_me_form_not_resident_reason_movedrecently');
+                willItWorkForMe.validator.element('#will_it_work_for_me_form_not_resident_reason_moved_recently');
                 willItWorkForMe.$notResidentReasonSection.addClass('js-hidden').removeClass('form-group-error')
                     .find('input').prop('checked', false);
             }

--- a/spec/javascripts/will_it_work_for_me_spec.js
+++ b/spec/javascripts/will_it_work_for_me_spec.js
@@ -46,7 +46,7 @@ describe("Will it work for me form", function () {
         '</legend>' +
         '<div class="govuk-radios">' +
         '<div class="govuk-radios__item">' +
-        '<input class="govuk-radios__input" type="radio" value="MovedRecently" name="will_it_work_for_me_form[not_resident_reason]" id="will_it_work_for_me_form_not_resident_reason_movedrecently" />' +
+        '<input class="govuk-radios__input" type="radio" value="MovedRecently" name="will_it_work_for_me_form[not_resident_reason]" id="will_it_work_for_me_form_not_resident_reason_moved_recently" />' +
         '<label class="govuk-label govuk-radios__label" for="will_it_work_for_me_form_not_resident_reason_moved_recently">I moved to the UK in the last 12 months</label>' +
         '</div>' +
         '<div class="govuk-radios__item">' +


### PR DESCRIPTION
Typo in element identifier will_it_work_for_me_form_not_resident_reason_movedrecently
causes error in javascript.

![image](https://user-images.githubusercontent.com/3749690/100229717-95939900-2f1c-11eb-9a99-900b50669818.png)
