### PR TITLE
HUB-744 Make Sentry look at the correct envvar

### DIFF
--- a/config/initializers/00_logging.rb
+++ b/config/initializers/00_logging.rb
@@ -19,7 +19,7 @@ Raven.configure do |config|
   config.ssl_verification = false
   config.processors << Raven::Processor::Cookies
   config.current_environment = ENV.fetch("SENTRY_ENV", "unspecified")
-  config.release = ENV.fetch("RELEASE_VER", "unknown")
+  config.release = ENV.fetch("SENTRY_RELEASE", "unknown")
 end
 
 Rails.logger.extend(ActiveSupport::Logger.broadcast(Support::Raven::Logger.new))


### PR DESCRIPTION
This PR makes sentry look at the SENTRY_RELEASE environment variable which is provided by our Pipeline and in our Dockfile.  This standardise the name of the variable across our projects.  Sadly the Sentry Gems aren't automatically configured from environment variables.