### PR TITLE
HUB-920: Fix logging

### DIFF
--- a/app/controllers/partials/viewable_idp_partial_controller.rb
+++ b/app/controllers/partials/viewable_idp_partial_controller.rb
@@ -37,7 +37,7 @@ module ViewableIdpPartialController
   end
 
   def current_identity_providers_for_sign_in
-    CONFIG_PROXY.get_idp_list_for_sign_in(session[:transaction_entity_id]).idps
+    CONFIG_PROXY.get_idp_list_for_sign_in(session[:transaction_entity_id], session).idps
   end
 
   def current_available_identity_providers_for_sign_in

--- a/app/models/config_endpoints.rb
+++ b/app/models/config_endpoints.rb
@@ -13,11 +13,11 @@ module ConfigEndpoints
     PATH_PREFIX.join(IDP_LIST_REGISTRATION_SUFFIX % { transaction_name: CGI.escape(transaction_id), loa: CGI.escape(loa) }).to_s
   end
 
-  def idp_list_for_sign_in_endpoint(transaction_id)
+  def idp_list_for_sign_in_endpoint(transaction_id, session)
     begin
       PATH_PREFIX.join(IDP_LIST_SIGN_IN_SUFFIX % { transaction_name: CGI.escape(transaction_id) }).to_s
     rescue TypeError
-      Rails.logger.error("TypeError thrown by #idp_list_for_sign_in_endpoint - see HUB-920. Session was #{session.inspect}")
+      Rails.logger.error("TypeError thrown by #idp_list_for_sign_in_endpoint - see HUB-920. Session was #{session.each {}}")
       raise
     end
   end

--- a/app/models/config_proxy.rb
+++ b/app/models/config_proxy.rb
@@ -40,8 +40,8 @@ class ConfigProxy
     IdpListResponse.validated_response(response)
   end
 
-  def get_idp_list_for_sign_in(transaction_id)
-    response = @api_client.get(idp_list_for_sign_in_endpoint(transaction_id))
+  def get_idp_list_for_sign_in(transaction_id, session = "Not passed in")
+    response = @api_client.get(idp_list_for_sign_in_endpoint(transaction_id, session))
     IdpListResponse.validated_response(response)
   end
 

--- a/spec/api_test_helper.rb
+++ b/spec/api_test_helper.rb
@@ -301,11 +301,11 @@ module ApiTestHelper
   end
 
   def stub_api_idp_list_for_sign_in(idps = default_idps)
-    stub_request(:get, config_api_uri(idp_list_for_sign_in_endpoint(default_transaction_entity_id))).to_return(body: idps.to_json)
+    stub_request(:get, config_api_uri(idp_list_for_sign_in_endpoint(default_transaction_entity_id, nil))).to_return(body: idps.to_json)
   end
 
   def stub_api_idp_list_for_sign_in_without_session(idps = default_idps, transaction_entity_id = default_transaction_entity_id)
-    stub_request(:get, config_api_uri(idp_list_for_sign_in_endpoint(transaction_entity_id))).to_return(body: idps.to_json)
+    stub_request(:get, config_api_uri(idp_list_for_sign_in_endpoint(transaction_entity_id, nil))).to_return(body: idps.to_json)
   end
 
   def stub_api_idp_list_for_single_idp_journey(transaction_id = default_transaction_entity_id, idps = default_idps)


### PR DESCRIPTION
The session object is not available in a model (confusingly it is when
running tests...).

The only reasonable way to get that information into the model is to
pass it in from the controller.