### PR TITLE
BAU: fix alignment issues on picker page

### DIFF
--- a/app/assets/stylesheets/pages/_company.scss
+++ b/app/assets/stylesheets/pages/_company.scss
@@ -44,13 +44,12 @@
 .company-logo {
   position: relative;
   width: 50%;
-  padding-bottom: 25%;
-  margin: 0 auto 15px;
+  margin: 0 auto;
 
   @include govuk-media-query($from: tablet) {
     margin: 0 auto 15px;
     width: 80%;
-    padding-bottom: 40%;
+    padding-bottom: 42%;
   }
 }
 
@@ -77,10 +76,6 @@
   }
 }
 
-.company dialog .govuk-button {
-  margin: 0 0 15px;
-}
-
 .company-about {
   @include govuk-font(16);
   margin-bottom: 0;
@@ -90,8 +85,26 @@
   text-align: left;
 }
 
+.company-logo + .govuk-button {
+  width: 100%;
+  margin-bottom: 10px;
+}
+
+.govuk-grid-column-one-third > .govuk-button {
+  width: 100%;
+  margin-bottom: 10px;
+  margin-top: 15px;
+}
+
+.idp-choice > .govuk-grid-row {
+  margin-bottom: 0;
+  padding-bottom: 0;
+}
+
 .idp-choice {
-  padding: 15px 0;
+  padding-top: 15px;
+  padding-bottom: 5px;
+  margin-bottom: 0;
   border-bottom: 1px solid govuk-colour("dark-grey");
   @include govuk-clearfix;
 
@@ -124,7 +137,7 @@
       bottom: 0;
       margin: auto;
       width: 200px;
-      height: 96px;
+      height: 74px;
       text-align: center;
     }
   }
@@ -151,7 +164,6 @@
 
     button a {
       margin: 0 auto;
-      width: 65%;
     }
   }
 

--- a/app/views/choose_a_certified_company/_idp_option.html.erb
+++ b/app/views/choose_a_certified_company/_idp_option.html.erb
@@ -5,7 +5,7 @@
       <%= image_submit_tag(identity_provider.logo_path, alt: "#{identity_provider.display_name} logo") %>
     </div>
 
-    <div class="govuk-grid-column-one-third  govuk-!-padding-top-2">
+    <div class="govuk-grid-column-one-third">
       <% unless identity_provider.unavailable %>
           <%= f.button t('hub.choose_a_certified_company.choose_idp', display_name: identity_provider.display_name),
                         class: "govuk-button#{ ' govuk-button--secondary' unless recommended }",
@@ -21,7 +21,7 @@
           <p><%= t 'hub.certified_companies_unavailable.verify_another_company_text' %></p>
       <% end %>
     </div>
-    <div class="govuk-grid-column-one-third  govuk-!-padding-top-2">
+    <div class="govuk-grid-column-one-third">
       <%= button_link_to t('hub.choose_a_certified_company.about_idp', display_name: identity_provider.display_name),
                           choose_a_certified_company_about_path(identity_provider.simple_id),
                           id: 'about-button',


### PR DESCRIPTION
This PR is the 3rd refinement of this
- Horizontally center buttons and buttons same width
- Center table rows vertically
- Reduce space between primary and secondary buttons

![image](https://user-images.githubusercontent.com/3749690/108180264-74e37580-70fe-11eb-8129-9201c6b4acbb.png)

  **when in mobile view**

![image](https://user-images.githubusercontent.com/3749690/108180423-a9efc800-70fe-11eb-93af-3c513f40f441.png)

- Also attempted to fix who do you have an identity account with?
  The buttons are now relatively the same width and only wrap if
  the text is really very long

![image](https://user-images.githubusercontent.com/3749690/108180564-d572b280-70fe-11eb-9eda-f7380eec39e7.png)

Other buttons are not affected by this change

![image](https://user-images.githubusercontent.com/3749690/108180903-2d111e00-70ff-11eb-8a89-14a030c8cb51.png)

