### PR TITLE
HUB-1078: Set journey type in the session later in the journey

### DIFF
--- a/app/controllers/choose_a_certified_company_controller.rb
+++ b/app/controllers/choose_a_certified_company_controller.rb
@@ -27,6 +27,7 @@ class ChooseACertifiedCompanyController < IdpSelectionController
 private
 
   def select_idp_for_registration(entity_id)
+    session[:journey_type] = JourneyType::REGISTRATION
     register_idp_selection_in_session(entity_id) do |decorated_idp|
       track_selected_idp decorated_idp.display_name
       report_idp_registration_to_piwik

--- a/app/controllers/sign_in_controller.rb
+++ b/app/controllers/sign_in_controller.rb
@@ -43,6 +43,7 @@ class SignInController < IdpSelectionController
 private
 
   def select_idp_for_sign_in(entity_id)
+    session[:journey_type] = JourneyType::SIGN_IN
     register_idp_selection_in_session(entity_id) do |decorated_idp|
       unless idp_disconnecting_for_sign_in(decorated_idp)
         if has_journey_hint?

--- a/app/controllers/start_controller.rb
+++ b/app/controllers/start_controller.rb
@@ -32,13 +32,11 @@ class StartController < ApplicationController
 
   def register
     FEDERATION_REPORTER.report_registration(current_transaction, request)
-    session[:journey_type] = JourneyType::REGISTRATION
     redirect_to about_path
   end
 
   def sign_in
     FEDERATION_REPORTER.report_sign_in(current_transaction, request)
-    session[:journey_type] = JourneyType::SIGN_IN
     redirect_to sign_in_path
   end
 end

--- a/spec/features/idp_selections_reported_to_piwik_spec.rb
+++ b/spec/features/idp_selections_reported_to_piwik_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe "When the user selects an IDP" do
 
   before(:each) do
     set_session_and_session_cookies!
-    set_journey_type_in_session(JourneyType::REGISTRATION)
     stub_api_select_idp
     stub_api_idp_list_for_sign_in
     stub_api_idp_list_for_registration

--- a/spec/features/user_gets_soft_session_timeout_page_spec.rb
+++ b/spec/features/user_gets_soft_session_timeout_page_spec.rb
@@ -4,7 +4,6 @@ require "api_test_helper"
 RSpec.describe "When the user visits a page that triggers an API call when the session has soft timed out" do
   before(:each) do
     set_session_and_session_cookies!
-    set_journey_type_in_session(JourneyType::REGISTRATION)
     stub_api_idp_list_for_registration
     stub_api_select_idp
   end

--- a/spec/features/user_submits_start_page_form_spec.rb
+++ b/spec/features/user_submits_start_page_form_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe "when user submits start page form" do
     stub_api_select_idp
     visit "/start"
     when_i_select_an_idp idp_display_name
-    then_im_at_the_idp journey_type: JourneyType::SIGN_IN_LAST_SUCCESSFUL_IDP
+    then_im_at_the_idp
     expect(page.get_rack_session_key("selected_provider")["identity_provider"]).to include("entity_id" => idp_entity_id, "simple_id" => "stub-idp-one", "levels_of_assurance" => %w(LEVEL_2))
   end
 

--- a/spec/features/user_visits_choose_a_certified_company_about_idp_page_spec.rb
+++ b/spec/features/user_visits_choose_a_certified_company_about_idp_page_spec.rb
@@ -16,7 +16,6 @@ RSpec.feature "user visits the choose a certified company about idp page", type:
   scenario "user chooses a recommended IDP" do
     entity_id = "my-entity-id"
     given_a_session_with_selected_idp
-    set_journey_type_in_session(JourneyType::REGISTRATION)
     stub_session_idp_authn_request(registration: true)
     stub_select_idp_request(entity_id, JourneyType::REGISTRATION)
     stub_api_idp_list_for_sign_in [{ "simpleId" => "stub-idp-one", "entityId" => entity_id, "levelsOfAssurance" => %w(LEVEL_1 LEVEL_2) }]

--- a/spec/features/user_visits_choose_a_certified_company_page_spec.rb
+++ b/spec/features/user_visits_choose_a_certified_company_page_spec.rb
@@ -18,7 +18,6 @@ describe "When the user visits the choose a certified company page" do
         stub_session_idp_authn_request(registration: true)
         stub_session_select_idp_request(encrypted_entity_id)
         set_session_and_session_cookies!(cookie_hash: create_cookie_hash_with_piwik_session)
-        set_journey_type_in_session(JourneyType::REGISTRATION)
 
         visit choose_a_certified_company_path
 
@@ -53,7 +52,6 @@ describe "When the user visits the choose a certified company page" do
 
     it "redirects the user to IDP on clicking Continue" do
       stub_api_select_idp
-      set_journey_type_in_session(JourneyType::REGISTRATION)
       stub_session_idp_authn_request(registration: true)
 
       visit choose_a_certified_company_path

--- a/spec/features/user_visits_confirm_your_identity_page_spec.rb
+++ b/spec/features/user_visits_confirm_your_identity_page_spec.rb
@@ -142,7 +142,6 @@ RSpec.describe "When the user visits the confirm-your-identity page" do
   describe "when the user changes language" do
     it "will preserve the language from sign-in" do
       set_up_session("stub-idp-one")
-      set_journey_type_in_session(JourneyType::SIGN_IN)
       stub_api_idp_list_for_sign_in
       stub_session_creation
       visit "/sign-in"

--- a/spec/sign_in_helper.rb
+++ b/spec/sign_in_helper.rb
@@ -4,7 +4,7 @@ def when_i_select_an_idp(idp_display_name)
   all(:button, idp_display_name)[0].click
 end
 
-def then_im_at_the_idp(ab_value: nil, journey_type: "sign-in")
+def then_im_at_the_idp(ab_value: nil, journey_type: JourneyType::SIGN_IN)
   expect(page).to have_current_path(ApiTestHelper::IDP_LOCATION)
   expect(page).to have_content("SAML Request is 'a-saml-request'")
   expect(page).to have_content("relay state is 'a-relay-state'")
@@ -17,7 +17,7 @@ def then_im_at_the_idp(ab_value: nil, journey_type: "sign-in")
                          PolicyEndpoints::PARAM_REGISTRATION => false,
                          PolicyEndpoints::PARAM_REQUESTED_LOA => "LEVEL_2",
                          PolicyEndpoints::PARAM_PERSISTENT_SESSION_ID => instance_of(String), # no longer comes from matomo
-                         PolicyEndpoints::PARAM_JOURNEY_TYPE => journey_type,
+                         PolicyEndpoints::PARAM_JOURNEY_TYPE => journey_type.downcase,
                          PolicyEndpoints::PARAM_VARIANT => ab_value })).to have_been_made.once
   expect(a_request(:get, saml_proxy_api_uri(authn_request_endpoint(default_session_id)))
            .with(headers: { "X_FORWARDED_FOR" => ApiTestHelper::ORIGINATING_IP })).to have_been_made.once


### PR DESCRIPTION
The sign-in and registration controllers should set their own type when an IDP is selected.