### PR TITLE
HUB-863: Fix bug with Welsh translation

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -589,7 +589,7 @@ cy:
       select_service: Dewiswch y gwasanaeth rydych angen
     sign_in_hint:
       heading: Mewngofnodwch i barhau
-      intro: Y cwmni olaf gafodd ei ddewis ar y ddyfais hon oedd %{idp_enw}.
+      intro: Y cwmni olaf gafodd ei ddewis ar y ddyfais hon oedd %{idp_name}.
       continue_with_idp: Parhau gyda %{idp_name} os ydych wedi creu cyfrif hunaniaeth gyda hwy.
       button: Mewngofnodwch gyda %{idp_name}
       other_way_button: Dewiswch ffordd arall o fewngofnodi


### PR DESCRIPTION
The arg key had been translated too.

Fixes https://sentry.io/organizations/gds-verify/issues/2440058223/?environment=production&project=549439