### PR TITLE
HUB-891 Update README to reflect new prerequisite for OS X

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ docker build . --network host -t verify-frontend
 
 ### Additional prerequisites
 
-If running on OS X, you'll also need to used [homebrew](https://brew.sh/) to install this dependency:
+If running on OS X, you'll also need to use [homebrew](https://brew.sh/) to install this dependency:
 
 ```bash
 brew install shared-mime-info

--- a/README.md
+++ b/README.md
@@ -16,7 +16,17 @@ Alternatively, build a Docker container with a command such as:
 docker build . --network host -t verify-frontend
 ```
 
+### Additional prerequisites
+
+If running on OS X, you'll also need to used [homebrew](https://brew.sh/) to install this dependency:
+
+```bash
+brew install shared-mime-info
+```
+
 ## Running the application
+
+### Standalone
 
 You can start the application without having any of the closed source components installed with:
 
@@ -28,6 +38,13 @@ To start a journey on the front end visit http://localhost:50300/test-saml and c
 
 If you're on the Verify team and have the rest of the federation running locally you should omit the `--stub-api` argument
 and start your journey from the test-rp.
+
+### With microservices
+
+The [verify-local-startup](https://github.com/alphagov/verify-local-startup) project allows you to
+build and run the Verify Hub and related microservices.
+
+It makes use of Git, Docker and Ruby to achieve this.
 
 ## Running the tests
 
@@ -49,15 +66,18 @@ pre-commit install
 ```
 
 ## Deploying the application
+
 The application is deployed using our [CI/CD pipeline](https://cd.gds-reliability.engineering/teams/verify/pipelines/deploy-verify-hub?groups=build-apps&groups=default).
 Any changes merged to master are automatically deployed. This repo has an active branch protection for `master`. Any changes need to be raised via PR and approved by two other developers.
 
 ## PR reviews
+
 When a PR is raised, it's automatically tested using Travis (runs the ./pre-commit.sh script on the branch and against master) which is configured in the [.travis file](/.travis). The test results are shown directly on the PR.
 
 In addition to the Travis tests we have also enabled Codacy to check coding style. Again, the results are shown within the PR. Codacy is configured using the [.rubocop.yml file](/.rubocop.yml).
 
 The PR is also deployed to Heroku as [a review app](https://devcenter.heroku.com/articles/github-integration-review-apps). The app is destroyed when the PR is closed/merged or after 5 days of inactivity. It uses docker to run both the Rails app and the stub API server. The Heroku deployment is configured using the 4 files:
+
 * `Dockerfile.heroku` - to configure the docker image of frontend
 * `heroku.yml` - Heroku [deployment manifest](https://devcenter.heroku.com/articles/build-docker-images-heroku-yml)
 * `app.json` - Heroku [application manifest](https://devcenter.heroku.com/articles/app-json-schema)
@@ -80,7 +100,7 @@ by setting the `cross_gov_ga_domain_names` variable in the `site.tf` for the rel
 Should you have to update the GOV.UK frontend in the future you'll need to run npm within the lib directory and
 commit the results. e.g.
 
-```
+```bash
 git checkout -b <some_branch_name>
 cd ./lib
 npm update
@@ -88,5 +108,3 @@ git add .
 git commit
 push
 ```
-
-


### PR DESCRIPTION
* The changes in mimemagic 0.3.8 to keep it MIT licensed mean there's an additional prerequisite to install on OS X now.
* I also added mention of verify-local-startup as an option for running the frontend.