### PR TITLE
HUB-740: Fix double render

### DIFF
--- a/app/controllers/paused_registration_controller.rb
+++ b/app/controllers/paused_registration_controller.rb
@@ -99,7 +99,7 @@ private
     @idp = IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate(idp)
     if not @idp.viewable?
       logger.error "IDP from cookie not viewable. IDP found was '#{@idp}' from enabled IDP list '#{enabled_idp_list}'. Journey hint value: '#{journey_hint_value}'"
-      render :without_user_session
+      render :without_user_session && return
     end
     render :with_user_session
   end


### PR DESCRIPTION
[This PR ](https://github.com/alphagov/verify-frontend/pull/924)to diagnose a bug introduced a new bug. You can't call `render` twice in the same controller action. `render` doesn't return, so you need to call it yourself.

