### PR TITLE
HUB-783: Failed registration bug

### DIFF
--- a/app/controllers/choose_a_certified_company_about.rb
+++ b/app/controllers/choose_a_certified_company_about.rb
@@ -8,7 +8,6 @@ module ChooseACertifiedCompanyAbout
     matching_idp = current_available_identity_providers_for_registration.detect { |idp| idp.simple_id == simple_id }
     @idp = IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate(matching_idp)
     if @idp.viewable?
-      @recommended = IDP_RECOMMENDATION_ENGINE.recommended?(@idp, current_available_identity_providers_for_registration, selected_evidence, current_transaction_simple_id)
       render "choose_a_certified_company/about"
     else
       render "errors/404", status: 404

--- a/app/controllers/choose_a_certified_company_loa2_controller.rb
+++ b/app/controllers/choose_a_certified_company_loa2_controller.rb
@@ -8,12 +8,12 @@ class ChooseACertifiedCompanyLoa2Controller < ChooseACertifiedCompanyRedirectCon
   def index
     session[:selected_answers]&.delete("interstitial")
     idps = current_available_identity_providers_for_registration_loa2(current_transaction_entity_id)
-    suggestions = IDP_RECOMMENDATION_ENGINE.get_suggested_idps_for_registration(idps, selected_evidence, current_transaction_simple_id)
+    suggestions = IDP_RECOMMENDATION_ENGINE.get_suggested_idps_for_registration(idps, selected_evidence, current_transaction_simple_id, idps_tried)
     @recommended_idps = order_with_unavailable_last(IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate_collection(suggestions[:recommended]))
     @non_recommended_idps = order_with_unavailable_last(IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate_collection(suggestions[:unlikely]))
     FEDERATION_REPORTER.report_number_of_idps_recommended(current_transaction, request, @recommended_idps.length)
 
-    idps_available = IDP_RECOMMENDATION_ENGINE.any?(idps, selected_evidence, current_transaction_simple_id)
+    idps_available = IDP_RECOMMENDATION_ENGINE.any?(idps, selected_evidence, current_transaction_simple_id, idps_tried)
     if idps_available
       session[:user_segments] = suggestions[:user_segments]
       render "choose_a_certified_company/choose_a_certified_company_LOA2"
@@ -26,7 +26,7 @@ class ChooseACertifiedCompanyLoa2Controller < ChooseACertifiedCompanyRedirectCon
     return render "errors/something_went_wrong", status: 400 unless params[:entity_id].present?
 
     select_viewable_idp_for_registration(params.fetch("entity_id")) do |decorated_idp|
-      session[:selected_idp_was_recommended] = IDP_RECOMMENDATION_ENGINE.recommended?(decorated_idp.identity_provider, current_available_identity_providers_for_sign_in, selected_evidence, current_transaction_simple_id)
+      session[:selected_idp_was_recommended] = IDP_RECOMMENDATION_ENGINE.recommended?(decorated_idp.identity_provider, current_available_identity_providers_for_sign_in, selected_evidence, current_transaction_simple_id, idps_tried)
       # TODO - do the spinny thing page
       do_redirect(decorated_idp)
     end

--- a/app/controllers/partials/failed_registration_partial_controller.rb
+++ b/app/controllers/partials/failed_registration_partial_controller.rb
@@ -28,9 +28,12 @@ private
   end
 
   def suggested_idps
-    @suggested_idps ||= @idp_recommendation_engine.get_suggested_idps_for_registration(current_available_identity_providers_for_registration,
-                                                                                       selected_evidence,
-                                                                                       current_transaction_simple_id)
+    @suggested_idps ||= @idp_recommendation_engine.get_suggested_idps_for_registration(
+      current_available_identity_providers_for_registration,
+      selected_evidence,
+      current_transaction_simple_id,
+      idps_tried,
+    )
   end
 
   def possible_idps

--- a/app/controllers/select_documents_controller.rb
+++ b/app/controllers/select_documents_controller.rb
@@ -12,7 +12,7 @@ class SelectDocumentsController < ApplicationController
     @form = SelectDocumentsForm.from_post(params["select_documents_form"] || {})
     if @form.valid?
       selected_answer_store.store_selected_answers("documents", @form.to_session_storage)
-      idps_available = IDP_RECOMMENDATION_ENGINE.any?(current_available_identity_providers_for_registration, selected_evidence, current_transaction_simple_id)
+      idps_available = IDP_RECOMMENDATION_ENGINE.any?(current_available_identity_providers_for_registration, selected_evidence, current_transaction_simple_id, idps_tried)
       report_user_evidence_to_piwik(selected_evidence)
       redirect_to idps_available ? choose_a_certified_company_path : select_documents_advice_path
     else

--- a/app/models/idp_recommendations/recommendations_engine.rb
+++ b/app/models/idp_recommendations/recommendations_engine.rb
@@ -9,9 +9,10 @@ class RecommendationsEngine
     @hide_soft_disconnecting_idps_mins = hide_soft_disconnecting_idps_mins
   end
 
-  def get_suggested_idps_for_registration(idps, user_profile, transaction_simple_id)
+  def get_suggested_idps_for_registration(idps, user_profile, transaction_simple_id, idps_tried)
     viewable_idps = idps.reject { |idp| is_hidden_for_registration?(idp) }
-    capable_idps = viewable_idps.select { |idp| is_capable?(idp, user_profile) }
+    not_tried_idps = viewable_idps.reject { |idp| has_already_tried_registration_and_failed?(idp, idps_tried) }
+    capable_idps = not_tried_idps.select { |idp| is_capable?(idp, user_profile) }
     transaction_group = @transaction_grouper.get_transaction_group(transaction_simple_id)
     user_segments = @segment_matcher.find_matching_segments(user_profile)
 
@@ -21,13 +22,13 @@ class RecommendationsEngine
     { recommended: recommended_idps, unlikely: unlikely_idps, user_segments: user_segments }
   end
 
-  def recommended?(idp, enabled_idps, user_profile, transaction_simple_id)
-    suggested_idps = get_suggested_idps_for_registration(enabled_idps, user_profile, transaction_simple_id)
+  def recommended?(idp, enabled_idps, user_profile, transaction_simple_id, idps_tried)
+    suggested_idps = get_suggested_idps_for_registration(enabled_idps, user_profile, transaction_simple_id, idps_tried)
     suggested_idps[:recommended].include? idp
   end
 
-  def any?(idps, user_profile, transaction_simple_id)
-    suggested_idps = get_suggested_idps_for_registration(idps, user_profile, transaction_simple_id)
+  def any?(idps, user_profile, transaction_simple_id, idps_tried)
+    suggested_idps = get_suggested_idps_for_registration(idps, user_profile, transaction_simple_id, idps_tried)
     suggested_idps[:recommended].any? || suggested_idps[:unlikely].any?
   end
 
@@ -60,5 +61,9 @@ private
   def is_unlikely_for_segment(idp, user_segments, transaction_group)
     segments_for_idp = @idp_rules[idp.simple_id].unlikely_segments(transaction_group)
     !(segments_for_idp & user_segments).empty?
+  end
+
+  def has_already_tried_registration_and_failed?(idp, idps_tried)
+    idps_tried === idp.simple_id
   end
 end

--- a/spec/features/user_visits_choose_a_certified_company_page_spec.rb
+++ b/spec/features/user_visits_choose_a_certified_company_page_spec.rb
@@ -49,7 +49,7 @@ describe "When the user visits the choose a certified company page" do
     end
 
     it "doesn't display IDPs the user has previously failed to register with" do
-      page.set_rack_session(page.get_rack_session.merge(idps_tried: ["stub-idp-two"]))
+      page.set_rack_session(page.get_rack_session.merge(idps_tried: %w[stub-idp-two]))
 
       visit "/choose-a-certified-company"
 

--- a/spec/features/user_visits_choose_a_certified_company_page_spec.rb
+++ b/spec/features/user_visits_choose_a_certified_company_page_spec.rb
@@ -48,6 +48,21 @@ describe "When the user visits the choose a certified company page" do
       end
     end
 
+    it "doesn't display IDPs the user has previously failed to register with" do
+      page.set_rack_session(page.get_rack_session.merge(idps_tried: ["stub-idp-two"]))
+
+      visit "/choose-a-certified-company"
+
+      expect(page).to have_current_path(choose_a_certified_company_path)
+      expect(page).to have_content t("hub.choose_a_certified_company.idp_count")
+
+      within("#matching-idps") do
+        expect(page).to have_button("Choose IDCorp")
+        expect(page).not_to have_button("Choose Bob’s Identity Service")
+        expect(page).not_to have_button("Carol’s Secure ID")
+      end
+    end
+
     it "redirects to the choose a certified company about page when selecting About link" do
       visit "/choose-a-certified-company"
 

--- a/spec/models/idp_recommendations/recommendations_engine_spec.rb
+++ b/spec/models/idp_recommendations/recommendations_engine_spec.rb
@@ -6,16 +6,18 @@ describe "recommendations engine" do
   let(:idp_one) { double(:idp_one, simple_id: "idp", provide_registration_until: nil) }
   let(:idp_two) { double(:idp_two, simple_id: "idp2", provide_registration_until: nil) }
   let(:idp_three) { double(:idp_three, simple_id: "idp3", provide_registration_until: nil) }
+  let(:idp_four) { double(:idp_four, simple_id: "idp4", provide_registration_until: nil) }
   let(:hidden_soft_disconnecting_idp) { double(:hidden_soft_disconnecting_idp, simple_id: "hidden_soft_disconnecting_idp", provide_registration_until: DateTime.now + 14.minutes) }
   let(:not_hidden_soft_disconnecting_idp) { double(:not_hidden_soft_disconnecting_idp, simple_id: "not_hidden_soft_disconnecting_idp", provide_registration_until: DateTime.now + 17.minutes) }
   let(:less_capable_idp) { double(:less_capable_idp, simple_id: "less_capable_idp", provide_registration_until: nil) }
-  let(:idps) { [idp_one, idp_two, idp_three, less_capable_idp, hidden_soft_disconnecting_idp, not_hidden_soft_disconnecting_idp] }
+  let(:idps) { [idp_one, idp_two, idp_three, idp_four, less_capable_idp, hidden_soft_disconnecting_idp, not_hidden_soft_disconnecting_idp] }
   let(:user_profile) { %i(driving_licence passport) }
   let(:idp_rules) {
     {
         "idp" => generate_idp_rules(capabilities: %w(passport), protected_recommended_segments: %w(SEGMENT_1)),
         "idp2" => generate_idp_rules(capabilities: %w(passport), protected_unlikely_segments: %w(SEGMENT_1 SEGMENT_2)),
         "idp3" => generate_idp_rules(capabilities: %w(passport)),
+        "idp4" => generate_idp_rules(capabilities: %w(passport), protected_recommended_segments: %w(SEGMENT_3)),
         "less_capable_idp" => generate_idp_rules(capabilities: %w(passport smart_phone), protected_recommended_segments: %w(SEGMENT_1)),
         "hidden_soft_disconnecting_idp" => generate_idp_rules(capabilities: %w(passport), protected_recommended_segments: %w(SEGMENT_3)),
         "not_hidden_soft_disconnecting_idp" => generate_idp_rules(capabilities: %w(passport), protected_recommended_segments: %w(SEGMENT_3)),
@@ -23,26 +25,39 @@ describe "recommendations engine" do
   }
   let(:segment_matcher) { double("segment_matcher") }
   let(:transaction_grouper) { double("transaction_grouper") }
+  let(:idps_tried) { Set[] }
 
   before(:each) do
     @recommendations_engine = RecommendationsEngine.new(idp_rules, segment_matcher, transaction_grouper, 15)
   end
 
-  it "should hide IDPs disconnecting for registration" do
-    allow(segment_matcher).to receive(:find_matching_segments).with(user_profile).and_return(%w(SEGMENT_3))
-    allow(transaction_grouper).to receive(:get_transaction_group).with("test-rp").and_return(TransactionGroups::PROTECTED)
+  describe "get_suggested_idps_for_registration" do
+    it "should hide IDPs disconnecting for registration" do
+      allow(segment_matcher).to receive(:find_matching_segments).with(user_profile).and_return(%w(SEGMENT_3))
+      allow(transaction_grouper).to receive(:get_transaction_group).with("test-rp").and_return(TransactionGroups::PROTECTED)
 
-    recommended_idps = @recommendations_engine.get_suggested_idps_for_registration(idps, user_profile, "test-rp")
+      recommended_idps = @recommendations_engine.get_suggested_idps_for_registration(idps, user_profile, "test-rp", idps_tried)
 
-    expected_suggestions = { recommended: [not_hidden_soft_disconnecting_idp], unlikely: [], user_segments: %w(SEGMENT_3) }
-    expect(recommended_idps).to eql expected_suggestions
+      expected_suggestions = { recommended: [idp_four, not_hidden_soft_disconnecting_idp], unlikely: [], user_segments: %w(SEGMENT_3) }
+      expect(recommended_idps).to eql expected_suggestions
+    end
+
+    it "should not return IDPs the user has already tried and failed with" do
+      allow(segment_matcher).to receive(:find_matching_segments).with(user_profile).and_return(%w(SEGMENT_3))
+      allow(transaction_grouper).to receive(:get_transaction_group).with("test-rp").and_return(TransactionGroups::PROTECTED)
+
+      recommended_idps = @recommendations_engine.get_suggested_idps_for_registration(idps, user_profile, "test-rp", Set['idp4'])
+
+      expected_suggestions = { recommended: [not_hidden_soft_disconnecting_idp], unlikely: [], user_segments: %w(SEGMENT_3) }
+      expect(recommended_idps).to eql expected_suggestions
+    end
   end
 
   it "should return recommendations given a user profile" do
     allow(segment_matcher).to receive(:find_matching_segments).with(user_profile).and_return(%w(SEGMENT_1))
     allow(transaction_grouper).to receive(:get_transaction_group).with("test-rp").and_return(TransactionGroups::PROTECTED)
 
-    recommended_idps = @recommendations_engine.get_suggested_idps_for_registration(idps, user_profile, "test-rp")
+    recommended_idps = @recommendations_engine.get_suggested_idps_for_registration(idps, user_profile, "test-rp", idps_tried)
 
     expected_suggestions = { recommended: [idp_one], unlikely: [idp_two], user_segments: %w(SEGMENT_1) }
     expect(recommended_idps).to eql expected_suggestions
@@ -55,17 +70,22 @@ describe "recommendations engine" do
     end
 
     it "should return true if the idp is in the recommended list" do
-      result = @recommendations_engine.recommended?(idp_one, idps, user_profile, "test-rp")
+      result = @recommendations_engine.recommended?(idp_one, idps, user_profile, "test-rp", idps_tried)
       expect(result).to eql true
     end
 
     it "should return false if the idp is in the unlikely list" do
-      result = @recommendations_engine.recommended?(idp_two, idps, user_profile, "test-rp")
+      result = @recommendations_engine.recommended?(idp_two, idps, user_profile, "test-rp", idps_tried)
       expect(result).to eql false
     end
 
     it "should return false if the idp is not recommended" do
-      result = @recommendations_engine.recommended?(idp_three, idps, user_profile, "test-rp")
+      result = @recommendations_engine.recommended?(idp_three, idps, user_profile, "test-rp", idps_tried)
+      expect(result).to eql false
+    end
+
+    it "should return false if registration with the idp has been tried before and failed" do
+      result = @recommendations_engine.recommended?(idp_one, idps, user_profile, "test-rp", Set['idp'])
       expect(result).to eql false
     end
   end
@@ -77,17 +97,22 @@ describe "recommendations engine" do
     end
 
     it "should return true if there is at least 1 recommended IDP" do
-      result = @recommendations_engine.any?([idp_one], user_profile, "test-rp")
+      result = @recommendations_engine.any?([idp_one], user_profile, "test-rp", idps_tried)
       expect(result).to eql true
     end
 
     it "should return true if there is at least 1 unlikely IDP" do
-      result = @recommendations_engine.any?([idp_two], user_profile, "test-rp")
+      result = @recommendations_engine.any?([idp_two], user_profile, "test-rp", idps_tried)
       expect(result).to eql true
     end
 
     it "should return false if there are no recommended or unlikely IDPs" do
-      result = @recommendations_engine.any?([idp_three], user_profile, "test-rp")
+      result = @recommendations_engine.any?([idp_three], user_profile, "test-rp", idps_tried)
+      expect(result).to eql false
+    end
+
+    it "should return false if only recommended IDP has already been tried and failed" do
+      result = @recommendations_engine.any?([idp_one], user_profile, "test-rp", Set['idp'])
       expect(result).to eql false
     end
   end

--- a/spec/models/idp_recommendations/recommendations_engine_spec.rb
+++ b/spec/models/idp_recommendations/recommendations_engine_spec.rb
@@ -46,7 +46,7 @@ describe "recommendations engine" do
       allow(segment_matcher).to receive(:find_matching_segments).with(user_profile).and_return(%w(SEGMENT_3))
       allow(transaction_grouper).to receive(:get_transaction_group).with("test-rp").and_return(TransactionGroups::PROTECTED)
 
-      recommended_idps = @recommendations_engine.get_suggested_idps_for_registration(idps, user_profile, "test-rp", Set['idp4'])
+      recommended_idps = @recommendations_engine.get_suggested_idps_for_registration(idps, user_profile, "test-rp", Set["idp4"])
 
       expected_suggestions = { recommended: [not_hidden_soft_disconnecting_idp], unlikely: [], user_segments: %w(SEGMENT_3) }
       expect(recommended_idps).to eql expected_suggestions
@@ -85,7 +85,7 @@ describe "recommendations engine" do
     end
 
     it "should return false if registration with the idp has been tried before and failed" do
-      result = @recommendations_engine.recommended?(idp_one, idps, user_profile, "test-rp", Set['idp'])
+      result = @recommendations_engine.recommended?(idp_one, idps, user_profile, "test-rp", Set["idp"])
       expect(result).to eql false
     end
   end
@@ -112,7 +112,7 @@ describe "recommendations engine" do
     end
 
     it "should return false if only recommended IDP has already been tried and failed" do
-      result = @recommendations_engine.any?([idp_one], user_profile, "test-rp", Set['idp'])
+      result = @recommendations_engine.any?([idp_one], user_profile, "test-rp", Set["idp"])
       expect(result).to eql false
     end
   end


### PR DESCRIPTION
The journey now looks like this:

![failed_registration_2](https://user-images.githubusercontent.com/13836290/104478573-5dbede80-55ba-11eb-91ca-ec8f3d333000.gif)
### HUB-783: Don't return failed IDPs from recommendations engine
This fixes a bug in the frontend. If a user failed to register with an
IDP and their AuthnResponse was returned with a "FAILED" state, they
would be directed via a landing page and a link back to the choose a
company page.

The logic on that page would retrieve a list of IDPs from the
recommendation engine, including the IDP they just failed with. If they
the selected that IDP again, it's entity ID would be compared to a
separate list of available IDPs - this time with any IDPs the user had
already failed with removed. This caused an error.

This change ensures the recommendation engine doesn't return an IDP the
user has failed with, and so it's not presented to them on the choose an
IDP page.

### HUB-783: Remove IDP recommendation where not needed
The rendered partial never uses it, so there is no need to pass it in.