### PR TITLE
BAU Fix title on select document advice page

### DIFF
--- a/app/views/select_documents/advice.html.erb
+++ b/app/views/select_documents/advice.html.erb
@@ -1,4 +1,4 @@
-<%= page_title 'hub.select_documents.title' %>
+<%= page_title 'hub.select_documents_advice.title' %>
 <% content_for :feedback_source, 'SELECT_DOCUMENTS_ADVICE_PAGE' %>
 
 <div class="govuk-grid-row">

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -140,6 +140,7 @@ cy:
       errors:
         no_selection: Select the items you have available right now
     select_documents_advice:
+      title: Advice about your documents
       advice_html:
         heading: You need more evidence to verify your identity
         sub_heading: 'To use GOV.UK Verify, you also need either:'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -141,6 +141,7 @@ en:
       errors:
         no_selection: Select the items you have available right now
     select_documents_advice:
+      title: Advice about your documents
       advice_html:
         heading: You need more evidence to verify your identity
         sub_heading: 'To use GOV.UK Verify, you also need either:'

--- a/spec/features/user_visits_select_documents_advice_page_spec.rb
+++ b/spec/features/user_visits_select_documents_advice_page_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature "user visits select documents advice pages", type: :feature do
   it "includes the appropriate feedback source" do
     visit select_documents_advice_path
 
-    expect(page).to have_title t("hub.select_documents.title")
+    expect(page).to have_title t("hub.select_documents_advice.title")
     expect_feedback_source_to_be(page, "SELECT_DOCUMENTS_ADVICE_PAGE", select_documents_advice_path)
   end
 

--- a/spec/features/user_visits_select_documents_page_spec.rb
+++ b/spec/features/user_visits_select_documents_page_spec.rb
@@ -57,7 +57,7 @@ RSpec.feature "When user visits document selection page" do
     check t("hub.select_documents.has_credit_card"), allow_label_click: true
     click_button t("navigation.continue")
 
-    expect(page).to have_title t("hub.select_documents.title")
+    expect(page).to have_title t("hub.select_documents_advice.title")
     expect(page).to have_current_path(select_documents_advice_path)
   end
 


### PR DESCRIPTION
The accessibility audit turn up duplicate titles on the select documents and select documents advice page.  This PR is to fix this minor issue.