### PR TITLE
HUB-920: Fail invalid CSRF with exception on sign in

### DIFF
--- a/app/controllers/partials/viewable_idp_partial_controller.rb
+++ b/app/controllers/partials/viewable_idp_partial_controller.rb
@@ -37,7 +37,7 @@ module ViewableIdpPartialController
   end
 
   def current_identity_providers_for_sign_in
-    CONFIG_PROXY.get_idp_list_for_sign_in(session[:transaction_entity_id], session).idps
+    CONFIG_PROXY.get_idp_list_for_sign_in(session[:transaction_entity_id]).idps
   end
 
   def current_available_identity_providers_for_sign_in

--- a/app/controllers/sign_in_controller.rb
+++ b/app/controllers/sign_in_controller.rb
@@ -8,7 +8,7 @@ class SignInController < ApplicationController
   include AnalyticsCookiePartialController
   include ActionView::Helpers::UrlHelper
 
-  protect_from_forgery except: :warn_idp_disconnecting
+  protect_from_forgery with: :exception, except: :warn_idp_disconnecting
 
   def index
     entity_id = success_entity_id

--- a/app/models/config_endpoints.rb
+++ b/app/models/config_endpoints.rb
@@ -13,13 +13,8 @@ module ConfigEndpoints
     PATH_PREFIX.join(IDP_LIST_REGISTRATION_SUFFIX % { transaction_name: CGI.escape(transaction_id), loa: CGI.escape(loa) }).to_s
   end
 
-  def idp_list_for_sign_in_endpoint(transaction_id, session)
-    begin
-      PATH_PREFIX.join(IDP_LIST_SIGN_IN_SUFFIX % { transaction_name: CGI.escape(transaction_id) }).to_s
-    rescue TypeError
-      Rails.logger.error("TypeError thrown by #idp_list_for_sign_in_endpoint - see HUB-920. Session was #{session.each {}}")
-      raise
-    end
+  def idp_list_for_sign_in_endpoint(transaction_id)
+    PATH_PREFIX.join(IDP_LIST_SIGN_IN_SUFFIX % { transaction_name: CGI.escape(transaction_id) }).to_s
   end
 
   def idp_list_for_single_idp_endpoint(transaction_id)

--- a/app/models/config_proxy.rb
+++ b/app/models/config_proxy.rb
@@ -40,8 +40,8 @@ class ConfigProxy
     IdpListResponse.validated_response(response)
   end
 
-  def get_idp_list_for_sign_in(transaction_id, session = "Not passed in")
-    response = @api_client.get(idp_list_for_sign_in_endpoint(transaction_id, session))
+  def get_idp_list_for_sign_in(transaction_id)
+    response = @api_client.get(idp_list_for_sign_in_endpoint(transaction_id))
     IdpListResponse.validated_response(response)
   end
 

--- a/spec/api_test_helper.rb
+++ b/spec/api_test_helper.rb
@@ -301,11 +301,11 @@ module ApiTestHelper
   end
 
   def stub_api_idp_list_for_sign_in(idps = default_idps)
-    stub_request(:get, config_api_uri(idp_list_for_sign_in_endpoint(default_transaction_entity_id, nil))).to_return(body: idps.to_json)
+    stub_request(:get, config_api_uri(idp_list_for_sign_in_endpoint(default_transaction_entity_id))).to_return(body: idps.to_json)
   end
 
   def stub_api_idp_list_for_sign_in_without_session(idps = default_idps, transaction_entity_id = default_transaction_entity_id)
-    stub_request(:get, config_api_uri(idp_list_for_sign_in_endpoint(transaction_entity_id, nil))).to_return(body: idps.to_json)
+    stub_request(:get, config_api_uri(idp_list_for_sign_in_endpoint(transaction_entity_id))).to_return(body: idps.to_json)
   end
 
   def stub_api_idp_list_for_single_idp_journey(transaction_id = default_transaction_entity_id, idps = default_idps)


### PR DESCRIPTION
We set `protect_from_forgery with: :exception` in the
`ApplicationController`. This means that if we receive an invalid CSRF
token Rails will throw an error. This behaviour is propagated to all
controllers that inherit from the `ApplicationController` (all of them).

The default behaviour of `protect_from_forgery` (if we didn't set `with:
:exception`) is to use the `:null_session` strategy. This sets the
session to empty for the duration of the request but not completely
reset it.

In the sign-in controller we redefine `protect_from_forgery` so that we
exclude one particular action. We don't set the `with:` option though.
This overrides the `with: :exception` set in the `ApplicationController`
and means we run with the default for this controller.

This is problematic for us. The session is validated before the CSRF
token check. This results in the session passing validation but the
getting wiped by the CSRF protection. The request then continues as
usual. We then attempt to use data from the session, which throws
errors.

This updates the overriding `protect_from_forgery` in the
`SignInController` to maintain the expected behaviour as defined in the
`ApplicaitonController`.