### PR TITLE
HUB-242: Make short-Hub page title more accessible

### DIFF
--- a/app/controllers/feedback_landing_controller.rb
+++ b/app/controllers/feedback_landing_controller.rb
@@ -5,7 +5,7 @@ class FeedbackLandingController < ApplicationController
 
   def index
     flash["feedback_referer"] = request.referer
-    flash["feedback_source"] = params["feedback-source"].nil? ? flash["feedback_source"] : params["feedback-source"]
+    flash["feedback_source"] = params["feedback-source"] || flash["feedback_source"]
     @feedback_landing_heading = t("hub.feedback_landing.basic_heading")
 
     return if current_transaction_simple_id.nil?

--- a/app/controllers/redirect_to_service_controller.rb
+++ b/app/controllers/redirect_to_service_controller.rb
@@ -3,21 +3,21 @@ class RedirectToServiceController < ApplicationController
 
   def signing_in
     redirect_to_service(
-      "hub.redirect_to_service.signing_in.title",
+      "hub.redirect_to_service.signing_in.heading",
       "hub.redirect_to_service.signing_in.transition_heading",
     )
   end
 
   def start_again
     redirect_to_service(
-      "hub.redirect_to_service.start_again.title",
+      "hub.redirect_to_service.start_again.heading",
       "hub.redirect_to_service.start_again.transition_heading",
     )
   end
 
   def error
     redirect_to_service(
-      "hub.redirect_to_service.start_again.title",
+      "hub.redirect_to_service.start_again.heading",
       "hub.redirect_to_service.start_again.transition_heading",
       is_error: true,
     )

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,8 +1,8 @@
 module ApplicationHelper
-  def page_title(title_key, locale_data = {}, extra_string = nil)
+  def page_title(title_key = nil, locale_data = {}, extra_string = nil)
     title = ""
     title << "#{t('title.error', locale_data)}: " if flash[:errors]
-    title << t(title_key, locale_data)
+    title << (block_given? ? yield : t(title_key, locale_data))
     en_title = [t(title_key, locale_data.merge(locale: :en)), extra_string, "GOV.UK Verify", "GOV.UK"]
     en_title << session[:requested_loa] if session[:requested_loa]
     content_for :page_title, title

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,7 @@
 module ApplicationHelper
   def page_title(title_key = nil, locale_data = {}, extra_string = nil)
+    raise ArgumentError.new("Missing page title") if title_key.nil? && !block_given?
+
     title = ""
     title << "#{t('title.error', locale_data)}: " if flash[:errors]
     title << (block_given? ? yield : t(title_key, locale_data))

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -5,7 +5,7 @@ module ApplicationHelper
     title = ""
     title << "#{t('title.error', locale_data)}: " if flash[:errors]
     title << (block_given? ? yield : t(title_key, locale_data))
-    en_title = [t(title_key, locale_data.merge(locale: :en)), extra_string, "GOV.UK Verify", "GOV.UK"]
+    en_title = [t(title_key, locale_data.merge(locale: :en)), extra_string, "GOV.UK Verify"]
     en_title << session[:requested_loa] if session[:requested_loa]
     content_for :page_title, title
     analytics_title en_title.compact.join(" - ")

--- a/app/views/about/about_combined_LOA.html.erb
+++ b/app/views/about/about_combined_LOA.html.erb
@@ -1,4 +1,4 @@
-<%= page_title 'hub.about.title' %>
+<%= page_title 'hub.about_what_is_verify.heading' %>
 <% content_for :feedback_source, 'ABOUT_PAGE' %>
 
 <h1 class="govuk-heading-l"><%= t 'hub.about_what_is_verify.heading' %></h1>

--- a/app/views/about/choosing_a_company.html.erb
+++ b/app/views/about/choosing_a_company.html.erb
@@ -1,4 +1,4 @@
-<%= page_title 'hub.about_choosing_a_company.title' %>
+<%= page_title 'hub.about_choosing_a_company.heading' %>
 <% content_for :feedback_source, 'ABOUT_CHOOSING_A_COMPANY_PAGE' %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/cancelled_registration_loa1/cancelled_registration_LOA1.html.erb
+++ b/app/views/cancelled_registration_loa1/cancelled_registration_LOA1.html.erb
@@ -1,4 +1,4 @@
-<%= page_title 'hub.cancelled_registration.title' %>
+<%= page_title 'hub.cancelled_registration.heading', idp_name: @idp.display_name %>
 <% content_for :feedback_source, 'CANCELLED_REGISTRATION' %>
 
 <div class="govuk-grid-column-two-thirds">

--- a/app/views/cancelled_registration_loa2/cancelled_registration_LOA2.html.erb
+++ b/app/views/cancelled_registration_loa2/cancelled_registration_LOA2.html.erb
@@ -1,4 +1,4 @@
-<%= page_title 'hub.cancelled_registration.title' %>
+<%= page_title 'hub.cancelled_registration.heading', idp_name: @idp.display_name %>
 <% content_for :feedback_source, 'CANCELLED_REGISTRATION' %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/choose_a_certified_company/_idp_option.html.erb
+++ b/app/views/choose_a_certified_company/_idp_option.html.erb
@@ -17,7 +17,7 @@
                         'data-order': order
           %>
       <% else %>
-          <h3 class="heading-small"><%= t 'hub.certified_companies_unavailable.title', count: 1, company: identity_provider.display_name %></h3>
+          <h3 class="heading-small"><%= t 'hub.certified_companies_unavailable.heading', count: 1, company: identity_provider.display_name %></h3>
           <p><%= t 'hub.certified_companies_unavailable.verify_another_company_text' %></p>
       <% end %>
     </div>

--- a/app/views/choose_a_certified_company/about.html.erb
+++ b/app/views/choose_a_certified_company/about.html.erb
@@ -1,4 +1,4 @@
-<% page_title 'hub.choose_a_certified_company.about.title', { :display_name => @idp.display_name } %>
+<% page_title 'hub.choose_a_certified_company.about.heading', { :display_name => @idp.display_name } %>
 <% content_for :feedback_source, "CHOOSE_A_CERTIFIED_COMPANY_ABOUT_#{@idp.simple_id.upcase}_PAGE" %>
 <%= link_to t('navigation.back'), choose_a_certified_company_path, class: 'govuk-back-link' %>
 <div class="govuk-grid-row">

--- a/app/views/choose_a_certified_company/choose_a_certified_company_LOA1.html.erb
+++ b/app/views/choose_a_certified_company/choose_a_certified_company_LOA1.html.erb
@@ -1,4 +1,4 @@
-<%= page_title 'hub.choose_a_certified_company.title' %>
+<%= page_title 'hub.choose_a_certified_company.heading' %>
 <% content_for :feedback_source, 'CHOOSE_A_CERTIFIED_COMPANY_PAGE' %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-thirds">

--- a/app/views/choose_a_certified_company/choose_a_certified_company_LOA2.html.erb
+++ b/app/views/choose_a_certified_company/choose_a_certified_company_LOA2.html.erb
@@ -1,4 +1,4 @@
-<%= page_title 'hub.choose_a_certified_company.title' %>
+<%= page_title 'hub.choose_a_certified_company.heading' %>
 <% content_for :feedback_source, 'CHOOSE_A_CERTIFIED_COMPANY_PAGE' %>
 <% content_for :additional_javascript do %>
     <%= javascript_include_tag 'piwik_idp_picker_tracking' %>

--- a/app/views/choose_a_country/choose_a_country.html.erb
+++ b/app/views/choose_a_country/choose_a_country.html.erb
@@ -1,8 +1,8 @@
-<%= page_title 'hub.choose_a_country.title' %>
+<%= page_title 'hub.choose_a_country.heading' %>
 <% content_for :feedback_source, 'CHOOSE_A_COUNTRY_PAGE' %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    
+
     <h1 class="govuk-heading-l"><%= t('hub.choose_a_country.heading') %></h1>
     <p><%= t 'hub.choose_a_country.description' %></p>
     <div class="govuk-inset-text">

--- a/app/views/completed_registration/index.erb
+++ b/app/views/completed_registration/index.erb
@@ -1,4 +1,4 @@
-<%= page_title 'hub.completed_registration.title' %>
+<%= page_title 'hub.completed_registration.heading', idp_name: @idp.display_name %>
 
 <% content_for :feedback_source, 'COMPLETED_REGISTRATION_PAGE' %>
 <% content_for :show_to_search_engine, false %>

--- a/app/views/confirm_your_identity/index.html.erb
+++ b/app/views/confirm_your_identity/index.html.erb
@@ -1,4 +1,4 @@
-<%= page_title 'hub.confirm_your_identity.title' %>
+<%= page_title 'hub.signin.sign_in_idp', display_name: @identity_providers[0].display_name %>
 <% content_for :feedback_source, 'CONFIRM_YOUR_IDENTITY' %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds js-continue-to-idp confirm-your-identity" data-location="<%= url_for(controller: 'sign_in', action: 'select_idp_ajax', locale: I18n.locale)  %>">

--- a/app/views/confirmation_loa1/confirmation_LOA1.html.erb
+++ b/app/views/confirmation_loa1/confirmation_LOA1.html.erb
@@ -1,4 +1,4 @@
-<%= page_title 'hub.confirmation.title' %>
+<%= page_title 'hub.confirmation.heading', display_name: @idp_name %>
 <% content_for :feedback_source, 'CONFIRMATION_PAGE' %>
 
 <div class="govuk-grid-row">

--- a/app/views/confirmation_loa2/confirmation_LOA2.html.erb
+++ b/app/views/confirmation_loa2/confirmation_LOA2.html.erb
@@ -1,4 +1,4 @@
-<%= page_title 'hub.confirmation.title' %>
+<%= page_title 'hub.confirmation.heading', display_name: @idp_name %>
 <% content_for :feedback_source, 'CONFIRMATION_PAGE' %>
 
 <div class="govuk-grid-row">

--- a/app/views/errors/404.html.erb
+++ b/app/views/errors/404.html.erb
@@ -1,4 +1,4 @@
-<%= page_title 'errors.page_not_found.title' %>
+<%= page_title 'errors.page_not_found.heading' %>
 <% content_for :feedback_source, 'ERROR_PAGE' %>
 
 <div class="govuk-grid-row">

--- a/app/views/errors/eidas_scheme_unavailable.html.erb
+++ b/app/views/errors/eidas_scheme_unavailable.html.erb
@@ -1,4 +1,4 @@
-<%= page_title 'errors.eidas_scheme_unavailable.title' %>
+<%= page_title 'errors.eidas_scheme_unavailable.heading', country_name: @selected_country.display_name %>
 <% content_for :feedback_source, 'EIDAS_SCHEME_UNAVAILABLE_PAGE' %>
 
 <div class="govuk-grid-row">

--- a/app/views/errors/no_cookies.html.erb
+++ b/app/views/errors/no_cookies.html.erb
@@ -1,4 +1,4 @@
-<%= page_title 'errors.no_cookies.title' %>
+<%= page_title 'errors.no_cookies.heading' %>
 <% content_for :feedback_source, 'COOKIE_NOT_FOUND_PAGE' %>
 <% content_for :piwik_custom_path, '/cookies-not-found' %>
 
@@ -6,7 +6,7 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l"><%= t 'errors.no_cookies.heading' %></h1>
     <p><%= t 'errors.no_cookies.access_restriction' %></p>
-    <h2 class="govuk-heading-m"><%= t 'hub.transaction_list.title' %></h2>
+    <h2 class="govuk-heading-m"><%= t 'hub.transaction_list.heading' %></h2>
     <%= render partial: 'shared/transaction_list' %>
     <p><%= t 'errors.no_cookies.read_more_html'  %></p>
     <p class="govuk-inset-text"><%= t 'errors.no_cookies.enable_cookies' %></p>

--- a/app/views/errors/proxy_node_error.html.erb
+++ b/app/views/errors/proxy_node_error.html.erb
@@ -1,4 +1,4 @@
-<%= page_title 'errors.something_went_wrong.title' %>
+<%= page_title 'errors.something_went_wrong.heading' %>
 <% content_for :feedback_source, 'PROXY_NODE_ERROR_PAGE' %>
 
 <div class="govuk-grid-row">

--- a/app/views/errors/session_error.html.erb
+++ b/app/views/errors/session_error.html.erb
@@ -1,4 +1,4 @@
-<%= page_title 'errors.session_error.title' %>
+<%= page_title 'errors.session_error.heading' %>
 <% content_for :feedback_source, 'ERROR_PAGE' %>
 <% content_for :piwik_custom_path, '/errors/session-error' %>
 

--- a/app/views/errors/something_went_wrong.html.erb
+++ b/app/views/errors/something_went_wrong.html.erb
@@ -1,4 +1,4 @@
-<%= page_title 'errors.something_went_wrong.title' %>
+<%= page_title 'errors.something_went_wrong.heading' %>
 <% content_for :feedback_source, 'ERROR_PAGE' %>
 <% content_for :piwik_custom_path, 'errors/generic-error' %>
 
@@ -8,7 +8,7 @@
     <p class="govuk-body"><%= t 'errors.something_went_wrong.error_message' %></p>
     <p class="govuk-body"><%= t 'errors.something_went_wrong.start_again' %></p>
     <% if transaction_taxon_list.any? %>
-      <h2 class="govuk-heading-m"><%= t 'hub.transaction_list.title' %></h2>
+      <h2 class="govuk-heading-m"><%= t 'hub.transaction_list.heading' %></h2>
       <%= render partial: 'shared/transaction_list' %>
     <% end %>
   </div>

--- a/app/views/failed_registration/_custom_failed_registration.html.erb
+++ b/app/views/failed_registration/_custom_failed_registration.html.erb
@@ -1,4 +1,4 @@
-<h1 class="govuk-heading-l"><%= raw transaction.custom_fail_heading  %></h1>
+<h1 class="govuk-heading-l"><%= raw transaction.custom_fail_heading %></h1>
 
 <p class="govuk-body"><%= raw(transaction.custom_fail_what_next_content % { idp_name: idp.display_name }) %></p>
 

--- a/app/views/failed_registration/_non_continue_rp.html.erb
+++ b/app/views/failed_registration/_non_continue_rp.html.erb
@@ -1,4 +1,5 @@
-<h1 class="govuk-heading-l"><%= t 'hub.failed_registration.alt_heading', idp: idp.display_name %></h1>
+<%= page_title 'hub.failed_registration.heading', idp_name: idp.display_name %>
+<h1 class="govuk-heading-l"><%= t 'hub.failed_registration.heading', idp_name: idp.display_name %></h1>
 <p class="govuk-body"><%= t 'hub.failed_registration.you_can_still', service: @transaction.name %></p>
 
 <%= render partial: @remaining_options_partial %>

--- a/app/views/failed_registration/index_LOA1.html.erb
+++ b/app/views/failed_registration/index_LOA1.html.erb
@@ -1,4 +1,4 @@
-<%= page_title 'hub.failed_registration.title' %>
+<%= page_title 'hub.failed_registration.heading', idp_name: @idp.display_name %>
 <% content_for :feedback_source, 'FAILED_REGISTRATION_PAGE' %>
 
 <div class="govuk-grid-row">

--- a/app/views/failed_registration/index_LOA2.html.erb
+++ b/app/views/failed_registration/index_LOA2.html.erb
@@ -1,4 +1,4 @@
-<%= page_title 'hub.failed_registration.title' %>
+<%= page_title 'hub.failed_registration.heading', idp_name: @idp.display_name %>
 <% content_for :feedback_source, 'FAILED_REGISTRATION_PAGE' %>
 
 <div class="govuk-grid-row">

--- a/app/views/failed_registration/index_continue_on_failed_registration_LOA1.html.erb
+++ b/app/views/failed_registration/index_continue_on_failed_registration_LOA1.html.erb
@@ -1,4 +1,4 @@
-<%= page_title 'hub.failed_registration.title' %>
+<%= page_title 'hub.failed_registration.heading', idp_name: @idp.display_name %>
 <% content_for :feedback_source, 'FAILED_REGISTRATION_PAGE' %>
 
 <div class="govuk-grid-row">

--- a/app/views/failed_registration/index_continue_on_failed_registration_LOA2.html.erb
+++ b/app/views/failed_registration/index_continue_on_failed_registration_LOA2.html.erb
@@ -1,4 +1,4 @@
-<%= page_title 'hub.failed_registration.title' %>
+<%= page_title 'hub.failed_registration.heading', idp_name: @idp.display_name %>
 <% content_for :feedback_source, 'FAILED_REGISTRATION_PAGE' %>
 
 <div class="govuk-grid-row">

--- a/app/views/failed_sign_in/country.html.erb
+++ b/app/views/failed_sign_in/country.html.erb
@@ -1,4 +1,4 @@
-<%= page_title 'hub.failed_country_sign_in.title' %>
+<%= page_title 'hub.failed_country_sign_in.heading', country_name: @entity.display_name %>
 <% content_for :feedback_source, 'FAILED_COUNTRY_SIGN_IN_PAGE' %>
 
 <div class="govuk-grid-row">

--- a/app/views/failed_sign_in/idp.html.erb
+++ b/app/views/failed_sign_in/idp.html.erb
@@ -1,4 +1,4 @@
-<%= page_title 'hub.failed_sign_in.title' %>
+<%= page_title 'hub.failed_sign_in.heading', display_name: @entity.display_name %>
 <% content_for :feedback_source, 'FAILED_SIGN_IN_PAGE' %>
 
 <div class="govuk-grid-row">

--- a/app/views/failed_uplift/index.html.erb
+++ b/app/views/failed_uplift/index.html.erb
@@ -1,4 +1,4 @@
-<%= page_title 'hub.failed_uplift.title' %>
+<%= page_title 'hub.failed_uplift.heading', display_name: @idp.display_name %>
 <% content_for :feedback_source, 'FAILED_UPLIFT_PAGE' %>
 
 <div class="govuk-grid-row">

--- a/app/views/feedback/disabled.html.erb
+++ b/app/views/feedback/disabled.html.erb
@@ -1,5 +1,4 @@
-<%= page_title 'hub.feedback_disabled.title' %>
-
+<%= page_title 'hub.feedback_disabled.heading' %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/feedback/index.html.erb
+++ b/app/views/feedback/index.html.erb
@@ -1,4 +1,4 @@
-<%= page_title 'hub.feedback.title' %>
+<%= page_title 'hub.feedback.heading' %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -6,7 +6,7 @@
     <%= render 'shared/form-errors', errors: flash[:errors], form: @form %>
 
     <h1 class="govuk-heading-l"><%= t 'hub.feedback.heading' %></h1>
-    
+
     <%= t 'hub.feedback.introduction_html' %>
 
     <% if @has_email_sending_error %>

--- a/app/views/feedback/sent.html.erb
+++ b/app/views/feedback/sent.html.erb
@@ -1,4 +1,4 @@
-<%= page_title 'hub.feedback_sent.title' %>
+<%= page_title 'hub.feedback_sent.heading' %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/feedback_landing/index.html.erb
+++ b/app/views/feedback_landing/index.html.erb
@@ -1,6 +1,5 @@
-<%= page_title 'hub.feedback_landing.title' %>
+<%= page_title { @feedback_landing_heading } %>
 <% content_for :feedback_source, flash['feedback_source'] %>
-
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -8,7 +7,7 @@
     <h2 class="govuk-heading-m"><%= link_to(t('hub.feedback_landing.idps.heading'), t('hub.feedback_landing.idps.href')) %></h2>
     <p><%= raw t('hub.feedback_landing.idps.description', bank_holidays: link_to(t('hub.feedback_landing.idps.bank_holidays'), "http://www.gov.uk/bank-holidays")) %></p>
 
-    <% unless @other_ways_text.nil? %>
+    <% if @other_ways_text.present? %>
       <h2 class="govuk-heading-m"><%= raw @other_ways_heading %></h2>
       <p><%= raw @other_ways_text %></p>
     <% end %>

--- a/app/views/feedback_sent/index.html.erb
+++ b/app/views/feedback_sent/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, t('hub.feedback_sent.title') %>
+<% content_for :page_title, t('hub.feedback_sent.heading') %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l"><%= t 'hub.feedback_sent.heading' %></h1>
@@ -16,7 +16,7 @@
           <%= link_to t('hub.feedback_sent.session_valid_link'), @link_back %>
       <% else %>
           <%= t('hub.feedback_sent.session_not_valid') %>
-          <h2 class="govuk-heading-m"><%= t 'hub.transaction_list.title' %></h2>
+          <h2 class="govuk-heading-m"><%= t 'hub.transaction_list.heading' %></h2>
           <%= render partial: 'shared/transaction_list' %>
       <% end %>
     </p>

--- a/app/views/further_information/index.html.erb
+++ b/app/views/further_information/index.html.erb
@@ -1,4 +1,4 @@
-<%= page_title 'hub.further_information.title', cycle_three_name: @cycle_three_attribute.field_name %>
+<%= page_title 'hub.further_information.heading', cycle_three_name: @cycle_three_attribute.field_name %>
 <% content_for :feedback_source, 'CYCLE_3_PAGE' %>
 
 <div class="govuk-grid-row">
@@ -26,7 +26,7 @@
                 <%= @cycle_three_attribute.errors[:cycle_three_data].first %>
               </span>
             <% end %>
-          
+
           <%= f.text_field :cycle_three_data, required: true, pattern: h(@cycle_three_attribute.pattern.source),
                             class: 'govuk-input govuk-!-width-three-quarters',
                             'data-msg': t('hub.further_information.attribute_validation_message',

--- a/app/views/further_information/timeout.html.erb
+++ b/app/views/further_information/timeout.html.erb
@@ -1,4 +1,4 @@
-<%= page_title 'hub.further_information.timeout.title' %>
+<%= page_title 'hub.further_information.timeout.heading' %>
 <% content_for :feedback_source, 'TIMEOUT_PAGE' %>
 
 <div class="govuk-grid-row">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,7 +11,7 @@
     <title><%= display_page_title %> - GOV.UK Verify - GOV.UK</title>
 
     <%= tag('meta', name: 'viewport', content: 'width=device-width, initial-scale=1, viewport-fit=cover') %>
-    
+
     <%= tag('meta', name: 'verify|title', content: content_for(:page_title_in_english)) %>
 
     <%= csrf_meta_tags %>
@@ -31,9 +31,9 @@
     <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
 
     <a href="#content" class="govuk-skip-link"><%= t 'navigation.skip_link' %></a>
-    
+
     <% if cookies[:seen_cookie_message].nil? %>
-      
+
       <div id="global-cookie-message">
         <div class="govuk-width-container">
           <div class="govuk-grid-row">
@@ -70,24 +70,24 @@
         </div>
       </div>
     </header>
-    
+
     <div class="govuk-width-container">
-      <main class="govuk-main-wrapper govuk-!-padding-top-0" id="content" role="main">        
+      <main class="govuk-main-wrapper govuk-!-padding-top-0" id="content" role="main">
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-two-thirds">&nbsp;</div>
           <div class="govuk-grid-column-one-third hide-mobile">
             <%= render 'shared/available_languages' unless @hide_available_languages %>
           </div>
         </div>
-        
+
           <%= content_for?(:main) ? yield(:main) : yield %>
 
           <div class="govuk-grid-row">
             <div class="govuk-grid-column-full">
-              <%= render 'shared/feedback_landing_link' if feedback_source.present? && !@hide_feedback_link %>      
+              <%= render 'shared/feedback_landing_link' if feedback_source.present? && !@hide_feedback_link %>
             </div>
           </div>
-        
+
           <div class="verify-logo-right">
             <%= image_tag 'govuk-verify-small-black-text.png', srcset: "#{asset_path 'govuk-verify-small-black-text.svg'} 1x", alt: ' ', role:'presentation' %>
           </div>
@@ -103,14 +103,14 @@
             <h2 class="govuk-visually-hidden"><%= t 'footer.support_links' %></h2>
             <ul class="govuk-footer__inline-list">
               <li class="govuk-footer__inline-list-item"><a href="https://www.gov.uk/help" hreflang="en"><%= t 'footer.help' %></a></li>
-              <li class="govuk-footer__inline-list-item"><%= link_to(t('hub.accessibility.title'), accessibility_path) %></li>
-              <li class="govuk-footer__inline-list-item"><%= link_to(t('hub.cookies.title'), cookies_path) %></li>
-              <li class="govuk-footer__inline-list-item"><%= link_to(t('hub.privacy_notice.title'), privacy_notice_path) %></li>
+              <li class="govuk-footer__inline-list-item"><%= link_to(t('hub.accessibility.heading'), accessibility_path) %></li>
+              <li class="govuk-footer__inline-list-item"><%= link_to(t('hub.cookies.heading'), cookies_path) %></li>
+              <li class="govuk-footer__inline-list-item"><%= link_to(t('hub.privacy_notice.heading'), privacy_notice_path) %></li>
               <li class="govuk-footer__inline-list-item">
               <% if feedback_source.present? %>
-                  <%= raw link_to(t('hub.feedback.title'), feedback_path('feedback-source' => feedback_source)) %>
+                  <%= raw link_to(t('hub.feedback.heading'), feedback_path('feedback-source' => feedback_source)) %>
               <% else %>
-                  <%= link_to(t('hub.feedback.title'), feedback_path) %>
+                  <%= link_to(t('hub.feedback.heading'), feedback_path) %>
               <% end %>
               </li>
               <li class="govuk-footer__inline-list-item"><%= t 'footer.built_by_the' %> <a href="https://gds.blog.gov.uk" lang="en" hreflang="en">Government Digital Service</a></li>
@@ -131,7 +131,7 @@
         </div>
       </div>
     </footer>
-    
+
     <%= javascript_include_tag 'application', nonce: true %>
     <script>window.GOVUKFrontend.initAll()</script>
   </body>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,7 +8,7 @@
        <meta http-equiv="refresh" content="<%= yield(:meta_refresh) %>">
     <% end %>
 
-    <title><%= display_page_title %> - GOV.UK Verify - GOV.UK</title>
+    <title><%= display_page_title %> - GOV.UK Verify</title>
 
     <%= tag('meta', name: 'viewport', content: 'width=device-width, initial-scale=1, viewport-fit=cover') %>
 

--- a/app/views/no_idps_available/no_idps_available.html.erb
+++ b/app/views/no_idps_available/no_idps_available.html.erb
@@ -1,4 +1,4 @@
-<%= page_title 'hub.no_idps_available.title' %>
+<%= page_title 'hub.no_idps_available.heading' %>
 <% content_for :feedback_source, 'NO_IDPS_AVAILABLE' %>
 
 <div class="govuk-grid-row">

--- a/app/views/other_ways_to_access_service/after_eidas.html.erb
+++ b/app/views/other_ways_to_access_service/after_eidas.html.erb
@@ -1,4 +1,4 @@
-<%= page_title 'hub.other_ways_after_eidas.title' %>
+<%= page_title 'hub.other_ways_after_eidas.heading', other_ways_description: @other_ways_description %>
 <% content_for :feedback_source, 'OTHER_WAYS_AFTER_EIDAS_PAGE' %>
 
 <div class="govuk-grid-row">

--- a/app/views/other_ways_to_access_service/index.html.erb
+++ b/app/views/other_ways_to_access_service/index.html.erb
@@ -1,4 +1,4 @@
-<%= page_title 'hub.other_ways_title' %>
+<%= page_title 'hub.other_ways_heading', other_ways_description: @other_ways_description %>
 <% content_for :feedback_source, 'OTHER_WAYS_PAGE' %>
 
 <div class="govuk-grid-row">

--- a/app/views/paused_registration/from_resume_link.html.erb
+++ b/app/views/paused_registration/from_resume_link.html.erb
@@ -1,4 +1,4 @@
-<%= page_title 'hub.paused_registration.from_resume_link.title', idp_name: @idp_display_data.name %>
+<%= page_title 'hub.paused_registration.from_resume_link.heading', idp_name: @idp_display_data.name %>
 <% content_for :feedback_source, 'PAUSED_REGISTRATION_PAGE' %>
 
 <div class="govuk-grid-row">
@@ -7,7 +7,7 @@
 
     <p><%= t 'hub.paused_registration.from_resume_link.restart_instructions_html', idp_name: @idp_display_data.name %></p>
 
-    <h2 class="govuk-heading-m"><%= t 'hub.transaction_list.title' %></h2>
+    <h2 class="govuk-heading-m"><%= t 'hub.transaction_list.heading' %></h2>
     <%= render partial: 'shared/transaction_list_prefer_headless_start' %>
   </div>
 </div>

--- a/app/views/paused_registration/resume.html.erb
+++ b/app/views/paused_registration/resume.html.erb
@@ -1,4 +1,4 @@
-<%= page_title 'hub.paused_registration.resume.title', display_name: @idp.display_name %>
+<%= page_title 'hub.paused_registration.resume.heading', display_name: @idp.display_name %>
 <% content_for :body_classes, 'hub-start' %>
 <% content_for :feedback_source, 'RESUME_PAGE' %>
 
@@ -17,7 +17,7 @@
                       type: 'submit'
         %>
       <% end %>
-      
+
       <p class="govuk-body"><%= t('hub.paused_registration.resume.alternatives') %></p>
       <ul class="govuk-list govuk-list--bullet">
         <li><%= link_to t('hub.paused_registration.resume.alternative_new_identity'), begin_registration_path %></li>

--- a/app/views/paused_registration/with_user_session.html.erb
+++ b/app/views/paused_registration/with_user_session.html.erb
@@ -1,4 +1,4 @@
-<%= page_title 'hub.paused_registration.with_session.title', idp_name: @idp.display_name %>
+<%= page_title 'hub.paused_registration.with_session.heading', idp_name: @idp.display_name %>
 <% content_for :feedback_source, 'PAUSED_REGISTRATION_PAGE' %>
 
 <div class="govuk-grid-row">

--- a/app/views/paused_registration/without_user_session.html.erb
+++ b/app/views/paused_registration/without_user_session.html.erb
@@ -1,4 +1,4 @@
-<%= page_title 'hub.paused_registration.without_session.title' %>
+<%= page_title 'hub.paused_registration.without_session.heading' %>
 <% content_for :feedback_source, 'PAUSED_REGISTRATION_PAGE' %>
 
 <div class="govuk-grid-row">
@@ -7,7 +7,7 @@
 
     <p><%= t 'hub.paused_registration.without_session.restart_instructions_html' %></p>
 
-    <h2 class="govuk-heading-m"><%= t 'hub.transaction_list.title' %></h2>
+    <h2 class="govuk-heading-m"><%= t 'hub.transaction_list.heading' %></h2>
     <%= render partial: 'shared/transaction_list' %>
   </div>
 </div>

--- a/app/views/prove_identity/prove_identity.html.erb
+++ b/app/views/prove_identity/prove_identity.html.erb
@@ -1,4 +1,4 @@
-<%= page_title 'hub.prove_identity.title' %>
+<%= page_title 'hub.prove_identity.heading' %>
 <% content_for :feedback_source, 'PROVE_IDENTITY_PAGE' %>
 
 <div class="govuk-grid-row">

--- a/app/views/redirect_to_country/index.html.erb
+++ b/app/views/redirect_to_country/index.html.erb
@@ -1,4 +1,4 @@
-<%= page_title 'hub.redirect_to_country.title' %>
+<%= page_title 'hub.redirect_to_country.heading' %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/redirect_to_idp/redirect_to_idp.html.erb
+++ b/app/views/redirect_to_idp/redirect_to_idp.html.erb
@@ -1,4 +1,4 @@
-<% page_title 'hub.redirect_to_idp.title' %>
+<% page_title 'hub.redirect_to_idp.heading' %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/response_processing/index.html.erb
+++ b/app/views/response_processing/index.html.erb
@@ -1,4 +1,4 @@
-<%= page_title 'hub.response_processing.title' %>
+<%= page_title 'hub.response_processing.heading', rp_name: @rp_name %>
 <% content_for :meta_refresh, '2' %>
 
 <div class="govuk-grid-row no-right-hand-logo">

--- a/app/views/response_processing/matching_error.html.erb
+++ b/app/views/response_processing/matching_error.html.erb
@@ -1,4 +1,4 @@
-<%= page_title 'errors.something_went_wrong.title' %>
+<%= page_title 'hub.response_processing.matching_error.heading' %>
 <% content_for :feedback_source, error_feedback_source %>
 
 <div class="govuk-grid-row">

--- a/app/views/select_documents/advice.html.erb
+++ b/app/views/select_documents/advice.html.erb
@@ -1,4 +1,4 @@
-<%= page_title 'hub.select_documents_advice.title' %>
+<%= page_title 'hub.select_documents_advice.advice_html.heading' %>
 <% content_for :feedback_source, 'SELECT_DOCUMENTS_ADVICE_PAGE' %>
 
 <div class="govuk-grid-row">

--- a/app/views/select_documents/index.html.erb
+++ b/app/views/select_documents/index.html.erb
@@ -1,4 +1,4 @@
-<%= page_title 'hub.select_documents.title' %>
+<%= page_title 'hub.select_documents.heading' %>
 <% content_for :feedback_source, 'SELECT_DOCUMENTS_PAGE' %>
 
 <div class="govuk-grid-row">
@@ -49,7 +49,7 @@
 
         <details id="progressive_disclosure"  piwik_event_tracking="progressive_disclosure" class="govuk-details govuk-!-padding-top-6" data-module="govuk-details">
           <summary class="govuk-details__summary">
-            <span class="govuk-details__summary-text"><%= t 'hub.select_documents.further_explanation.title' %></span>
+            <span class="govuk-details__summary-text"><%= t 'hub.select_documents.further_explanation.heading' %></span>
           </summary>
           <div class="govuk-details__text">
             <%= t 'hub.select_documents.further_explanation.content_html' %>

--- a/app/views/select_documents/prove_your_identity_another_way.html.erb
+++ b/app/views/select_documents/prove_your_identity_another_way.html.erb
@@ -1,4 +1,4 @@
-<%= page_title 'hub.select_documents.title' %>
+<%= page_title 'hub.prove_your_identity_another_way.heading' %>
 <% content_for :feedback_source, 'PROVE_YOUR_IDENTITY_ANOTHER_WAY_PAGE' %>
 
 <div class="govuk-grid-row">

--- a/app/views/shared/_disconnected_idp_list.erb
+++ b/app/views/shared/_disconnected_idp_list.erb
@@ -1,5 +1,5 @@
 
-<h2 class="govuk-heading-m"><%= t 'hub.certified_companies_disconnected.title' %></h2>
+<h2 class="govuk-heading-m"><%= t 'hub.certified_companies_disconnected.heading' %></h2>
 <p><%=
   t('hub.certified_companies_disconnected.verify_another_company_html',
     link: link_to(t('hub.certified_companies_disconnected.verify_another_company_link'), begin_registration_path, id: 'begin-registration-route-2')

--- a/app/views/shared/_unavailable_idp_list.erb
+++ b/app/views/shared/_unavailable_idp_list.erb
@@ -1,6 +1,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h2 class="govuk-heading-m"><%= t('hub.certified_companies_unavailable.title',
+    <h2 class="govuk-heading-m"><%= t('hub.certified_companies_unavailable.heading',
                                      count: unavailable_identity_providers.length,
                                      company: unavailable_identity_providers.first.display_name) %></h2>
     <p><%=

--- a/app/views/shared/sign_in_hint.html.erb
+++ b/app/views/shared/sign_in_hint.html.erb
@@ -1,4 +1,4 @@
-<%= page_title 'hub.sign_in_hint.title' %>
+<%= page_title 'hub.sign_in_hint.heading' %>
 <% content_for :feedback_source, 'START_PAGE' %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full js-continue-to-idp" data-location="<%= url_for(controller: 'sign_in', action: 'select_idp_ajax', locale: I18n.locale)  %>">

--- a/app/views/sign_in/index.html.erb
+++ b/app/views/sign_in/index.html.erb
@@ -1,4 +1,4 @@
-<%= page_title 'hub.signin.title' %>
+<%= page_title 'hub.signin.heading' %>
 <% content_for :feedback_source, 'SIGN_IN_PAGE' %>
 
 <div class="govuk-grid-row">

--- a/app/views/single_idp_journey/continue_to_your_idp.html.erb
+++ b/app/views/single_idp_journey/continue_to_your_idp.html.erb
@@ -1,4 +1,4 @@
-<%= page_title 'hub.single_idp_journey.title', display_name: @idp.display_name %>
+<%= page_title 'hub.single_idp_journey.heading', display_name: @idp.display_name %>
 <% content_for :feedback_source, 'CONTINUE_TO_YOUR_IDP_PAGE' %>
 
 <div class="govuk-grid-row">
@@ -16,7 +16,7 @@
                           type: 'submit'
             %>
         <% end %>
-        
+
         <p class="govuk-body"><%= t('hub.single_idp_journey.alternatives') %></p>
         <ul class="govuk-list govuk-list--bullet">
           <li><%= link_to t('hub.single_idp_journey.alternative_one'), start_path %></li>

--- a/app/views/start/start.html.erb
+++ b/app/views/start/start.html.erb
@@ -1,4 +1,4 @@
-<%= page_title 'hub.start.title', {}, @journey_hint %>
+<%= page_title 'hub.start.heading', {}, @journey_hint %>
 <% content_for :body_classes, 'hub-start' %>
 <% content_for :feedback_source, 'START_PAGE' %>
 <% # Uses slide layout %>

--- a/app/views/static/forgot_company.cy.html.erb
+++ b/app/views/static/forgot_company.cy.html.erb
@@ -1,4 +1,4 @@
-<%= page_title 'hub.forgot_company.title' %>
+<%= page_title 'hub.forgot_company.heading' %>
 <% content_for :feedback_source, 'FORGOT_COMPANY_PAGE' %>
 
 <div class="govuk-grid-row">

--- a/app/views/static/forgot_company.en.html.erb
+++ b/app/views/static/forgot_company.en.html.erb
@@ -1,4 +1,4 @@
-<%= page_title 'hub.forgot_company.title' %>
+<%= page_title 'hub.forgot_company.heading' %>
 <% content_for :feedback_source, 'FORGOT_COMPANY_PAGE' %>
 
 <div class="govuk-grid-row">

--- a/app/views/static/verify_services.html.erb
+++ b/app/views/static/verify_services.html.erb
@@ -1,4 +1,4 @@
-<%= page_title 'hub.verify_services.title' %>
+<%= page_title 'hub.verify_services.heading' %>
 
 <% content_for :feedback_source, 'VERIFY_SERVICES_PAGE' %>
 <% content_for :show_to_search_engine, true %>

--- a/app/views/why_companies_loa1/why_companies_LOA1.html.erb
+++ b/app/views/why_companies_loa1/why_companies_LOA1.html.erb
@@ -1,10 +1,10 @@
-<%= page_title 'hub.why_companies.title' %>
+<%= page_title 'hub.why_companies.heading' %>
 <% content_for :feedback_source, 'WHY_COMPANIES_PAGE' %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= link_to t('navigation.back'), choose_a_certified_company_path, class: 'govuk-back-link' %>
-    <h1 class="govuk-heading-l"><%= t('hub.why_companies.title') %></h1>
+    <h1 class="govuk-heading-l"><%= t('hub.why_companies.heading') %></h1>
     <%= t('hub.why_companies.content_loa1_html') %>
     <p><%= link_to(t('hub.why_companies.choose_a_company'), choose_a_certified_company_path) %></p>
   </div>

--- a/app/views/why_companies_loa2/why_companies_LOA2.html.erb
+++ b/app/views/why_companies_loa2/why_companies_LOA2.html.erb
@@ -1,10 +1,10 @@
-<%= page_title 'hub.why_companies.title' %>
+<%= page_title 'hub.why_companies.heading' %>
 <% content_for :feedback_source, 'WHY_COMPANIES_PAGE' %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= link_to t('navigation.back'), choose_a_certified_company_path, class: 'govuk-back-link' %>
-    <h1 class="govuk-heading-l"><%= t('hub.why_companies.title') %></h1>
+    <h1 class="govuk-heading-l"><%= t('hub.why_companies.heading') %></h1>
     <%= t('hub.why_companies.content_html') %>
     <p><%= link_to(t('hub.why_companies.choose_a_company'), choose_a_certified_company_path) %></p>
   </div>

--- a/app/views/will_it_work_for_me/index.html.erb
+++ b/app/views/will_it_work_for_me/index.html.erb
@@ -1,4 +1,4 @@
-<%= page_title 'hub.will_it_work_for_me.title' %>
+<%= page_title 'hub.will_it_work_for_me.heading' %>
 <% content_for :feedback_source, 'WILL_IT_WORK_FOR_ME_PAGE' %>
 
 <div class="govuk-grid-row">
@@ -61,7 +61,7 @@
                   <fieldset class="govuk-fieldset">
                     <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
                       <h2 class="govuk-heading-s">
-                        <%= t 'hub.will_it_work_for_me.question.not_resident_reason.title' %>
+                        <%= t 'hub.will_it_work_for_me.question.not_resident_reason.sub_heading' %>
                       </h2>
                     </legend>
                     <% if @form.errors.include?(:not_resident_reason_moved_recently) %>
@@ -89,7 +89,7 @@
               </div>
             </div>
           </fieldset>
-        </div>       
+        </div>
 
         <div class="govuk-error-message" id="validation-error-message-js"></div>
 

--- a/app/views/will_it_work_for_me/may_not_work_if_you_live_overseas.html.erb
+++ b/app/views/will_it_work_for_me/may_not_work_if_you_live_overseas.html.erb
@@ -1,4 +1,4 @@
-<%= page_title 'hub.may_not_work_if_you_live_overseas.title' %>
+<%= page_title 'hub.may_not_work_if_you_live_overseas.heading' %>
 <% content_for :feedback_source, 'MAY_NOT_WORK_IF_YOU_LIVE_OVERSEAS_PAGE' %>
 
 <div class="govuk-grid-row">

--- a/app/views/will_it_work_for_me/why_might_this_not_work_for_me.html.erb
+++ b/app/views/will_it_work_for_me/why_might_this_not_work_for_me.html.erb
@@ -1,4 +1,4 @@
-<%= page_title 'hub.why_might_this_not_work_for_me.title' %>
+<%= page_title 'hub.why_might_this_not_work_for_me.heading' %>
 <% content_for :feedback_source, 'WHY_THIS_MIGHT_NOT_WORK_FOR_ME_PAGE' %>
 
 <div class="govuk-grid-row">

--- a/app/views/will_it_work_for_me/will_not_work_without_uk_address.html.erb
+++ b/app/views/will_it_work_for_me/will_not_work_without_uk_address.html.erb
@@ -1,4 +1,4 @@
-<%= page_title 'hub.will_not_work_without_uk_address.title' %>
+<%= page_title 'hub.will_not_work_without_uk_address.heading' %>
 <% content_for :feedback_source, 'WILL_NOT_WORK_WITHOUT_UK_ADDRESS_PAGE' %>
 
 <div class="govuk-grid-row">

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -99,8 +99,6 @@ cy:
     help: Help
     built_by_the: Adeiladwyd gan yr
   hub:
-    about:
-      title: About
     about_what_is_verify:
       heading: What GOV.UK Verify is
       content: GOV.UK Verify is a secure way to prove who you are online. It helps protect you against online identity theft.
@@ -111,7 +109,6 @@ cy:
       content_html: <p class="govuk-body">The company will ask you questions and check your identity documents.</p>
         <p class="govuk-body">It will never share your information for any other purpose without your consent.</p>
     select_documents:
-      title: Your documents
       heading: Which of these do you have available right now?
       explanation: This will help us tell you if GOV.UK Verify will work for you. The more items you have, the more likely it is that you can verify your identity.
       select_all_that_apply: "Select all that apply:"
@@ -122,7 +119,7 @@ cy:
       has_nothing: None of the above
       has_driving_license_and_credit_card: A full or provisional driving licence with your photo on it and a credit or debit card
       further_explanation:
-        title: What GOV.UK Verify uses these for
+        heading: What GOV.UK Verify uses these for
         content_html: |
           <p class="govuk-body">
             The companies can check your passport and driving licence against official records.
@@ -140,7 +137,6 @@ cy:
       errors:
         no_selection: Select the items you have available right now
     select_documents_advice:
-      title: Advice about your documents
       advice_html:
         heading: You need more evidence to verify your identity
         sub_heading: 'To use GOV.UK Verify, you also need either:'
@@ -158,7 +154,6 @@ cy:
           <p class="govuk-body">If you have these things but they’re somewhere else, come back when you have them with you.</p>
           <p class="govuk-body">%{prove_your_identity_link} if you do not have these things.</p>
     choose_a_certified_company:
-      title: Pick a certified company
       heading: Pick a company to verify you
       intro: One of these companies will create your identity account.
       idp_count: You can pick either company.
@@ -180,7 +175,7 @@ cy:
         information_provided_by: Information provided by %{display_name}
         close: close
       about:
-        title: About %{display_name}
+        heading: About %{display_name}
         information_provided_by: Information provided by %{display_name}
         close: close
     prove_your_identity_another_way:
@@ -189,7 +184,6 @@ cy:
     other_ways_title: Other ways to access the service
     other_ways_heading: Other ways to %{other_ways_description}
     other_ways_after_eidas:
-      title: Gwlad heb ei rhestru
       heading: Ffyrdd eraill o %{other_ways_description}
       explanation: Os nad yw'ch cynllun hunaniaeth ddigidol ar gael eto, gallwch brofi pwy ydych mewn ffordd arall o %{other_ways_description}.
       verify:
@@ -205,7 +199,6 @@ cy:
         button: Defnyddiwch GOV.UK Verify
       cannot_verify: Beth i'w wneud os na allwch ddefnyddio GOV.UK Verify
     choose_a_country:
-      title: Dewiswch wlad
       heading: Defnyddio hunaniaeth digidol o wlad Ewropeaidd arall
       description: Gallwch ddefnyddio hunaniaeth digidol o wlad Ewropeaidd arall i gael mynediad i wasanaethau ar GOV.UK.
       eu_exit_warn: Ni fyddwch yn gallu defnyddio hunaniaeth digidol o wlad Ewropeaidd arall i gael mynediad i wasanaethau ar GOV.UK ar ôl 31 Rhagfyr 2020.
@@ -214,11 +207,9 @@ cy:
       country_not_listed_link: "%{other_ways_description}."
       select_label: "Dewis %{scheme_name}"
     redirect_to_country:
-      title: Ailgyfeirio i wlad
       heading: Mynd ymlaen i’r cam nesaf
       description: Oherwydd nad yw Javascript wedi’i alluogi ar eich porwr, mae’n rhaid i chi bwyso’r botwm parhau
     prove_identity:
-      title: Profwch eich hunaniaeth i barhau
       heading: Profwch eich hunaniaeth i barhau
       header_content: Dewiswch sut rydych eisiau profi eich hunaniaeth er mwyn i chi allu
       use_verify:
@@ -237,7 +228,6 @@ cy:
           <p class="govuk-body">Os ydych yn rhan o gynllun ID mewn gwlad sy'n cymryd rhan, efallai y gallwch ei ddefnyddio yma.</p>
         button_text: Dewiswch eich hunaniaeth digidol Ewropeaidd
     start:
-      title: Dechrau
       heading: Mewngofnodi gyda GOV.UK Verify
       answer_yes: Dyma’r tro cyntaf i mi ddefnyddio Verify
       answer_no: Rwyf wedi defnyddio Verify o’r blaen
@@ -245,7 +235,6 @@ cy:
       continue: Parhau
       error_message: Dewiswch opsiwn
     signin:
-      title: Mewngofnodi gyda chwmni ardystiedig
       heading: Gyda phwy mae gennych gyfrif hunaniaeth?
       back: Yn ôl
       about_link: Dechreuwch nawr
@@ -259,19 +248,17 @@ cy:
       company_no_longer_verifies_text: Os oes gennych gyfrif hunaniaeth gyda %{company}, bydd angen i chi o %{link}.
       company_no_longer_verifies_link: dilysu eich hunaniaeth gyda chwmni arall
     cookies:
-      title: Cwcis
+      heading: Cwcis
     privacy_notice:
-      title: Hysbysiad preifatrwydd
+      heading: Hysbysiad preifatrwydd
     verify_services:
-      title: Gwasanaethau Verify
       heading: GOV.UK Verify
       message: "Mae GOV.UK Verify yn newydd ac mae gwasanaethau’r llywodraeth yn ymuno drwy’r amser. Y gwasanaethau presennol sy’n defnyddio Verify yw:"
     transaction_list:
-      title: Dod o hyd i’r gwasanaeth rydych yn ei ddefnyddio i ddechrau eto
+      heading: Dod o hyd i’r gwasanaeth rydych yn ei ddefnyddio i ddechrau eto
       hint: Dilynnwch y cyfarwyddiadau rydych wedi’u derbyn.
       other_services: Gwasanaethau eraill
     about_choosing_a_company:
-      title: Am ddewis cwmni
       heading: Dod o hyd i’r cwmni iawn i’ch dilysu chi
       content_html: |
         <p class="govuk-body">Mae cwmnïau ardystiedig wedi adeiladu systemau newydd, diogel i ddilysu hunaniaeth. Mae'r systemau hyn yn gweithio trwy wirio:</p>
@@ -282,14 +269,13 @@ cy:
         <p class="govuk-body">Fodd bynnag, mae gan bob cwmni ddulliau gwahanol ar gyfer pob un o'r camau hyn.</p>
         <p class="govuk-body">Felly byddwn nawr yn gofyn rhai cwestiynau i chi wirio pa gwmnïau all eich dilysu. Byddwn wedyn yn eich anfon at wefan y cwmni rydych yn ei ddewis.</p>
     will_it_work_for_me:
-      title: Allai i gael fy nilysu?
       heading: Amdanoch chi
       question:
         option_yes: Ydw
         above_age_threshold: Ydych chi’n 20 oed neu drosodd?
         resident_last_12_months: Ydych chi wedi byw yn y DU am y 12 mis diwethaf?
         not_resident_reason:
-          title: Pa un o’r rhain sy’n berthnasol i chi?
+          sub_heading: Pa un o’r rhain sy’n berthnasol i chi?
           recently: Rwyf wedi symud i’r DU yn y 12 mis diwethaf
           not_resident: Mae gennyf gyfeiriad yn y DU ond nid wyf yn byw yno
           no_address: Nid oes gennyf gyfeiriad yn y DU
@@ -299,7 +285,6 @@ cy:
           resident_12_months: Please tell us if you lived in the UK for the last 12 months
           not_resident_reason: Dewiswch opsiwn
     idp_wont_work_for_you_one_doc:
-      title: Ni all %{idp_name} cadarnhau pwy ydych chi
       heading: Ni all %{idp_name} cadarnhau pwy ydych chi
       choose_another_company: Mae'n rhaid i chi ddewis cwmni ardystiedig wahanol i wirio eich hunaniaeth.
       choose_another_certified_company_link: Dewiswch gwmni arall
@@ -308,7 +293,6 @@ cy:
       content_html: |
         <p class="govuk-body">Yn seiliedig ar eich atebion, nid oes unrhyw un o'r darparwyr hunaniaeth (a elwir hefyd yn gwmnïau ardystiedig) sy'n gweithio gyda GOV.UK Verify yn gallu cadarnhau'ch hunaniaeth.</p>
     may_not_work_if_you_live_overseas:
-      title: Efallai na fyddwch yn gallu cael eich hunaniaeth wedi’i ddilysu
       heading: Efallai na fyddwch yn gallu cael eich hunaniaeth wedi’i ddilysu
       try_to_verify: Hoffwn roi cynnig ar ddilysu fy hunaniaeth ar-lein
       explanation1: I ddilysu hunaniaeth, mae cwmnïau ardystiedig yn cael mynediad i gofnodion credyd ac yna gallant ofyn i chi gadarnhau’r wybodaeth hyn. Mae gan y mwyfrif o bobl sy’n byw y tu allan i’r DU hanes gweithgaredd cyfyngedig ar eu cofnod credyd y DU, felly efallai na fydd cwmnïau yn gallu gwirio eich hunaniaeth yn y ffordd hyn.
@@ -325,7 +309,6 @@ cy:
       mail_order_account: cyfrif archebu drwy’r post
       youll_also_need: Byddwch hefyd angen pasport y DU neu drwydded yrru’r DU.
     why_might_this_not_work_for_me:
-      title: Pam efallai na fydd hyn yn gweithio i mi
       heading: Efallai na fyddwch yn gallu cael eich hunaniaeth wedi’i ddilysu
       try_to_verify: Hoffwn roi cynnig ar ddilysu fy hunaniaeth ar-lein
       explanation: I ddilysu hunaniaeth, mae cwmnïau ardystiedig yn cael mynediad i’ch cofnodion credyd ac yna yn gofyn i chi gadarnhau’r wybodaeth hyn. Mae gan y mwyafrif o bobl ifanc a newydd ddyfodiaid i’r DU &lsquo;hanes credyd&rsquo; cyfyngedig, efallai na fydd cwmnïau yn gallu gwirio eich hunaniaeth yn y ffordd hyn.
@@ -340,11 +323,10 @@ cy:
       registered_to_vote: rydych wedi cofrestru i bleidleisio
       youll_also_need: Byddwch hefyd angen pasport y DU neu drwydded yrru’r DU.
     will_not_work_without_uk_address:
-      title: Ni fydd GOV.UK Verify yn gweithio i chi
       heading: Ni fyddwch yn gallu defnyddio GOV.UK Verify
       explanation: Rydych angen cyfeiriad presennol yn y DU i gael eich hunaniaeth wedi’i ddilysu.
     why_companies:
-      title: Pam fod dewis o gwmnïau
+      heading: Pam fod dewis o gwmnïau
       choose_a_company: Dewiswch gwmni
       content_html: |
         <p class="govuk-body">Mae mwy nag un cwmni ardystiedig yn golygu system mwy diogel - nid yw gwybodaeth yn cael ei gadw mewn un lle, ond mae’n cael ei rannu mewn nifer o wahannol lefydd, sydd yn ei gwneud yn fwy diogel.</p>
@@ -359,7 +341,7 @@ cy:
         <p class="govuk-body">Mae cwmnïau ardystiedig yn bodloni safoau preifatrwydd llym y llywodraeth, felly gallwch ymddiried ynddynt gyda’ch gwybodaeth. Ni fyddant yn defnyddio eich gwybodaeth ar gyfer unrhyw ddibenion eraill heb eich caniatâd.</p>
         <p class="govuk-body">Nid oes effaith ar eich sgor credyd.</p>
     redirect_to_idp_warning:
-      title: Byddwch nawr yn cael eich ailgyfeirio
+      heading: Byddwch nawr yn cael eich ailgyfeirio
       create_account: Crëwch eich cyfrif hunaniaeth %{display_name}
       continue_website: Parhau i wefan %{display_name}
       identity_account_use_html: |
@@ -369,7 +351,6 @@ cy:
       other_ways_link: ffyrdd eraill i %{transaction}
       no_docs_other_ways_message_html: "%{idp_no_docs_requirement}, mae %{other_ways_link}"
     redirect_to_idp_question:
-      title: Cwestiwn ychwanegol
       heading: Dilysu gyda %{display_name}
       loa1_heading: Sefydlu cyfrif %{display_name}
       answer_yes: Ydw
@@ -382,20 +363,16 @@ cy:
       or_html: neu %{choose_another_company_link}
       validation_message: Dewiswch opsiwn
     confirm_your_identity:
-      title: Cadarnhau eich hunaniaeth
       use_other_idp: Os nad hwn yw’r cwmni a wnaeth eich dilysu, %{sign_in_link}.
       sign_in_link_message: llofnodwch i mewn gyda chwmni ardystiedig gwahanol
       need_to_signin_again: Er mwyn %{transaction_name}, mae angen i chi lofnodi i mewn eto gyda’ch cwmni ardystiedig. Nid oes angen i chi gofrestru eto.
     confirmation:
-      title: Mae eich hunaniaeth wedi cael ei ddilysu
       message: Gallwch fewngofnodi ble bynnag rydych yn gweld logo GOV.UK Verify gyda'ch enw defnyddiwr a chyfrinair eich cyfrif hunaniaeth %{display_name}
       continue_to_rp: Gallwch nawr ddefnyddio %{transaction_name}.
       heading: Mae %{display_name} wedi dilysu eich hunaniaeth
       add_security_loa1: Pan fyddwch yn defnyddio rhai o wasanaethau'r llywodraeth, gofynnir i chi ddarparu mwy o dystiolaeth gan fod angen i'r gwasanaethau hyn fod yn hyderus nad yw rhywun arall yn honni i fod yn chi.
       extra_security: Gwasanaethau'r llywodraeth sydd angen tystiolaeth ychwanegol
     failed_registration:
-      title: Methu dilysu eich hunaniaeth
-      alt_heading: "%{idp} could not verify your identity"
       you_can_still: You can still %{service}
       your_account_with_heading: Your account with %{idp}
       your_account_with_text: "%{idp} will not contact you or use your data for anything that is not related to your account. You can contact %{idp} for more help."
@@ -422,21 +399,18 @@ cy:
       try_another_summary: Ceisiwch wirio gyda chwmni ardystiedig arall
       contact_details_intro: Cysylltwch â %{idp_name}
     failed_country_sign_in:
-      title: Methu eich mewngofnodi
       heading: Mae'r cynllun hunaniaeth yn eich gwlad wedi methu â chadarnhau eich hunaniaeth.
       other_ways: "Mae yna ffyrdd eraill y gallwch %{other_ways_description}."
       online_link: Ffyrdd eraill i brofi eich hunaniaeth ar-lein
       online: Ar-lein
       offline: All-lein
     failed_sign_in:
-      title: Methu eich mewngofnodi
       heading: Ni all %{display_name} eich mewngofnodi
       reasons_html: |
         <p class="govuk-body">Efallai eich bod wedi dewis y cwmni anghywir. Edrychwch ar eich e-byst a negeseuon testun am gadarnhad o bwy wnaeth eich dilysu.</p>
         <p class="govuk-body">Gallwch gael eich dilysu gan gwmni arall unrhyw bryd. Ni fyddwch yn colli unrhyw ddata ar wasanaethau GOV.UK rydych wedi’u defnyddio.</p>
       start_again: Dechrau eto
     failed_uplift:
-      title: Methwyd yr ymgodiad
       heading: "Nid oedd %{display_name} yn gallu dilysu'r dystiolaeth a ddarparwyd gennych"
       reasons_html: |
         <p class="govuk-body">Mae ychydig o resymau pam allai hyn ddigwydd, yn cynnwys:</p>
@@ -453,7 +427,6 @@ cy:
       other_ways_summary: Gweld ffyrdd eraill o %{other_ways_description}
       contact_summary: Cysylltwch â %{idp_name}
     response_processing:
-      title: Arhoswch
       heading: Mae %{rp_name} yn prosesu eich manylion
       bear_with_us: Gallai hyn gymryd ychydig o eiliadau, diolch am eich amynedd.
       matching_error:
@@ -463,24 +436,22 @@ cy:
         online: Ar-lein
         offline: All-lein
     forgot_company:
-      title: Cyngor ar gyfer cwmni sydd wedi’i anghofio
+      heading: Cyngor ar gyfer cwmni sydd wedi’i anghofio
     redirect_to_service:
       heading: Mynd ymlaen i'r cam nesaf
       signing_in:
-        title: Arhoswch. Yn eich mewngofnodi
+        heading: Arhoswch. Yn eich mewngofnodi
         transition_heading: Mae %{rp_name} yn prosesu eich manylion
       start_again:
-        title: Arhoswch. Dechrau eto.
+        heading: Arhoswch. Dechrau eto.
         transition_heading: Dechrau eto
       no_javascript: Oherwydd nad yw Javascript wedi'i alluogi ar eich porwr, mae'n rhaid i chi bwyso'r botwm parhau
       loading: Llwytho…
       please_wait: Gall hyn gymryd ychydig o eiliadau, arhoswch gyda ni.
     redirect_to_idp:
-      title: Llwytho
       heading: Mynd ymlaen i’r cam nesaf
       description: Oherwydd nad yw Javascript wedi’i alluogi ar eich porwr, mae’n rhaid i chi bwyso’r botwm parhau
     feedback_landing:
-      title: Help
       basic_heading: Cael help i ddefnyddio GOV.UK Verify
       heading: Cael help i gael mynediad %{service_name}
       idps:
@@ -494,7 +465,6 @@ cy:
         heading: Rhoi adborth ar GOV.UK Verify
         paragraph: Gofyn cwestiwn, rhoi gwybod am broblem neu awgrymu gwelliant y gall GOV.UK Verify ei wneud. Nod y tîm cymorth yw ymateb i gwestiynau mewn 5 diwrnod gwaith.
     feedback:
-      title: Adborth
       heading: Anfonnwch eich adborth i GOV.UK Verify
       introduction_html: |
         <p class="govuk-body">Defnyddiwch y ffurflen hon i ofyn cwestiwn, hysbysu problem neu awgrymu gwelliant y gall GOV.UK Verify ei wneud.</p>
@@ -522,11 +492,9 @@ cy:
         reply: Dylech ddewis opsiwn
       send_message: Anfon neges
     feedback_disabled:
-      title: Adborth wedi'i Analluogi
       heading: Mae adborth wedi'i analluogi ar yr amgylchedd hwn
       error_content: Ar hyn o bryd rydych yn defnyddio fersiwn ddi-gynhyrchu o Verify, lle mae adborth wedi'i analluogi.
     feedback_sent:
-      title: Adborth
       heading: Diolch am eich adborth
       message_email: Rydym wedi derbyn eich neges a byddwn yn ymateb cyn gynted â phosibl.
       session_valid_link: Dychwelyd i GOV.UK Verify
@@ -534,7 +502,7 @@ cy:
       session_not_valid_link: ddechrau eto
       product_page: Dychwelyd i dudalen GOV.UK  Verify
     certified_companies_unavailable:
-      title:
+      heading:
         one: Nid yw %{company} ar gael ar hyn o bryd ar GOV.UK Verify
         other: Nid yw'r cwmnïau hyn ar gael dros dro gyda GOV.UK Verify
       verify_another_company_html: Gallwch gynnig eto yn nes ymlaen neu %{link}.
@@ -542,11 +510,11 @@ cy:
       verify_another_company_text: Gallwch geisio nes ymlaen eto neu wirio'ch hunaniaeth gyda chwmni ardystiedig arall.
       company_text: Nid yw %{company} ar gael
     certified_companies_disconnected:
-      title: Nid yw'r cwmnïau canlynol bellach yn rhan o GOV.UK Verify
+      sub_heading: Nid yw'r cwmnïau canlynol bellach yn rhan o GOV.UK Verify
       verify_another_company_html: Os oedd gennych gyfrif hunaniaeth gydag un o'r cwmnïau hyn, bydd angen i chi %{link}.
       verify_another_company_link: dilysu eich hunaniaeth gyda chwmni arall
     further_information:
-      title: Rhowch eich %{cycle_three_name}
+      heading: Rhowch eich %{cycle_three_name}
       first_time: Hwn yw'r tro cyntaf i chi fewngofnodi.
       help_with_your: Ble i ddod o hyd i'ch %{cycle_three_name}
       cancel: Dileu a dychwelyd i %{transaction_name}
@@ -554,7 +522,6 @@ cy:
       attribute_validation_message: Rhowch %{cycle_three_name} dilys
       null_attribute: Nid oes gennyf %{cycle_three_name}
       timeout:
-        title: "Rydych wedi cael eich allgofnodi"
         heading: "Rydych wedi cael eich allgofnodi"
         intro: "I gadw'ch wybodaeth yn ddiogel, rydych wedi cael eich allgofnodi ar ôl cyfnod o anweithgarwch."
         continue: "I barhau i %{service_name}, bydd angen i chi fewngofnodi eto gyda %{idp_name}."
@@ -562,13 +529,11 @@ cy:
         other_ways_text: Gallwch hefyd weld
         other_ways_link: ffyrdd eraill i %{service_name}
     no_idps_available:
-      title: Dim IDPS ar gael
       heading: Ni fydd GOV.UK Verify yn gweithio i chi
       text: Yn seiliedig ar eich atebion ni all yr un o'r cwmniau ardystiedig eich dilysu.
       details_html: Gallwch %{href}; y mwyaf cywir y gallwch ateb y cwestiynau y mwyaf tebygol yw hi y bydd cwmni ardystiedig yn gallu eich dilysu.
       details_link: newid eich atebion i'r cwestiynau
     cancelled_registration:
-      title: Cofrestriad Verify Wedi'i Ganslo
       heading: "Gwnaethoch ganslo eich dilysiad hunaniaeth gyda %{idp_name}"
       what_next: 'Gallwch ddal %{service_name}.'
       try_another_summary: 'Rhowch gynnig ar ddarparwr hunaniaeth arall'
@@ -586,7 +551,6 @@ cy:
         contact_verify: Cysylltu â GOV.UK Verify
     paused_registration:
       with_session:
-        title: "Dilysu Wedi'i Oedi %{idp_name}"
         heading: "Mae eich cyfrif hunaniaeth %{idp_name} wedi cael ei arbed"
         restart_instructions_html: |
           <p class="govuk-body">I ddychwelyd gallwch:</p>
@@ -608,7 +572,6 @@ cy:
               <li>ffordd arall i brofi eich hunaniaeth</li>
           </ul>
       without_session:
-        title: Dilysu Wedi'i Oedi
         heading: Mae eich cwmni ardystiedig wedi arbed eich gwybodaeth.
         restart_instructions_html: |
           <p class="govuk-body">I ddychwelyd gallwch:</p>
@@ -619,7 +582,6 @@ cy:
           </ul>
           <p class="govuk-body">Bydd angen yr e-bost neu'r enw defnyddiwr a'r cyfrinair a ddefnyddiwyd gennych i greu cyfrif.</p>
       from_resume_link:
-        title: "Dilysu Wedi'i Oedi %{idp_name} - Link"
         heading: "Mae eich cyfrif hunaniaeth %{idp_name} wedi cael ei arbed"
         restart_instructions_html: |
           <p class="govuk-body">I ddychwelyd gallwch:</p>
@@ -630,7 +592,6 @@ cy:
           </ul>
           <p class="govuk-body">Bydd angen yr e-bost neu'r enw defnyddiwr a'r cyfrinair a ddefnyddiwyd gennych i greu cyfrif.</p>
       resume:
-        title: "Parhau i ddilysu gyda %{display_name}"
         heading: "Parhau i ddilysu gyda %{display_name}"
         intro: "Bydd angen i chi orffen gwirio'ch hunaniaeth gyda %{display_name} i %{service_name}."
         continue: "Parhewch gyda %{display_name}"
@@ -639,7 +600,6 @@ cy:
         alternative_start: "mewngofnodi gyda chwmni ardystiedig arall"
         alternative_other_ways: "gwelwch ffyrdd eraill i %{service_name}"
     single_idp_journey:
-      title: Parhau gyda %{display_name}
       heading: Prove your identity with %{display_name}
       intro: "Bydd %{idp_display_name} yn cadarnhau eich hunaniaeth gyda GOV.UK Verify, a gallwch barhau i %{service_display_name}."
       continue_button: Profi eich hunaniaeth gyda %{display_name}
@@ -647,15 +607,13 @@ cy:
       alternative_one: defnyddio cwmni ardystiedig gwahanol
       alternative_two: gweld ffyrdd eraill i %{service_display_name}
     accessibility:
-      title: Accessibility
+      heading: Accessibility
     completed_registration:
-      title: You've successfully proved your identity
       heading: You’ve successfully proved your identity with %{idp_name}
       message_one: You now need to return to the government service you were trying to access.
       message_two: When the service asks you to prove your identity, you can do so by signing in to your %{idp_name} identity account.
       select_service: Select the service you need
     sign_in_hint:
-      title: Sign in to continue
       heading: Sign in to continue
       intro: The last company selected on this device was %{idp_name}.
       continue_with_idp: Continue with %{idp_name} if you've created an identity account with them.
@@ -663,13 +621,11 @@ cy:
       other_way_button: Choose another way to sign in
   errors:
     no_cookies:
-      title: Cwcis Ar Goll
-      heading: GOV.UK Verify
+      heading: Cwcis Ar Goll
       access_restriction: Gellir ond cael mynediad i GOV.UK Verify o wasanaeth y llywodraeth.
       read_more_html: 'Darllenwch y <a href="https://www.gov.uk/verify" hreflang="en">Cyflwyniad i GOV.UK Verify</a> am fwy o wybodaeth.'
       enable_cookies: Os na allwch gael mynediad i GOV.UK Verify o wasanaeth y llywodraeth, dylech alluogi eich cwcis.
     session_error:
-      title: Mae rhywbeth wedi mynd o’i le
       heading: Mae angen i chi ddechrau eto
       security: Am resymau diogelwch, os ydych yn defnyddio’r botwm ‘back’ i ddychwelyd o gwmni ardystiedig, mae’n rhaid i chi ddechrau eto.
       start_again: Dechrau eto
@@ -680,20 +636,17 @@ cy:
       return_to_service_html: Dylech fynd yn ôl at eich gwasanaeth i ddechrau eto.
       start_again: Dechrau eto
     something_went_wrong:
-      title: Mae rhywbeth wedi mynd o’i le
       heading: Mae’n ddrwg gennym, mae rhywbeth wedi mynd o’i le
       error_message: Gall hyn fod oherwydd bod eich sesiwn wedi’i amseru allan neu roedd gwall yn y system.
       start_again: Oherwydd bod hwn yn wasanaeth diogel, bydd angen i chi ddechrau eto.
     proxy_node_error:
       start_again: Gan eich bod yn defnyddio gwasanaeth diogel o wlad Ewropeaidd arall, bydd angen i chi fynd yn ôl i'r dudalen lle dechreuoch ddefnyddio'r gwasanaeth hwnnw.
     page_not_found:
-      title: Ni ellir dod o hyd i’r dudalen hon
       heading: Ni ellir dod o hyd i’r dudalen hon
       reason_pre: "Gallai hyn fod oherwydd:"
       reason_one: bod y ddolen rydych wedi clicio arni wedi torri
       reason_two: rydych wedi rhoi cyfeiriad gwefan anghywir
     eidas_scheme_unavailable:
-      title: Cynllun hunaniaeth ddim ar gael
       heading: Nid yw eich cynllun hunaniaeth ar gael ar hyn o bryd
       other_ways: "Ceisiwch eto yn nes ymlaen neu ddewis ffordd arall i "
       other_ways_link: "profi eich hunaniaeth ar-lein"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -100,8 +100,6 @@ en:
     help: Help
     built_by_the: Built by the
   hub:
-    about:
-      title: About
     about_what_is_verify:
       heading: What GOV.UK Verify is
       content: GOV.UK Verify is a secure way to prove who you are online. It helps protect you against online identity theft.
@@ -112,7 +110,6 @@ en:
       content_html: <p class="govuk-body">The company will ask you questions and check your identity documents.</p>
                     <p class="govuk-body">It will never share your information for any other purpose without your consent.</p>
     select_documents:
-      title: Your documents
       heading: Which of these do you have available right now?
       explanation: This will help us tell you if GOV.UK Verify will work for you. The more items you have, the more likely it is that you can verify your identity.
       select_all_that_apply: "Select all that apply:"
@@ -123,7 +120,7 @@ en:
       has_nothing: None of the above
       has_driving_license_and_credit_card: A full or provisional driving licence with your photo on it and a credit or debit card
       further_explanation:
-        title: What GOV.UK Verify uses these for
+        heading: What GOV.UK Verify uses these for
         content_html: |
           <p class="govuk-body">
             The companies can check your passport and driving licence against official records.
@@ -141,7 +138,6 @@ en:
       errors:
         no_selection: Select the items you have available right now
     select_documents_advice:
-      title: Advice about your documents
       advice_html:
         heading: You need more evidence to verify your identity
         sub_heading: 'To use GOV.UK Verify, you also need either:'
@@ -159,8 +155,7 @@ en:
           <p class="govuk-body">If you have these things but they’re somewhere else, come back when you have them with you.</p>
           <p class="govuk-body">%{prove_your_identity_link} if you do not have these things.</p>
     choose_a_certified_company:
-      title: Pick a certified company
-      heading: Pick a company to verify you
+      heading: Pick a certified company to verify you
       intro: One of these companies will create your identity account.
       idp_count: You can pick either company.
       idp_explanation: "There’s more than one so that:"
@@ -181,16 +176,14 @@ en:
         information_provided_by: Information provided by %{display_name}
         close: close
       about:
-        title: About %{display_name}
+        heading: About %{display_name}
         information_provided_by: Information provided by %{display_name}
         close: close
     prove_your_identity_another_way:
       heading: Prove your identity another way
       sub_heading: You can still %{service_name}.
-    other_ways_title: Other ways to access the service
     other_ways_heading: Other ways to %{other_ways_description}
     other_ways_after_eidas:
-      title: Country not listed
       heading: Other ways to %{other_ways_description}
       explanation: If your digital identity scheme isn't available yet, you can prove who you are another way so you can %{other_ways_description}.
       verify:
@@ -206,7 +199,6 @@ en:
         button: "Use GOV.UK Verify"
       cannot_verify: What to do if you cannot use GOV.UK Verify
     choose_a_country:
-      title: Choose a country
       heading: Use a digital identity from another European country
       description: You can use a digital identity from another European country to access services on GOV.UK.
       eu_exit_warn: You will not be able to use a digital identity from another European country to access services on GOV.UK after 31 December 2020.
@@ -215,11 +207,9 @@ en:
       country_not_listed_link: "%{other_ways_description}."
       select_label: "Select %{scheme_name}"
     redirect_to_country:
-      title: Redirect to country
       heading: Continue to next step
       description: Because Javascript is not enabled on your browser, you must press the continue button
     prove_identity:
-      title: Prove your identity to continue
       heading: Prove your identity to continue
       header_content: Choose how you want to prove your identity so you can
       use_verify:
@@ -238,7 +228,6 @@ en:
           <p class="govuk-body">If you’re part of an ID scheme in a participating country, you may be able to use it here.</p>
         button_text: Select your European digital identity
     start:
-      title: Start
       heading: Sign in with GOV.UK Verify
       answer_yes: This is my first time using GOV.UK Verify
       answer_no: I've already signed up for Verify
@@ -246,7 +235,6 @@ en:
       continue: Continue
       error_message: Please select an option
     signin:
-      title: Sign in with a certified company
       heading: Who do you have an identity account with?
       back: Back
       about_link: set one up now
@@ -260,19 +248,17 @@ en:
       company_no_longer_verifies_text: If you have an identity account with %{company}, you’ll need to %{link}.
       company_no_longer_verifies_link: verify your identity with another company
     cookies:
-      title: Cookies
+      heading: Cookies
     privacy_notice:
-      title: Privacy notice
+      heading: Privacy notice
     verify_services:
-      title: Verify services
       heading: GOV.UK Verify
       message: "The current services using GOV.UK Verify are:"
     transaction_list:
-      title: Find the service you were using to start again
+      heading: Find the service you were using to start again
       hint: Follow the instructions you received.
       other_services: Other services
     about_choosing_a_company:
-      title: About choosing a company
       heading: Finding the right company to verify you
       content_html: |
         <p class="govuk-body">These companies have built secure systems to verify identities. These systems work by checking:</p>
@@ -282,14 +268,13 @@ en:
         </ul>
         <p class="govuk-body">We need to ask you some questions to check if the companies can verify you. We’ll then send you to the website of the company you select.</p>
     will_it_work_for_me:
-      title: Can I be verified?
       heading: About you
       question:
         option_yes: 'Yes'
         above_age_threshold: Are you 20 or over?
         resident_last_12_months: Have you lived in the UK for the last 12 months?
         not_resident_reason:
-          title: Which of these applies to you?
+          sub_heading: Which of these applies to you?
           recently: I moved to the UK in the last 12 months
           not_resident: I have an address in the UK but I don’t live there
           no_address: I don’t have a UK address
@@ -299,7 +284,6 @@ en:
           resident_12_months: Tell us if you've lived in the UK for the last 12 months
           not_resident_reason: Select an option
     idp_wont_work_for_you_one_doc:
-      title: "%{idp_name} cannot verify your identity"
       heading: "%{idp_name} cannot verify your identity"
       choose_another_company: You have to choose a different certified company to verify your identity.
       choose_another_certified_company_link: Choose another company
@@ -308,7 +292,6 @@ en:
       content_html: |
         <p class="govuk-body">Based on your answers, the companies will not be able to verify your identity.</p>
     may_not_work_if_you_live_overseas:
-      title: You might not be able to have your identity verified
       heading: You might not be able to have your identity verified
       try_to_verify: I’d like to try to verify my identity using GOV.UK Verify
       explanation1: To verify an identity, these companies access credit records and ask you to confirm this information. Most people living outside the UK have a limited activity history on their UK credit record, so companies might not be able to check your identity in this way.
@@ -325,7 +308,6 @@ en:
       mail_order_account: mail order account
       youll_also_need: You’ll also need a UK passport or a UK driving licence.
     why_might_this_not_work_for_me:
-      title: Why might this not work for me
       heading: You might not be able to have your identity verified
       try_to_verify: I’d like to try to verify my identity using GOV.UK Verify
       explanation: To verify an identity, these companies access credit records and ask you to confirm this information. Most young people and newcomers to the UK have a limited credit history, so some companies might not be able to check their identity in this way.
@@ -340,11 +322,10 @@ en:
       registered_to_vote: you’re registered to vote
       youll_also_need: You’ll also need a UK passport or a UK driving licence.
     will_not_work_without_uk_address:
-      title: GOV.UK Verify will not work for you
       heading: You won’t be able to use GOV.UK Verify
       explanation: You need a current UK address to get your identity verified.
     why_companies:
-      title: Why you need to use a company
+      heading: Why you need to use a company
       choose_a_company: Choose a company
       content_html: |
         <p class="govuk-body">When verifying your identity, the companies access information like credit records. They can also check that any documents you provide, such as passports and driving licences, are valid.</p>
@@ -353,7 +334,7 @@ en:
         <p class="govuk-body">When verifying your identity, the companies access information like credit records. They can also check that any documents you provide, such as passports and driving licences, are valid.</p>
         <p class="govuk-body">These companies meet strict government privacy standards, so you can trust them with your information. They won’t use your information for any other purpose without your consent.</p>
     redirect_to_idp_warning:
-      title: "You'll now be redirected"
+      heading: "You'll now be redirected"
       create_account: Create your %{display_name} identity account
       continue_website: Continue to the %{display_name} website
       identity_account_use_html: |
@@ -363,7 +344,6 @@ en:
       other_ways_link: "other ways to %{transaction}"
       no_docs_other_ways_message_html: "%{idp_no_docs_requirement}, there are %{other_ways_link}"
     redirect_to_idp_question:
-      title: "Extra question"
       heading: Verifying with %{display_name}
       loa1_heading: Setting up a %{display_name} account
       answer_yes: "Yes"
@@ -376,20 +356,16 @@ en:
       or_html: or %{choose_another_company_link}
       validation_message: Select an option
     confirm_your_identity:
-      title: Confirm your identity
       use_other_idp: If this isn’t the company that verified you, %{sign_in_link}.
       sign_in_link_message: sign in with a different certified company
       need_to_signin_again: In order to %{transaction_name}, you need to sign in again with your certified company. You don’t need to register again.
     confirmation:
-      title: Your identity has been verified
       message: "You can sign in wherever you see the GOV.UK Verify logo with your %{display_name} identity account username and password."
       continue_to_rp: "You can now %{transaction_name}."
       heading: "%{display_name} has verified your identity"
       add_security_loa1: When you access some government services, you'll be asked to provide more evidence, but you only need to do this once.
       extra_security: Government services requiring extra evidence
     failed_registration:
-      title: Unable to verify your identity
-      alt_heading: "%{idp} could not verify your identity"
       you_can_still: You can still %{service}
       your_account_with_heading: Your account with %{idp}
       your_account_with_text: "%{idp} will not contact you or use your data for anything that is not related to your account. You can contact %{idp} for more help."
@@ -416,21 +392,18 @@ en:
       try_another_summary: Try verifying with another certified company
       contact_details_intro: "Contact %{idp_name}"
     failed_country_sign_in:
-      title: Unable to sign you in
       heading: "Your identity scheme in %{country_name} was unable to confirm your identity"
       other_ways: "There are other ways you can %{other_ways_description}."
       online_link: Other ways to prove your identity online
       online: Online
       offline: Offline
     failed_sign_in:
-      title: Unable to sign you in
       heading: "%{display_name} couldn’t sign you in"
       reasons_html: |
         <p class="govuk-body">You may have selected the wrong company. Check your emails and text messages for confirmation of who verified you.</p>
         <p class="govuk-body">You can be verified by another company at any time. You won’t lose any data on GOV.UK services you’ve used.</p>
       start_again: "Start again"
     failed_uplift:
-      title: Failed to uplift
       heading: "%{display_name} was not able to validate the evidence you provided"
       reasons_html: |
         <p class="govuk-body">There are a few reasons why this might happen, including:</p>
@@ -447,7 +420,6 @@ en:
       other_ways_summary: "View other ways to %{other_ways_description}"
       contact_summary: "Contact %{idp_name}"
     response_processing:
-      title: Please wait
       heading: "%{rp_name} is processing your details"
       bear_with_us: "This may take a few seconds, please bear with us."
       matching_error:
@@ -457,24 +429,22 @@ en:
         online: Online
         offline: Offline
     forgot_company:
-      title: Advice for forgotten company
+      heading: Advice for forgotten company
     redirect_to_service:
       heading: Continue to next step
       signing_in:
-        title: "Please wait. Signing you in"
+        heading: "Please wait. Signing you in"
         transition_heading: "%{rp_name} is processing your details"
       start_again:
-        title: "Please wait. Starting again."
+        heading: "Please wait. Starting again."
         transition_heading: "Starting again"
       no_javascript: Because Javascript is not enabled on your browser, you must press the continue button
       please_wait: This may take a few seconds, please bear with us.
       loading: "Loading…"
     redirect_to_idp:
-      title: Loading
       heading: Continue to next step
       description: Because Javascript is not enabled on your browser, you must press the continue button
     feedback_landing:
-      title: Help
       basic_heading: Get help using GOV.UK Verify
       heading: Get help accessing %{service_name}
       idps:
@@ -488,7 +458,6 @@ en:
         heading: Give feedback on GOV.UK Verify
         paragraph: Ask a question, report a problem or suggest an improvement GOV.UK Verify can make. The support team aims to respond to questions in 5 working days.
     feedback:
-      title: Feedback
       heading: Send your feedback to GOV.UK Verify
       introduction_html: |
         <p class="govuk-body">Use this form to ask a question, report a problem or suggest an improvement GOV.UK Verify can make.</p>
@@ -517,11 +486,9 @@ en:
         reply: Tell us if you want a reply
       send_message: Send message
     feedback_disabled:
-      title: Feedback Disabled
       heading: Feedback is disabled on this environment
       error_content: You are currently using a non-production version of Verify, where feedback has been disabled.
     feedback_sent:
-      title: Feedback
       heading: Thank you for your feedback
       message_email: We've received your message, and we'll reply as soon as possible.
       session_valid_link: Return to GOV.UK Verify
@@ -529,7 +496,7 @@ en:
       session_not_valid_link: start again
       product_page: Return to the GOV.UK Verify product page
     certified_companies_unavailable:
-      title:
+      heading:
         one: "%{company} is temporarily unavailable with GOV.UK Verify"
         other: These companies are temporarily unavailable with GOV.UK Verify
       verify_another_company_html: You can try again later or %{link}.
@@ -537,11 +504,11 @@ en:
       verify_another_company_text: You can try again later or verify your identity with another certified company.
       company_text: "%{company} is unavailable"
     certified_companies_disconnected:
-      title: The following companies are no longer part of GOV.UK Verify
+      heading: The following companies are no longer part of GOV.UK Verify
       verify_another_company_html: If you had an identity account with one of these companies, you'll need to %{link}.
       verify_another_company_link: verify your identity with a different company
     further_information:
-      title: Enter your %{cycle_three_name}
+      heading: Enter your %{cycle_three_name}
       first_time: This is the first time you’ve signed in.
       help_with_your: Where to find your %{cycle_three_name}
       cancel: Cancel and return to %{transaction_name}
@@ -549,7 +516,6 @@ en:
       attribute_validation_message: Enter a valid %{cycle_three_name}
       null_attribute: I don’t have an %{cycle_three_name}
       timeout:
-        title: "You've been signed out"
         heading: "You've been signed out"
         intro: "To keep your information safe, you've been signed out after a period of inactivity."
         continue: "To continue to %{service_name}, you'll need to sign in again with %{idp_name}."
@@ -557,13 +523,11 @@ en:
         other_ways_text: You can also see
         other_ways_link: other ways to %{service_name}
     no_idps_available:
-      title: No IDPS available
       heading: GOV.UK Verify won’t work for you
       text: Based on your answers, none of the certified companies can verify you.
       details_html: You can %{href}; the more accurately you answer the questions, the more likely it is that a certified company can verify you.
       details_link: change your answers to the questions
     cancelled_registration:
-      title: Verify registration cancelled
       heading: "You cancelled your identity verification with %{idp_name}"
       next: 'What do you want to do next?'
       what_next: 'You can still %{service_name}.'
@@ -581,7 +545,6 @@ en:
         contact_verify: 'Contact GOV.UK Verify'
     paused_registration:
       with_session:
-        title: "Verification Paused %{idp_name}"
         heading: "Your %{idp_name} identity account has been saved"
         restart_instructions_html: |
           <p class="govuk-body">To return you can:</p>
@@ -603,7 +566,6 @@ en:
               <li>another way to prove your identity</li>
           </ul>
       without_session:
-        title: Verification Paused
         heading: The certified company has saved your information
         restart_instructions_html: |
           <p class="govuk-body">To return you can:</p>
@@ -614,7 +576,6 @@ en:
           </ul>
           <p class="govuk-body">You'll need the email or username and password you used to create an account.</p>
       from_resume_link:
-        title: "Verification Paused %{idp_name} - Link"
         heading: "Your %{idp_name} identity account has been saved"
         restart_instructions_html: |
           <p class="govuk-body">To return you can:</p>
@@ -625,7 +586,6 @@ en:
           </ul>
           <p class="govuk-body">You'll need the email or username and password you used to create an account.</p>
       resume:
-        title: "Continue verifying with %{display_name}"
         heading: "Continue verifying with %{display_name}"
         intro: "You'll need to finish verifying your identity with %{display_name} to %{service_name}."
         continue: "Continue with %{display_name}"
@@ -634,7 +594,6 @@ en:
         alternative_start: "sign in with another certified company"
         alternative_other_ways: "see other ways to %{service_name}"
     single_idp_journey:
-      title: Continue with %{display_name}
       heading: Prove your identity with %{display_name}
       intro: "%{idp_display_name} will confirm your identity with GOV.UK Verify, and you can continue to %{service_display_name}."
       continue_button: Continue with %{display_name}
@@ -642,15 +601,13 @@ en:
       alternative_one: use a different certified company
       alternative_two: see other ways to %{service_display_name}
     accessibility:
-      title: Accessibility
+      heading: Accessibility
     completed_registration:
-      title: You've successfully proved your identity
       heading: You’ve successfully proved your identity with %{idp_name}
       message_one: You now need to return to the government service you were trying to access.
       message_two: When the service asks you to prove your identity, you can do so by signing in to your %{idp_name} identity account.
       select_service: Select the service you need
     sign_in_hint:
-      title: Sign in to continue
       heading: Sign in to continue
       intro: The last company selected on this device was %{idp_name}.
       continue_with_idp: Continue with %{idp_name} if you've created an identity account with them.
@@ -658,13 +615,11 @@ en:
       other_way_button: Choose another way to sign in
   errors:
     no_cookies:
-      title: Cookies Missing
-      heading: GOV.UK Verify
+      heading: Cookies Missing
       access_restriction: GOV.UK Verify can only be accessed from a government service.
       read_more_html: 'Read the <a href="https://www.gov.uk/verify">Introduction to GOV.UK Verify</a> for more information.'
       enable_cookies: If you can’t access GOV.UK Verify from a service, enable your cookies.
     session_error:
-      title: Something went wrong
       heading: You need to start again
       security: For security reasons, if you use the back button to return from a certified company, you must start again.
       start_again: Start again
@@ -679,20 +634,17 @@ en:
         </ol>
       start_again: Return to the service
     something_went_wrong:
-      title: Something went wrong
       heading: Sorry, something went wrong
       error_message: This may be because your session timed out or there was a system error.
       start_again: Because this is a secure service, you’ll need to start again.
     proxy_node_error:
       start_again: Because you were using a secure service from another European country, you’ll need to go back to the page where you started using that service.
     page_not_found:
-      title: This page can’t be found
       heading: This page can’t be found
       reason_pre: "This may be because:"
       reason_one: the link you clicked is broken
       reason_two: you entered an incorrect web address
     eidas_scheme_unavailable:
-      title: Identity scheme unavailable
       heading: "Your identity scheme in %{country_name} is currently unavailable"
       other_ways: "Try again later or choose another way to "
       other_ways_link: "prove your identity online"

--- a/spec/features/user_encounters_error_page_spec.rb
+++ b/spec/features/user_encounters_error_page_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "user encounters error page" do
     visit "/test-saml"
     click_button "saml-post"
     expect(page).to have_content t("errors.something_went_wrong.heading")
-    expect(page).to_not have_content t("hub.transaction_list.title")
+    expect(page).to_not have_content t("hub.transaction_list.heading")
     expect(page).to have_css "#piwik-custom-url", text: "errors/generic-error"
     expect(page.status_code).to eq(500)
   end

--- a/spec/features/user_sends_authn_request_spec.rb
+++ b/spec/features/user_sends_authn_request_spec.rb
@@ -16,7 +16,7 @@ describe "user sends authn requests" do
       visit("/test-saml")
       click_button "saml-post"
 
-      expect(page).to have_title t("hub.start.title")
+      expect(page).to have_title t("hub.start.heading")
 
       expect(page.get_rack_session["transaction_simple_id"]).to eql "test-rp"
       expect(page.get_rack_session["verify_session_id"]).to eql default_session_id
@@ -40,7 +40,7 @@ describe "user sends authn requests" do
       visit("/test-saml")
       click_button "saml-post-eidas"
 
-      expect(page).to have_title t("hub.choose_a_country.title")
+      expect(page).to have_title t("hub.choose_a_country.heading")
       expect(page.get_rack_session["requested_loa"]).to eql "LEVEL_1"
       expect(page.get_rack_session["transaction_supports_eidas"]).to eql true
     end
@@ -53,7 +53,7 @@ describe "user sends authn requests" do
       visit("/test-saml")
       click_button "saml-post-eidas"
 
-      expect(page).to have_title t("hub.choose_a_country.title")
+      expect(page).to have_title t("hub.choose_a_country.heading")
       expect(page.get_rack_session["transaction_supports_eidas"]).to eql true
     end
 
@@ -68,7 +68,7 @@ describe "user sends authn requests" do
       visit("/test-saml")
       click_button "saml-post-journey-hint-registration"
 
-      expect(page).to have_title t("hub.start.title")
+      expect(page).to have_title t("hub.start.heading")
       # expect(stub_piwik_request).to have_been_made.once
     end
 
@@ -83,7 +83,7 @@ describe "user sends authn requests" do
       visit("/test-saml")
       click_button "saml-post-journey-hint-sign-in"
 
-      expect(page).to have_title t("hub.start.title")
+      expect(page).to have_title t("hub.start.heading")
       # expect(stub_piwik_request).to have_been_made.once
     end
 
@@ -98,7 +98,7 @@ describe "user sends authn requests" do
       visit("/test-saml")
       click_button "saml-post-journey-hint-sign-in"
 
-      expect(page).to have_title t("hub.single_idp_journey.title", display_name: "IDCorp")
+      expect(page).to have_title t("hub.single_idp_journey.heading", display_name: "IDCorp")
     end
 
     it "will set ab_test cookie" do
@@ -168,7 +168,7 @@ describe "user sends authn requests" do
     visit("/test-saml")
     click_button "saml-post"
 
-    expect(page).to have_title t("hub.start.title")
+    expect(page).to have_title t("hub.start.heading")
     expect(page.get_rack_session.has_key?(:journey_hint)).to be false
   end
 
@@ -179,7 +179,7 @@ describe "user sends authn requests" do
     visit("/test-saml")
     click_button "saml-post"
 
-    expect(page).to have_title t("hub.start.title")
+    expect(page).to have_title t("hub.start.heading")
     expect(page.get_rack_session.has_key?(:journey_hint)).to be false
   end
 
@@ -190,7 +190,7 @@ describe "user sends authn requests" do
       visit("/test-saml?_ga=123456")
       click_button "saml-post"
 
-      expect(page).to have_title t("hub.start.title")
+      expect(page).to have_title t("hub.start.heading")
       expect(page).to have_current_path start_path(_ga: "123456")
       expect(page).to have_selector "span#cross-gov-ga-tracker-id", text: "UA-XXXXX-Y"
       expect(page).to have_selector "span#cross-gov-ga-domain-list", text: '["www.gov.uk"]'

--- a/spec/features/user_submits_feedback_page_spec.rb
+++ b/spec/features/user_submits_feedback_page_spec.rb
@@ -22,11 +22,11 @@ RSpec.feature "When the user submits the feedback page" do
       fill_in "feedback_form_email", with: "bob@smith.com"
 
       click_button t("hub.feedback.send_message")
-      expect(page).to have_title t("hub.feedback_sent.title")
+      expect(page).to have_title t("hub.feedback_sent.heading")
       expect(page).to have_current_path(feedback_sent_path, ignore_query: true)
       expect(page).to have_content t("hub.feedback_sent.message_email")
       expect(page).to have_content session_not_valid_link
-      expect(page).to have_content t("hub.transaction_list.title")
+      expect(page).to have_content t("hub.transaction_list.heading")
     end
 
     it "when user does not provide email should not say message has been sent and show invalid session link" do
@@ -40,7 +40,7 @@ RSpec.feature "When the user submits the feedback page" do
       expect(page).to have_current_path(feedback_sent_path, ignore_query: true)
       expect(page).to_not have_content t("hub.feedback_sent.message_email")
       expect(page).to have_content session_not_valid_link
-      expect(page).to have_content t("hub.transaction_list.title")
+      expect(page).to have_content t("hub.transaction_list.heading")
     end
 
     it "when session has timed out should show invalid session link" do
@@ -58,7 +58,7 @@ RSpec.feature "When the user submits the feedback page" do
 
       click_button t("hub.feedback.send_message")
       expect(page).to have_content session_not_valid_link
-      expect(page).to have_content t("hub.transaction_list.title")
+      expect(page).to have_content t("hub.transaction_list.heading")
     end
   end
 
@@ -80,7 +80,7 @@ RSpec.feature "When the user submits the feedback page" do
     allow_any_instance_of(FeedbackService).to receive(:submit!).and_return(true)
 
     click_button t("hub.feedback.send_message")
-    expect(page).to have_title t("hub.feedback_sent.title")
+    expect(page).to have_title t("hub.feedback_sent.heading")
     expect(page).to have_link t("hub.feedback_sent.product_page"), href: "https://govuk-verify.cloudapps.digital/"
   end
 
@@ -153,7 +153,7 @@ RSpec.feature "When the user submits the feedback page" do
       choose "feedback_form_reply_false"
       click_button t("hub.feedback.send_message", locale: :cy)
 
-      expect(page).to have_title t("hub.feedback_sent.title", locale: :cy)
+      expect(page).to have_title t("hub.feedback_sent.heading", locale: :cy)
       expect(page).to have_css "html[lang=cy]"
       expect(page).to have_link t("hub.feedback_sent.session_valid_link", locale: :cy), href: select_documents_cy_path
     end

--- a/spec/features/user_submits_start_page_form_spec.rb
+++ b/spec/features/user_submits_start_page_form_spec.rb
@@ -88,10 +88,10 @@ RSpec.describe "when user submits start page form" do
     stub_api_idp_list_for_sign_in
     stub_api_select_idp
     visit "/start"
-    expect(page).to have_title t("hub.sign_in_hint.title")
+    expect(page).to have_title t("hub.sign_in_hint.heading")
     expect(page).to have_content t("hub.sign_in_hint.heading")
     visit "/start/ignore-hint"  # the "choose another way" button
-    expect(page).to have_title t("hub.start.title")
+    expect(page).to have_title t("hub.start.heading")
     expect(page).to have_content t("hub.start.heading")
   end
 
@@ -101,10 +101,10 @@ RSpec.describe "when user submits start page form" do
     stub_api_idp_list_for_sign_in
     stub_api_select_idp
     visit "/start"
-    expect(page).to have_title t("hub.sign_in_hint.title")
+    expect(page).to have_title t("hub.sign_in_hint.heading")
     expect(page).to have_content t("hub.sign_in_hint.heading")
     visit "/start/ignore-hint"  # the "choose another way" button
-    expect(page).to have_title t("hub.start.title")
+    expect(page).to have_title t("hub.start.heading")
     expect(page).to have_content t("hub.start.heading")
   end
 end

--- a/spec/features/user_visits_accessibility_page_spec.rb
+++ b/spec/features/user_visits_accessibility_page_spec.rb
@@ -3,7 +3,7 @@ require "feature_helper"
 RSpec.describe "When the user visits the accessibility page" do
   it "displays the page in English" do
     visit "/accessibility"
-    expect(page).to have_title t("hub.accessibility.title")
+    expect(page).to have_title t("hub.accessibility.heading")
     expect(page).to have_content "We want as many people as possible to be able to use this website"
     expect(page).to have_content "Reporting accessibility problems with this website"
   end

--- a/spec/features/user_visits_an_idp_emailed_link_to_paused_page_spec.rb
+++ b/spec/features/user_visits_an_idp_emailed_link_to_paused_page_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "When the user is sent to the paused registration page using a li
     it "renders page with a list of available services with headless RP links where applicable" do
       visit "/paused/stub-idp-one"
 
-      expect(page).to have_title(t("hub.paused_registration.from_resume_link.title", idp_name: idp_display_name))
+      expect(page).to have_title(t("hub.paused_registration.from_resume_link.heading", idp_name: idp_display_name))
       expect(page).to have_content(t("hub.paused_registration.from_resume_link.heading", idp_name: idp_display_name))
       expect(page).to have_link("test GOV.UK Verify user journeys", href: "http://localhost:50130/success?rp-name=test-rp")
     end
@@ -25,7 +25,7 @@ RSpec.describe "When the user is sent to the paused registration page using a li
     it "renders page with a list of available services with RP homepage links when headless page not configured" do
       visit "/paused/stub-idp-one"
 
-      expect(page).to have_title(t("hub.paused_registration.from_resume_link.title", idp_name: idp_display_name))
+      expect(page).to have_title(t("hub.paused_registration.from_resume_link.heading", idp_name: idp_display_name))
       expect(page).to have_content(t("hub.paused_registration.from_resume_link.heading", idp_name: idp_display_name))
       expect(page).to have_link "Test GOV.UK Verify user journeys (forceauthn & no cycle3)", href: "http://localhost:50130/test-rp-noc3"
     end

--- a/spec/features/user_visits_cancelled_registration_page_spec.rb
+++ b/spec/features/user_visits_cancelled_registration_page_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "When user visits cancelled registration page" do
 
     visit("/cancelled-registration")
 
-    expect(page).to have_title t("hub.cancelled_registration.title")
+    expect(page).to have_title t("hub.cancelled_registration.heading", idp_name: "IDCorp")
     expect(page).to have_link t("hub.cancelled_registration.send_feedback")
     expect(page).to have_link t("hub.cancelled_registration.about_choosing_a_company"), href: about_choosing_a_company_path
   end
@@ -24,7 +24,7 @@ RSpec.describe "When user visits cancelled registration page" do
 
     visit("/cancelled-registration")
 
-    expect(page).to have_title t("hub.cancelled_registration.title")
+    expect(page).to have_title t("hub.cancelled_registration.heading", idp_name: "IDCorp")
     expect(page).to have_link t("hub.cancelled_registration.send_feedback")
     expect(page).to have_link t("hub.cancelled_registration.about_choosing_a_company"), href: about_choosing_a_company_path
   end

--- a/spec/features/user_visits_choose_a_certified_company_page_spec.rb
+++ b/spec/features/user_visits_choose_a_certified_company_page_spec.rb
@@ -27,7 +27,7 @@ describe "When the user visits the choose a certified company page" do
                                             "levelsOfAssurance" => %w(LEVEL_2),
                                             "temporarilyUnavailable" => true }])
       visit "/choose-a-certified-company"
-      expect(page).to have_content t("hub.certified_companies_unavailable.title", count: 1, company: "IDCorp")
+      expect(page).to have_content t("hub.certified_companies_unavailable.heading", count: 1, company: "IDCorp")
     end
 
     it "includes the appropriate feedback source" do
@@ -39,6 +39,7 @@ describe "When the user visits the choose a certified company page" do
       visit "/choose-a-certified-company"
 
       expect(page).to have_current_path(choose_a_certified_company_path)
+      expect(page).to have_title t("hub.choose_a_certified_company.heading")
       expect(page).to have_content t("hub.choose_a_certified_company.idp_count")
 
       within("#matching-idps") do
@@ -74,7 +75,7 @@ describe "When the user visits the choose a certified company page" do
     it "displays the page in Welsh but actually the text is still English" do
       visit "/dewis-cwmni-ardystiedig"
 
-      expect(page).to have_title t("hub.choose_a_certified_company.title", locale: :cy)
+      expect(page).to have_title t("hub.choose_a_certified_company.heading", locale: :cy)
       expect(page).to have_css "html[lang=cy]"
     end
   end
@@ -109,7 +110,7 @@ describe "When the user visits the choose a certified company page" do
                                             "levelsOfAssurance" => %w(LEVEL_1),
                                             "temporarilyUnavailable" => true }], "LEVEL_1")
       visit "/choose-a-certified-company"
-      expect(page).to have_content t("hub.certified_companies_unavailable.title", count: 1, company: "IDCorp")
+      expect(page).to have_content t("hub.certified_companies_unavailable.heading", count: 1, company: "IDCorp")
     end
   end
 

--- a/spec/features/user_visits_choose_a_country_page_spec.rb
+++ b/spec/features/user_visits_choose_a_country_page_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "When the user visits the choose a country page" do
 
   def then_im_at_the_interstitial_page(locale = "en")
     expect(page).to have_current_path("/#{t('routes.redirect_to_country', locale: locale)}")
-    expect(page).to have_title t("hub.redirect_to_country.title")
+    expect(page).to have_title t("hub.redirect_to_country.heading")
     expect(page).to have_content t("hub.redirect_to_country.heading")
     expect(page).to have_content t("hub.redirect_to_country.description")
     expect(page).to have_css("input[id=SAMLRequest]", visible: false)
@@ -110,7 +110,7 @@ RSpec.describe "When the user visits the choose a country page" do
     given_a_session_supporting_eidas
     visit "/dewiswch-wlad"
 
-    expect(page).to have_title t("hub.choose_a_country.title", locale: :cy)
+    expect(page).to have_title t("hub.choose_a_country.heading", locale: :cy)
     expect(page).to have_css "html[lang=cy]"
   end
 end

--- a/spec/features/user_visits_confirm_your_identity_page_spec.rb
+++ b/spec/features/user_visits_confirm_your_identity_page_spec.rb
@@ -31,13 +31,13 @@ RSpec.describe "When the user visits the confirm-your-identity page" do
 
     it "displays the page in Welsh" do
       visit "/cadarnhau-eich-hunaniaeth"
-      expect(page).to have_title t("hub.confirm_your_identity.title", locale: :cy)
+      expect(page).to have_title t("hub.signin.sign_in_idp", display_name: "Welsh IDCorp", locale: :cy)
       expect(page).to have_css "html[lang=cy]"
     end
 
     it "displays the page in English" do
       visit "/confirm-your-identity"
-      expect(page).to have_title t("hub.confirm_your_identity.title")
+      expect(page).to have_title t("hub.signin.sign_in_idp", display_name: "IDCorp")
       expect(page).to have_css "html[lang=en]"
     end
 
@@ -112,7 +112,7 @@ RSpec.describe "When the user visits the confirm-your-identity page" do
       set_session_and_session_cookies!
       stub_api_idp_list_for_sign_in
       visit "/confirm-your-identity"
-      expect(page).to have_title t("hub.signin.title")
+      expect(page).to have_title t("hub.signin.heading")
       expect(page).to have_current_path(sign_in_path)
     end
 
@@ -120,7 +120,7 @@ RSpec.describe "When the user visits the confirm-your-identity page" do
       set_session_and_session_cookies!
       stub_api_idp_list_for_sign_in
       visit "/confirm-your-identity"
-      expect(page).to have_title t("hub.signin.title")
+      expect(page).to have_title t("hub.signin.heading")
       expect(page).to have_current_path(sign_in_path)
     end
 
@@ -128,7 +128,7 @@ RSpec.describe "When the user visits the confirm-your-identity page" do
       set_up_session("bad-entity-id")
       stub_api_idp_list_for_sign_in
       visit "/confirm-your-identity"
-      expect(page).to have_title t("hub.signin.title")
+      expect(page).to have_title t("hub.signin.heading")
       expect(page).to have_current_path(sign_in_path)
     end
   end
@@ -145,7 +145,7 @@ RSpec.describe "When the user visits the confirm-your-identity page" do
 
       visit "/test-saml"
       click_button "saml-post-journey-hint-non-repudiation"
-      expect(page).to have_title t("hub.confirm_your_identity.title", locale: :cy)
+      expect(page).to have_title t("hub.signin.sign_in_idp", display_name: "Welsh IDCorp", locale: :cy)
       expect(page).to have_current_path("/cadarnhau-eich-hunaniaeth")
       expect(page).to have_css "html[lang=cy]"
     end

--- a/spec/features/user_visits_confirmation_page_spec.rb
+++ b/spec/features/user_visits_confirmation_page_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe "When user visits the confirmation page" do
   it "includes the appropriate feedback source, title and content" do
     visit "/confirmation"
     expect(page).not_to have_link t("feedback_link.feedback_form")
-    expect(page).to have_link t("hub.feedback.title"), href: "/feedback?feedback-source=CONFIRMATION_PAGE"
-    expect(page).to have_title t("hub.confirmation.title")
+    expect(page).to have_link t("hub.feedback.heading"), href: "/feedback?feedback-source=CONFIRMATION_PAGE"
+    expect(page).to have_title t("hub.confirmation.heading", display_name: "IDCorp")
     expect(page).to have_text t("hub.confirmation.message", display_name: "IDCorp")
     expect(page).to have_text t("hub.confirmation.continue_to_rp", transaction_name: "test GOV.UK Verify user journeys")
   end

--- a/spec/features/user_visits_continue_to_your_idp_page_spec.rb
+++ b/spec/features/user_visits_continue_to_your_idp_page_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe "When the user visits the continue to your IDP page" do
       visit "/continue-to-your-idp"
 
       expect(page).to have_current_path("/continue-to-your-idp")
-      expect(page).to have_title t("hub.single_idp_journey.title", display_name: idp_display_name)
+      expect(page).to have_title t("hub.single_idp_journey.heading", display_name: idp_display_name)
       expect_feedback_source_to_be(page, "CONTINUE_TO_YOUR_IDP_PAGE", "/continue-to-your-idp")
       piwik_custom_variable_single_idp_journey = '{"index":3,"name":"JOURNEY_TYPE","value":"SINGLE_IDP","scope":"visit"}'
       expect(page).to have_content(piwik_custom_variable_single_idp_journey)
@@ -46,7 +46,7 @@ RSpec.describe "When the user visits the continue to your IDP page" do
       set_single_idp_journey_cookie
       visit "/parhau-ich-idp"
 
-      expect(page).to have_title t("hub.single_idp_journey.title", locale: :cy, display_name: "Welsh IDCorp")
+      expect(page).to have_title t("hub.single_idp_journey.heading", locale: :cy, display_name: "Welsh IDCorp")
       expect(page).to have_css "html[lang=cy]"
     end
 

--- a/spec/features/user_visits_failed_registration_page_spec.rb
+++ b/spec/features/user_visits_failed_registration_page_spec.rb
@@ -140,22 +140,22 @@ describe "When the user visits the failed registration page and" do
 
   def expect_page_to_have_main_content_continue_on_fail
     expect_feedback_source_to_be(page, "FAILED_REGISTRATION_PAGE", "/failed-registration")
-    expect(page).to have_title t("hub.failed_registration.title")
+    expect(page).to have_title t("hub.failed_registration.heading", idp_name: "IDCorp")
     expect(page).to have_content t("hub.failed_registration.heading", idp_name: "IDCorp")
     expect(page).to have_content t("hub.failed_registration.contact_details_intro", idp_name: "IDCorp")
   end
 
   def expect_page_to_have_main_content_non_continue
     expect_feedback_source_to_be(page, "FAILED_REGISTRATION_PAGE", "/failed-registration")
-    expect(page).to have_title t("hub.failed_registration.title")
-    expect(page).to have_content t("hub.failed_registration.alt_heading", idp: "IDCorp")
+    expect(page).to have_title t("hub.failed_registration.heading", idp_name: "IDCorp")
+    expect(page).to have_content t("hub.failed_registration.heading", idp_name: "IDCorp")
     expect(page).to have_content t("hub.failed_registration.remaining_idps.different_way", service: "test GOV.UK Verify user journeys")
   end
 
   def expect_page_to_have_main_content_non_continue_for_no_idps
     expect_feedback_source_to_be(page, "FAILED_REGISTRATION_PAGE", "/failed-registration")
-    expect(page).to have_title t("hub.failed_registration.title")
-    expect(page).to have_content t("hub.failed_registration.alt_heading", idp: "IDCorp")
+    expect(page).to have_title t("hub.failed_registration.heading", idp_name: "IDCorp")
+    expect(page).to have_content t("hub.failed_registration.heading", idp_name: "IDCorp")
     expect(page).to have_content t("hub.failed_registration.last_idp.different_way", service: "test GOV.UK Verify user journeys")
   end
 end

--- a/spec/features/user_visits_failed_sign_in_page_spec.rb
+++ b/spec/features/user_visits_failed_sign_in_page_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "When the user visits the failed sign in page" do
       visit "/failed-sign-in"
 
       expect_feedback_source_to_be(page, "FAILED_SIGN_IN_PAGE", "/failed-sign-in")
-      expect(page).to have_title t("hub.failed_sign_in.title")
+      expect(page).to have_title t("hub.failed_sign_in.heading", display_name: "IDCorp")
       expect(page).to have_content t("hub.failed_sign_in.heading", display_name: "IDCorp")
       expect(page.body).to include t("hub.failed_sign_in.reasons_html")
       expect(page).to have_link t("hub.failed_sign_in.start_again"), href: start_path
@@ -40,7 +40,7 @@ RSpec.describe "When the user visits the failed sign in page" do
       visit "/failed-country-sign-in"
 
       expect_feedback_source_to_be(page, "FAILED_COUNTRY_SIGN_IN_PAGE", "/failed-country-sign-in")
-      expect(page).to have_title t("hub.failed_country_sign_in.title")
+      expect(page).to have_title t("hub.failed_country_sign_in.heading", country_name: "Stub Country")
       expect(page).to have_content t("hub.failed_country_sign_in.heading", country_name: "Stub Country")
       expect(page.body).to have_content t("hub.failed_country_sign_in.online")
       expect(page).to have_link t("hub.failed_country_sign_in.online_link"), href: prove_identity_retry_path

--- a/spec/features/user_visits_feedback_page_spec.rb
+++ b/spec/features/user_visits_feedback_page_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature "When the user visits the feedback page" do
 
     click_button t("hub.feedback.send_message")
 
-    expect(page).to have_title t("hub.feedback_sent.title")
+    expect(page).to have_title t("hub.feedback_sent.heading")
 
     expect(page).to have_link t("hub.feedback_sent.product_page"), href: "https://govuk-verify.cloudapps.digital/"
   end
@@ -27,7 +27,7 @@ RSpec.feature "When the user visits the feedback page" do
 
   it "should show errors for all input fields when missing input", js: true do
     visit feedback_path
-    expect(page).to have_title t("hub.feedback.title")
+    expect(page).to have_title t("hub.feedback.heading")
 
     click_button t("hub.feedback.send_message")
 
@@ -46,7 +46,7 @@ RSpec.feature "When the user visits the feedback page" do
 
   it "should show errors for email address when not valid", js: true do
     visit feedback_path
-    expect(page).to have_title t("hub.feedback.title")
+    expect(page).to have_title t("hub.feedback.heading")
 
     choose "feedback_form_reply_true", allow_label_click: true
     fill_in "feedback_form_email", with: "foo@bar"
@@ -62,7 +62,7 @@ RSpec.feature "When the user visits the feedback page" do
 
   it "should show errors for all input fields when missing input and user wants a reply" do
     visit feedback_path
-    expect(page).to have_title t("hub.feedback.title")
+    expect(page).to have_title t("hub.feedback.heading")
 
     choose "feedback_form_reply_true", allow_label_click: true
     click_button t("hub.feedback.send_message")
@@ -89,7 +89,7 @@ RSpec.feature "When the user visits the feedback page" do
 
   it "should not show errors for name and email when missing input and user does not want a reply" do
     visit feedback_path
-    expect(page).to have_title t("hub.feedback.title")
+    expect(page).to have_title t("hub.feedback.heading")
 
     choose "feedback_form_reply_false", allow_label_click: true
     click_button t("hub.feedback.send_message")
@@ -101,7 +101,7 @@ RSpec.feature "When the user visits the feedback page" do
 
   it "should not show errors for reply when it is not selected" do
     visit feedback_path
-    expect(page).to have_title t("hub.feedback.title")
+    expect(page).to have_title t("hub.feedback.heading")
 
     click_button t("hub.feedback.send_message")
 
@@ -198,7 +198,7 @@ RSpec.feature "When the user visits the feedback page" do
 
   it "should also be in welsh" do
     visit feedback_cy_path
-    expect(page).to have_title t("hub.feedback.title", locale: :cy)
+    expect(page).to have_title t("hub.feedback.heading", locale: :cy)
     expect(page).to have_css "html[lang=cy]"
   end
 end

--- a/spec/features/user_visits_further_information_page_spec.rb
+++ b/spec/features/user_visits_further_information_page_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "user visits further information page" do
   it "should also be in welsh" do
     stub_cycle_three_attribute_request("NationalInsuranceNumber")
     visit further_information_cy_path
-    expect(page).to have_title t("hub.further_information.title", cycle_three_name: attribute_field_name, locale: :cy)
+    expect(page).to have_title t("hub.further_information.heading", cycle_three_name: attribute_field_name, locale: :cy)
     expect(page).to have_css "html[lang=cy]"
   end
 
@@ -24,7 +24,7 @@ RSpec.describe "user visits further information page" do
 
     rp_name = t("rps.test-rp.name")
 
-    expect(page).to have_title t("hub.further_information.title", cycle_three_name: attribute_field_name)
+    expect(page).to have_title t("hub.further_information.heading", cycle_three_name: attribute_field_name)
     expect(page).to have_css ".govuk-label", text: attribute_field_name
     expect(page).to have_css "span.govuk-hint", text: t("hub.further_information.example_text", example: t("cycle3.NationalInsuranceNumber.example"))
     expect(page).to have_content t("hub.further_information.first_time")

--- a/spec/features/user_visits_other_ways_to_access_page_spec.rb
+++ b/spec/features/user_visits_other_ways_to_access_page_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "When the user visits the other ways to access page" do
   it "includes expected content" do
     visit "/other-ways-to-access-service"
 
-    expect(page).to have_title t("hub.other_ways_title")
+    expect(page).to have_title t("hub.other_ways_heading", other_ways_description: t("rps.test-rp.name"))
     expect(page).to have_content t("hub.other_ways_heading", other_ways_description: t("rps.test-rp.name"))
     expect(page.body).to include t("rps.test-rp.other_ways_text")
     expect(page).to have_link "here", href: "http://www.example.com"
@@ -19,7 +19,7 @@ RSpec.describe "When the user visits the other ways to access page" do
   it "includes expected content in welsh" do
     visit "/ffyrdd-eraill-i-gael-mynediad-i'r-gwasanaeth"
 
-    expect(page).to have_title t("hub.other_ways_title", locale: :cy)
+    expect(page).to have_title t("hub.other_ways_heading", locale: :cy, other_ways_description: t("rps.test-rp.name", locale: :cy))
     expect(page).to have_content t("hub.other_ways_heading", locale: :cy, other_ways_description: t("rps.test-rp.name", locale: :cy))
 
     expect(page.body).to include t("rps.test-rp.other_ways_text", locale: :cy)

--- a/spec/features/user_visits_privacy_notice_page_spec.rb
+++ b/spec/features/user_visits_privacy_notice_page_spec.rb
@@ -3,7 +3,7 @@ require "feature_helper"
 RSpec.describe "When the user visits the privacy notice page" do
   it "displays the page in English" do
     visit "/privacy-notice"
-    expect(page).to have_title t("hub.privacy_notice.title")
+    expect(page).to have_title t("hub.privacy_notice.heading")
     expect(page).to have_content "This privacy notice explains what data we might collect, how it's used and how it's protected."
     expect(page).to have_link "DPO@cabinetoffice.gov.uk", href: "mailto:DPO@cabinetoffice.gov.uk"
     expect(page).to have_content "Cabinet Office is the data controller for the data processed by GOV.UK Verify."
@@ -11,7 +11,7 @@ RSpec.describe "When the user visits the privacy notice page" do
 
   it "displays the page in Welsh" do
     visit "/hysbysiad-preifatrwydd"
-    expect(page).to have_title t("hub.privacy_notice.title", locale: :cy)
+    expect(page).to have_title t("hub.privacy_notice.heading", locale: :cy)
   end
 
   it "includes the appropriate feedback source" do

--- a/spec/features/user_visits_redirect_to_idp_page_spec.rb
+++ b/spec/features/user_visits_redirect_to_idp_page_spec.rb
@@ -66,6 +66,6 @@ RSpec.describe "When the user visits the redirect to IDP page" do
     given_a_session_with_a_hints_enabled_idp
     stub_session_idp_authn_request(originating_ip, location, false)
     visit redirect_to_idp_register_path
-    expect(page).to have_title t("hub.redirect_to_idp.title")
+    expect(page).to have_title t("hub.redirect_to_idp.heading")
   end
 end

--- a/spec/features/user_visits_redirect_to_service_page_spec.rb
+++ b/spec/features/user_visits_redirect_to_service_page_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "When the user visits the redirect to service page" do
 
     it "should redirect to service when path is error" do
       visit redirect_to_service_error_path
-      verify_redirect_to_service t("hub.redirect_to_service.start_again.title")
+      verify_redirect_to_service t("hub.redirect_to_service.start_again.heading")
 
       click_button t("navigation.continue")
       expect(page).to have_current_path("/test-rp")
@@ -70,7 +70,7 @@ RSpec.describe "When the user visits the redirect to service page" do
 
     it "should redirect to service when path is signing-in" do
       visit redirect_to_service_signing_in_path
-      verify_redirect_to_service t("hub.redirect_to_service.signing_in.title")
+      verify_redirect_to_service t("hub.redirect_to_service.signing_in.heading")
 
       click_button t("navigation.continue")
       expect(page).to have_current_path("/test-rp")
@@ -78,7 +78,7 @@ RSpec.describe "When the user visits the redirect to service page" do
 
     it "should redirect to service when path is start-again" do
       visit redirect_to_service_start_again_path
-      verify_redirect_to_service t("hub.redirect_to_service.start_again.title")
+      verify_redirect_to_service t("hub.redirect_to_service.start_again.heading")
 
       click_button t("navigation.continue")
       expect(page).to have_current_path("/test-rp")

--- a/spec/features/user_visits_select_documents_advice_page_spec.rb
+++ b/spec/features/user_visits_select_documents_advice_page_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature "user visits select documents advice pages", type: :feature do
   it "includes the appropriate feedback source" do
     visit select_documents_advice_path
 
-    expect(page).to have_title t("hub.select_documents_advice.title")
+    expect(page).to have_title t("hub.select_documents_advice.advice_html.heading")
     expect_feedback_source_to_be(page, "SELECT_DOCUMENTS_ADVICE_PAGE", select_documents_advice_path)
   end
 

--- a/spec/features/user_visits_select_documents_page_spec.rb
+++ b/spec/features/user_visits_select_documents_page_spec.rb
@@ -16,12 +16,12 @@ RSpec.feature "When user visits document selection page" do
   end
 
   it "should have a header about photo identity documents" do
-    expect(page).to have_content("Which of these do you have available right now?")
+    expect(page).to have_content t("hub.select_documents.heading")
   end
 
   it "should have a header about photo identity documents in Welsh if user selects Welsh" do
     visit "/dewis-dogfennau"
-    expect(page).to have_content("Which of these do you have available right now?")
+    expect(page).to have_content t("hub.select_documents.heading")
   end
 
   it "redirects to the idp picker page when selects 3 documents" do
@@ -35,7 +35,7 @@ RSpec.feature "When user visits document selection page" do
     check t("hub.select_documents.has_credit_card"), allow_label_click: true
     click_button t("navigation.continue")
 
-    expect(page).to have_title t("hub.choose_a_certified_company.title")
+    expect(page).to have_title t("hub.choose_a_certified_company.heading")
     expect(page).to have_current_path(choose_a_certified_company_path)
   end
 
@@ -57,7 +57,7 @@ RSpec.feature "When user visits document selection page" do
     check t("hub.select_documents.has_credit_card"), allow_label_click: true
     click_button t("navigation.continue")
 
-    expect(page).to have_title t("hub.select_documents_advice.title")
+    expect(page).to have_title t("hub.select_documents_advice.advice_html.heading")
     expect(page).to have_current_path(select_documents_advice_path)
   end
 

--- a/spec/features/user_visits_sign_in_page_spec.rb
+++ b/spec/features/user_visits_sign_in_page_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe "user selects an IDP on the sign in page" do
       given_the_piwik_request_has_been_stubbed
       given_im_on_the_sign_in_page
       when_i_click_start_now
-      expect(page).to have_title t("hub.about.title")
+      expect(page).to have_title t("hub.about_what_is_verify.heading")
       expect_to_have_updated_the_piwik_journey_type_variable
     end
 

--- a/spec/features/user_visits_the_choose_a_certified_company_about_idp_page_spec.rb
+++ b/spec/features/user_visits_the_choose_a_certified_company_about_idp_page_spec.rb
@@ -32,6 +32,7 @@ RSpec.feature "user visits the choose a certified company about idp page", type:
     given_a_session_with_selected_answers
 
     visit choose_a_certified_company_about_path("stub-idp-one")
+    expect(page).to have_title t("hub.choose_a_certified_company.about.heading", display_name: t("idps.stub-idp-one.name"))
     expect(page).to have_content("ID Corp is the premier identity proofing service around.")
     click_button t("hub.choose_a_certified_company.choose_idp", display_name: t("idps.stub-idp-one.name"))
     expect(page).to have_current_path(redirect_to_idp_register_path)
@@ -41,12 +42,12 @@ RSpec.feature "user visits the choose a certified company about idp page", type:
 
   scenario "for a non-existent idp" do
     visit choose_a_certified_company_about_path("foobar")
-    expect(page).to have_content t("errors.page_not_found.title")
+    expect(page).to have_content t("errors.page_not_found.heading")
   end
 
   scenario "for an idp that is not viewable" do
     visit choose_a_certified_company_about_path("foobar")
-    expect(page).to have_content t("errors.page_not_found.title")
+    expect(page).to have_content t("errors.page_not_found.heading")
   end
 
   scenario "user clicks back link" do

--- a/spec/features/user_visits_why_companies_page_spec.rb
+++ b/spec/features/user_visits_why_companies_page_spec.rb
@@ -14,13 +14,13 @@ RSpec.describe "When the user visits the why companies page" do
 
   it "displays the page in Welsh" do
     visit "/pam-cwmniau"
-    expect(page).to have_title t("hub.why_companies.title", locale: :cy)
+    expect(page).to have_title t("hub.why_companies.heading", locale: :cy)
     expect(page).to have_css "html[lang=cy]"
   end
 
   it "includes links to choose-a-certified-company page" do
     visit "/why-companies"
-    expect(page).to have_title t("hub.why_companies.title")
+    expect(page).to have_title t("hub.why_companies.heading")
     expect(page).to have_link "Back", href: "/choose-a-certified-company"
     expect(page).to have_link "Choose a company", href: "/choose-a-certified-company"
   end

--- a/spec/features/user_visits_will_it_work_for_me_page_spec.rb
+++ b/spec/features/user_visits_will_it_work_for_me_page_spec.rb
@@ -25,9 +25,9 @@ RSpec.describe "When the user visits the will it work for me page" do
     it "when js is on", js: true do
       visit "/will-it-work-for-me"
       choose "will_it_work_for_me_form_above_age_threshold_false", allow_label_click: true
-      expect(page).to_not have_content t("hub.will_it_work_for_me.question.not_resident_reason.title")
+      expect(page).to_not have_content t("hub.will_it_work_for_me.question.not_resident_reason.sub_heading")
       choose "will_it_work_for_me_form_resident_last_12_months_false", allow_label_click: true
-      expect(page).to have_content t("hub.will_it_work_for_me.question.not_resident_reason.title")
+      expect(page).to have_content t("hub.will_it_work_for_me.question.not_resident_reason.sub_heading")
       click_button t("navigation.continue")
 
       expect(page).to have_current_path(will_it_work_for_me_path)

--- a/spec/features/users_browser_sends_client_side_analytics_spec.rb
+++ b/spec/features/users_browser_sends_client_side_analytics_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "When the user visits a page" do
     it "sends a page view to analytics" do
       expect(request_log).to receive(:log).with(
         hash_including(
-          "action_name" => "Start - GOV.UK Verify - GOV.UK - LEVEL_2",
+          "action_name" => "Sign in with GOV.UK Verify - GOV.UK Verify - GOV.UK - LEVEL_2",
           "idsite" => "5",
         ),
       )
@@ -36,7 +36,7 @@ RSpec.describe "When the user visits a page" do
     it "and in Welsh sends the page title in English to analytics" do
       expect(request_log).to receive(:log).with(
         hash_including(
-          "action_name" => "Start - GOV.UK Verify - GOV.UK - LEVEL_2",
+          "action_name" => "Sign in with GOV.UK Verify - GOV.UK Verify - GOV.UK - LEVEL_2",
           "idsite" => "5",
         ),
       )
@@ -64,7 +64,7 @@ RSpec.describe "When the user visits a page" do
       set_session_and_session_cookies!
       expect(request_log).to receive(:log).with(
         hash_including(
-          "action_name" => "Start - GOV.UK Verify - GOV.UK - LEVEL_2",
+          "action_name" => "Sign in with GOV.UK Verify - GOV.UK Verify - GOV.UK - LEVEL_2",
         ),
       )
       expect(request_log).to receive(:log).with(
@@ -93,7 +93,7 @@ RSpec.describe "When the user visits a page" do
       page.set_rack_session(new_visit: "true")
       expect(request_log).to receive(:log).with(
         hash_including(
-          "action_name" => "Start - GOV.UK Verify - GOV.UK - LEVEL_2",
+          "action_name" => "Sign in with GOV.UK Verify - GOV.UK Verify - GOV.UK - LEVEL_2",
           "url" => /start/,
           "new_visit" => "1",
         ),
@@ -106,7 +106,7 @@ RSpec.describe "When the user visits a page" do
       page.set_rack_session(new_visit: "true")
       expect(request_log).to receive(:log).with(
         hash_including(
-          "action_name" => "Start - GOV.UK Verify - GOV.UK - LEVEL_2",
+          "action_name" => "Sign in with GOV.UK Verify - GOV.UK Verify - GOV.UK - LEVEL_2",
           "url" => /start/,
           "new_visit" => "1",
         ),
@@ -115,7 +115,7 @@ RSpec.describe "When the user visits a page" do
 
       expect(request_log).to receive(:log).with(
         hash_including(
-          "action_name" => "Start - GOV.UK Verify - GOV.UK - LEVEL_2",
+          "action_name" => "Sign in with GOV.UK Verify - GOV.UK Verify - GOV.UK - LEVEL_2",
           "url" => /start/,
           "new_visit" => "0",
         ),
@@ -123,14 +123,14 @@ RSpec.describe "When the user visits a page" do
       visit "/start"
     end
 
-    it "sends a page view with a new_visit parameter if new session and on next page the parameter is not present" do
+    it "sends a page view with a new_visit parameter What GOV.UK Verify is" do
       stub_api_idp_list_for_registration
       set_session_and_session_cookies!
       page.set_rack_session(new_visit: "true")
 
       expect(request_log).to receive(:log).with(
         hash_including(
-          "action_name" => "Start - GOV.UK Verify - GOV.UK - LEVEL_2",
+          "action_name" => "Sign in with GOV.UK Verify - GOV.UK Verify - GOV.UK - LEVEL_2",
           "url" => /start/,
           "new_visit" => "1",
         ),
@@ -139,7 +139,7 @@ RSpec.describe "When the user visits a page" do
 
       expect(request_log).to receive(:log).with(
         hash_including(
-          "action_name" => "About - GOV.UK Verify - GOV.UK - LEVEL_2",
+          "action_name" => "What GOV.UK Verify is - GOV.UK Verify - GOV.UK - LEVEL_2",
           "url" => /about/,
           "new_visit" => "0",
         ),
@@ -160,7 +160,7 @@ RSpec.describe "When the user visits a page" do
       expect(image_src).to match(/idsite=5/)
       expect(image_src).to match(/rec=1/)
       expect(image_src).to match(/rand=\d+/)
-      expect(image_src).to match(/action_name=Start\+-\+GOV\.UK\+Verify\+-\+GOV\.UK\+-\+LEVEL_2/)
+      expect(image_src).to match(/action_name=Sign\+in\+with\+GOV\.UK\+Verify\+-\+GOV\.UK\+Verify\+-\+GOV\.UK\+-\+LEVEL_2/)
       expect(image_src).to_not include("url")
     end
 
@@ -170,7 +170,7 @@ RSpec.describe "When the user visits a page" do
       noscript_image = page.find(:id, "piwik-noscript-tracker")
       expect(noscript_image).to_not be_nil
       image_src = noscript_image["src"]
-      expect(image_src).to match(/action_name=Start\+-\+GOV\.UK\+Verify\+-\+GOV\.UK\+-\+LEVEL_2/)
+      expect(image_src).to match(/action_name=Sign\+in\+with\+GOV\.UK\+Verify\+-\+GOV\.UK\+Verify\+-\+GOV\.UK\+-\+LEVEL_2/)
     end
 
     it "sends a page view with a custom url for error pages" do
@@ -202,7 +202,7 @@ RSpec.describe "When the user visits a page" do
       expect(image_src).to match(/rec=1/)
       expect(image_src).to match(/new_visit=1/)
       expect(image_src).to match(/rand=\d+/)
-      expect(image_src).to match(/action_name=Start\+-\+GOV\.UK\+Verify\+-\+GOV\.UK\+-\+LEVEL_2/)
+      expect(image_src).to match(/action_name=Sign\+in\+with\+GOV\.UK\+Verify\+-\+GOV\.UK\+Verify\+-\+GOV\.UK\+-\+LEVEL_2/)
     end
 
     it "sends a page view with a new_visit parameter when new visit but not on the following refresh" do
@@ -213,14 +213,14 @@ RSpec.describe "When the user visits a page" do
       expect(noscript_image).to_not be_nil
       image_src = noscript_image["src"]
       expect(image_src).to match(/new_visit=1/)
-      expect(image_src).to match(/action_name=Start\+-\+GOV\.UK\+Verify\+-\+GOV\.UK\+-\+LEVEL_2/)
+      expect(image_src).to match(/action_name=Sign\+in\+with\+GOV\.UK\+Verify\+-\+GOV\.UK\+Verify\+-\+GOV\.UK\+-\+LEVEL_2/)
 
       visit "/start"
       noscript_image = page.find(:id, "piwik-noscript-tracker")
       expect(noscript_image).to_not be_nil
       image_src = noscript_image["src"]
       expect(image_src).to match(/new_visit=0/)
-      expect(image_src).to match(/action_name=Start\+-\+GOV\.UK\+Verify\+-\+GOV\.UK\+-\+LEVEL_2/)
+      expect(image_src).to match(/action_name=Sign\+in\+with\+GOV\.UK\+Verify\+-\+GOV\.UK\+Verify\+-\+GOV\.UK\+-\+LEVEL_2/)
     end
   end
 end

--- a/spec/features/users_browser_sends_client_side_analytics_spec.rb
+++ b/spec/features/users_browser_sends_client_side_analytics_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "When the user visits a page" do
     it "sends a page view to analytics" do
       expect(request_log).to receive(:log).with(
         hash_including(
-          "action_name" => "Sign in with GOV.UK Verify - GOV.UK Verify - GOV.UK - LEVEL_2",
+          "action_name" => "Sign in with GOV.UK Verify - GOV.UK Verify - LEVEL_2",
           "idsite" => "5",
         ),
       )
@@ -36,7 +36,7 @@ RSpec.describe "When the user visits a page" do
     it "and in Welsh sends the page title in English to analytics" do
       expect(request_log).to receive(:log).with(
         hash_including(
-          "action_name" => "Sign in with GOV.UK Verify - GOV.UK Verify - GOV.UK - LEVEL_2",
+          "action_name" => "Sign in with GOV.UK Verify - GOV.UK Verify - LEVEL_2",
           "idsite" => "5",
         ),
       )
@@ -50,7 +50,7 @@ RSpec.describe "When the user visits a page" do
       stub_transactions_list
       expect(request_log).to receive(:log).with(
         hash_including(
-          "action_name" => "Cookies Missing - GOV.UK Verify - GOV.UK",
+          "action_name" => "Cookies Missing - GOV.UK Verify",
           "url" => /cookies-not-found/,
         ),
       )
@@ -64,7 +64,7 @@ RSpec.describe "When the user visits a page" do
       set_session_and_session_cookies!
       expect(request_log).to receive(:log).with(
         hash_including(
-          "action_name" => "Sign in with GOV.UK Verify - GOV.UK Verify - GOV.UK - LEVEL_2",
+          "action_name" => "Sign in with GOV.UK Verify - GOV.UK Verify - LEVEL_2",
         ),
       )
       expect(request_log).to receive(:log).with(
@@ -93,7 +93,7 @@ RSpec.describe "When the user visits a page" do
       page.set_rack_session(new_visit: "true")
       expect(request_log).to receive(:log).with(
         hash_including(
-          "action_name" => "Sign in with GOV.UK Verify - GOV.UK Verify - GOV.UK - LEVEL_2",
+          "action_name" => "Sign in with GOV.UK Verify - GOV.UK Verify - LEVEL_2",
           "url" => /start/,
           "new_visit" => "1",
         ),
@@ -106,7 +106,7 @@ RSpec.describe "When the user visits a page" do
       page.set_rack_session(new_visit: "true")
       expect(request_log).to receive(:log).with(
         hash_including(
-          "action_name" => "Sign in with GOV.UK Verify - GOV.UK Verify - GOV.UK - LEVEL_2",
+          "action_name" => "Sign in with GOV.UK Verify - GOV.UK Verify - LEVEL_2",
           "url" => /start/,
           "new_visit" => "1",
         ),
@@ -115,7 +115,7 @@ RSpec.describe "When the user visits a page" do
 
       expect(request_log).to receive(:log).with(
         hash_including(
-          "action_name" => "Sign in with GOV.UK Verify - GOV.UK Verify - GOV.UK - LEVEL_2",
+          "action_name" => "Sign in with GOV.UK Verify - GOV.UK Verify - LEVEL_2",
           "url" => /start/,
           "new_visit" => "0",
         ),
@@ -123,14 +123,14 @@ RSpec.describe "When the user visits a page" do
       visit "/start"
     end
 
-    it "sends a page view with a new_visit parameter What GOV.UK Verify is" do
+    it "sends a page view with a new_visit parameter if new session and on next page the parameter is not present" do
       stub_api_idp_list_for_registration
       set_session_and_session_cookies!
       page.set_rack_session(new_visit: "true")
 
       expect(request_log).to receive(:log).with(
         hash_including(
-          "action_name" => "Sign in with GOV.UK Verify - GOV.UK Verify - GOV.UK - LEVEL_2",
+          "action_name" => "Sign in with GOV.UK Verify - GOV.UK Verify - LEVEL_2",
           "url" => /start/,
           "new_visit" => "1",
         ),
@@ -139,7 +139,7 @@ RSpec.describe "When the user visits a page" do
 
       expect(request_log).to receive(:log).with(
         hash_including(
-          "action_name" => "What GOV.UK Verify is - GOV.UK Verify - GOV.UK - LEVEL_2",
+          "action_name" => "What GOV.UK Verify is - GOV.UK Verify - LEVEL_2",
           "url" => /about/,
           "new_visit" => "0",
         ),
@@ -160,7 +160,7 @@ RSpec.describe "When the user visits a page" do
       expect(image_src).to match(/idsite=5/)
       expect(image_src).to match(/rec=1/)
       expect(image_src).to match(/rand=\d+/)
-      expect(image_src).to match(/action_name=Sign\+in\+with\+GOV\.UK\+Verify\+-\+GOV\.UK\+Verify\+-\+GOV\.UK\+-\+LEVEL_2/)
+      expect(image_src).to match(/action_name=Sign\+in\+with\+GOV\.UK\+Verify\+-\+GOV\.UK\+Verify\+-\+LEVEL_2/)
       expect(image_src).to_not include("url")
     end
 
@@ -170,7 +170,7 @@ RSpec.describe "When the user visits a page" do
       noscript_image = page.find(:id, "piwik-noscript-tracker")
       expect(noscript_image).to_not be_nil
       image_src = noscript_image["src"]
-      expect(image_src).to match(/action_name=Sign\+in\+with\+GOV\.UK\+Verify\+-\+GOV\.UK\+Verify\+-\+GOV\.UK\+-\+LEVEL_2/)
+      expect(image_src).to match(/action_name=Sign\+in\+with\+GOV\.UK\+Verify\+-\+GOV\.UK\+Verify\+-\+LEVEL_2/)
     end
 
     it "sends a page view with a custom url for error pages" do
@@ -186,7 +186,7 @@ RSpec.describe "When the user visits a page" do
       expect(image_src).to match(/idsite=5/)
       expect(image_src).to match(/rec=1/)
       expect(image_src).to match(/rand=\d+/)
-      expect(image_src).to match(/action_name=Cookies\+Missing\+-\+GOV\.UK\+Verify\+-\+GOV\.UK/)
+      expect(image_src).to match(/action_name=Cookies\+Missing\+-\+GOV\.UK\+Verify/)
       expect(image_src).to match(/url=[^&]+cookies-not-found/)
     end
 
@@ -202,7 +202,7 @@ RSpec.describe "When the user visits a page" do
       expect(image_src).to match(/rec=1/)
       expect(image_src).to match(/new_visit=1/)
       expect(image_src).to match(/rand=\d+/)
-      expect(image_src).to match(/action_name=Sign\+in\+with\+GOV\.UK\+Verify\+-\+GOV\.UK\+Verify\+-\+GOV\.UK\+-\+LEVEL_2/)
+      expect(image_src).to match(/action_name=Sign\+in\+with\+GOV\.UK\+Verify\+-\+GOV\.UK\+Verify\+-\+LEVEL_2/)
     end
 
     it "sends a page view with a new_visit parameter when new visit but not on the following refresh" do
@@ -213,14 +213,14 @@ RSpec.describe "When the user visits a page" do
       expect(noscript_image).to_not be_nil
       image_src = noscript_image["src"]
       expect(image_src).to match(/new_visit=1/)
-      expect(image_src).to match(/action_name=Sign\+in\+with\+GOV\.UK\+Verify\+-\+GOV\.UK\+Verify\+-\+GOV\.UK\+-\+LEVEL_2/)
+      expect(image_src).to match(/action_name=Sign\+in\+with\+GOV\.UK\+Verify\+-\+GOV\.UK\+Verify\+-\+LEVEL_2/)
 
       visit "/start"
       noscript_image = page.find(:id, "piwik-noscript-tracker")
       expect(noscript_image).to_not be_nil
       image_src = noscript_image["src"]
       expect(image_src).to match(/new_visit=0/)
-      expect(image_src).to match(/action_name=Sign\+in\+with\+GOV\.UK\+Verify\+-\+GOV\.UK\+Verify\+-\+GOV\.UK\+-\+LEVEL_2/)
+      expect(image_src).to match(/action_name=Sign\+in\+with\+GOV\.UK\+Verify\+-\+GOV\.UK\+Verify\+-\+LEVEL_2/)
     end
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -16,6 +16,11 @@ RSpec.describe ApplicationHelper, type: :helper do
       expect(helper.content_for(:page_title)).to eql expected_title
     end
 
+    it "raise ArgumentError when called with nil" do
+      expect { helper.page_title(nil) }
+        .to raise_error ArgumentError, "Missing page title"
+    end
+
     it "should output Welsh page title if locale specified" do
       helper.page_title("hub.start.heading", locale: :cy)
       expect(helper.content_for(:page_title)).to eql t("hub.start.heading", locale: "cy")

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -5,32 +5,32 @@ RSpec.describe ApplicationHelper, type: :helper do
 
   describe "#page_title" do
     it "should output English page title by default" do
-      helper.page_title("hub.start.title")
-      expect(helper.content_for(:page_title)).to eql I18n.t("hub.start.title")
+      helper.page_title("hub.start.heading")
+      expect(helper.content_for(:page_title)).to eql t("hub.start.heading")
     end
 
     it 'should start with "Error:" when there are page errors' do
       flash[:errors] = ["some error"]
-      expected_title = "Error: #{I18n.t('hub.start.title', locale: 'en')}"
-      helper.page_title("hub.start.title", locale: :en)
+      expected_title = "Error: #{t('hub.start.heading', locale: 'en')}"
+      helper.page_title("hub.start.heading", locale: :en)
       expect(helper.content_for(:page_title)).to eql expected_title
     end
 
     it "should output Welsh page title if locale specified" do
-      helper.page_title("hub.start.title", locale: :cy)
-      expect(helper.content_for(:page_title)).to eql I18n.t("hub.start.title", locale: "cy")
+      helper.page_title("hub.start.heading", locale: :cy)
+      expect(helper.content_for(:page_title)).to eql t("hub.start.heading", locale: "cy")
     end
 
     it "should always output English page title and level of assurance for analytics" do
-      title = "#{I18n.t('hub.start.title', locale: 'en')} - GOV.UK Verify - GOV.UK - LEVEL_1"
+      title = "#{t('hub.start.heading', locale: 'en')} - GOV.UK Verify - GOV.UK - LEVEL_1"
       session["requested_loa"] = "LEVEL_1"
-      helper.page_title("hub.start.title", locale: :cy)
+      helper.page_title("hub.start.heading", locale: :cy)
       expect(helper.content_for(:page_title_in_english)).to eql title
     end
 
     it "should just output English page title when requested_loa not in session" do
-      title = "#{I18n.t('hub.start.title', locale: 'en')} - GOV.UK Verify - GOV.UK"
-      helper.page_title("hub.start.title", locale: :cy)
+      title = "#{t('hub.start.heading', locale: 'en')} - GOV.UK Verify - GOV.UK"
+      helper.page_title("hub.start.heading", locale: :cy)
       expect(helper.content_for(:page_title_in_english)).to eql title
     end
   end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -27,14 +27,14 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
 
     it "should always output English page title and level of assurance for analytics" do
-      title = "#{t('hub.start.heading', locale: 'en')} - GOV.UK Verify - GOV.UK - LEVEL_1"
+      title = "#{t('hub.start.heading', locale: 'en')} - GOV.UK Verify - LEVEL_1"
       session["requested_loa"] = "LEVEL_1"
       helper.page_title("hub.start.heading", locale: :cy)
       expect(helper.content_for(:page_title_in_english)).to eql title
     end
 
     it "should just output English page title when requested_loa not in session" do
-      title = "#{t('hub.start.heading', locale: 'en')} - GOV.UK Verify - GOV.UK"
+      title = "#{t('hub.start.heading', locale: 'en')} - GOV.UK Verify"
       helper.page_title("hub.start.heading", locale: :cy)
       expect(helper.content_for(:page_title_in_english)).to eql title
     end


### PR DESCRIPTION
see: https://govukverify.atlassian.net/browse/HUB-242
**Why**
As a part of UCD feedback for the ABC testing variant C (short hub) journey, and this uncovered the following accessibility feedback:

We generally advise that page titles and H1s should match. Use the H1 as the definitive version where they differ. This seems to be inconsistent everywhere but I’ve spotted them not matching on:

'Sign in with GOV.UK Verify' page
'What GOV.UK Verify is' page
'About you' page
'Which of these do you have available right now?' page
‘Pick a company to verify you’ page

**How**
This requirement implies that **page titles** and **H1** should be semantically
similar. It was decided all page titles are made exactly the same as the respective H1
this would ensure that this accessibility criteria is always respected and
prevent any deviation or inconsistencies from occurring in overtime.

