### PR TITLE
EID-2067 Don't accept SAML requests once eIDAS has been shut down

### DIFF
--- a/app/controllers/partials/eidas_validation_partial_controller.rb
+++ b/app/controllers/partials/eidas_validation_partial_controller.rb
@@ -1,8 +1,14 @@
 module EidasValidationPartialController
   def ensure_session_eidas_supported
     txn_supports_eidas = session[:transaction_supports_eidas]
-    unless txn_supports_eidas
+    unless txn_supports_eidas && before_eidas_shutdown?
       something_went_wrong_warn("Transaction does not support Eidas", :forbidden)
     end
+  end
+
+private
+
+  def before_eidas_shutdown?
+    CONFIG.eidas_disabled_after.nil? || DateTime.now < CONFIG.eidas_disabled_after
   end
 end

--- a/spec/controllers/choose_a_country_controller_spec.rb
+++ b/spec/controllers/choose_a_country_controller_spec.rb
@@ -42,5 +42,14 @@ describe ChooseACountryController do
       expect(Rails.logger).to receive(:warn).with("Transaction does not support Eidas")
       get :choose_a_country, params: { locale: "en" }
     end
+
+    it "shows an error if eIDAS is supported but eIDAS has been disabled" do
+      allow(Rails.logger).to receive(:error)
+      allow(Rails.logger).to receive(:warn)
+      allow(CONFIG).to receive(:eidas_disabled_after).and_return(1.day.ago)
+      expect(Rails.logger).not_to receive(:error)
+      expect(Rails.logger).to receive(:warn).with("Transaction does not support Eidas")
+      get :choose_a_country, params: { locale: "en" }
+    end
   end
 end

--- a/spec/controllers/redirect_to_country_controller_spec.rb
+++ b/spec/controllers/redirect_to_country_controller_spec.rb
@@ -30,5 +30,14 @@ describe RedirectToCountryController do
       expect(response).to have_http_status(:internal_server_error)
       expect(subject).to render_template(:something_went_wrong)
     end
+
+    it "will redirect to an error page when the country is valid but eIDAS has been disabled" do
+      stub_select_country_request("yy")
+      allow(CONFIG).to receive(:eidas_disabled_after).and_return(1.day.ago)
+
+      post :choose_a_country_submit, params: { locale: "en", country: "YY" }
+      expect(response).to have_http_status(:forbidden)
+      expect(subject).to render_template(:something_went_wrong)
+    end
   end
 end


### PR DESCRIPTION
Alter eidas_validation_partial_controller.rb to check whether eIDAS shutdown time has passed and act accordingly.

Add tests.