### PR TITLE
stop auto generating services page

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,8 @@ ADD . /verify-frontend/
 
 RUN useradd frontend
 RUN chown -R frontend verify-frontend/
+RUN mkdir /home/frontend
+RUN chown -R frontend home/
 
 USER frontend
 

--- a/app/views/shared/_transaction_list.html.erb
+++ b/app/views/shared/_transaction_list.html.erb
@@ -1,17 +1,16 @@
 <% taxons = transaction_taxon_list %>
 <% if taxons.any? %>
   <ul class="govuk-list govuk-list--bullet">
-  <% taxons.each do |taxon| %>
-      <% taxon.transactions.each do |transaction| %>
-        <li>
-          <% if transaction.homepage %>
-            <%= link_to transaction.name, transaction.homepage %>
-          <% else %>
-            <%= transaction.name %>
-            <p class="govuk-hint"><%= t 'hub.transaction_list.hint' %></p>
-          <% end %>
-        </li>
-      <% end %>
+
+  <% t('hub.transaction_list.items').each do |transaction| %>
+      <li>
+        <% if transaction[:homepage] %>
+          <%= link_to transaction[:name], transaction[:homepage] %>
+        <% else %>
+          <%= transaction[:name] %>
+          <p class="govuk-hint"><%= t 'hub.transaction_list.hint' %></p>
+        <% end %>
+      </li>
   <% end %>
   </ul>
 <% end %>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -216,6 +216,21 @@ cy:
     transaction_list:
       heading: Dod o hyd i’r gwasanaeth rydych yn ei ddefnyddio i ddechrau eto
       hint: Dilynnwch y cyfarwyddiadau rydych wedi’u derbyn.
+      items:
+        - name: "defnyddio Taliadau Cefn Gwlad"
+          homepage: "https://www.ruralpayments.service.gov.uk/"
+        - name: "gwneud cais am wiriad sylfaenol DBS"
+          homepage: "https://www.gov.uk/basic-dbs-check"
+        - name: "gwneud cais am drwydded gweithredu cerbyd"
+          homepage: "https://www.gov.uk/apply-vehicle-operator-licence"
+        - name: "ychwanegu tocyn sy'n cynnwys gwybodaeth am eich trwydded yrru i'ch ffôn glyfar"
+          homepage: "https://www.viewdrivingrecord.service.gov.uk/digital/index"
+        - name: "dilyswch eich hunaniaeth i wneud cais i fod yn weithiwr cymdeithasol cofrestredig yn Lloegr"
+          homepage: "https://www.socialworkengland.org.uk/"
+        - name: "mewngofnodwch i'ch 'Total Rewards Statement'"
+          homepage: "https://www.totalrewardstatements.nhs.uk/"
+        - name: "llofnodi eich gweithred morgais"
+          homepage: "https://sign-your-mortgage-deed.landregistry.gov.uk/"
       other_services: Gwasanaethau eraill
     will_it_work_for_me:
       heading: Amdanoch chi

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -228,6 +228,21 @@ en:
     transaction_list:
       heading: Find the service you were using to start again
       hint: Follow the instructions you received.
+      items:
+        - name: "use Rural Payments"
+          homepage: "https://www.ruralpayments.service.gov.uk/"
+        - name: "add a pass containing your driving licence information to your smartphone"
+          homepage: "https://www.viewdrivingrecord.service.gov.uk/digital/index"
+        - name: "apply for a vehicle operator licence"
+          homepage: "https://www.gov.uk/apply-vehicle-operator-licence"
+        - name: "apply for a DBS basic check"
+          homepage: "https://www.gov.uk/basic-dbs-check"
+        - name: "sign your mortgage deed"
+          homepage: "https://sign-your-mortgage-deed.landregistry.gov.uk/"
+        - name: "sign in to your Total Rewards Statement"
+          homepage: "https://www.totalrewardstatements.nhs.uk/"
+        - name: "verify your identity to apply to become a registered social worker in England"
+          homepage: "https://www.socialworkengland.org.uk/"
       other_services: Other services
     will_it_work_for_me:
       heading: About you

--- a/spec/features/user_encounters_error_page_spec.rb
+++ b/spec/features/user_encounters_error_page_spec.rb
@@ -5,13 +5,15 @@ RSpec.describe "user encounters error page" do
   let(:api_saml_endpoint) { saml_proxy_api_uri(new_session_endpoint) }
   let(:api_select_idp_endpoint) { policy_api_uri(select_idp_endpoint(default_session_id)) }
 
-  it "will present the user with a list of transactions" do
+  it "will present the user with a list of static transactions" do
     stub_session_creation_error
     visit "/test-saml"
     click_button "saml-post"
     expect(page).to have_content t("errors.something_went_wrong.heading")
     expect(page).to have_css "#piwik-custom-url", text: "errors/generic-error"
-    expect(page).to have_link "test GOV.UK Verify user journeys", href: "http://localhost:50130/test-rp"
+    t("hub.transaction_list.items").each do |transaction|
+      expect(page).to have_link transaction[:name], href: transaction[:homepage]
+    end
   end
 
   it "will present the user with no list of transactions if we cant read the errors" do
@@ -123,7 +125,9 @@ RSpec.describe "user encounters error page" do
         visit sign_in_path
         click_button "IDCorp"
         expect(page).to have_content t("errors.something_went_wrong.heading")
-        expect(page).to have_link "test GOV.UK Verify user journeys", href: "http://localhost:50130/test-rp"
+        t("hub.transaction_list.items").each do |transaction|
+          expect(page).to have_link transaction[:name], href: transaction[:homepage]
+        end
         expect(page).to have_css "#piwik-custom-url", text: "errors/generic-error"
         expect(page.status_code).to eq(500)
       end

--- a/spec/features/user_visits_prove_your_identity_page_spec.rb
+++ b/spec/features/user_visits_prove_your_identity_page_spec.rb
@@ -79,6 +79,8 @@ RSpec.describe "When the user visits the prove identity page" do
     expect(page).to have_content t("errors.no_cookies.enable_cookies")
     expect(page).to have_http_status :forbidden
     expect(page).to have_link "feedback", href: "/feedback-landing?feedback-source=COOKIE_NOT_FOUND_PAGE"
-    expect(page).to have_link "test GOV.UK Verify user journeys", href: "http://localhost:50130/test-rp"
+    t("hub.transaction_list.items").each do |transaction|
+      expect(page).to have_link transaction[:name], href: transaction[:homepage]
+    end
   end
 end

--- a/spec/features/user_visits_start_page_spec.rb
+++ b/spec/features/user_visits_start_page_spec.rb
@@ -67,7 +67,9 @@ RSpec.describe "When the user visits the start page" do
       expect(page).to have_content t("errors.no_cookies.enable_cookies")
       expect(page).to have_http_status :forbidden
       expect(page).to have_link "feedback", href: "/feedback-landing?feedback-source=COOKIE_NOT_FOUND_PAGE"
-      expect(page).to have_link "test GOV.UK Verify user journeys", href: "http://localhost:50130/test-rp"
+      t("hub.transaction_list.items").each do |transaction|
+        expect(page).to have_link transaction[:name], href: transaction[:homepage]
+      end
     end
 
     it "will display the generic error when start time is missing from session" do


### PR DESCRIPTION
## What 

The list of services on [this page](https://www.signin.service.gov.uk/verify-services) currently reflects which ones are still connected in the config. 

We need to stop this from happening, and just show the list of services in here as plain text that we’ll manually update in future. 

## Why

We’re going to let some services stay technically connected to Verify even after they’ve switched off sign ups/ins, just in case something goes wrong and they need to revert to using Verify. 

We don’t want this page to be misleading for users, or the journalists who use this page as a source of truth.

<img width="1113" alt="Screenshot 2022-11-21 at 13 04 44" src="https://user-images.githubusercontent.com/8051117/203062443-589df72e-6e86-4859-b3cc-72e144c6aa18.png">
<img width="1119" alt="Screenshot 2022-11-21 at 13 04 51" src="https://user-images.githubusercontent.com/8051117/203062459-1f2d9083-c350-494c-86ca-1f38a65d4978.png">


