### PR TITLE
HUB-863: Fix key for Welsh certified_companies_disconnected heading

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -485,7 +485,7 @@ cy:
       verify_another_company_text: Gallwch geisio nes ymlaen eto neu wirio'ch hunaniaeth gyda chwmni ardystiedig arall.
       company_text: Nid yw %{company} ar gael
     certified_companies_disconnected:
-      sub_heading: Nid yw'r cwmnïau canlynol bellach yn rhan o GOV.UK Verify
+      heading: Nid yw'r cwmnïau canlynol bellach yn rhan o GOV.UK Verify
       verify_another_company_html: Os oedd gennych gyfrif hunaniaeth gydag un o'r cwmnïau hyn, bydd angen i chi %{link}.
       verify_another_company_link: dilysu eich hunaniaeth gyda chwmni arall
     further_information:


### PR DESCRIPTION
The heading is currently appearing in English on the Welsh version of
the page, as the key is wrong.