### PR TITLE
HUB-1118 Last page update for the single idp world

### DIFF
--- a/app/controllers/cancelled_registration_controller.rb
+++ b/app/controllers/cancelled_registration_controller.rb
@@ -1,4 +1,7 @@
+require "partials/viewable_idp_partial_controller"
+
 class CancelledRegistrationController < ApplicationController
+  include ViewableIdpPartialController
   before_action { @hide_feedback_link = true }
 
   def index
@@ -6,6 +9,7 @@ class CancelledRegistrationController < ApplicationController
     @transaction = current_transaction
     @other_ways_decorated = @transaction.other_ways_description
     @other_ways_decorated[0] = @other_ways_decorated[0].capitalize
+    @identity_providers = IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate_collection(identity_providers_available_for_registration)
 
     render :cancelled_registration
   end

--- a/app/views/cancelled_registration/cancelled_registration.html.erb
+++ b/app/views/cancelled_registration/cancelled_registration.html.erb
@@ -6,13 +6,14 @@
     <h1 class="govuk-heading-l"><%= t 'hub.cancelled_registration.heading', idp_name: @idp.display_name %></h1>
 
     <p><%= t 'hub.cancelled_registration.what_next', service_name: @transaction.name %></p>
+    <% if @identity_providers.size > 1 %>
+      <h2 class="govuk-heading-m"><%= t 'hub.cancelled_registration.try_another_summary' %></h2>
 
-    <h2 class="govuk-heading-m"><%= t 'hub.cancelled_registration.try_another_summary' %></h2>
-
-    <div>
-      <p><%= t 'hub.cancelled_registration.try_another_text', idp_name: @idp.display_name %></p>
-      <p><%= link_to t('hub.cancelled_registration.about_choosing_a_company'), about_choosing_a_company_path %></p>
-    </div>
+      <div>
+        <p><%= t 'hub.cancelled_registration.try_another_text', idp_name: @idp.display_name %></p>
+        <p><%= link_to t('hub.cancelled_registration.about_choosing_a_company'), about_choosing_a_company_path %></p>
+      </div>
+    <% end %>
 
     <h2 class="govuk-heading-m"><%= t 'hub.cancelled_registration.other_ways_summary', other_ways_decorated: @other_ways_decorated %></h2>
     <div>

--- a/spec/controllers/cancelled_registration_controller_spec.rb
+++ b/spec/controllers/cancelled_registration_controller_spec.rb
@@ -3,20 +3,24 @@ require "controller_helper"
 require "api_test_helper"
 
 describe CancelledRegistrationController do
+  let(:identity_provider_display_decorator) { double(:IdentityProviderDisplayDecorator) }
   subject { get :index, params: { locale: "en" } }
 
   before :each do
+    stub_request(:get, CONFIG.config_api_host + "/config/transactions/enabled")
     set_selected_idp("entity_id" => "http://idcorp.com", "simple_id" => "stub-idp-one", "levels_of_assurance" => %w(LEVEL_1 LEVEL_2))
   end
 
   it "renders the cancelled registration LOA1 template when LEVEL_1 is the requested LOA" do
     set_session_and_cookies_with_loa("LEVEL_1")
+    stub_api_idp_list_for_registration(loa: "LEVEL_1")
 
     expect(subject).to render_template(:cancelled_registration)
   end
 
   it "renders the cancelled registration LOA2 template when LEVEL_2 is the requested LOA" do
     set_session_and_cookies_with_loa("LEVEL_2")
+    stub_api_idp_list_for_registration(loa: "LEVEL_2")
 
     expect(subject).to render_template(:cancelled_registration)
   end

--- a/spec/features/user_visits_cancelled_registration_page_spec.rb
+++ b/spec/features/user_visits_cancelled_registration_page_spec.rb
@@ -3,31 +3,54 @@ require "api_test_helper"
 require "piwik_test_helper"
 
 RSpec.describe "When user visits cancelled registration page" do
+  let(:identity_provider_display_decorator) { double(:IdentityProviderDisplayDecorator) }
   before :each do
+    stub_request(:get, CONFIG.config_api_host + "/config/transactions/enabled")
     set_session_and_session_cookies!
     page.set_rack_session transaction_simple_id: "test-rp"
     set_selected_idp_in_session(entity_id: "http://idcorp.com", simple_id: "stub-idp-one")
   end
 
-  it "the page is rendered with the correct content for LOA2 journey" do
-    set_loa_in_session("LEVEL_2")
+  context "If there is more than one IDP" do
+    it "the page is rendered with the correct content for LOA2 journey" do
+      set_loa_in_session("LEVEL_2")
+      stub_api_idp_list_for_registration(loa: "LEVEL_2")
 
-    visit("/cancelled-registration")
+      visit("/cancelled-registration")
 
-    expect(page).not_to have_link t("feedback_link.feedback_form")
-    expect(page).to have_title t("hub.cancelled_registration.heading", idp_name: "IDCorp")
-    expect(page).to have_link t("hub.cancelled_registration.send_feedback")
-    expect(page).to have_link t("hub.cancelled_registration.about_choosing_a_company"), href: about_choosing_a_company_path
+      expect(page).not_to have_link t("feedback_link.feedback_form")
+      expect(page).to have_title t("hub.cancelled_registration.heading", idp_name: "IDCorp")
+      expect(page).to have_content t("hub.cancelled_registration.try_another_summary")
+      expect(page).to have_link t("hub.cancelled_registration.send_feedback")
+      expect(page).to have_link t("hub.cancelled_registration.about_choosing_a_company"), href: about_choosing_a_company_path
+    end
+
+    it "the page is rendered with the correct content for LOA1 journey" do
+      set_loa_in_session("LEVEL_1")
+      stub_api_idp_list_for_registration(loa: "LEVEL_1")
+
+      visit("/cancelled-registration")
+
+      expect(page).not_to have_link t("feedback_link.feedback_form")
+      expect(page).to have_title t("hub.cancelled_registration.heading", idp_name: "IDCorp")
+      expect(page).to have_content t("hub.cancelled_registration.try_another_summary")
+      expect(page).to have_link t("hub.cancelled_registration.send_feedback")
+      expect(page).to have_link t("hub.cancelled_registration.about_choosing_a_company"), href: about_choosing_a_company_path
+    end
   end
 
-  it "the page is rendered with the correct content for LOA1 journey" do
-    set_loa_in_session("LEVEL_1")
+  context "If there is more than one IDP" do
+    it "the page won't have try another idp" do
+      set_loa_in_session("LEVEL_2")
+      stub_api_idp_list_for_registration([{ "simpleId" => "stub-idp-loa1", "entityId" => "http://idcorp-loa1.com", "levelsOfAssurance" => %w(LEVEL_1 LEVEL_2), "enabled" => true }])
 
-    visit("/cancelled-registration")
+      visit("/cancelled-registration")
 
-    expect(page).not_to have_link t("feedback_link.feedback_form")
-    expect(page).to have_title t("hub.cancelled_registration.heading", idp_name: "IDCorp")
-    expect(page).to have_link t("hub.cancelled_registration.send_feedback")
-    expect(page).to have_link t("hub.cancelled_registration.about_choosing_a_company"), href: about_choosing_a_company_path
+      expect(page).not_to have_link t("feedback_link.feedback_form")
+      expect(page).to have_title t("hub.cancelled_registration.heading", idp_name: "IDCorp")
+      expect(page).not_to have_content t("hub.cancelled_registration.try_another_summary")
+      expect(page).to have_link t("hub.cancelled_registration.send_feedback")
+      expect(page).not_to have_link t("hub.cancelled_registration.about_choosing_a_company"), href: about_choosing_a_company_path
+    end
   end
 end


### PR DESCRIPTION
This is the last change for single ISP world which removes the option to try another IDP on the cancel registration controller.