### PR TITLE
Removed reference to GOV.UK Verify Privacy Team

### DIFF
--- a/app/views/static/privacy_notice.cy.html.erb
+++ b/app/views/static/privacy_notice.cy.html.erb
@@ -9,7 +9,7 @@ end %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">Hysbysiad preifatrwydd</h1>
-      <p>Diweddarwyd diwethaf: 22 Hydref 2019</p>
+      <p>Diweddarwyd diwethaf: 15 Ionawr 2021</p>
 
       <h2 class="govuk-heading-l" id="who-we-are">Pwy ydym ni</h2>
       <p>Mae GOV.UK Verify wedi cael ei adeiladau ac yn cael ei redeg gan Gwasanaeth Digidol y Llywodraeth (GDS), sy'n rhan o Swyddfa'r Cabinet.</p>
@@ -144,7 +144,7 @@ end %>
     <p>Rydym yn eich annog i adolygu'r hysbysiad preifatrwydd hwn yn rheolaidd i ddarganfod sut rydym yn amddiffyn eich data.</p>
 
     <h2 class="govuk-heading-l" id="contact-us-or-make-a-complaint">Cysylltwch â ni neu gwnewch gŵyn</h2>
-    <p>Gallwch gysylltu â Thîm Dilysu Preifatrwydd GOV.UK Verify yn <a href="mailto:verify-privacy@digital.cabinet-office.gov.uk">verify-privacy@digital.cabinet-office.gov.uk</a> os ydych:</p>
+    <p>Gallwch gysylltu â Thîm Preifatrwydd GDS yn <a href="mailto:gds-privacy-office@digital.cabinet-office.gov.uk">gds-privacy-office@digital.cabinet-office.gov.uk</a> os ydych:</p>
     <ol class="govuk-list govuk-list--bullet">
     <li>â chwestiwn am unrhyw beth yn yr hysbysiad preifatrwydd</li>
     <li>yn credu bod eich data personol wedi cael ei gamddefnyddio neu ei gam-drin</li>
@@ -196,7 +196,7 @@ end %>
     </address>
     </p>
     <div class="meta-data group">
-      <p class="modified-date">Diweddarwyd diwethaf: 22 Hydref 2019</p>
+      <p class="modified-date">Diweddarwyd diwethaf: 15 Ionawr 2021</p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
The GOV.UK Verify Privacy Team email address is no longer being used. I've swapped this out for the GDS Privacy Team email address.