### PR TITLE
EID-2077 configure frontend with `eidas_disabled_after` from env var

### DIFF
--- a/config/initializers/00_configuration.rb
+++ b/config/initializers/00_configuration.rb
@@ -61,4 +61,7 @@ CONFIG = Configuration.load! do
 
   # Enables dev/test routes when compiled for a production env (i.e. when RAILS_ENV=production)
   option_bool "stub_mode", "STUB_MODE", default: false
+
+  option_datetime "eidas_disabled_after", "EIDAS_DISABLED_AFTER", allow_missing: true
 end
+Rails.logger.info "eidas_disabled_after: #{CONFIG.eidas_disabled_after}"

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -34,6 +34,17 @@ class Configuration
     end
   end
 
+  def option_datetime(name, envvar, options = {})
+    option(name, envvar, options) do |value|
+      begin
+        value.empty? ? nil : DateTime.parse(value)
+      rescue ArgumentError
+        Rails.logger.warn "DateTime Environment Variable '#{envvar}' must be a parseable DateTime i.e. '2020-12-31 22:59:59', given value was '#{value}'"
+        nil
+      end
+    end
+  end
+
 private
 
   def option(name, envvar, options = {})

--- a/spec/lib/configuration_spec.rb
+++ b/spec/lib/configuration_spec.rb
@@ -76,6 +76,51 @@ describe Configuration do
     end
   end
 
+  context "datetime" do
+    it "should parse a datetime string" do
+      expect(ENV).to receive(:fetch).with("FOOBAZ").and_return("2020-12-31 22:59:59")
+      config = Configuration.load! do
+        option_datetime "foobaz", "FOOBAZ"
+      end
+      expect(config.foobaz).to eql DateTime.parse("2020-12-31 22:59:59")
+    end
+
+    it "should allow a missing datetime variable with allow_missing option" do
+      config = Configuration.load! do
+        option_datetime "foobaz", "FOOBAZ", allow_missing: true
+      end
+      expect(config.foobaz).to eql nil
+    end
+
+    it "should raise an error on a missing datetime variable with no allow_missing option" do
+      expect {
+        Configuration.load! do
+          option_datetime "foobaz", "FOOBAZ"
+        end
+      }.to raise_error Configuration::MissingEnvVarError, "An Environment Variable named 'FOOBAZ' could not be found"
+    end
+
+    it "should log an error on a malformed datetime string and set value to nil" do
+      expect(ENV).to receive(:fetch).with("FOOBAZ").and_return("not a datetime")
+      allow(Rails.logger).to receive(:warn)
+      expect(Rails.logger).to receive(:warn).with("DateTime Environment Variable 'FOOBAZ' must be a parseable DateTime i.e. '2020-12-31 22:59:59', given value was 'not a datetime'")
+      config = Configuration.load! do
+        option_datetime "foobaz", "FOOBAZ"
+      end
+      expect(config.foobaz).to eql nil
+    end
+
+    it "should log an error on a illegal datetime string and set value to nil" do
+      expect(ENV).to receive(:fetch).with("FOOBAZ").and_return("2020-02-31 22:59:59")
+      allow(Rails.logger).to receive(:warn)
+      expect(Rails.logger).to receive(:warn).with("DateTime Environment Variable 'FOOBAZ' must be a parseable DateTime i.e. '2020-12-31 22:59:59', given value was '2020-02-31 22:59:59'")
+      config = Configuration.load! do
+        option_datetime "foobaz", "FOOBAZ"
+      end
+      expect(config.foobaz).to eql nil
+    end
+  end
+
   context "integers" do
     it "should load an integer environment variable" do
       expect(ENV).to receive(:fetch).with("FOOBAZ").and_return("10")


### PR DESCRIPTION
Add `option_datetime` method to enable parsing of date time environment variables

Write tests to ensure method is working to story spec.

Co-authored-by: John Watts <john.watts@digital.cabinet-office.gov.uk>