### PR TITLE
HUB-1117: One IDP updates to How Verify Works Page

### DIFF
--- a/app/controllers/about_controller.rb
+++ b/app/controllers/about_controller.rb
@@ -18,6 +18,7 @@ class AboutController < ApplicationController
   end
 
   def about_documents
+    @identity_providers = IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate_collection(identity_providers_available_for_registration)
     render :documents
   end
 

--- a/app/views/about/documents.html.erb
+++ b/app/views/about/documents.html.erb
@@ -1,24 +1,58 @@
-<%= page_title 'hub.about.documents.heading' %>
+<% if @identity_providers.size > 1 %>
+  <%= page_title 'hub.about.documents.multi_idp.heading' %>
+<% else %>
+  <%= page_title 'hub.about.documents.one_idp.heading', idp: @identity_providers.first.display_name %>
+<% end %>
+
 <% content_for :feedback_source, 'ABOUT_DOCUMENTS_PAGE' %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+<% if @identity_providers.size > 1 %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
 
-    <h1 class="govuk-heading-l"><%= t 'hub.about.documents.heading' %></h1>
-    <p><%= t 'hub.about.documents.explanation' %></p>
+      <h1 class="govuk-heading-l"><%= t 'hub.about.documents.multi_idp.heading' %></h1>
+      <p><%= t 'hub.about.documents.multi_idp.explanation' %></p>
 
-    <p><%= t 'hub.about.documents.document_list.heading' %></p>
-    <p><%= t 'hub.about.documents.document_list.list_html' %></p>
+      <p><%= t 'hub.about.documents.multi_idp.document_list.heading' %></p>
+      <p><%= t 'hub.about.documents.multi_idp.document_list.list_html' %></p>
 
-    <p><%= t 'hub.about.documents.further_explanation.doc_checking' %></p>
-    <p><%= t 'hub.about.documents.further_explanation.requirements' %></p>
-    <p><%= t 'hub.about.documents.further_explanation.come_back_later' %></p>
+      <p><%= t 'hub.about.documents.multi_idp.further_explanation.doc_checking' %></p>
+      <p><%= t 'hub.about.documents.multi_idp.further_explanation.requirements' %></p>
+      <p><%= t 'hub.about.documents.multi_idp.further_explanation.come_back_later' %></p>
 
-    <%= button_link_to t("navigation.continue"), choose_a_certified_company_path, id: 'next-button', class: 'govuk-button' %>
-
-    <p class="govuk-!-margin-top-4"><%= t('hub.about.documents.prove_identity_another_way.text_html',
-                                          link_text: link_to(t('hub.about.documents.prove_identity_another_way.link_text'), prove_your_identity_another_way_path, class: "govuk-link")
-                                        ) %>
-    </p>
+      <%= button_link_to t("navigation.continue"), choose_a_certified_company_path, id: 'next-button', class: 'govuk-button' %>
+      <p class="govuk-!-margin-top-4"><%= t('hub.about.documents.prove_identity_another_way.text_html',
+                                            link_text: link_to(t('hub.about.documents.prove_identity_another_way.link_text'), prove_your_identity_another_way_path, class: "govuk-link")
+                                          ) %>
+      </p>
+    </div>
   </div>
-</div>
+<% else %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l"><%= t 'hub.about.documents.one_idp.heading', idp: @identity_providers.first.display_name %></h1>
+
+      <%= raw t 'hub.about.documents.one_idp.content_html', idp: @identity_providers.first.display_name %>
+      <%= form_for(@identity_providers.first, url: choose_a_certified_company_submit_path, html: { class: 'js-idp-form', id: nil }) do |f| %>
+        <%= hidden_field_tag 'entity_id', @identity_providers.first.entity_id, id: nil, class: 'js-entity-id' %>
+        <%= f.button t("hub.about.documents.one_idp.continue_btn", idp: @identity_providers.first.display_name ),
+                     class: "govuk-button",
+                     name: @identity_providers.first.simple_id,
+                     id: nil,
+                     type: 'submit',
+                     value: @identity_providers.first.display_name %>
+      <% end %>
+      <div class="idp-choice govuk-grid-row" style="margin-top: 1em; min-height: 0; border: none">
+        <div class="govuk-width-container">
+          <div class="govuk-grid-column-one-third company-logo"><%= image_tag @identity_providers.first.logo_path, height: '60%', width: '60%', alt: t('common.logo', name: @identity_providers.first.display_name) %></div>
+          <div class="govuk-grid-column-two-third"><p class="govuk-body-s"><%= link_to t('hub.about.documents.one_idp.more_link', idp: @identity_providers.first.display_name), choose_a_certified_company_about_path(@identity_providers.first.simple_id) %></p></div>
+        </div>
+      </div>
+      <p class="govuk-!-margin-top-4"><%= t('hub.about.documents.prove_identity_another_way.text_html',
+                                            link_text: link_to(t('hub.about.documents.prove_identity_another_way.link_text'), prove_your_identity_another_way_path, class: "govuk-link")
+                                          ) %>
+      </p>
+    </div>
+  </div>
+<% end %>

--- a/app/views/about/how_verify_works.html.erb
+++ b/app/views/about/how_verify_works.html.erb
@@ -6,18 +6,21 @@
 <%= raw @tailored_text %>
 
 <h2 class="govuk-heading-m"><%= t 'hub.about.verify.how_it_works.heading' %></h2>
-<p><%= t 'hub.about.verify.how_it_works.content' %></p>
+<% if @identity_providers.size > 1 %>
+  <p><%= t 'hub.about.verify.how_it_works.content' %></p>
 
-<ul class="list-companies">
-  <% @identity_providers.each do |idp| %>
-    <li>
-      <%= image_tag idp.white_logo_path, alt: t('common.logo', name: idp.display_name) %>
-    </li>
-  <% end %>
-</ul>
+  <ul class="list-companies">
+    <% @identity_providers.each do |idp| %>
+      <li>
+        <%= image_tag idp.white_logo_path, alt: t('common.logo', name: idp.display_name) %>
+      </li>
+    <% end %>
+  </ul>
 
-<%= raw t 'hub.about.verify.company.content_html' %>
-
+  <%= raw t 'hub.about.verify.company.content_html' %>
+<% else %>
+  <%= raw t 'hub.about.verify.one_idp.content_html', provider_name: @identity_providers.first.display_name %>
+<% end %>
 <div class="actions">
   <%= button_link_to t("navigation.continue"), @next_page_path, id: 'next-button', class: 'govuk-button' %>
 </div>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -117,22 +117,23 @@ cy:
         heading: Profwch eich hunaniaeth mewn ffordd arall
         sub_heading: Gallwch ddal %{service_name}.
       documents:
-        heading: Cyn i chi ddechrau
-        explanation: I sefydlu cyfrif hunaniaeth, byddwch angen darparu tystiolaeth i'r  cwmnïau allu gwirio.
-        document_list:
-          heading: "Wrth greu'r cyfrif byddwch yn cael eich gofyn am:"
-          list_html: |
-            <ul class="govuk-list govuk-list--bullet">
-              <li>pasbort dilys</li>
-              <li>thrwydded yrru ddilys, llawn neu dros dro, gyda'ch llun arno</li>
-            </ul>
-        further_explanation:
-          doc_checking: Gall y cwmnïau wirio eich pasbort a thrwydded yrru yn erbyn cofnodion swyddogol. Gallant hefyd gadarnhau eich manylion personol drwy gyrchu gwybodaeth megis cofnodion credyd. Bydd hyn yn eu helpu i fod yn sicr mai chi ydyw.
-          requirements: Os mai dim ond un ddogfen hunaniaeth â llun (ID) sydd gennych, byddwch angen un ai ffôn neu dabled i lawr_lwytho ap am ddim a chymryd lluniau ohono. Bydd hyn yn gadael i chi brofi mai chi sy'n berchen ar yr ID.
-          come_back_later: Os oes gennych y pethau hyn ond eu bod yn rhywle arall, dewch nôl  pan fydd gennych hwy gyda chi.
         prove_identity_another_way:
           link_text: Profwch eich hunaniaeth mewn ffordd arall
           text_html: "%{link_text} os nad oes gennych y pethau hyn."
+        multi_idp:
+          heading: Cyn i chi ddechrau
+          explanation: I sefydlu cyfrif hunaniaeth, byddwch angen darparu tystiolaeth i'r  cwmnïau allu gwirio.
+          document_list:
+            heading: "Wrth greu'r cyfrif byddwch yn cael eich gofyn am:"
+            list_html: |
+              <ul class="govuk-list govuk-list--bullet">
+                <li>pasbort dilys</li>
+                <li>thrwydded yrru ddilys, llawn neu dros dro, gyda'ch llun arno</li>
+              </ul>
+          further_explanation:
+            doc_checking: Gall y cwmnïau wirio eich pasbort a thrwydded yrru yn erbyn cofnodion swyddogol. Gallant hefyd gadarnhau eich manylion personol drwy gyrchu gwybodaeth megis cofnodion credyd. Bydd hyn yn eu helpu i fod yn sicr mai chi ydyw.
+            requirements: Os mai dim ond un ddogfen hunaniaeth â llun (ID) sydd gennych, byddwch angen un ai ffôn neu dabled i lawr_lwytho ap am ddim a chymryd lluniau ohono. Bydd hyn yn gadael i chi brofi mai chi sy'n berchen ar yr ID.
+            come_back_later: Os oes gennych y pethau hyn ond eu bod yn rhywle arall, dewch nôl  pan fydd gennych hwy gyda chi.
     choose_a_certified_company:
       heading: Dewiswch gwmni i'ch gwirio
       intro: Bydd un o'r cwmniau hyn yn creu eich cyfrif hunaniaeth.

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -98,6 +98,11 @@ cy:
           content_html: |
             <p class="govuk-body">Bydd y cwmni yn gofyn cwestiynau i chi a gwirio eich dogfennau hunaniaeth.</p>
             <p class="govuk-body">Ni fyddant fyth yn rhannu eich gwybodaeth ar gyfer unrhyw bwrpas arall heb eich caniatâd.</p>
+        one_idp:
+          content_html: |
+            <p class="govuk-body">You create an identity account with the government’s chosen provider %{provider_name}.</p>
+            <p class="govuk-body">%{provider_name} will ask you questions and check your identity documents.</p>
+            <p class="govuk-body">It meets government privacy and security standards. It will never sell or share your information for any other reason without your consent.</p>
       choosing_a_company:
         heading: Dod o hyd i’r cwmni iawn i’ch dilysu chi
         content_html: |

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -99,6 +99,11 @@ en:
           content_html: |
             <p class="govuk-body">The company will ask you questions and check your identity documents.</p>
             <p class="govuk-body">It will never share your information for any other purpose without your consent.</p>
+        one_idp:
+          content_html: |
+            <p class="govuk-body">You create an identity account with the government’s chosen provider %{provider_name}.</p>
+            <p class="govuk-body">%{provider_name} will ask you questions and check your identity documents.</p>
+            <p class="govuk-body">It meets government privacy and security standards. It will never sell or share your information for any other reason without your consent.</p>
       choosing_a_company:
         heading: Finding the right company to verify you
         content_html: |

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -117,22 +117,38 @@ en:
         heading: Prove your identity another way
         sub_heading: You can still %{service_name}.
       documents:
-        heading: Before you start
-        explanation: To set up an identity account, you need to provide evidence for the companies to check.
-        document_list:
-          heading: "When creating the account you'll be asked for:"
-          list_html: |
+        prove_identity_another_way:
+          link_text: Prove your identity another way
+          text_html: "%{link_text} if you do not have these things."
+        multi_idp:
+          heading: Before you start
+          explanation: To set up an identity account, you need to provide evidence for the companies to check.
+          document_list:
+            heading: "When creating the account you'll be asked for:"
+            list_html: |
+              <ul class="govuk-list govuk-list--bullet">
+                <li>a valid passport</li>
+                <li>a valid driving licence, full or provisional, with your photo on it</li>
+              </ul>
+          further_explanation:
+            doc_checking: The companies can check your passport and driving licence against official records. They can also confirm your personal details by accessing information like credit records. This will help them be sure it's really you.
+            requirements: If you only have one photo identity document (ID), you'll also need a phone or a tablet to download a free app and take pictures of it. This will let you prove the ID is yours.
+            come_back_later: If you have these things but they’re somewhere else, come back when you have them with you.
+        one_idp:
+          heading: "Continue to %{idp} to verify your identity"
+          content_html: |
+            <p class="govuk-body">You'll now verify your identity on the %{idp} website.</p>
+            <p class="govuk-body">They'll give you an identity account you can use wherever you see the GOV.UK Verify logo.</p>
+            <p class="govuk-body">You’ll be asked for the following evidence for %{idp} to check:</p>
             <ul class="govuk-list govuk-list--bullet">
               <li>a valid passport</li>
               <li>a valid driving licence, full or provisional, with your photo on it</li>
             </ul>
-        further_explanation:
-          doc_checking: The companies can check your passport and driving licence against official records. They can also confirm your personal details by accessing information like credit records. This will help them be sure it's really you.
-          requirements: If you only have one photo identity document (ID), you'll also need a phone or a tablet to download a free app and take pictures of it. This will let you prove the ID is yours.
-          come_back_later: If you have these things but they’re somewhere else, come back when you have them with you.
-        prove_identity_another_way:
-          link_text: Prove your identity another way
-          text_html: "%{link_text} if you do not have these things."
+            <p class="govuk-body">%{idp} can check your passport and driving licence against official records. They can also confirm your personal details by accessing information like credit records. This will help them be sure it's really you.</p>
+            <p class="govuk-body">If you only have one photo identity document (ID), you'll also need a phone or a tablet to download a free app and take pictures of it. This will let you prove the ID is yours.</p>
+            <p class="govuk-body">If you have these things but they’re somewhere else, come back when you have them with you.</p>
+          continue_btn: "Continue to %{idp}"
+          more_link: "Read more about %{idp}"
     choose_a_certified_company:
       heading: Pick a certified company to verify you
       intro: One of these companies will create your identity account.

--- a/spec/features/user_visits_about_documents_spec.rb
+++ b/spec/features/user_visits_about_documents_spec.rb
@@ -2,34 +2,55 @@ require "feature_helper"
 require "cookie_names"
 
 RSpec.describe "When the user visits the about choosing a company page" do
-  before(:each) do
-    set_session_and_session_cookies!
-    stub_api_idp_list_for_registration
+  context "when there is more than one idp" do
+    before(:each) do
+      set_session_and_session_cookies!
+      stub_api_idp_list_for_registration
+    end
+
+    it "will include the appropriate feedback source" do
+      visit "/about-documents"
+
+      expect_feedback_source_to_be(page, "ABOUT_DOCUMENTS_PAGE", "/about-documents")
+    end
+
+    it "will display content in Welsh" do
+      visit "/am-ddogfennau"
+
+      expect(page).to have_content t("hub.about.documents.multi_idp.heading", locale: :cy)
+    end
+
+    it "will take the user to the IDP picker page when they click 'Continue'" do
+      visit "/about-documents"
+
+      click_link "Continue"
+      expect(page).to have_current_path(choose_a_certified_company_path)
+    end
+
+    it "will take the user to the prove your identity another way page when they click the link" do
+      visit "/about-documents"
+
+      click_link t("hub.about.documents.prove_identity_another_way.link_text")
+      expect(page).to have_current_path(prove_your_identity_another_way_path)
+    end
   end
+  context "when there is just one idp" do
+    before(:each) do
+      set_session_and_session_cookies!
+      stub_api_idp_list_for_registration([{ "simpleId" => "stub-idp-loa1", "entityId" => "http://idcorp-loa1.com", "levelsOfAssurance" => %w(LEVEL_1 LEVEL_2), "enabled" => true }])
+    end
 
-  it "will include the appropriate feedback source" do
-    visit "/about-documents"
+    it "It will give you the single idp view" do
+      visit "/about-documents"
 
-    expect_feedback_source_to_be(page, "ABOUT_DOCUMENTS_PAGE", "/about-documents")
-  end
+      expect(page).to have_content t("hub.about.documents.one_idp.heading", idp: "LOA1 Corp")
+    end
 
-  it "will display content in Welsh" do
-    visit "/am-ddogfennau"
+    it "will take the user to the prove your identity another way page when they click the link" do
+      visit "/about-documents"
 
-    expect(page).to have_content t("hub.about.documents.heading", locale: :cy)
-  end
-
-  it "will take the user to the IDP picker page when they click 'Continue'" do
-    visit "/about-documents"
-
-    click_link "Continue"
-    expect(page).to have_current_path(choose_a_certified_company_path)
-  end
-
-  it "will take the user to the prove your identity another way page when they click the link" do
-    visit "/about-documents"
-
-    click_link t("hub.about.documents.prove_identity_another_way.link_text")
-    expect(page).to have_current_path(prove_your_identity_another_way_path)
+      click_link t("hub.about.documents.prove_identity_another_way.link_text")
+      expect(page).to have_current_path(prove_your_identity_another_way_path)
+    end
   end
 end

--- a/spec/features/user_visits_may_not_work_if_you_live_overseas_spec.rb
+++ b/spec/features/user_visits_may_not_work_if_you_live_overseas_spec.rb
@@ -4,6 +4,7 @@ require "api_test_helper"
 RSpec.describe "When the user visits the may-not-work-if-you-live-overseas page" do
   before(:each) do
     set_session_and_session_cookies!
+    stub_api_idp_list_for_registration
     page.set_rack_session(transaction_simple_id: "test-rp")
   end
 

--- a/spec/features/user_visits_sign_in_page_spec.rb
+++ b/spec/features/user_visits_sign_in_page_spec.rb
@@ -104,6 +104,18 @@ RSpec.describe "user selects an IDP on the sign in page" do
       given_im_on_the_sign_in_page
       when_i_click_start_now
       expect(page).to have_title t("hub.about.verify.what_it_is.heading")
+      expect(page).to have_content t("hub.about.verify.how_it_works.content")
+      expect_to_have_updated_the_piwik_journey_type_variable
+    end
+
+    it "will redirect the user to the about page of the registration journey with content for one IDP and update the Piwik Custom Variables" do
+      stub_api_idp_list_for_registration([{ "simpleId" => "stub-idp-loa1", "entityId" => "http://idcorp-loa1.com", "levelsOfAssurance" => %w(LEVEL_1 LEVEL_2), "enabled" => true }])
+      given_api_requests_have_been_mocked!
+      given_the_piwik_request_has_been_stubbed
+      given_im_on_the_sign_in_page
+      when_i_click_start_now
+      expect(page).to have_title t("hub.about.verify.what_it_is.heading")
+      expect(page).to have_content ActionController::Base.helpers.strip_tags(t("hub.about.verify.one_idp.content_html", provider_name: "LOA1 Corp"))
       expect_to_have_updated_the_piwik_journey_type_variable
     end
 

--- a/spec/features/user_visits_why_might_this_not_work_for_me_page_spec.rb
+++ b/spec/features/user_visits_why_might_this_not_work_for_me_page_spec.rb
@@ -4,6 +4,7 @@ require "api_test_helper"
 RSpec.describe "When the user visits the why-might-this-not-work-for-me page" do
   before(:each) do
     set_session_and_session_cookies!
+    stub_api_idp_list_for_registration
     page.set_rack_session(transaction_simple_id: "test-rp")
   end
 

--- a/spec/features/user_visits_will_it_work_for_me_page_spec.rb
+++ b/spec/features/user_visits_will_it_work_for_me_page_spec.rb
@@ -4,6 +4,7 @@ require "api_test_helper"
 RSpec.describe "When the user visits the will it work for me page" do
   before(:each) do
     set_session_and_session_cookies!
+    stub_api_idp_list_for_registration
   end
 
   it "includes the appropriate feedback source" do


### PR DESCRIPTION
Preparing for a single IDP world we've been asked to make some content changes to the How Verify Works page.  This commit introduces an if statement to the view which renders the existing content if there is more than one page or the new content if only 1 IDP is present.

Multiple IDP Jounrey:
![image](https://user-images.githubusercontent.com/29251905/140415773-c384e095-6ac7-4818-a905-a37a8b4660e6.png)

Single IDP Journey:
![image](https://user-images.githubusercontent.com/29251905/140416391-b391a6cc-6b44-419a-a141-5e5000f98c38.png)
