### PR TITLE
HUB-853: Change IDP disconnecting warning page title to be the same as the heading

### DIFF
--- a/app/views/sign_in/warn_idp_disconnecting.html.erb
+++ b/app/views/sign_in/warn_idp_disconnecting.html.erb
@@ -1,12 +1,12 @@
-<%= page_title 'hub.signin.heading' %>
+<%= page_title 'hub.signin.warning.heading', company_name:  @idp.display_name %>
 <% content_for :feedback_source, 'SIGN_IN_PAGE' %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds page-with-back-button">
     <%= link_to t('navigation.back'), start_path, class: 'govuk-back-link' %>
 
-    <h1 class="govuk-heading-l"><%= t 'hub.signinwarning.heading', company_name:  @idp.display_name %></h1>
-    <p><%= t 'hub.signinwarning.warning_html', company_name:  @idp.display_name, expiry_date: @idp.provide_authentication_until.strftime("%e %B %Y") %></p>
+    <h1 class="govuk-heading-l"><%= t 'hub.signin.warning.heading', company_name:  @idp.display_name %></h1>
+    <p><%= t 'hub.signin.warning.warning_html', company_name:  @idp.display_name, expiry_date: @idp.provide_authentication_until.strftime("%e %B %Y") %></p>
 
     <%= form_for(@idp, url: sign_in_confirm_path) do |f| %>
       <% button_text = local_assigns.fetch(:non_repudiation, false) ? 'hub.signin.sign_in_idp' : 'hub.signin.select_idp' %>
@@ -19,8 +19,8 @@
       <%= hidden_field_tag 'entity_id', @idp.entity_id, id: nil %>
     <% end %>
   
-    <h1 class="govuk-heading-l"><%= t 'hub.signinwarning.afterheading' %></h1>
+    <h1 class="govuk-heading-l"><%= t 'hub.signin.warning.after_heading' %></h1>
     
-    <p><%= t 'hub.signinwarning.aftertext_html', afterlink: link_to(t('hub.signinwarning.afterlink'), begin_registration_path, id: 'begin-registration-route') %> </p>
+    <p><%= t 'hub.signin.warning.after_text', afterlink: link_to(t('hub.signin.warning.after_link'), begin_registration_path, id: 'begin-registration-route') %> </p>
   </div>
 </div>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -250,17 +250,17 @@ cy:
       company_no_longer_verifies_title: "Nid yw %{company} bellach yn rhan o GOV.UK Verify"
       company_no_longer_verifies_text: Os oes gennych gyfrif hunaniaeth gyda %{company}, bydd angen i chi o %{link}.
       company_no_longer_verifies_link: dilysu eich hunaniaeth gyda chwmni arall
-    signinwarning:
-      heading: Changes to your %{company_name} identity account
-      warning_html: |
-        <p>%{company_name} will stop being a GOV.UK Verify identity provider on %{expiry_date}. 
-        You will not be able to use your %{company_name} identity account to access 
-        government services after then.</p>
-        
-        <p>%{company_name} will delete your account and any of your personal data when this happens.</p>
-      afterheading: What to do after your account has been deleted
-      aftertext_html: You can verify your identity and %{afterlink} with one of the current identity providers. You might also be able to prove your identity in another way to access some services.
-      afterlink: create a new account
+      warning:
+        heading: Changes to your %{company_name} identity account
+        warning_html: |
+          <p>%{company_name} will stop being a GOV.UK Verify identity provider on %{expiry_date}.
+          You will not be able to use your %{company_name} identity account to access
+          government services after then.</p>
+
+          <p>%{company_name} will delete your account and any of your personal data when this happens.</p>
+        after_heading: What to do after your account has been deleted
+        after_text: You can verify your identity and %{afterlink} with one of the current identity providers. You might also be able to prove your identity in another way to access some services.
+        after_link: create a new account
     cookies:
       heading: Cwcis
     privacy_notice:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -250,17 +250,17 @@ en:
       company_no_longer_verifies_title: "%{company} is no longer a part of GOV.UK Verify"
       company_no_longer_verifies_text: If you have an identity account with %{company}, you’ll need to %{link}.
       company_no_longer_verifies_link: verify your identity with another company
-    signinwarning:
-      heading: Changes to your %{company_name} identity account
-      warning_html: |
-        <p>%{company_name} will stop being a GOV.UK Verify identity provider on %{expiry_date}. 
-        You will not be able to use your %{company_name} identity account to access 
-        government services after then.</p>
-        
-        <p>%{company_name} will delete your account and any of your personal data when this happens.</p>
-      afterheading: What to do after your account has been deleted
-      aftertext_html: You can verify your identity and %{afterlink} with one of the current identity providers. You might also be able to prove your identity in another way to access some services.
-      afterlink: create a new account
+      warning:
+        heading: Changes to your %{company_name} identity account
+        warning_html: |
+          <p>%{company_name} will stop being a GOV.UK Verify identity provider on %{expiry_date}.
+          You will not be able to use your %{company_name} identity account to access
+          government services after then.</p>
+
+          <p>%{company_name} will delete your account and any of your personal data when this happens.</p>
+        after_heading: What to do after your account has been deleted
+        after_text: You can verify your identity and %{afterlink} with one of the current identity providers. You might also be able to prove your identity in another way to access some services.
+        after_link: create a new account
     cookies:
       heading: Cookies
     privacy_notice:


### PR DESCRIPTION
To be compliant with accessibility and also to make smoke tests pass