### PR TITLE
Remove self assessment link

### DIFF
--- a/app/views/static/privacy_notice.en.html.erb
+++ b/app/views/static/privacy_notice.en.html.erb
@@ -12,7 +12,7 @@ end %>
     <p>Last updated: 15 January 2021</p>
     <h2 class="govuk-heading-l" id="who-we-are">Who we are</h2>
     <p>GOV.UK Verify is built and run by the Government Digital Service (GDS), which is part of the Cabinet Office.</p>
-    <p>GOV.UK Verify allows you to prove your identity when using digital government services, like the service you use to <a href="https://www.gov.uk/log-in-file-self-assessment-tax-return">file your Self Assessment tax return</a>.</p>
+    <p>GOV.UK Verify allows you to prove your identity when using digital government services.</p>
     <p>GOV.UK Verify has been designed to meet the <a href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/361496/PCAG_IDA_Principles_3.1__4_.pdf">Identity Assurance Principles</a>, written by the Cabinet Office <a href="https://www.gov.uk/government/groups/privacy-and-consumer-advisory-group">Privacy and Consumer Advisory Group</a>.</p>
     <p>You can find more detailed information about GOV.UK Verify on the <a href="https://gds.blog.gov.uk/category/id-assurance/">GOV.UK Verify blog</a>.</p>
     <p>This privacy notice explains what data we might collect, how it's used and how it's protected.</p>


### PR DESCRIPTION
Self-assessment no longer uses GOV.UK Verify.