### PR TITLE
HUB-740: Log referer on pause page

### DIFF
--- a/app/controllers/paused_registration_controller.rb
+++ b/app/controllers/paused_registration_controller.rb
@@ -98,7 +98,7 @@ private
     idp = get_idp_choice(enabled_idp_list, last_idp)
     @idp = IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate(idp)
     if not @idp.viewable?
-      logger.error "IDP from cookie not viewable. IDP found was '#{@idp}' from enabled IDP list '#{enabled_idp_list}'. Journey hint value: '#{journey_hint_value}'"
+      logger.error "IDP from cookie not viewable. IDP found was '#{@idp}' from enabled IDP list '#{enabled_idp_list}'. Journey hint value: '#{journey_hint_value}'. Referer: '#{request.referer}'"
       render :without_user_session && return
     end
     render :with_user_session


### PR DESCRIPTION
To help check that users aren't being sent to the pause page by IDPs
that no longer offer registrations.