### PR TITLE
BAU: Fix a couple of bugs

### DIFF
--- a/app/controllers/completed_registration_controller.rb
+++ b/app/controllers/completed_registration_controller.rb
@@ -24,6 +24,7 @@ class CompletedRegistrationController < ApplicationController
       entity_id = decorate_idp_by_simple_id(identity_providers, idp_simple_id).entity_id
       set_attempt_journey_hint(entity_id)
       set_journey_hint_by_status(entity_id, "SUCCESS")
+      remove_resume_link_journey_hint
       render :index
     end
   end

--- a/app/controllers/paused_registration_controller.rb
+++ b/app/controllers/paused_registration_controller.rb
@@ -14,7 +14,7 @@ class PausedRegistrationController < ApplicationController
   include AnalyticsCookiePartialController
 
   # Validate the session manually within the action, as we don't want the normal 'no session' page.
-  skip_before_action :validate_session, except: :resume
+  skip_before_action :validate_session, only: %i[index from_resume_link]
   skip_before_action :set_piwik_custom_variables, except: :resume
   layout "slides", only: :resume
 

--- a/spec/controllers/completed_registration_controller_spec.rb
+++ b/spec/controllers/completed_registration_controller_spec.rb
@@ -10,6 +10,11 @@ describe CompletedRegistrationController do
 
   context "#index" do
     it "renders the page when the IDP is valid" do
+      cookies.encrypted[CookieNames::VERIFY_FRONT_JOURNEY_HINT] = {
+        value: { "RESUMELINK": { IDP: :valid_idp_simple_id } }.to_json,
+        expires: 18.months.from_now,
+      }
+
       stub_api_idp_list_for_sign_in_without_session([
         { "simpleId" => "stub-idp-one",
           "entityId" => entity_id,
@@ -24,6 +29,7 @@ describe CompletedRegistrationController do
 
       expect(cookie_hint["ATTEMPT"]).to eq(entity_id)
       expect(cookie_hint["SUCCESS"]).to eq(entity_id)
+      expect((cookie_hint.has_key? "RESUMELINK")).to be false
     end
 
     it "redirects to the verify services page and does not set the journey hint cookie if IDP invalid" do


### PR DESCRIPTION
### Only skip session validation where necessary

In the PausedRegistration controller we were skipping session
validation, except for the `resume` action. This was so that users
returning after pausing, via the #index or #from_resume_link actions,
who's sessions may have expired, weren't booted to the usual error page.

We were explicitly still validating the `resume` action however. This
action is accessed with a GET request. The `resume_with_idp` and
`resume_with_idp_ajax` actions are accessed with POST requests made from
the `resume-registration` page rendered by the `resume` action. We were
not validating the session on theses POSTs.

We've seen occurrences of a users session becoming invalid in between the
initial GET for `resume` and then the following POSTs. We should
validate the POSTs too to capture this.

Hopefully this will resolve https://sentry.io/organizations/gds-verify/issues/2318188798 and https://sentry.io/organizations/gds-verify/issues/2318188790

### Remove `RESUMELINK` from journey hint after CompletedRegistration

The `RESUMELINK` value is set in the journey hint controller when a
users registration is paused with a resume link. This value is checked
in the AuthnRequest controller and the user is redirected to the resume
registration path if it exists.

We unset the value once a user has completed a journey with an IDP -
this is done in the AuthnResponseController#idp_response action. This is
where IDP responses are POSTed to.

Some users however are returned by IDPs to the
CompletedRegistrationController. This is when the IDP no longer has the
original SAML request for the user, and so can't issue the response back
to the hub. This happens when a user resumes a paused registration
journey.

We weren't unsetting the RESUMELINK value in the journey hint cookie in
this scenario. This was resulting in users being directed back down the
resume registration path when trying to sign in with a service, despite
having already registered.

This issue was noticed when investigating a bug with users not having
`transaction_entity_id` set in their session when hitting the
PausedRegistrationController#from_resume_link method. This is happening
because we're also setting `session[:transaction_entity_id] = nil` in
the CompletedRegistrationController (a hack). This change won't fix the
underlying issues, but it will stop us channeling users down that route.

[This is the Sentry issues that this should help with.](https://sentry.io/organizations/gds-verify/issues/2225146752/?environment=production&project=5494394&query=is%3Aunresolved)