### PR TITLE
BAU: Fix squashed logo

### DIFF
--- a/app/assets/stylesheets/pages/_company.scss
+++ b/app/assets/stylesheets/pages/_company.scss
@@ -138,7 +138,7 @@
       bottom: 0;
       margin: auto;
       width: 200px;
-      height: 74px;
+      height: 96px;
       text-align: center;
     }
   }


### PR DESCRIPTION
The company logo on the "last company selected" page is squashed. This
reverts the height to what it was previously, which resolves.

The original change was brought in [here.](https://github.com/alphagov/verify-frontend/commit/c24065e4b3ba702cde3c4b1da73d1c615bafb577)

### Before
![Screenshot 2021-03-23 at 09 59 24](https://user-images.githubusercontent.com/13836290/112128607-810b9880-8bbe-11eb-92f7-b2657cff7aba.png)

### After
![Screenshot 2021-03-23 at 09 58 17](https://user-images.githubusercontent.com/13836290/112128619-849f1f80-8bbe-11eb-89ef-80d176b0765d.png)
