### PR TITLE
BAU: Fix local startup after Puma upgrade

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,6 +28,10 @@ Style/MixinUsage:
     - 'config/routes.rb'
     - 'config/main_routes.rb'
 
+Style/StringLiterals:
+  Exclude:
+    - 'Gemfile'
+
 Style/HashEachMethods:
   Enabled: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -6,16 +6,16 @@ gem 'rails-i18n', '~> 5.1.3'
 gem 'route_translator', '~> 8.2.1'
 
 # Server
+gem 'connection_pool'
+gem 'http', '~> 2.0.0'
 gem 'puma'
 gem 'rack-handlers'
-gem 'http', '~> 2.0.0'
-gem 'connection_pool'
 
 # Assets
-gem 'sassc', '~> 2.0.1'
 gem 'autoprefixer-rails'
-gem 'uglifier', '~> 2.7.0'
 gem 'jquery-rails'
+gem 'sassc', '~> 2.0.1'
+gem 'uglifier', '~> 2.7.0'
 
 gem 'mini_racer'
 
@@ -35,19 +35,18 @@ gem 'sentry-raven'
 gem 'logstash-logger'
 gem 'request_store', '~> 1.3.1'
 
-gem 'zendesk_api'
 gem 'email_validator', '~> 1.6'
+gem 'zendesk_api'
 
 # Use multi_json because pkgr forces the json gem to < 2.0, which is an old specification of JSON (doesn't allow top level strings)
 gem 'multi_json'
 
 gem 'browser'
 
-# SameSite is now a thing in Google Chrome and Chromium browsers which
-# has started causing issues for endusers.  This gem works round the
-# issue.  See Chromium issue: https://www.chromium.org/updates/same-site
-
-gem 'rails_same_site_cookie', :git => "https://github.com/alphagov/rails-same-site-cookie.git", :ref => "704c1958bf2518ba8248fe3d21a49361e38e911a"
+# Google Chrome and Chromium browsers now treat cookies as SameSite=Lax by default
+# which causes issues for end users. This gem fixes the issue by making all cookies
+# specify SameSite=None. See Chromium issue: https://www.chromium.org/updates/same-site
+gem 'rails_same_site_cookie', { git: "https://github.com/alphagov/rails-same-site-cookie.git", ref: "704c1958bf2518ba8248fe3d21a49361e38e911a" }
 
 # Gem ffi in Ruby 2.6.6 requires a version of the system library `/usr/lib/libffi.dylib` that's not available on MacOS Mojave.
 # Revert the gem to a previous version that works with the library available on our dev machines.
@@ -69,18 +68,18 @@ group :test, :development do
   gem 'dotenv-rails'
 
   # Automated testing
-  gem 'rspec', '~> 3.9.0'
-  gem 'rspec-rails', '~> 3.9.1'
   gem 'capybara', '~> 3.30'
-  gem 'webmock', require: false
   gem 'jasmine'
   gem 'jasmine-jquery-rails'
-  gem 'selenium-webdriver'
   gem 'rails-controller-testing'
+  gem 'rspec', '~> 3.9.0'
+  gem 'rspec-rails', '~> 3.9.1'
+  gem 'selenium-webdriver'
+  gem 'webmock', require: false
 
+  gem 'headless'
   gem 'rack-test'
   gem 'rack_session_access'
-  gem 'headless'
   gem 'thin'
 
   gem 'rubocop-govuk', '~> 3.6.0'
@@ -88,11 +87,11 @@ group :test, :development do
 
   gem 'geckodriver-helper'
 
-  gem 'codacy-coverage', :require => false
+  gem 'codacy-coverage', { require: false }
 end
 
 platforms :mswin, :mingw, :x64_mingw do
-  gem 'windows-pr'
-  gem 'win32-process'
   gem 'tzinfo-data'
+  gem 'win32-process'
+  gem 'windows-pr'
 end

--- a/kill-service.sh
+++ b/kill-service.sh
@@ -5,7 +5,7 @@ cd "$(dirname "$0")"
 if [ -a './tmp/stub_api.pid' ]
 then
   kill "$(< ./tmp/stub_api.pid)"
-  rm ./tmp/stub_api.pid
+  rm ./tmp/stub_api.pid 2>/dev/null
 fi
 
 if [ -a './tmp/puma.pid' ]

--- a/startup.sh
+++ b/startup.sh
@@ -1,12 +1,17 @@
 #!/usr/bin/env bash
 
+set -e
 cd "$(dirname "$0")"
 
 ./kill-service.sh
 
+RUN_IN_BACKGROUND=true
+if ! [ -d tmp ]; then mkdir tmp; fi
+
 if [ "$1" == '--stub-api' ]
 then
   echo "Starting stub-api server on port 50199"
+  unset RUN_IN_BACKGROUND
   export CONFIG_API_HOST=http://localhost:50199
   export POLICY_HOST=http://localhost:50199
   export SAML_PROXY_HOST=http://localhost:50199
@@ -18,4 +23,4 @@ then
 fi
 
 bundle check || bundle install
-bundle exec puma -e development -d -p 50300
+eval bundle exec puma -e development -p 50300 ${RUN_IN_BACKGROUND:+&}


### PR DESCRIPTION
- Remove the `-d`(aemonize) option removed in version 5. Use the bash background task management instead. Append `&` to run the server in background when frontend is run as part of the full hub configuration. If running as stub API, run in foreground so it can be stopped by pressing Ctrl+C

- Create the `tmp` folder if it doesn't exist. Puma/Rake needs this folder to hold its state. If it doesn't exist, the process will quit immediately without printing any error message

- Don't print error message from `rm` when killing the service. Running `kill` removes the pid file under certain conditions

- Reorder gems in the Gemfile to be in alphabetical order to appease Rubocop
- Exclude the Gemfile from the `StringLiterals` Rubocop check