### PR TITLE
EID-2065 Controllers don't route to eIDAS content after EU exit

### DIFF
--- a/app/controllers/authn_request_controller.rb
+++ b/app/controllers/authn_request_controller.rb
@@ -111,13 +111,13 @@ private
   end
 
   def do_eidas_sign_in_redirect(redirect_params = {})
-    return redirect_to start_path(redirect_params) unless session[:transaction_supports_eidas]
+    return redirect_to start_path(redirect_params) unless session[:transaction_supports_eidas] && before_eidas_shutdown
 
     redirect_to choose_a_country_path(redirect_params)
   end
 
   def do_default_redirect(redirect_params = {})
-    return redirect_to start_path(redirect_params) unless session[:transaction_supports_eidas]
+    return redirect_to start_path(redirect_params) unless session[:transaction_supports_eidas] && before_eidas_shutdown
 
     redirect_to prove_identity_path(redirect_params)
   end
@@ -130,5 +130,9 @@ private
 
   def raise_error_if_params_invalid
     something_went_wrong_warn("Missing/empty SAML message from #{request.referer}", :bad_request) if params["SAMLRequest"].blank?
+  end
+
+  def before_eidas_shutdown
+    CONFIG.eidas_disabled_after.nil? || DateTime.now < CONFIG.eidas_disabled_after
   end
 end

--- a/app/controllers/authn_request_controller.rb
+++ b/app/controllers/authn_request_controller.rb
@@ -111,13 +111,13 @@ private
   end
 
   def do_eidas_sign_in_redirect(redirect_params = {})
-    return redirect_to start_path(redirect_params) unless session[:transaction_supports_eidas] && before_eidas_shutdown
+    return redirect_to start_path(redirect_params) unless session[:transaction_supports_eidas] && before_eidas_shutdown?
 
     redirect_to choose_a_country_path(redirect_params)
   end
 
   def do_default_redirect(redirect_params = {})
-    return redirect_to start_path(redirect_params) unless session[:transaction_supports_eidas] && before_eidas_shutdown
+    return redirect_to start_path(redirect_params) unless session[:transaction_supports_eidas] && before_eidas_shutdown?
 
     redirect_to prove_identity_path(redirect_params)
   end
@@ -132,7 +132,7 @@ private
     something_went_wrong_warn("Missing/empty SAML message from #{request.referer}", :bad_request) if params["SAMLRequest"].blank?
   end
 
-  def before_eidas_shutdown
+  def before_eidas_shutdown?
     CONFIG.eidas_disabled_after.nil? || DateTime.now < CONFIG.eidas_disabled_after
   end
 end

--- a/spec/controllers/authn_request_controller_spec.rb
+++ b/spec/controllers/authn_request_controller_spec.rb
@@ -42,28 +42,28 @@ describe AuthnRequestController do
 
   context "authn request without sign in hint" do
     it "will route to blue start path when transaction enabled for eidas and past eu exit date" do
-      stub_session_creation({ "transactionSupportsEidas" => true })
+      stub_session_creation("transactionSupportsEidas" => true)
       allow(CONFIG).to receive(:eidas_disabled_after).and_return(DateTime.now - 1.day)
       post :rp_request, params: { "_ga" => :ga_id, "SAMLRequest" => "my-saml-request", "RelayState" => "my-relay-state" }
       expect(response).to redirect_to start_path(_ga: :ga_id)
     end
 
     it "will route to blue start path when transaction not enabled for eidas and past eu exit date" do
-      stub_session_creation({ "transactionSupportsEidas" => false })
+      stub_session_creation("transactionSupportsEidas" => false)
       allow(CONFIG).to receive(:eidas_disabled_after).and_return(DateTime.now - 1.day)
       post :rp_request, params: { "_ga" => :ga_id, "SAMLRequest" => "my-saml-request", "RelayState" => "my-relay-state" }
       expect(response).to redirect_to start_path(_ga: :ga_id)
     end
 
     it "will route to prove identity page when transaction enabled for eidas and before eu exit date" do
-      stub_session_creation({ "transactionSupportsEidas" => true })
+      stub_session_creation("transactionSupportsEidas" => true)
       allow(CONFIG).to receive(:eidas_disabled_after).and_return(DateTime.now + 1.day)
       post :rp_request, params: { "_ga" => :ga_id, "SAMLRequest" => "my-saml-request", "RelayState" => "my-relay-state" }
       expect(response).to redirect_to prove_identity_path(_ga: :ga_id)
     end
 
     it "will route to prove identity page when transaction enabled for eidas and no eu exit config set" do
-      stub_session_creation({ "transactionSupportsEidas" => true })
+      stub_session_creation("transactionSupportsEidas" => true)
       allow(CONFIG).to receive(:eidas_disabled_after).and_return(nil)
       post :rp_request, params: { "_ga" => :ga_id, "SAMLRequest" => "my-saml-request", "RelayState" => "my-relay-state" }
       expect(response).to redirect_to prove_identity_path(_ga: :ga_id)
@@ -72,21 +72,21 @@ describe AuthnRequestController do
 
   context "authn request with journey_hint set to eidas_sign_in" do
     it "will route to blue start path when transaction enabled for eidas and past eu exit date" do
-      stub_session_creation({ "transactionSupportsEidas" => true })
+      stub_session_creation("transactionSupportsEidas" => true)
       allow(CONFIG).to receive(:eidas_disabled_after).and_return(DateTime.now - 1.day)
       post :rp_request, params: { "_ga" => :ga_id, "SAMLRequest" => "my-saml-request", "RelayState" => "my-relay-state", "journey_hint" => "eidas_sign_in" }
       expect(response).to redirect_to start_path(_ga: :ga_id)
     end
 
     it "will route to blue start path when transaction not enabled for eidas and past eu exit date" do
-      stub_session_creation({ "transactionSupportsEidas" => false })
+      stub_session_creation("transactionSupportsEidas" => false)
       allow(CONFIG).to receive(:eidas_disabled_after).and_return(DateTime.now - 1.day)
       post :rp_request, params: { "_ga" => :ga_id, "SAMLRequest" => "my-saml-request", "RelayState" => "my-relay-state", "journey_hint" => "eidas_sign_in" }
       expect(response).to redirect_to start_path(_ga: :ga_id)
     end
 
     it "will route to prove identity page when transaction enabled for eidas and before eu exit date" do
-      stub_session_creation({ "transactionSupportsEidas" => true })
+      stub_session_creation("transactionSupportsEidas" => true)
       allow(CONFIG).to receive(:eidas_disabled_after).and_return(DateTime.now + 1.day)
       post :rp_request, params: { "_ga" => :ga_id, "SAMLRequest" => "my-saml-request", "RelayState" => "my-relay-state", "journey_hint" => "eidas_sign_in" }
       expect(response).to redirect_to choose_a_country_path(_ga: :ga_id)

--- a/spec/controllers/authn_request_controller_spec.rb
+++ b/spec/controllers/authn_request_controller_spec.rb
@@ -39,4 +39,57 @@ describe AuthnRequestController do
     post :rp_request, params: { "SAMLRequest" => nil, "RelayState" => "my-relay-state" }
     expect(response).to have_http_status :bad_request
   end
+
+  context "authn request without sign in hint" do
+    it "will route to blue start path when transaction enabled for eidas and past eu exit date" do
+      stub_session_creation({ "transactionSupportsEidas" => true })
+      allow(CONFIG).to receive(:eidas_disabled_after).and_return(DateTime.now - 1.day)
+      post :rp_request, params: { "_ga" => :ga_id, "SAMLRequest" => "my-saml-request", "RelayState" => "my-relay-state" }
+      expect(response).to redirect_to start_path(_ga: :ga_id)
+    end
+
+    it "will route to blue start path when transaction not enabled for eidas and past eu exit date" do
+      stub_session_creation({ "transactionSupportsEidas" => false })
+      allow(CONFIG).to receive(:eidas_disabled_after).and_return(DateTime.now - 1.day)
+      post :rp_request, params: { "_ga" => :ga_id, "SAMLRequest" => "my-saml-request", "RelayState" => "my-relay-state" }
+      expect(response).to redirect_to start_path(_ga: :ga_id)
+    end
+
+    it "will route to prove identity page when transaction enabled for eidas and before eu exit date" do
+      stub_session_creation({ "transactionSupportsEidas" => true })
+      allow(CONFIG).to receive(:eidas_disabled_after).and_return(DateTime.now + 1.day)
+      post :rp_request, params: { "_ga" => :ga_id, "SAMLRequest" => "my-saml-request", "RelayState" => "my-relay-state" }
+      expect(response).to redirect_to prove_identity_path(_ga: :ga_id)
+    end
+
+    it "will route to prove identity page when transaction enabled for eidas and no eu exit config set" do
+      stub_session_creation({ "transactionSupportsEidas" => true })
+      allow(CONFIG).to receive(:eidas_disabled_after).and_return(nil)
+      post :rp_request, params: { "_ga" => :ga_id, "SAMLRequest" => "my-saml-request", "RelayState" => "my-relay-state" }
+      expect(response).to redirect_to prove_identity_path(_ga: :ga_id)
+    end
+  end
+
+  context "authn request with journey_hint set to eidas_sign_in" do
+    it "will route to blue start path when transaction enabled for eidas and past eu exit date" do
+      stub_session_creation({ "transactionSupportsEidas" => true })
+      allow(CONFIG).to receive(:eidas_disabled_after).and_return(DateTime.now - 1.day)
+      post :rp_request, params: { "_ga" => :ga_id, "SAMLRequest" => "my-saml-request", "RelayState" => "my-relay-state", "journey_hint" => "eidas_sign_in" }
+      expect(response).to redirect_to start_path(_ga: :ga_id)
+    end
+
+    it "will route to blue start path when transaction not enabled for eidas and past eu exit date" do
+      stub_session_creation({ "transactionSupportsEidas" => false })
+      allow(CONFIG).to receive(:eidas_disabled_after).and_return(DateTime.now - 1.day)
+      post :rp_request, params: { "_ga" => :ga_id, "SAMLRequest" => "my-saml-request", "RelayState" => "my-relay-state", "journey_hint" => "eidas_sign_in" }
+      expect(response).to redirect_to start_path(_ga: :ga_id)
+    end
+
+    it "will route to prove identity page when transaction enabled for eidas and before eu exit date" do
+      stub_session_creation({ "transactionSupportsEidas" => true })
+      allow(CONFIG).to receive(:eidas_disabled_after).and_return(DateTime.now + 1.day)
+      post :rp_request, params: { "_ga" => :ga_id, "SAMLRequest" => "my-saml-request", "RelayState" => "my-relay-state", "journey_hint" => "eidas_sign_in" }
+      expect(response).to redirect_to choose_a_country_path(_ga: :ga_id)
+    end
+  end
 end

--- a/spec/controllers/authn_request_controller_spec.rb
+++ b/spec/controllers/authn_request_controller_spec.rb
@@ -43,21 +43,21 @@ describe AuthnRequestController do
   context "authn request without sign in hint" do
     it "will route to blue start path when transaction enabled for eidas and past eu exit date" do
       stub_session_creation("transactionSupportsEidas" => true)
-      allow(CONFIG).to receive(:eidas_disabled_after).and_return(DateTime.now - 1.day)
+      allow(CONFIG).to receive(:eidas_disabled_after).and_return(1.day.ago)
       post :rp_request, params: { "_ga" => :ga_id, "SAMLRequest" => "my-saml-request", "RelayState" => "my-relay-state" }
       expect(response).to redirect_to start_path(_ga: :ga_id)
     end
 
     it "will route to blue start path when transaction not enabled for eidas and past eu exit date" do
       stub_session_creation("transactionSupportsEidas" => false)
-      allow(CONFIG).to receive(:eidas_disabled_after).and_return(DateTime.now - 1.day)
+      allow(CONFIG).to receive(:eidas_disabled_after).and_return(1.day.ago)
       post :rp_request, params: { "_ga" => :ga_id, "SAMLRequest" => "my-saml-request", "RelayState" => "my-relay-state" }
       expect(response).to redirect_to start_path(_ga: :ga_id)
     end
 
     it "will route to prove identity page when transaction enabled for eidas and before eu exit date" do
       stub_session_creation("transactionSupportsEidas" => true)
-      allow(CONFIG).to receive(:eidas_disabled_after).and_return(DateTime.now + 1.day)
+      allow(CONFIG).to receive(:eidas_disabled_after).and_return(1.day.from_now)
       post :rp_request, params: { "_ga" => :ga_id, "SAMLRequest" => "my-saml-request", "RelayState" => "my-relay-state" }
       expect(response).to redirect_to prove_identity_path(_ga: :ga_id)
     end
@@ -73,21 +73,21 @@ describe AuthnRequestController do
   context "authn request with journey_hint set to eidas_sign_in" do
     it "will route to blue start path when transaction enabled for eidas and past eu exit date" do
       stub_session_creation("transactionSupportsEidas" => true)
-      allow(CONFIG).to receive(:eidas_disabled_after).and_return(DateTime.now - 1.day)
+      allow(CONFIG).to receive(:eidas_disabled_after).and_return(1.day.ago)
       post :rp_request, params: { "_ga" => :ga_id, "SAMLRequest" => "my-saml-request", "RelayState" => "my-relay-state", "journey_hint" => "eidas_sign_in" }
       expect(response).to redirect_to start_path(_ga: :ga_id)
     end
 
     it "will route to blue start path when transaction not enabled for eidas and past eu exit date" do
       stub_session_creation("transactionSupportsEidas" => false)
-      allow(CONFIG).to receive(:eidas_disabled_after).and_return(DateTime.now - 1.day)
+      allow(CONFIG).to receive(:eidas_disabled_after).and_return(1.day.ago)
       post :rp_request, params: { "_ga" => :ga_id, "SAMLRequest" => "my-saml-request", "RelayState" => "my-relay-state", "journey_hint" => "eidas_sign_in" }
       expect(response).to redirect_to start_path(_ga: :ga_id)
     end
 
     it "will route to prove identity page when transaction enabled for eidas and before eu exit date" do
       stub_session_creation("transactionSupportsEidas" => true)
-      allow(CONFIG).to receive(:eidas_disabled_after).and_return(DateTime.now + 1.day)
+      allow(CONFIG).to receive(:eidas_disabled_after).and_return(1.day.from_now)
       post :rp_request, params: { "_ga" => :ga_id, "SAMLRequest" => "my-saml-request", "RelayState" => "my-relay-state", "journey_hint" => "eidas_sign_in" }
       expect(response).to redirect_to choose_a_country_path(_ga: :ga_id)
     end


### PR DESCRIPTION
If EU exit date is set in config, and in the past, then controllers will route to pages without eIDAS content.

Follows on from the [PR to set an EU exit date in frontend](https://github.com/alphagov/verify-frontend/pull/910).

Co-authored-by: Amrit Sidhu <amrit.sidhu@digital.cabinet-office.gov.uk>
Co-authored-by: John Watts <john.watts@digital.cabinet-office.gov.uk>