### PR TITLE
Fixed Startup Script

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -18,4 +18,4 @@ then
 fi
 
 bundle check || bundle install
-bundle exec puma -e development -d -p 50300
+bundle exec puma -e development -p 50300 &


### PR DESCRIPTION
Changes to Puma means the `-d` option has been deprecated.  As an alternative I have remove the use of `-d` in favour of `&`

This should fix things for everyone.