### PR TITLE
HUB-740: Log info when PausedRegistration IDP not viewable

### DIFF
--- a/app/controllers/paused_registration_controller.rb
+++ b/app/controllers/paused_registration_controller.rb
@@ -97,6 +97,10 @@ private
     enabled_idp_list = get_idp_list(last_rp)
     idp = get_idp_choice(enabled_idp_list, last_idp)
     @idp = IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate(idp)
+    if not @idp.viewable?
+      logger.error "IDP from cookie not viewable. IDP found was '#{@idp}' from enabled IDP list '#{enabled_idp_list}'. Journey hint value: '#{journey_hint_value}'"
+      render :without_user_session
+    end
     render :with_user_session
   end
 


### PR DESCRIPTION
We've been getting a constant trickle of errors in Sentry from the
PausedRegistration controller. The errors are kicked when we try to
render the "with_user_session" paused registration view with a
NotViewableIdentityProvider. The view calls the `display_name` method on
the IDP object, but that doesn't exists for non viewable IDPs.

We get this error after trying to retrieve the users IDP from their
journey hint cookie. We attempt this as we've already determined that
their session isn't valid so can't retrieve it from there. Unfortunately
we jump through a lot of hoops which could all return nil (and so force
a non viewable IDP from the IDP decorators `correlate_display_data`
method), which makes determining the exact issue difficult.

This commit catches a non viewable IDP before we pass it to the view,
and switches to a `without_user_session` view, which doesn't try to
extract anything from the IDP object, but provides very similar but
slightly less tailored information to the user. This isn't perfect but
at least prevents them getting an error.

It also logs the current state of their journey hint cookie as as error
(so we hopefully see it in Sentry rather than just forgetting to check
the logs), so we can hopefully get a better understanding of the issue.