### PR TITLE
HUB-740: Handle paused journeys for sign in only IDPs

### DIFF
--- a/app/controllers/partials/journey_hinting_partial_controller.rb
+++ b/app/controllers/partials/journey_hinting_partial_controller.rb
@@ -44,6 +44,11 @@ module JourneyHintingPartialController
     last_status_value.nil? ? nil : last_status_value.fetch("RP", nil)
   end
 
+  def last_verify_journey_type
+    last_status_value = last_status
+    last_status_value.nil? ? nil : last_status_value.fetch("VERIFY_JOURNEY_TYPE", nil)
+  end
+
   def user_followed_journey_hint(entity_id_followed_by_user)
     hinted_id = success_entity_id
     !hinted_id.nil? && hinted_id == entity_id_followed_by_user

--- a/app/controllers/partials/user_cookies_partial_controller.rb
+++ b/app/controllers/partials/user_cookies_partial_controller.rb
@@ -36,6 +36,7 @@ module UserCookiesPartialController
     journey_hint_by_status_value["STATE"] = { IDP: idp_entity_id,
                                               RP: rp_entity_id.nil? ? session[:transaction_entity_id] : rp_entity_id,
                                               STATUS: status }
+    journey_hint_by_status_value["STATE"][:VERIFY_JOURNEY_TYPE] = session[:journey_type] if status == "PENDING"
 
     cookies.encrypted[CookieNames::VERIFY_FRONT_JOURNEY_HINT] = { value: journey_hint_by_status_value.to_json, expires: 18.months.from_now }
   end

--- a/app/controllers/paused_registration_controller.rb
+++ b/app/controllers/paused_registration_controller.rb
@@ -95,10 +95,10 @@ private
   def with_cookie
     set_transaction_from_cookie
 
-    if (idp = last_idp_from_those_offering_registration)
+    if (idp = get_idp_from_idps_available_for_registration)
       @idp = IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate(idp)
       render :with_user_session
-    elsif (idp = last_idp_from_those_offering_sign_in)
+    elsif (idp = get_idp_from_idps_available_for_sign_in)
       @idp = IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate(idp)
       render :idp_no_longer_providing_registrations
     else
@@ -155,11 +155,11 @@ private
     list.idps
   end
 
-  def last_idp_from_those_offering_sign_in
+  def get_idp_from_idps_available_for_sign_in
     get_idp_choice(get_idp_list_for_sign_in, last_idp)
   end
 
-  def last_idp_from_those_offering_registration
+  def get_idp_from_idps_available_for_registration
     get_idp_choice(get_idp_list_for_registration(last_rp), last_idp)
   end
 

--- a/app/controllers/paused_registration_controller.rb
+++ b/app/controllers/paused_registration_controller.rb
@@ -94,14 +94,15 @@ private
 
   def with_cookie
     set_transaction_from_cookie
-    enabled_idp_list = get_idp_list(last_rp)
-    idp = get_idp_choice(enabled_idp_list, last_idp)
-    @idp = IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate(idp)
-    if not @idp.viewable?
-      logger.error "IDP from cookie not viewable. IDP found was '#{@idp}' from enabled IDP list '#{enabled_idp_list}'. Journey hint value: '#{journey_hint_value}'. Referer: '#{request.referer}'"
-      render :without_user_session
-    else
+
+    if (idp = last_idp_from_those_offering_registration)
+      @idp = IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate(idp)
       render :with_user_session
+    elsif (idp = last_idp_from_those_offering_sign_in)
+      @idp = IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate(idp)
+      render :idp_no_longer_providing_registrations
+    else
+      raise(Errors::WarningLevelError, "IDP not found in those providing registration or sign in. IDP was '#{last_idp}'")
     end
   end
 
@@ -140,11 +141,26 @@ private
     CONFIG_PROXY.get_transaction_translations(simple_id, params[:locale]).fetch(:name, nil)
   end
 
-  def get_idp_list(transaction_id)
+  def get_idp_list_for_registration(transaction_id)
     list = CONFIG_PROXY.get_available_idp_list_for_registration(transaction_id, "LEVEL_2")
     return nil if list.nil?
 
     list.idps
+  end
+
+  def get_idp_list_for_sign_in
+    list = CONFIG_PROXY.get_idp_list_for_sign_in(last_rp)
+    return nil if list.nil?
+
+    list.idps
+  end
+
+  def last_idp_from_those_offering_sign_in
+    get_idp_choice(get_idp_list_for_sign_in, last_idp)
+  end
+
+  def last_idp_from_those_offering_registration
+    get_idp_choice(get_idp_list_for_registration(last_rp), last_idp)
   end
 
   def preferred_start_page(selected_rp)

--- a/app/controllers/paused_registration_controller.rb
+++ b/app/controllers/paused_registration_controller.rb
@@ -95,7 +95,10 @@ private
   def with_cookie
     set_transaction_from_cookie
 
-    if (idp = get_idp_from_idps_available_for_registration)
+    if last_verify_journey_type == JourneyType::Verify::SIGN_IN
+      @idp = IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate(get_idp_from_idps_available_for_sign_in)
+      render :with_user_session
+    elsif (idp = get_idp_from_idps_available_for_registration)
       @idp = IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate(idp)
       render :with_user_session
     elsif (idp = get_idp_from_idps_available_for_sign_in)

--- a/app/views/paused_registration/idp_no_longer_providing_registrations.html.erb
+++ b/app/views/paused_registration/idp_no_longer_providing_registrations.html.erb
@@ -1,0 +1,11 @@
+<%= page_title 'hub.paused_registration.idp_no_longer_providing_registrations.title', idp_name: @idp.display_name %>
+<% content_for :feedback_source, 'PAUSED_REGISTRATION_PAGE' %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l"><%= t 'hub.paused_registration.idp_no_longer_providing_registrations.heading', idp_name: @idp.display_name %></h1>
+
+    <p><%= t 'hub.paused_registration.idp_no_longer_providing_registrations.return_html', rp_name: @transaction[:name], rp_start_page: @transaction[:homepage] %></p>
+
+  </div>
+</div>

--- a/app/views/paused_registration/idp_no_longer_providing_registrations.html.erb
+++ b/app/views/paused_registration/idp_no_longer_providing_registrations.html.erb
@@ -1,11 +1,10 @@
 <%= page_title 'hub.paused_registration.idp_no_longer_providing_registrations.title', idp_name: @idp.display_name %>
-<% content_for :feedback_source, 'PAUSED_REGISTRATION_PAGE' %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l"><%= t 'hub.paused_registration.idp_no_longer_providing_registrations.heading', idp_name: @idp.display_name %></h1>
 
-    <p><%= t 'hub.paused_registration.idp_no_longer_providing_registrations.return_html', rp_name: @transaction[:name], rp_start_page: @transaction[:homepage] %></p>
+    <p><%= t 'hub.paused_registration.idp_no_longer_providing_registrations.return_html', rp_start_page: @transaction[:homepage] %></p>
 
   </div>
 </div>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -606,8 +606,13 @@ cy:
         return_html: 'Neu dychwelyd i <a href="%{rp_start_page}">%{rp_name}</a>.'
       idp_no_longer_providing_registrations:
         title: "Verification Paused %{idp_name}"
-        heading: "%{idp_name} are no longer providing registrations"
-        return_html: 'You can return to <a href="%{rp_start_page}">%{rp_name}</a> and register with a different certified company.'
+        heading: "You can no longer verify your identity with %{idp_name}"
+        return_html: |
+          Go back to <a href="%{rp_start_page}">the service you were trying to access</a> where you can choose either:
+          <ul class="govuk-list govuk-list--bullet">
+              <li>a new identity provider</li>
+              <li>another way to prove your identity</li>
+          </ul>
       without_session:
         title: Dilysu Wedi'i Oedi
         heading: Mae eich cwmni ardystiedig wedi arbed eich gwybodaeth.

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -604,6 +604,10 @@ cy:
           <p class="govuk-body">Bydd angen yr e-bost neu'r enw defnyddiwr a'r cyfrinair a ddefnyddiwyd gennych i greu cyfrif gyda %{idp_name}.</p>
         continue_verifying: 'Parhau i wirio gyda %{idp_name}'
         return_html: 'Neu dychwelyd i <a href="%{rp_start_page}">%{rp_name}</a>.'
+      idp_no_longer_providing_registrations:
+        title: "Verification Paused %{idp_name}"
+        heading: "%{idp_name} are no longer providing registrations"
+        return_html: 'You can return to <a href="%{rp_start_page}">%{rp_name}</a> and register with a different certified company.'
       without_session:
         title: Dilysu Wedi'i Oedi
         heading: Mae eich cwmni ardystiedig wedi arbed eich gwybodaeth.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -599,6 +599,10 @@ en:
           <p class="govuk-body">You'll need the email or username and password you used to create an account with %{idp_name}.</p>
         continue_verifying: 'Continue verifying with %{idp_name}'
         return_html: 'Or return to <a href="%{rp_start_page}">%{rp_name}</a>.'
+      idp_no_longer_providing_registrations:
+        title: "Verification Paused %{idp_name}"
+        heading: "%{idp_name} are no longer providing registrations"
+        return_html: 'You can return to <a href="%{rp_start_page}">%{rp_name}</a> and register with a different certified company.'
       without_session:
         title: Verification Paused
         heading: The certified company has saved your information

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -601,8 +601,13 @@ en:
         return_html: 'Or return to <a href="%{rp_start_page}">%{rp_name}</a>.'
       idp_no_longer_providing_registrations:
         title: "Verification Paused %{idp_name}"
-        heading: "%{idp_name} are no longer providing registrations"
-        return_html: 'You can return to <a href="%{rp_start_page}">%{rp_name}</a> and register with a different certified company.'
+        heading: "You can no longer verify your identity with %{idp_name}"
+        return_html: |
+          Go back to <a href="%{rp_start_page}">the service you were trying to access</a> where you can choose either:
+          <ul class="govuk-list govuk-list--bullet">
+              <li>a new identity provider</li>
+              <li>another way to prove your identity</li>
+          </ul>
       without_session:
         title: Verification Paused
         heading: The certified company has saved your information

--- a/spec/controller_helper.rb
+++ b/spec/controller_helper.rb
@@ -7,6 +7,7 @@ def set_session_and_cookies_with_loa(loa_requested, transaction_simple_id = "tes
   session[:transaction_entity_id] = "http://www.test-rp.gov.uk/SAML2/MD"
   session[:transaction_homepage] = "www.example.com"
   session[:start_time] = Time.now.to_i * 1000
+  session[:journey_type] = JourneyType::Verify::SIGN_IN
   cookies[CookieNames::SESSION_COOKIE_NAME] = "my-session-cookie"
   cookies[CookieNames::SESSION_ID_COOKIE_NAME] = "my-session-id-cookie"
 end

--- a/spec/controllers/authn_response_controller_spec.rb
+++ b/spec/controllers/authn_response_controller_spec.rb
@@ -174,7 +174,8 @@ describe AuthnResponseController do
       let(:cookie_with_pending_status) {
         { STATE: { IDP: "http://idcorp.com",
                    RP: "http://www.test-rp.gov.uk/SAML2/MD",
-                   STATUS: "PENDING" } }.to_json
+                   STATUS: "PENDING",
+                   VERIFY_JOURNEY_TYPE: "sign-in" } }.to_json
       }
       it { should eq cookie_with_pending_status }
     end
@@ -184,7 +185,8 @@ describe AuthnResponseController do
       let(:cookie_with_pending_status) {
         { STATE: { IDP: "http://idcorp.com",
                    RP: "http://www.test-rp.gov.uk/SAML2/MD",
-                   STATUS: "PENDING" } }.to_json
+                   STATUS: "PENDING",
+                   VERIFY_JOURNEY_TYPE: "sign-in" } }.to_json
       }
       it { should eq cookie_with_pending_status }
       it { expect(cookies.encrypted[CookieNames::VERIFY_SINGLE_IDP_JOURNEY]).to be_nil }

--- a/spec/controllers/paused_registration_controller_spec.rb
+++ b/spec/controllers/paused_registration_controller_spec.rb
@@ -68,12 +68,28 @@ describe PausedRegistrationController do
         expect(subject).to render_template(:without_user_session)
       end
 
-      it "should render IDP no longer providing registrations page when no session and the selected IDP is sign in only" do
+      it "should render with session page when it's a sign in journey" do
         front_journey_hint_cookie = {
           STATE: {
             IDP: "http://idcorp-three.com",
             RP: valid_rp,
             STATUS: "PENDING",
+            VERIFY_JOURNEY_TYPE: JourneyType::Verify::SIGN_IN,
+          },
+        }
+
+        cookies.encrypted[CookieNames::VERIFY_FRONT_JOURNEY_HINT] = front_journey_hint_cookie.to_json
+
+        expect(subject).to render_template(:with_user_session)
+      end
+
+      it "should render IDP no longer providing registrations page when no session, the selected IDP is sign in only, and it's not a sign-in journey" do
+        front_journey_hint_cookie = {
+          STATE: {
+            IDP: "http://idcorp-three.com",
+            RP: valid_rp,
+            STATUS: "PENDING",
+            JOURNEY_TYPE: JourneyType::Verify::REGISTRATION,
           },
         }
 


### PR DESCRIPTION
We get a few errors coming through for users attempting to restart
journeys with IDPs that are no longer providing registrations. The
cookie that informs this last for 18 months.

This will show users a new page if their paused journey is for an IDP
that no longer offers registrations and advise them to go back to their
service and try again.

This PR needs a content review as well as Welsh translations.

### Screenshot of new page.

![Screenshot 2021-01-27 at 12 53 44](https://user-images.githubusercontent.com/13836290/106001620-15b6b600-60a8-11eb-833f-7b467a0aa7e8.png)


### Screenshots of existing page
This new page is a new variant for an existing endpoint. The two screenshots below show what happens if the IDP is still offering registrations - the difference between them is whether the user had a session or not at the time of the page load. The new page is for when the IDP is no longer offering registrations.

<img width="997" alt="Screenshot 2021-01-20 at 11 14 34" src="https://user-images.githubusercontent.com/13836290/105168753-770fdf80-5b12-11eb-9f85-104c335edbda.png">
<img width="988" alt="Screenshot 2021-01-20 at 11 15 18" src="https://user-images.githubusercontent.com/13836290/105168758-78d9a300-5b12-11eb-9bc8-f41e2ba15b38.png">
