### PR TITLE
Make skiplink anchor link to main content area

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -30,7 +30,7 @@
 
     <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
 
-    <a href="#main-content" class="govuk-skip-link"><%= t 'navigation.skip_link' %></a>
+    <a href="#content" class="govuk-skip-link"><%= t 'navigation.skip_link' %></a>
     
     <% if cookies[:seen_cookie_message].nil? %>
       


### PR DESCRIPTION
When I was logging into Verify I noticed the skiplink on the /start page doesn't work because it's URL doesn't point to the id of the main content area.

This should fix it for that and other pages I think. I chose to change the skiplink URL rather than the main content area id because:
- www.gov.uk uses that id for its one
- I can't find anything in this repository using the 'main-content' id