### PR TITLE
Removed reference to GOV.UK Verify Privacy Team

### DIFF
--- a/app/views/static/privacy_notice.en.html.erb
+++ b/app/views/static/privacy_notice.en.html.erb
@@ -9,7 +9,7 @@ end %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">Privacy notice</h1>
-    <p>Last updated: 22 October 2019</p>
+    <p>Last updated: 15 January 2021</p>
     <h2 class="govuk-heading-l" id="who-we-are">Who we are</h2>
     <p>GOV.UK Verify is built and run by the Government Digital Service (GDS), which is part of the Cabinet Office.</p>
     <p>GOV.UK Verify allows you to prove your identity when using digital government services, like the service you use to <a href="https://www.gov.uk/log-in-file-self-assessment-tax-return">file your Self Assessment tax return</a>.</p>
@@ -148,7 +148,7 @@ end %>
     <p>We encourage you to review this privacy notice regularly to find out how we are protecting your data.</p>
 
     <h2 class="govuk-heading-l" id="contact-us-or-make-a-complaint">Contact us or make a complaint</h2>
-    <p>You can contact the GOV.UK Verify Privacy Team at <a href="mailto:verify-privacy@digital.cabinet-office.gov.uk">verify-privacy@digital.cabinet-office.gov.uk</a> if you:</p>
+    <p>You can contact the GDS Privacy Team at <a href="mailto:gds-privacy-office@digital.cabinet-office.gov.uk">gds-privacy-office@digital.cabinet-office.gov.uk</a> if you:</p>
     <ol class="govuk-list govuk-list--bullet">
       <li>have a question about anything in the privacy notice</li>
       <li>think that your personal data has been misused or mishandled</li>
@@ -205,7 +205,7 @@ end %>
     </p>
 
     <div class="meta-data group">
-      <p class="modified-date">Last updated: 22 October 2019</p>
+      <p class="modified-date">Last updated: 15 January 2021</p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
The GOV.UK Verify Privacy Team email address is no longer being used. I've swapped this out for the GDS Privacy Team email address.