### PR TITLE
HUB-792: Align idp logo with button

### DIFF
--- a/app/assets/stylesheets/pages/_company.scss
+++ b/app/assets/stylesheets/pages/_company.scss
@@ -125,6 +125,7 @@
       margin: auto;
       width: 200px;
       height: 96px;
+      text-align: center;
     }
   }
 
@@ -149,6 +150,7 @@
     }
 
     button a {
+      margin: 0 auto;
       width: 65%;
     }
   }

--- a/app/views/choose_a_certified_company/_idp_option.html.erb
+++ b/app/views/choose_a_certified_company/_idp_option.html.erb
@@ -5,7 +5,7 @@
       <%= image_submit_tag(identity_provider.logo_path, alt: "#{identity_provider.display_name} logo") %>
     </div>
 
-    <div class="govuk-grid-column-one-third">
+    <div class="govuk-grid-column-one-third  govuk-!-padding-top-2">
       <% unless identity_provider.unavailable %>
           <%= f.button t('hub.choose_a_certified_company.choose_idp', display_name: identity_provider.display_name),
                         class: "govuk-button#{ ' govuk-button--secondary' unless recommended }",
@@ -21,7 +21,7 @@
           <p><%= t 'hub.certified_companies_unavailable.verify_another_company_text' %></p>
       <% end %>
     </div>
-    <div class="govuk-grid-column-one-third">
+    <div class="govuk-grid-column-one-third  govuk-!-padding-top-2">
       <%= button_link_to t('hub.choose_a_certified_company.about_idp', display_name: identity_provider.display_name),
                           choose_a_certified_company_about_path(identity_provider.simple_id),
                           id: 'about-button',


### PR DESCRIPTION
I am hoping this align the IDP logo with the buttons an attempt to line up the Idp logo with buttons

Currently it looks like this

![image](https://user-images.githubusercontent.com/3749690/106937830-21445580-6716-11eb-87cf-0a0e86eb9880.png)

This change

![image](https://user-images.githubusercontent.com/3749690/106936863-032a2580-6715-11eb-8dfc-d42f6eb3b2ca.png)
