### PR TITLE
Revert "Bump prometheus-client from 0.10.0 to 4.0.0"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem 'statsd-ruby', '~> 1.5.0'
 # prometheus/client_ruby had a massive rewrite in
 # https://github.com/prometheus/client_ruby/pull/95
 # This is the prerelease version of that work
-gem 'prometheus-client', '~> 4.0.0'
+gem 'prometheus-client', '~> 0.10.0.pre.alpha.1'
 
 # Use sentry-raven for sending logs to Sentry via the raven protocol
 gem 'sentry-raven'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -184,7 +184,7 @@ GEM
     parser (3.0.2.0)
       ast (~> 2.4.1)
     phantomjs (2.1.1.0)
-    prometheus-client (4.0.0)
+    prometheus-client (0.10.0)
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -385,7 +385,7 @@ DEPENDENCIES
   logstash-logger
   mini_racer
   multi_json
-  prometheus-client (~> 4.0.0)
+  prometheus-client (~> 0.10.0.pre.alpha.1)
   pry (~> 0.14.2)
   puma
   rack-handlers


### PR DESCRIPTION
Reverts alphagov/verify-frontend#1016
This PR blocks the pipeline. We will temporarily revert it, in favour of higher priority ITHC updates.