### PR TITLE
BAU Fix for broken link on warning page

### DIFF
--- a/app/views/sign_in/warn_idp_disconnecting.html.erb
+++ b/app/views/sign_in/warn_idp_disconnecting.html.erb
@@ -21,6 +21,6 @@
   
     <h1 class="govuk-heading-l"><%= t 'hub.signin.warning.after_heading' %></h1>
     
-    <p><%= t 'hub.signin.warning.after_text', afterlink: link_to(t('hub.signin.warning.after_link'), begin_registration_path, id: 'begin-registration-route') %> </p>
+    <p><%= t 'hub.signin.warning.after_text_html', afterlink: link_to(t('hub.signin.warning.after_link'), begin_registration_path, id: 'begin-registration-route') %> </p>
   </div>
 </div>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -259,7 +259,7 @@ cy:
 
           <p>Bydd % {company_name} yn dileu eich cyfrif a'ch data personol pan fydd hyn yn digwydd.</p>
         after_heading: Beth i'w wneud ar ôl i'ch cyfrif cael ei ddileu
-        after_text: |
+        after_text_html: |
           Gallwch wirio'ch hunaniaeth a %{afterlink} gydag un o'r darparwyr hunaniaeth cyfredol.
           Efallai y byddwch hefyd yn gallu profi'ch hunaniaeth mewn ffordd arall i gael mynediad at rai gwasanaethau.
         after_link: creu cyfrif newydd

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -259,7 +259,7 @@ en:
 
           <p>%{company_name} will delete your account and any of your personal data when this happens.</p>
         after_heading: What to do after your account has been deleted
-        after_text: You can verify your identity and %{afterlink} with one of the current identity providers. You might also be able to prove your identity in another way to access some services.
+        after_text_html: You can verify your identity and %{afterlink} with one of the current identity providers. You might also be able to prove your identity in another way to access some services.
         after_link: create a new account
     cookies:
       heading: Cookies


### PR DESCRIPTION
One of the recent PRs broke the link on the IDP warning page.  This PR fixes this broken link so it display correctly