### PR TITLE
HUB-920: Add logging to help diagnose issue

### DIFF
--- a/app/models/config_endpoints.rb
+++ b/app/models/config_endpoints.rb
@@ -14,7 +14,12 @@ module ConfigEndpoints
   end
 
   def idp_list_for_sign_in_endpoint(transaction_id)
-    PATH_PREFIX.join(IDP_LIST_SIGN_IN_SUFFIX % { transaction_name: CGI.escape(transaction_id) }).to_s
+    begin
+      PATH_PREFIX.join(IDP_LIST_SIGN_IN_SUFFIX % { transaction_name: CGI.escape(transaction_id) }).to_s
+    rescue TypeError
+      Rails.logger.error("TypeError thrown by #idp_list_for_sign_in_endpoint - see HUB-920. Session was #{session.inspect}")
+      raise
+    end
   end
 
   def idp_list_for_single_idp_endpoint(transaction_id)


### PR DESCRIPTION
We're getting TypeErrors in Sentry which are implying that the
transaction ID retrieved from the users session is nil. We have a
validator however that should be preventing requests without this value
in their session from being accepted.

This logging will allow us to inspect the session in these cases to
determine what is actually happening.