### PR TITLE
HUB-809 add legend to start page

### DIFF
--- a/app/views/start/start.html.erb
+++ b/app/views/start/start.html.erb
@@ -9,13 +9,15 @@
 
   <%= form_for @form, url: start_path, html: {id: 'start-page-form', class: 'js-validate', novalidate: 'novalidate'} do |f| %>
     <%= content_tag :div, class: form_question_class do %>
+      <% if @form.errors.include?(:selection_true) %>
+          <span class="govuk-error-message">
+            <%= @form.errors[:selection_true].first %>
+          </span>
+      <% end %>
       <fieldset class="govuk-fieldset">
-        <% if @form.errors.include?(:selection_true) %>
-            <span class="govuk-error-message">
-              <%= @form.errors[:selection_true].first %>
-            </span>
-        <% end %>
-        <h2 class="govuk-heading-m"><%= t 'hub.start.sub_heading' %></h2>
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+          <h2 class="govuk-fieldset__heading"><%= t 'hub.start.sub_heading' %></h2>
+        </legend>
         <div class="govuk-radios">
           <div class="govuk-radios__item">
             <%= f.radio_button :selection, true, {required: true, data: { msg: t('hub.start.error_message')}, piwik_event_tracking: 'journey_user_type', class: "govuk-radios__input", id: "start_form_selection_true"}%>

--- a/app/views/start/start.html.erb
+++ b/app/views/start/start.html.erb
@@ -15,6 +15,7 @@
               <%= @form.errors[:selection_true].first %>
             </span>
         <% end %>
+        <h2 class="govuk-heading-m"><%= t 'hub.start.sub_heading' %></h2>
         <div class="govuk-radios">
           <div class="govuk-radios__item">
             <%= f.radio_button :selection, true, {required: true, data: { msg: t('hub.start.error_message')}, piwik_event_tracking: 'journey_user_type', class: "govuk-radios__input", id: "start_form_selection_true"}%>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -239,6 +239,7 @@ cy:
     start:
       title: Dechrau
       heading: Mewngofnodi gyda GOV.UK Verify
+      sub_heading: Have you used GOV.UK Verify before?
       answer_yes: Dyma’r tro cyntaf i mi ddefnyddio Verify
       answer_no: Rwyf wedi defnyddio Verify o’r blaen
       answer_no_hint: ""

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -239,7 +239,7 @@ cy:
     start:
       title: Dechrau
       heading: Mewngofnodi gyda GOV.UK Verify
-      sub_heading: Have you used GOV.UK Verify before?
+      sub_heading: Ydych chi wedi defnyddio GOV.UK Verify o'r blaen?
       answer_yes: Dyma’r tro cyntaf i mi ddefnyddio Verify
       answer_no: Rwyf wedi defnyddio Verify o’r blaen
       answer_no_hint: ""

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -240,6 +240,7 @@ en:
     start:
       title: Start
       heading: Sign in with GOV.UK Verify
+      sub_heading: Have you used GOV.UK Verify before?
       answer_yes: This is my first time using GOV.UK Verify
       answer_no: I've already signed up for Verify
       answer_no_hint: This includes if you've got part way through creating an identity account


### PR DESCRIPTION
Christopher Thomas took a look at hub as a part of UCD feedback for the short hub, before it was famous. (The variant formerly known as "C".)

* The hub's start page is missing a legend.
* It should contain the question that the user is being asked.
* In this case, that's "Have you used GOV.UK Verify before?"
* Also, Welsh.