### PR TITLE
BAU Avoid Nil reference when reporting a sign_in journey hint

### DIFF
--- a/app/controllers/partials/journey_hinting_partial_controller.rb
+++ b/app/controllers/partials/journey_hinting_partial_controller.rb
@@ -57,6 +57,7 @@ module JourneyHintingPartialController
 
   def decorate_idp_by_entity_id(providers, entity_id)
     retrieved_idp = providers.detect { |idp| idp.entity_id == entity_id }
+    logger.info("could not decorate idp by entity_id '#{entity_id}'") if retrieved_idp.nil?
     retrieved_idp && IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate(retrieved_idp)
   end
 

--- a/app/controllers/sign_in_controller.rb
+++ b/app/controllers/sign_in_controller.rb
@@ -10,7 +10,9 @@ class SignInController < IdpSelectionController
 
     if success_entity_id
       @suggested_idp = decorate_idp_by_entity_id(all_idps[:available] + all_idps[:disconnected], success_entity_id)
-      FEDERATION_REPORTER.report_sign_in_journey_hint_shown(current_transaction, request, @suggested_idp.display_name)
+      if @suggested_idp
+        FEDERATION_REPORTER.report_sign_in_journey_hint_shown(current_transaction, request, @suggested_idp.display_name)
+      end
     end
 
     @available_identity_providers = IDENTITY_PROVIDER_DISPLAY_DECORATOR.decorate_collection(all_idps[:available])

--- a/spec/feature_helper.rb
+++ b/spec/feature_helper.rb
@@ -8,7 +8,8 @@ WebMock.disable_net_connect!(
   allow_localhost: true,
   allow: ["chromedriver.storage.googleapis.com",
           %r{github.com/mozilla/geckodriver/releases.*},
-          %r{github-releases.githubusercontent.com/.*geckodriver}],
+          %r{github-releases.githubusercontent.com/.*geckodriver},
+          %r{objects.githubusercontent.com/github-production-release-asset-*}],
 )
 
 RACK_COOKIE_DATE_FORMAT = "%a, %d %b %Y".freeze


### PR DESCRIPTION
Avoid a Nil reference when reporting a sign_in journey hint.

Log the entity that cannot be found in the set of active and disconnected idps.