### PR TITLE
HUB-859 Show IDP as no longer available at 2 hours

### DIFF
--- a/app/controllers/partials/viewable_idp_partial_controller.rb
+++ b/app/controllers/partials/viewable_idp_partial_controller.rb
@@ -41,7 +41,7 @@ module ViewableIdpPartialController
   end
 
   def current_available_identity_providers_for_sign_in
-    current_identity_providers_for_sign_in.select(&:authentication_enabled).reject(&:unavailable)
+    current_identity_providers_for_sign_in.select(&:authentication_enabled).reject { |idp| idp.unavailable || (idp.provide_authentication_until.present? && idp.provide_authentication_until < 2.hours.from_now) }
   end
 
   def current_unavailable_identity_providers_for_sign_in
@@ -49,7 +49,7 @@ module ViewableIdpPartialController
   end
 
   def current_disconnected_identity_providers_for_sign_in
-    current_identity_providers_for_sign_in.reject(&:authentication_enabled)
+    current_identity_providers_for_sign_in.select { |idp| !idp.authentication_enabled || (idp.provide_authentication_until.present? && idp.provide_authentication_until < 2.hours.from_now) }
   end
 
   def current_available_identity_providers_for_registration_loa2(rp_entity_id)

--- a/spec/controllers/sign_in_controller_spec.rb
+++ b/spec/controllers/sign_in_controller_spec.rb
@@ -36,6 +36,27 @@ describe SignInController do
     end
   end
 
+  context "With IDPs expiring in less than 2 hours" do
+    before(:example) do
+      stub_api_idp_list_for_sign_in([{ "simpleId" => "stub-idp-one",
+                                      "entityId" => "http://idcorp.com",
+                                      "levelsOfAssurance" => %w(LEVEL_1),
+                                      "provideAuthenticationUntil" => 1.hours.from_now.to_s },
+                                     { "simpleId" => "stub-idp-two",
+                                      "entityId" => "http://idcorp-two.com",
+                                      "levelsOfAssurance" => %w(LEVEL_1) }])
+      set_session_and_cookies_with_loa("LEVEL_1")
+    end
+
+    it "will have one available IDP" do
+      expect(subject.current_available_identity_providers_for_sign_in.length).to eq(1)
+    end
+
+    it "will have one unavilable IDP" do
+      expect(subject.current_disconnected_identity_providers_for_sign_in.length).to eq(1)
+    end
+  end
+
   context "Without Expiring IDPs" do
     before(:example) do
       stub_api_idp_list_for_sign_in([{ "simpleId" => "stub-idp-one",


### PR DESCRIPTION
This is a draft PR to hide IDPs 2 hours before they are due to be disconnected.

![image](https://user-images.githubusercontent.com/29251905/111626803-51d3e080-87e6-11eb-9445-33f831a4666b.png)
