### PR TITLE
HUB-726 Statement updated to reflect accessibility fixes

### DIFF
--- a/app/views/static/accessibility.en.html.erb
+++ b/app/views/static/accessibility.en.html.erb
@@ -20,14 +20,9 @@ end %>
 
     <p>We’ve also made the website text as simple as possible to understand.</p>
     <p><a href="https://mcmw.abilitynet.org.uk/">AbilityNet</a> has advice on making your device easier to use if you have a disability.</p>
-    
+
     <h2 class="govuk-heading-m">How accessible this website is</h2>
-    <p>We know some parts of this website are not fully accessible:</p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>you might not be given a warning before a page times out</li>
-      <li>the colour contrast is not high enough for some of the text</li>
-      <li>the colour contrast is not high enough for the focus indicator that shows you what you’ve selected on the page</li>
-    </ul>
+    <p>This website is fully compliant with the <a href="https://www.w3.org/TR/WCAG21/">Web Content Accessibility Guidelines version 2.1</a> AA standard.</p>
 
     <h2 class="govuk-heading-m">What to do if you cannot access parts of this website</h2>
     <p>If you need information on this website in a different format like accessible PDF, large print, easy read, audio recording or braille, please contact <a href="mailto:idasupport@digital.cabinet-office.gov.uk">idasupport@digital.cabinet-office.gov.uk</a> with details of your request.</p>
@@ -41,19 +36,10 @@ end %>
 
     <h1 class="govuk-heading-l">Technical information about this website’s accessibility</h1>
     <p>GDS is committed to making its website accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.</p>
-    <p>This website is partially compliant with the <a href="https://www.w3.org/TR/WCAG21/">Web Content Accessibility Guidelines version 2.1</a> AA standard, due to the non-compliances listed below.</p>
-
-    <h1 class="govuk-heading-l">Non accessible content</h1>
-    <p>The content listed below is non-accessible for the following reasons.</p>
-    
-    <h2 class="govuk-heading-m">Non compliance with the accessibility regulations</h2>
-    <p>Some pages do not give a warning before timing out, or let you adjust or extend the time limit. This fails WCAG 2.1 success criterion <a href="https://www.w3.org/TR/WCAG21/#timing-adjustable">2.2.1 (timing adjustable)</a>.</p>
-    <p>The colour contrast ratio for some of the text is less than 4.5:1. This fails WCAG 2.1 success criterion <a href="https://www.w3.org/TR/WCAG21/#contrast-minimum">1.4.3 (minimum contrast)</a>.</p>
-    <p>The colour contrast ratio for the focus indicator is less than 3:1. This fails WCAG 2.1 success criterion <a href="https://www.w3.org/TR/WCAG21/#non-text-contrast">1.4.11 (non-text contrast)</a>.</p>
-    <p>We will make all these elements fully accessible by February 2020.</p>
+    <p>This website is fully compliant with the <a href="https://www.w3.org/TR/WCAG21/">Web Content Accessibility Guidelines version 2.1</a> AA standard.</p>
 
     <h1 class="govuk-heading-l">How we tested this website</h1>
-    <p>We last tested this website for accessibility issues in September 2019.</p>
+    <p>We last tested this website for accessibility issues in January 2021.</p>
     <p>We used manual and automated tests to look for issues such as:</p>
     <ul class="govuk-list govuk-list--bullet">
       <li>lack of keyboard accessibility</li>
@@ -65,14 +51,7 @@ end %>
     </ul>
 
     <h1 class="govuk-heading-l">What we’re doing to improve accessibility</h1>
-    <p>We will make changes to this website to make it fully accessible. </p>
-    <p>We will:</p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>give a warning before a page times out, or let you adjust or extend the time limit</li>
-      <li>increase the colour contrast ratio for all text to 4.5:1 or higher</li>
-      <li>increase the colour contrast ratio for the focus indicator to 3:1 or higher</li>
-    </ul>
-    <p>We will make these changes by February 2020.</p>
-    <p>This statement was prepared on 20 September 2019. It was last updated on 27 January 2020.</p>
+    <p>We are committed to maintaining full compliance with the <a href="https://www.w3.org/TR/WCAG21/">Web Content Accessibility Guidelines version 2.1</a> AA standard.</p>
+    <p>This statement was prepared on 20 September 2019. It was last updated on 30 March 2021.</p>
   </div>
 </div>


### PR DESCRIPTION
Context: Our recent accessibility audit raised some issues which we have fixed, including previously known problems. We have a legal obligation to make our website accessible and we are now fully compliant with Web Content Accessibility Guidelines version 2.1 AA standard. This PR updates our accessibility statement to say this. 

Accessibility fixes include:

- [Making page titles accessible](https://github.com/alphagov/verify-frontend/pull/939)
- [Removing modal timeout](https://github.com/alphagov/verify-frontend/pull/936)
- [Removing duplicate page titles](https://github.com/alphagov/verify-frontend/pull/922)
- [Colour contrast and other fixes](https://github.com/alphagov/verify-frontend/pull/736)