### PR TITLE
BAU Remove eIDAS content from Verify Privacy Notice page

### DIFF
--- a/app/views/static/privacy_notice.cy.html.erb
+++ b/app/views/static/privacy_notice.cy.html.erb
@@ -14,7 +14,6 @@ end %>
       <h2 class="govuk-heading-l" id="who-we-are">Pwy ydym ni</h2>
       <p>Mae GOV.UK Verify wedi cael ei adeiladau ac yn cael ei redeg gan Gwasanaeth Digidol y Llywodraeth (GDS), sy'n rhan o Swyddfa'r Cabinet.</p>
       <p>Mae GOV.UK Verify yn caniatáu i chi brofi'ch hunaniaeth wrth ddefnyddio gwasanaethau digidol y llywodraeth, fel y gwasanaeth rydych yn ei ddefnyddio i <a href="https://www.gov.uk/cofrestru-ar-gyfer-a-chyflwynoch-ffurflen-dreth-hunanasesiad">ffeilio'ch ffurflen dreth Hunanasesiad.</a>.</p>
-      <p>Mae GOV.UK Verify hefyd yn bodloni rheoliad eIDAS, sy'n galluogi defnyddwyr sydd â hunaniaethau digidol o rai o wledydd yr UE i gael mynediad at wasanaethau'r llywodraeth yn y DU. Mae hefyd yn caniatáu i ddefnyddwyr sydd wedi profi eu hunaniaeth gyda GOV.UK Verify cael mynedidad at wasanaethau mewn rhai o wledydd yr UE.</p>
       <p>Mae GOV.UK Verify wedi cael ei gynllunio i fodloni'r <a href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/361496/PCAG_IDA_Principles_3.1__4_.pdf">Egwyddorion Sicrwydd Hunaniaeth</a>, a ysgrifennwyd gan <a href="https://www.gov.uk/government/groups/privacy-and-consumer-advisory-group">Grŵp Cynghori Preifatrwydd a Defnyddwyr</a> Swyddfa'r Cabinet.</p>
       <p>Gallwch ddod o hyd i wybodaeth fanylach am GOV.UK Verify ar <a href=https://gds.blog.gov.uk/category/id-assurance/>blog GOV.UK Verify</a>.</p>
       <p>Mae'r hysbysiad preifatrwydd hwn yn esbonio pa ddata y gallem ei gasglu, sut mae'n cael ei ddefnyddio a sut mae'n cael ei ddiogelu.</p>
@@ -23,7 +22,6 @@ end %>
       <p>Rydym yn casglu data personol gennych pan fyddwch yn:</p>
         <ol class="govuk-list govuk-list--bullet">
           <li>mewngofnodi i wasanaeth gyda GOV.UK Verify</li>
-          <li>mewngofnodi i wasanaeth sydd â hunaniaeth ddigidol o wlad yn yr UE</li>
           <li>anfon cwestiynau ac adborth atom</li>
       </ol>
       
@@ -40,18 +38,7 @@ end %>
           <li>cyfeiriad ip</li>
           <li>dynodwr parhaus (PID) - rhoddir hwn i chi gan y cwmni a brofodd eich hunaniaeth</li>
         </ol>
-      <p>Os ydych yn defnyddio GOV.UK Verify i fewngofnodi i wasanaeth mewn gwlad yn yr UE, bydd yr hyb yn anfon unrhyw ddata personol y mae'n ei gasglu i'r gwasanaeth rydych am ei ddefnyddio.</p>
-      
-      <h3 class="govuk-heading-m" id="when-you-sign-in-with-a-digital-identity-from-an-eu-country">Pan fyddwch yn mewngofnodi gyda hunaniaeth ddigidol o wlad yn yr UE</h3>
-      <p>Ar ôl i chi fewngofnodi, byddwn yn casglu eich data personol a'i anfon at wasanaeth y llywodraeth rydych am ei ddefnyddio. Rydym yn gwneud hyn i helpu amddiffyn eich hunaniaeth pan fyddwch yn defnyddio gwasanaethau'r llywodraeth.</p>
-      <p>Efallai bydd y data personol hwn yn cynnwys eich:</p>
-        <ol class="govuk-list govuk-list--bullet">
-          <li>enw teuluol</li>
-          <li>enw cyntaf</li>
-          <li>dyddiad geni</li>
-          <li>adnabyddwr personol (PID)</li>
-        </ol>
-      
+
       <h3 class="govuk-heading-m" id="when-you-send-us-a-question-or-feedback">Pan anfonwch gwestiwn neu adborth atom</h3>
       <p>Rydym yn cadw unrhyw gwestiynau neu adborth rydych yn eu hanfon am GOV.UK Verify, yn ogystal â manylion am yr hyn rydym wedi'i wneud i helpu. Byddwn hefyd yn cadw rhywfaint o ddata personol, fel eich enw a'ch cyfeiriad e-bost.</p>
       

--- a/app/views/static/privacy_notice.cy.html.erb
+++ b/app/views/static/privacy_notice.cy.html.erb
@@ -9,7 +9,7 @@ end %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">Hysbysiad preifatrwydd</h1>
-      <p>Diweddarwyd diwethaf: 22 Hydref 2019</p>
+      <p>Diweddarwyd diwethaf: 15 Ionawr 2021</p>
 
       <h2 class="govuk-heading-l" id="who-we-are">Pwy ydym ni</h2>
       <p>Mae GOV.UK Verify wedi cael ei adeiladau ac yn cael ei redeg gan Gwasanaeth Digidol y Llywodraeth (GDS), sy'n rhan o Swyddfa'r Cabinet.</p>
@@ -183,7 +183,7 @@ end %>
     </address>
     </p>
     <div class="meta-data group">
-      <p class="modified-date">Diweddarwyd diwethaf: 22 Hydref 2019</p>
+      <p class="modified-date">Diweddarwyd diwethaf: 15 Ionawr 2021</p>
     </div>
   </div>
 </div>

--- a/app/views/static/privacy_notice.en.html.erb
+++ b/app/views/static/privacy_notice.en.html.erb
@@ -9,7 +9,7 @@ end %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">Privacy notice</h1>
-    <p>Last updated: 22 October 2019</p>
+    <p>Last updated: 15 January 2021</p>
     <h2 class="govuk-heading-l" id="who-we-are">Who we are</h2>
     <p>GOV.UK Verify is built and run by the Government Digital Service (GDS), which is part of the Cabinet Office.</p>
     <p>GOV.UK Verify allows you to prove your identity when using digital government services, like the service you use to <a href="https://www.gov.uk/log-in-file-self-assessment-tax-return">file your Self Assessment tax return</a>.</p>
@@ -185,7 +185,7 @@ end %>
     </p>
 
     <div class="meta-data group">
-      <p class="modified-date">Last updated: 22 October 2019</p>
+      <p class="modified-date">Last updated: 15 January 2021</p>
     </div>
   </div>
 </div>

--- a/app/views/static/privacy_notice.en.html.erb
+++ b/app/views/static/privacy_notice.en.html.erb
@@ -13,7 +13,6 @@ end %>
     <h2 class="govuk-heading-l" id="who-we-are">Who we are</h2>
     <p>GOV.UK Verify is built and run by the Government Digital Service (GDS), which is part of the Cabinet Office.</p>
     <p>GOV.UK Verify allows you to prove your identity when using digital government services, like the service you use to <a href="https://www.gov.uk/log-in-file-self-assessment-tax-return">file your Self Assessment tax return</a>.</p>
-    <p>GOV.UK Verify also meets the eIDAS regulation, which lets users with digital identities from some EU countries access government services in the UK. It also lets users who have proved their identity with GOV.UK Verify access services in some EU countries.</p>
     <p>GOV.UK Verify has been designed to meet the <a href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/361496/PCAG_IDA_Principles_3.1__4_.pdf">Identity Assurance Principles</a>, written by the Cabinet Office <a href="https://www.gov.uk/government/groups/privacy-and-consumer-advisory-group">Privacy and Consumer Advisory Group</a>.</p>
     <p>You can find more detailed information about GOV.UK Verify on the <a href="https://gds.blog.gov.uk/category/id-assurance/">GOV.UK Verify blog</a>.</p>
     <p>This privacy notice explains what data we might collect, how it's used and how it's protected.</p>
@@ -22,7 +21,6 @@ end %>
     <p>We collect personal data from you when you:</p>
     <ol class="govuk-list govuk-list--bullet">
       <li>sign in to a service with GOV.UK Verify</li>
-      <li>sign in to a service with a digital identity from an EU country</li>
       <li>send us questions or feedback</li>
     </ol>
 
@@ -38,24 +36,6 @@ end %>
       <li>gender (this is usually optional)</li>
       <li>IP address</li>
       <li>persistent identifier (PID) - this is given to you by the company that proved your identity</li>
-    </ol>
-    <p>If you use GOV.UK Verify to sign in to a service in an EU country, the hub will send limited personal data it collects to the service you want to use.</p>
-    <p>This personal data might include your:</p>
-    <ol class="govuk-list govuk-list--bullet">
-      <li>family name</li>
-      <li>first name</li>
-      <li>date of birth</li>
-      <li>PID</li>
-    </ol>
-
-    <h3 class="govuk-heading-l" id="when-you-sign-in-with-a-digital-identity-from-an-eu-country">When you sign in with a digital identity from an EU country</h3>
-    <p>After you've signed in, we'll collect your personal data and send it to the government service that you want to use. We do this to help protect your identity when you use government services.</p>
-    <p>This personal data might include your:</p>
-    <ol class="govuk-list govuk-list--bullet">
-      <li>family name</li>
-      <li>first name</li>
-      <li>date of birth</li>
-      <li>PID</li>
     </ol>
 
     <h3 class="govuk-heading-l" id="when-you-send-us-a-question-or-feedback">When you send us a question or feedback</h3>


### PR DESCRIPTION
There is some eIDAS content on the [Verify Privacy Notice page](https://www.signin.service.gov.uk/privacy-notice), which we should remove.

Remove both the English and Welsh content.